### PR TITLE
fix: filter missing addon plugins in e2e wp-env setup

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -56,9 +56,25 @@ jobs:
       - name: Install Composer dependencies
         run: composer install
 
-      - name: Set PHP version for wp-env
+      - name: Set PHP version and filter missing plugins for wp-env
         run: |
-          echo "{\"config\": {\"phpVersion\": \"${{ matrix.php }}\"}}" > .wp-env.override.json
+          node -e "
+            const fs = require('fs');
+            const path = require('path');
+            const config = JSON.parse(fs.readFileSync('.wp-env.json', 'utf8'));
+            const override = { config: { phpVersion: '${{ matrix.php }}' }, env: {} };
+            for (const [envName, envConfig] of Object.entries(config.env || {})) {
+              if (envConfig.plugins) {
+                const existing = envConfig.plugins.filter(p => {
+                  const resolved = path.resolve(p);
+                  return fs.existsSync(resolved);
+                });
+                override.env[envName] = { plugins: existing };
+              }
+            }
+            fs.writeFileSync('.wp-env.override.json', JSON.stringify(override, null, 2));
+            console.log('Override:', JSON.stringify(override, null, 2));
+          "
 
       - name: Start WordPress Test Environment
         run: npm run env:start:test


### PR DESCRIPTION
## Summary
- The `.wp-env.json` includes addon plugin paths (e.g. `../addons/ultimate-multisite-domain-seller`) that exist in the local monorepo but not in CI where only the core plugin is checked out
- This caused `wp-env start` to fail with "The 'ultimate-multisite-domain-seller' plugin could not be found"
- The override step now reads `.wp-env.json`, checks each plugin path with `fs.existsSync()`, and only includes plugins that are actually present on disk
- Locally (where addons exist) nothing changes; in CI, missing addon paths are silently filtered out

## Test plan
- [ ] Verify the e2e workflow passes in CI without the domain-seller addon present
- [ ] Verify local `npm run env:start:test` still works with addons present

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated end-to-end testing workflow to improve environment configuration management and plugin validation during test setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->