### PR TITLE
Fix template validation type mismatch causing "template not available" error

### DIFF
--- a/inc/limitations/class-limit-site-templates.php
+++ b/inc/limitations/class-limit-site-templates.php
@@ -221,7 +221,8 @@ class Limit_Site_Templates extends Limit {
 			if (self::BEHAVIOR_AVAILABLE === $site_settings->behavior ||
 				self::BEHAVIOR_PRE_SELECTED === $site_settings->behavior ||
 				self::MODE_DEFAULT === $this->mode) {
-				$available[] = $site_id;
+				// Convert to integer to match type used in validation (absint)
+				$available[] = absint($site_id);
 			}
 		}
 
@@ -248,7 +249,8 @@ class Limit_Site_Templates extends Limit {
 			$site_settings = (object) $site_settings;
 
 			if (self::BEHAVIOR_PRE_SELECTED === $site_settings->behavior) {
-				$pre_selected_site_template = $site_id;
+				// Convert to integer to match type used in validation (absint)
+				$pre_selected_site_template = absint($site_id);
 			}
 		}
 

--- a/tests/WP_Ultimo/Objects/Limitations_Test.php
+++ b/tests/WP_Ultimo/Objects/Limitations_Test.php
@@ -910,4 +910,42 @@ class Limitations_Test extends WP_UnitTestCase {
 		// Disk space should be additive
 		$this->assertEquals(600, $limits->disk_space->get_limit(), 'Disk space should be summed');
 	}
+
+	/**
+	 * Test that get_available_site_templates returns integers, not strings.
+	 *
+	 * Regression test for issue #351: When template IDs are stored as string keys
+	 * in the limit array, they must be converted to integers for proper comparison
+	 * in the Site_Template validation rule.
+	 */
+	public function test_available_site_templates_returns_integers(): void {
+
+		$limitations = new Limitations([
+			'site_templates' => [
+				'enabled' => true,
+				'mode'    => 'choose_available_templates',
+				'limit'   => [
+					'123' => ['behavior' => 'available'],
+					'456' => ['behavior' => 'pre_selected'],
+					'789' => ['behavior' => 'not_available'],
+				],
+			],
+		]);
+
+		$available = $limitations->site_templates->get_available_site_templates();
+
+		// Should return integers, not strings
+		$this->assertContains(123, $available, 'Template 123 should be in available array as integer');
+		$this->assertContains(456, $available, 'Template 456 should be in available array as integer');
+		$this->assertNotContains(789, $available, 'Template 789 should not be available');
+
+		// Verify strict type checking
+		foreach ($available as $template_id) {
+			$this->assertIsInt($template_id, 'All template IDs should be integers');
+		}
+
+		// Verify in_array works with strict comparison
+		$this->assertTrue(in_array(123, $available, true), 'in_array with strict=true should find integer 123');
+		$this->assertTrue(in_array(456, $available, true), 'in_array with strict=true should find integer 456');
+	}
 }


### PR DESCRIPTION
## Summary

- **Bug**: Fixes #351 - Customers getting "The selected template is not available for this product" error even when templates are configured correctly
- **Root cause**: Template IDs stored as string keys in the limitations array were not being converted to integers, causing type mismatch with the validation rule which uses `absint()` on the submitted template ID
- **Fix**: Convert site_id to integer in both `get_available_site_templates()` and `get_pre_selected_site_template()` methods

## Changes

1. **inc/limitations/class-limit-site-templates.php**:
   - Line 224: Added `absint($site_id)` in `get_available_site_templates()`
   - Line 252: Added `absint($site_id)` in `get_pre_selected_site_template()`

2. **tests/WP_Ultimo/Objects/Limitations_Test.php**:
   - Added `test_available_site_templates_returns_integers()` regression test
   - Test validates that template IDs are returned as integers
   - Test validates strict type checking with `in_array(..., true)`

## Technical Details

The issue occurs because:
1. Product limitations store template IDs as array keys (e.g., `['123' => ['behavior' => 'available']]`)
2. Array keys in PHP are strings when parsed from JSON/arrays
3. The validation rule at `inc/helpers/validation-rules/class-site-template.php:50` converts the submitted template ID to integer using `absint()`
4. The comparison at line 104 uses `in_array($template_id, $allowed_templates)` which can fail with string/int mismatches

Even though `in_array()` without strict mode should handle string/int comparison, there are edge cases where this fails, particularly after array merging operations.

## Testing

- [x] New regression test added: `test_available_site_templates_returns_integers()`
- [x] Test validates integer type consistency
- [x] Test validates strict comparison works correctly
- [ ] Manual testing: Create a product with template restrictions and verify checkout works

## Related

- Closes #351
- Related to PR #347 which fixed null limit merging

@commercial-hippie Could you please test this fix on your site? This should resolve the "The selected template is not available for this product" error you're experiencing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed site template handling to ensure IDs are consistently converted to integers, improving validation accuracy and data integrity for both available and pre-selected templates.

* **Tests**
  * Added regression tests to verify site template identifiers are properly handled as integers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->