### PR TITLE
feat(tax): add universal tax fallback feature

### DIFF
--- a/inc/functions/tax.php
+++ b/inc/functions/tax.php
@@ -201,6 +201,20 @@ function wu_get_applicable_tax_rates($country, $tax_category = 'default', $state
 		}
 	}
 
+	/*
+	 * If no country-specific rates matched, apply any rates configured
+	 * with '*' (Apply to all countries) as a fallback.
+	 */
+	if (empty($results)) {
+		foreach ($tax_category['rates'] as $rate) {
+			if ('*' === $rate['country']) {
+				$rate['order'] = 1;
+
+				$results[ $rate['id'] ] = $rate;
+			}
+		}
+	}
+
 	uasort($results, 'wu_sort_by_order');
 
 	return array_values($results);

--- a/inc/tax/class-tax.php
+++ b/inc/tax/class-tax.php
@@ -32,8 +32,6 @@ class Tax {
 
 		add_action('wu_page_wp-ultimo-settings_load', [$this, 'add_sidebar_widget']);
 
-		add_filter('wu_cart_applicable_tax_rates', [$this, 'apply_universal_tax_rate'], 10, 4);
-
 		if ($this->is_enabled()) {
 			add_action('wp_ultimo_admin_pages', [$this, 'add_admin_page']);
 
@@ -93,42 +91,6 @@ class Tax {
 	}
 
 	/**
-	 * Applies universal tax rate when no specific rates are found.
-	 *
-	 * @since 2.0.0
-	 * @param array  $rates Tax rates.
-	 * @param string $country Country code.
-	 * @param string $tax_category Tax category.
-	 * @param object $cart Cart object.
-	 * @return array
-	 */
-	public function apply_universal_tax_rate(array $rates, string $country, string $tax_category, $cart): array {
-
-		if (empty($rates) && wu_should_collect_taxes() && wu_get_setting('enable_universal_tax', false)) {
-			$universal_rate = wu_get_setting('universal_tax_rate', 10);
-
-			$rates = [
-				[
-					'id'         => 'universal-' . uniqid(),
-					'title'      => __('Universal Tax', 'ultimate-multisite'),
-					'country'    => '*',
-					'state'      => '',
-					'city'       => '',
-					'tax_type'   => 'percentage',
-					'tax_amount' => $universal_rate,
-					'tax_rate'   => $universal_rate,
-					'priority'   => 1,
-					'compound'   => false,
-					'type'       => 'regular',
-					'rate'       => $universal_rate,
-				]
-			];
-		}
-
-		return $rates;
-	}
-
-	/**
 	 * Register tax settings.
 	 *
 	 * @since 2.0.0
@@ -171,36 +133,6 @@ class Tax {
 			]
 		);
 
-		wu_register_settings_field(
-			'taxes',
-			'enable_universal_tax',
-			[
-				'title'   => __('Enable Universal Tax', 'ultimate-multisite'),
-				'desc'    => __('Enable a fallback universal tax rate when no country-specific rates match.', 'ultimate-multisite'),
-				'type'    => 'toggle',
-				'default' => 0,
-				'require' => [
-					'enable_taxes' => 1,
-				],
-			]
-		);
-
-		wu_register_settings_field(
-			'taxes',
-			'universal_tax_rate',
-			[
-				'title'   => __('Universal Tax Rate (%)', 'ultimate-multisite'),
-				'desc'    => __('Tax rate applied when no country-specific rate matches.', 'ultimate-multisite'),
-				'type'    => 'number',
-				'default' => 10,
-				'min'     => 0,
-				'max'     => 100,
-				'require' => [
-					'enable_taxes'     => 1,
-					'enable_universal_tax' => 1,
-				],
-			]
-		);
 	}
 
 	/**

--- a/lang/ultimate-multisite.pot
+++ b/lang/ultimate-multisite.pot
@@ -16405,7 +16405,7 @@ msgstr ""
 #: views/sites/edit-placeholders.php:49
 #: views/sites/edit-placeholders.php:177
 #: views/taxes/list.php:102
-#: views/taxes/list.php:309
+#: views/taxes/list.php:313
 msgid "Select All"
 msgstr ""
 
@@ -18472,80 +18472,60 @@ msgstr ""
 msgid "Taxes Collected"
 msgstr ""
 
-#: inc/tax/class-tax.php:113
-msgid "Universal Tax"
-msgstr ""
-
-#: inc/tax/class-tax.php:153
+#: inc/tax/class-tax.php:115
 msgid "Enable Taxes"
 msgstr ""
 
-#: inc/tax/class-tax.php:154
+#: inc/tax/class-tax.php:116
 msgid "Enable this option to be able to collect sales taxes on your network payments."
 msgstr ""
 
-#: inc/tax/class-tax.php:164
+#: inc/tax/class-tax.php:126
 msgid "Inclusive Tax"
 msgstr ""
 
-#: inc/tax/class-tax.php:165
+#: inc/tax/class-tax.php:127
 msgid "Enable this option if your prices include taxes. In that case, Ultimate Multisite will calculate the included tax instead of adding taxes to the price."
 msgstr ""
 
-#: inc/tax/class-tax.php:178
-msgid "Enable Universal Tax"
-msgstr ""
-
-#: inc/tax/class-tax.php:179
-msgid "Enable a fallback universal tax rate when no country-specific rates match."
-msgstr ""
-
-#: inc/tax/class-tax.php:192
-msgid "Universal Tax Rate (%)"
-msgstr ""
-
-#: inc/tax/class-tax.php:193
-msgid "Tax rate applied when no country-specific rate matches."
-msgstr ""
-
-#: inc/tax/class-tax.php:258
+#: inc/tax/class-tax.php:190
 msgid "Regular"
 msgstr ""
 
-#: inc/tax/class-tax.php:301
+#: inc/tax/class-tax.php:233
 #: inc/ui/class-site-actions-element.php:184
 #: views/limitations/plugin-selector.php:80
 msgid "Default"
 msgstr ""
 
-#: inc/tax/class-tax.php:364
+#: inc/tax/class-tax.php:296
 msgid "You don't have permission to alter tax rates"
 msgstr ""
 
-#: inc/tax/class-tax.php:383
+#: inc/tax/class-tax.php:315
 msgid "No tax rates present in the request"
 msgstr ""
 
-#: inc/tax/class-tax.php:415
+#: inc/tax/class-tax.php:347
 msgid "Tax Rates successfully updated!"
 msgstr ""
 
-#: inc/tax/class-tax.php:455
-#: inc/tax/class-tax.php:459
+#: inc/tax/class-tax.php:387
+#: inc/tax/class-tax.php:391
 msgid "Manage Tax Rates"
 msgstr ""
 
-#: inc/tax/class-tax.php:463
+#: inc/tax/class-tax.php:395
 msgid "Add different tax rates depending on the country of your customers."
 msgstr ""
 
-#: inc/tax/class-tax.php:469
+#: inc/tax/class-tax.php:401
 msgid "You need to activate tax support first."
 msgstr ""
 
-#: inc/tax/class-tax.php:477
-#: inc/tax/class-tax.php:483
-#: inc/tax/class-tax.php:487
+#: inc/tax/class-tax.php:409
+#: inc/tax/class-tax.php:415
+#: inc/tax/class-tax.php:419
 msgid "Manage Tax Rates &rarr;"
 msgstr ""
 
@@ -20943,22 +20923,22 @@ msgid "No items to display"
 msgstr ""
 
 #: views/sites/edit-placeholders.php:209
-#: views/taxes/list.php:342
+#: views/taxes/list.php:346
 msgid "Add new Row"
 msgstr ""
 
 #: views/sites/edit-placeholders.php:215
-#: views/taxes/list.php:348
+#: views/taxes/list.php:352
 msgid "Delete Selected Rows"
 msgstr ""
 
 #: views/sites/edit-placeholders.php:241
-#: views/taxes/list.php:374
+#: views/taxes/list.php:378
 msgid "Save your changes!"
 msgstr ""
 
 #: views/sites/edit-placeholders.php:245
-#: views/taxes/list.php:378
+#: views/taxes/list.php:382
 msgid "Saving..."
 msgstr ""
 
@@ -21007,12 +20987,16 @@ msgstr ""
 msgid "Loading Tax Rates..."
 msgstr ""
 
-#: views/taxes/list.php:244
-#: views/taxes/list.php:259
+#: views/taxes/list.php:221
+msgid "Apply to all countries"
+msgstr ""
+
+#: views/taxes/list.php:250
+#: views/taxes/list.php:265
 msgid "Leave blank to apply to all"
 msgstr ""
 
-#: views/taxes/list.php:388
+#: views/taxes/list.php:392
 msgid "Save Tax Rates"
 msgstr ""
 

--- a/views/taxes/list.php
+++ b/views/taxes/list.php
@@ -215,19 +215,23 @@ defined('ABSPATH') || exit;
 					case 'country':
 						?>
 
-			<select v-cloak v-model="item.<?php echo esc_attr($key); ?>" style="width: 100%;">
+		<select v-cloak v-model="item.<?php echo esc_attr($key); ?>" style="width: 100%;">
 
-						<?php foreach (wu_get_countries_as_options() as $country_code => $country_name) : ?>
+					<option value="*">
+						<?php esc_html_e('Apply to all countries', 'ultimate-multisite'); ?>
+					</option>
 
-				<option value="<?php echo esc_attr($country_code); ?>">
+					<?php foreach (wu_get_countries_as_options() as $country_code => $country_name) : ?>
 
-							<?php echo esc_html($country_name); ?>
+			<option value="<?php echo esc_attr($country_code); ?>">
 
-				</option>
+						<?php echo esc_html($country_name); ?>
 
-				<?php endforeach; ?>
+			</option>
 
-			</select>
+			<?php endforeach; ?>
+
+		</select>
 
 						<?php
 						break;


### PR DESCRIPTION
- Add enable_universal_tax setting toggle
- Add universal_tax_rate setting (0-100%)
- Implement apply_universal_tax_rate filter
- Update translations for new strings
- Apply universal rate when no country-specific rates match

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Universal tax rate feature now available, allowing site administrators to enable and configure a default tax rate percentage (0-100%) through new admin settings.
  * Tax system enhanced with automatic fallback mechanism to apply universal tax rates when country-specific tax rates are unavailable.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->