### PR TITLE
Fix Stripe Connect button to save settings before OAuth redirect

### DIFF
--- a/inc/admin-pages/class-settings-admin-page.php
+++ b/inc/admin-pages/class-settings-admin-page.php
@@ -554,7 +554,23 @@ class Settings_Admin_Page extends Wizard_Admin_Page {
 
 		WP_Ultimo()->settings->save_settings($filtered_data);
 
-		wp_safe_redirect(add_query_arg('updated', 1, wu_get_current_url()));
+		$redirect_url = add_query_arg('updated', 1, wu_get_current_url());
+
+		/**
+		 * Filters the redirect URL after settings are saved.
+		 *
+		 * Allows gateways or other components to redirect elsewhere
+		 * after a settings save (e.g. to initiate an OAuth flow).
+		 *
+		 * @since 2.x.x
+		 *
+		 * @param string $redirect_url The default redirect URL.
+		 * @param array  $filtered_data The saved settings data.
+		 * @return string
+		 */
+		$redirect_url = apply_filters('wu_settings_save_redirect', $redirect_url, $filtered_data);
+
+		wp_safe_redirect($redirect_url);
 
 		exit;
 	}

--- a/inc/gateways/class-stripe-gateway.php
+++ b/inc/gateways/class-stripe-gateway.php
@@ -48,6 +48,9 @@ class Stripe_Gateway extends Base_Stripe_Gateway {
 		// Handle OAuth callbacks and disconnects
 		add_action('admin_init', [$this, 'handle_oauth_callbacks']);
 
+		// Redirect to OAuth init after settings save when connect button was clicked
+		add_filter('wu_settings_save_redirect', [$this, 'maybe_redirect_to_stripe_oauth'], 10, 2);
+
 		add_filter(
 			'wu_customer_payment_methods',
 			function ($fields, $customer): array {
@@ -61,6 +64,29 @@ class Stripe_Gateway extends Base_Stripe_Gateway {
 			10,
 			2
 		);
+	}
+
+	/**
+	 * Redirect to Stripe OAuth init URL after settings are saved.
+	 *
+	 * When the user clicks the "Connect with Stripe" button, the settings form
+	 * is submitted first (saving sandbox mode, active gateways, etc.), then
+	 * this filter redirects to the OAuth init URL instead of the normal
+	 * settings page.
+	 *
+	 * @since 2.x.x
+	 *
+	 * @param string $redirect_url The default redirect URL.
+	 * @param array  $saved_data   The saved settings data.
+	 * @return string
+	 */
+	public function maybe_redirect_to_stripe_oauth(string $redirect_url, array $saved_data): string {
+
+		if (empty($_POST['wu_connect_stripe'])) { // phpcs:ignore WordPress.Security.NonceVerification
+			return $redirect_url;
+		}
+
+		return $this->get_oauth_init_url();
 	}
 
 	/**
@@ -891,18 +917,17 @@ class Stripe_Gateway extends Base_Stripe_Gateway {
 				);
 			}
 
-			// Disconnected state - show connect button
+			// Disconnected state - show connect button (submits form to save settings first)
 			printf(
 				'<div class="wu-oauth-status wu-disconnected wu-p-4 wu-bg-blue-50 wu-border wu-border-blue-200 wu-rounded">
 				<p class="wu-text-sm wu-text-gray-700 wu-mb-3">%s</p>
-				<a href="%s" class="button button-primary">
+				<button type="submit" name="wu_connect_stripe" value="1" class="button button-primary">
 					<span class="dashicons dashicons-admin-links wu-mr-1 wu-mt-1"></span>
 					%s
-				</a>
+				</button>
 				<p class="wu-text-xs wu-text-gray-500 wu-mt-2">%s</p>
 			</div>',
 				esc_html__('Connect your Stripe account with one click.', 'ultimate-multisite'),
-				esc_url($this->get_oauth_init_url()),
 				esc_html__('Connect with Stripe', 'ultimate-multisite'),
 				esc_html__('You will be redirected to Stripe to securely authorize the connection.', 'ultimate-multisite'),
 			);


### PR DESCRIPTION
## Summary
- The "Connect with Stripe" button was an `<a>` link that navigated directly to the OAuth init URL without saving settings first
- When a user enabled Stripe and toggled sandbox mode for the first time, the unsaved settings meant the OAuth flow used the wrong Stripe environment (live instead of test, or vice versa)
- Changed the connect button to a `<button type="submit">` that submits the settings form, saving all settings before redirecting to the OAuth init URL
- Added a `wu_settings_save_redirect` filter in the settings save handler so gateways can intercept the redirect after save

## Test plan
- [ ] Enable Stripe gateway for the first time, toggle sandbox mode ON, click "Connect with Stripe" — verify settings are saved and OAuth starts in test mode
- [ ] With sandbox mode already saved OFF, click "Connect with Stripe" — verify OAuth starts in live mode
- [ ] Normal settings save (without clicking Connect) still redirects to the settings page with `?updated=1`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced Stripe account connection workflow to save configuration settings before initiating OAuth authorization, ensuring a more reliable and secure integration setup experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->