### PR TITLE
fix: remove strict bool type hint from upgrader_pre_download() to prevent fatal TypeError

### DIFF
--- a/inc/class-addon-repository.php
+++ b/inc/class-addon-repository.php
@@ -164,7 +164,7 @@ class Addon_Repository {
 	 * @param array                 $hook_extra Extra arguments passed to hooked filters.
 	 */
 	public function upgrader_pre_download($reply, $package, \WP_Upgrader $upgrader, $hook_extra) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter
-		if (!is_bool($reply)) {
+		if (! is_bool($reply)) {
 			return $reply; // Pass through non-bool values (e.g. WP_Error or string) set by other filters.
 		}
 		if (str_starts_with($package, MULTISITE_ULTIMATE_UPDATE_URL)) {


### PR DESCRIPTION
## Summary

Fixes a fatal `TypeError` that crashes the entire WordPress update process when any other plugin hooks `upgrader_pre_download` and returns a `WP_Error` or string value before our callback runs.

## Root Cause

`Addon_Repository::upgrader_pre_download()` declared a strict `bool $reply` type hint:

```php
public function upgrader_pre_download(bool $reply, $package, \WP_Upgrader $upgrader, $hook_extra) {
```

WordPress's `upgrader_pre_download` filter chain legitimately passes `WP_Error` or string (file path) values — not just `bool`. On PHP 8.1+, passing a `WP_Error` to a strict `bool` parameter throws a fatal `TypeError`, crashing the update process entirely.

Affected plugins that trigger this: Kadence Blocks Pro (StellarWP Uplink), GPLVault Updater, WooCommerce Helper.

## Fix

- Removed the `bool` type hint from `$reply` (matches WordPress core's filter signature)
- Added an `is_bool()` guard at the top of the method that passes through any non-bool value unchanged
- Updated the `@param` docblock to reflect the accepted types

```php
public function upgrader_pre_download($reply, $package, \WP_Upgrader $upgrader, $hook_extra) {
    if (!is_bool($reply)) {
        return $reply; // Pass through non-bool values (e.g. WP_Error or string) set by other filters.
    }
    // ... existing logic unchanged
}
```

This is the approach recommended in the issue and matches WordPress core's own filter signature.

## Testing

1. Install a plugin that hooks `upgrader_pre_download` and may return `WP_Error` (e.g. Kadence Blocks Pro, GPLVault)
2. Attempt to update any plugin via WP-CLI or admin UI
3. Verify no fatal `TypeError` is thrown and updates proceed normally

Closes #371

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved compatibility with WordPress plugin filter chains during addon upgrades to ensure proper handling of various response types from other plugins.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->