### PR TITLE
fix(deps): add PHP 8.5 compatibility patch for mpdf/psr-http-message-shim

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -165,6 +165,9 @@
             "mpdf/psr-log-aware-trait": [
                 "patches/mpdf-psr-log-aware-trait-void-return.patch",
                 "patches/mpdf-mpdf-psr-log-aware-trait-void-return.patch"
+            ],
+            "mpdf/psr-http-message-shim": [
+                "patches/mpdf-psr-http-message-shim-php8-compat.patch"
             ]
         },
         "installer-paths": {

--- a/patches/mpdf-psr-http-message-shim-php8-compat.patch
+++ b/patches/mpdf-psr-http-message-shim-php8-compat.patch
@@ -1,0 +1,137 @@
+--- a/vendor/mpdf/psr-http-message-shim/src/Request.php
++++ b/vendor/mpdf/psr-http-message-shim/src/Request.php
+@@ -66,7 +66,7 @@ class Request implements \Psr\Http\Message\RequestInterface
+ 		}
+ 	}
+ 
+-	public function getRequestTarget()
++	public function getRequestTarget(): string
+ 	{
+ 		if ($this->requestTarget !== null) {
+ 			return $this->requestTarget;
+@@ -83,7 +83,7 @@ class Request implements \Psr\Http\Message\RequestInterface
+ 		return $target;
+ 	}
+ 
+-	public function withRequestTarget($requestTarget)
++	public function withRequestTarget(string $requestTarget): \Psr\Http\Message\RequestInterface
+ 	{
+ 		if (preg_match('#\s#', $requestTarget)) {
+ 			throw new \InvalidArgumentException('Invalid request target provided; cannot contain whitespace');
+@@ -95,11 +95,11 @@ class Request implements \Psr\Http\Message\RequestInterface
+ 		return $new;
+ 	}
+ 
+-	public function getMethod()
++	public function getMethod(): string
+ 	{
+ 		return $this->method;
+ 	}
+ 
+-	public function withMethod($method)
++	public function withMethod(string $method): \Psr\Http\Message\RequestInterface
+ 	{
+ 		$new = clone $this;
+ 		$new->method = $method;
+@@ -107,11 +107,11 @@ class Request implements \Psr\Http\Message\RequestInterface
+ 		return $new;
+ 	}
+ 
+-	public function getUri()
++	public function getUri(): \Psr\Http\Message\UriInterface
+ 	{
+ 		return $this->uri;
+ 	}
+ 
+-	public function withUri(UriInterface $uri, $preserveHost = false)
++	public function withUri(\Psr\Http\Message\UriInterface $uri, bool $preserveHost = false): \Psr\Http\Message\RequestInterface
+ 	{
+ 		if ($uri === $this->uri) {
+ 			return $this;
+@@ -152,11 +152,11 @@ class Request implements \Psr\Http\Message\RequestInterface
+ 		$this->headers = [$header => [$host]] + $this->headers;
+ 	}
+ 
+-	public function getProtocolVersion()
++	public function getProtocolVersion(): string
+ 	{
+ 		return $this->protocol;
+ 	}
+ 
+-	public function withProtocolVersion($version)
++	public function withProtocolVersion(string $version): \Psr\Http\Message\MessageInterface
+ 	{
+ 		if ($this->protocol === $version) {
+ 			return $this;
+@@ -168,15 +168,15 @@ class Request implements \Psr\Http\Message\RequestInterface
+ 		return $new;
+ 	}
+ 
+-	public function getHeaders()
++	public function getHeaders(): array
+ 	{
+ 		return $this->headers;
+ 	}
+ 
+-	public function hasHeader($header)
++	public function hasHeader(string $header): bool
+ 	{
+ 		return isset($this->headerNames[strtolower($header)]);
+ 	}
+ 
+-	public function getHeader($header)
++	public function getHeader(string $header): array
+ 	{
+ 		$header = strtolower($header);
+ 
+@@ -192,11 +192,11 @@ class Request implements \Psr\Http\Message\RequestInterface
+ 		return $this->headers[$header];
+ 	}
+ 
+-	public function getHeaderLine($header)
++	public function getHeaderLine(string $header): string
+ 	{
+ 		return implode(', ', $this->getHeader($header));
+ 	}
+ 
+-	public function withHeader($header, $value)
++	public function withHeader(string $header, $value): \Psr\Http\Message\MessageInterface
+ 	{
+ 		if (!is_array($value)) {
+ 			$value = [$value];
+@@ -216,7 +216,7 @@ class Request implements \Psr\Http\Message\RequestInterface
+ 		return $new;
+ 	}
+ 
+-	public function withAddedHeader($header, $value)
++	public function withAddedHeader(string $header, $value): \Psr\Http\Message\MessageInterface
+ 	{
+ 		if (!is_array($value)) {
+ 			$value = [$value];
+@@ -237,7 +237,7 @@ class Request implements \Psr\Http\Message\RequestInterface
+ 		return $new;
+ 	}
+ 
+-	public function withoutHeader($header)
++	public function withoutHeader(string $header): \Psr\Http\Message\MessageInterface
+ 	{
+ 		$normalized = strtolower($header);
+ 
+@@ -253,7 +253,7 @@ class Request implements \Psr\Http\Message\RequestInterface
+ 		return $new;
+ 	}
+ 
+-	public function getBody()
++	public function getBody(): \Psr\Http\Message\StreamInterface
+ 	{
+ 		if (!$this->stream) {
+ 			$this->stream = Stream::create('');
+@@ -263,7 +263,7 @@ class Request implements \Psr\Http\Message\RequestInterface
+ 		return $this->stream;
+ 	}
+ 
+-	public function withBody(StreamInterface $body)
++	public function withBody(\Psr\Http\Message\StreamInterface $body): \Psr\Http\Message\MessageInterface
+ 	{
+ 		if ($body === $this->stream) {
+ 			return $this;


### PR DESCRIPTION
## Summary
- Fixes PHP 8.5 fatal error in mpdf/psr-http-message-shim package
- Adds type declarations to Request class methods to match PSR-7 interface requirements

## Problem
The `mpdf/psr-http-message-shim` package was written for PHP 5.6 and lacks type declarations. In PHP 8.x, the PSR-7 interfaces require strict type hints, causing this fatal error:

```
PHP Fatal error: Declaration of Mpdf\PsrHttpMessageShim\Request::getRequestTarget() must be compatible with Psr\Http\Message\RequestInterface::getRequestTarget(): string
```

## Solution
Created a comprehensive patch that adds:
- Return type declarations (`:string`, `:array`, `:bool`, etc.)
- Parameter type hints (`string $header`, `bool $preserveHost`)
- Interface return types (`:RequestInterface`, `:MessageInterface`, `:StreamInterface`)

## Compatibility
- ✅ PHP 7.4+ (all type hints use PHP 7.0+ features)
- ✅ PHP 8.0-8.5
- ✅ Automatically applied via composer patches plugin

## Testing
- [x] PHP syntax validation passes
- [x] Request class instantiates correctly
- [x] All methods return expected types
- [x] Compatible with existing mpdf patches

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated mPDF library dependency with PHP 8 compatibility enhancements through improved type declarations and strict typing to ensure better stability with modern PHP versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->