### PR TITLE
Fix gateway_customer_id type from integer to string in membership-update schema

### DIFF
--- a/inc/api/schemas/membership-update.php
+++ b/inc/api/schemas/membership-update.php
@@ -130,7 +130,7 @@ return [
 	],
 	'gateway_customer_id'         => [
 		'description' => __('The ID of the customer on the payment gateway database.', 'multisite-ultimate'),
-		'type'        => 'integer',
+		'type'        => 'string',
 		'required'    => false,
 	],
 	'gateway_subscription_id'     => [


### PR DESCRIPTION
## Summary
• Fix gateway_customer_id type from integer to string in membership-update schema
• Resolves type mismatch issues with Stripe customer IDs

## Test plan
- [x] Verify schema accepts string customer IDs
- [x] Test with actual Stripe customer ID formats

🤖 Generated with [Claude Code](https://claude.ai/code)