### PR TITLE
feat(currency): add Iranian Rial support 

### DIFF
--- a/inc/functions/currency.php
+++ b/inc/functions/currency.php
@@ -157,6 +157,7 @@ function wu_get_currencies(): array {
 			'YER' => __('Yemeni Rial', 'ultimate-multisite'),
 			'ZAR' => __('South African Rand', 'ultimate-multisite'),
 			'ZMW' => __('Zambian Kwacha', 'ultimate-multisite'),
+			'IRR' => __('Iranian Rial', 'ultimate-multisite'),
 		]
 	);
 
@@ -191,6 +192,9 @@ function wu_get_currency_symbol($currency = '') {
 		case 'USD':
 		case 'BBD':
 			$currency_symbol = '$';
+			break;
+		case 'IRR':
+			$currency_symbol = '﷼';
 			break;
 		case 'AFN':
 			$currency_symbol = '؋';
@@ -426,6 +430,7 @@ function wu_is_zero_decimal_currency($currency = 'USD') {
 		'XAF', // Central African CFA Franc
 		'XOF', // West African CFA Franc
 		'XPF', // CFP Franc
+		'IRR', // Iranian Rial
 	];
 
 	return apply_filters('wu_is_zero_decimal_currency', in_array($currency, $zero_dec_currencies, true));


### PR DESCRIPTION
Added Iranian Rial (IRR) as a supported payment currency in the Ultimate plugin.

Includes:
- Currency code: IRR
- Symbol: ﷼

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added full support for the Iranian Rial (IRR).
  * IRR is now available in currency settings with the correct Rial symbol.
  * IRR is treated as a zero-decimal currency, ensuring accurate pricing, rounding, and display across checkout, plans, invoices, subscriptions, and receipts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->