### PR TITLE
fix(domain): prevent multiple primary domains per site

### DIFF
--- a/inc/admin-pages/class-domain-list-admin-page.php
+++ b/inc/admin-pages/class-domain-list-admin-page.php
@@ -241,22 +241,6 @@ class Domain_List_Admin_Page extends List_Admin_Page {
 				wp_send_json_error($domain);
 			}
 
-			if (wu_request('primary_domain')) {
-				$old_primary_domains = wu_get_domains(
-					[
-						'primary_domain' => true,
-						'blog_id'        => wu_request('blog_id'),
-						'id__not_in'     => [$domain->get_id()],
-						'fields'         => 'ids',
-					]
-				);
-
-				/*
-				 * Trigger async action to update the old primary domains.
-				 */
-				do_action('wu_async_remove_old_primary_domains', [$old_primary_domains]);
-			}
-
 			wu_enqueue_async_action('wu_async_process_domain_stage', ['domain_id' => $domain->get_id()], 'domain');
 
 			wp_send_json_success(

--- a/inc/models/class-domain.php
+++ b/inc/models/class-domain.php
@@ -9,6 +9,7 @@
 
 namespace WP_Ultimo\Models;
 
+use stdClass;
 use WP_Ultimo\Domain_Mapping\Helper;
 use WP_Ultimo\Database\Domains\Domain_Stage;
 
@@ -53,14 +54,6 @@ class Domain extends Base_Model {
 	 * @var boolean
 	 */
 	protected $primary_domain = false;
-
-	/**
-	 * Original primary_domain value before changes (for tracking edits).
-	 *
-	 * @since 2.0.0
-	 * @var boolean|null
-	 */
-	protected $original_primary;
 
 	/**
 	 * Should this domain be forced to be used only on HTTPS?
@@ -303,11 +296,6 @@ class Domain extends Base_Model {
 	 * @return void
 	 */
 	public function set_primary_domain($primary_domain): void {
-
-		if ($this->id > 0 && !isset($this->original_primary)) {
-			$this->original_primary = $this->primary_domain;
-		}
-
 		$this->primary_domain = $primary_domain;
 	}
 
@@ -531,7 +519,7 @@ class Domain extends Base_Model {
 					 */
 					do_action_deprecated('mercator.mapping.updated', $deprecated_args, '2.0.0', 'wu_domain_post_save');
 			}
-			
+
 			/*
 			 * Resets cache.
 			 *
@@ -543,7 +531,7 @@ class Domain extends Base_Model {
 			/*
 			 * If this domain was just set as primary, unset other primaries for this site.
 			 */
-			if ($this->primary_domain && ($was_new || (isset($this->original_primary) && ! $this->original_primary))) {
+			if ($this->primary_domain && ($was_new || (isset($this->_original['primary_domain']) && ! $this->_original['primary_domain']))) {
 				$old_primary_domains = wu_get_domains(
 					[
 						'primary_domain' => true,

--- a/inc/ui/class-domain-mapping-element.php
+++ b/inc/ui/class-domain-mapping-element.php
@@ -426,22 +426,6 @@ class Domain_Mapping_Element extends Base_Element {
 			wp_send_json_error($domain);
 		}
 
-		if (wu_request('primary_domain')) {
-			$old_primary_domains = wu_get_domains(
-				[
-					'primary_domain' => true,
-					'blog_id'        => $current_site_id,
-					'id__not_in'     => [$domain->get_id()],
-					'fields'         => 'ids',
-				]
-			);
-
-			/*
-			 * Trigger async action to update the old primary domains.
-			 */
-			do_action_ref_array('wu_async_remove_old_primary_domains', [$old_primary_domains]);
-		}
-
 		wu_enqueue_async_action('wu_async_process_domain_stage', ['domain_id' => $domain->get_id()], 'domain');
 
 		/**
@@ -629,10 +613,7 @@ class Domain_Mapping_Element extends Base_Element {
 				]
 			);
 
-			/*
-			 * Trigger async action to update the old primary domains.
-			 */
-			do_action_ref_array('wu_async_remove_old_primary_domains', [$old_primary_domains]);
+			// Updating the old primaries now happens in the save method.
 
 			wp_send_json_success(
 				[


### PR DESCRIPTION
- Track original primary state in Domain model to detect changes
- Unset other primary domains when setting a new primary
- Ensure consistency across API, admin, and creation flows

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic cleanup of previous primary domain assignments when a new primary is set.

* **Behavior Changes**
  * Improved detection of when a domain becomes primary to ensure updates run only when needed.
  * Cleanup now consistently runs as part of the domain save process (removed redundant immediate triggers elsewhere), reducing duplicate background tasks.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->