### PR TITLE
feat: add Cloudflare for SaaS Custom Hostnames API integration

### DIFF
--- a/inc/integrations/providers/cloudflare/class-cloudflare-domain-mapping.php
+++ b/inc/integrations/providers/cloudflare/class-cloudflare-domain-mapping.php
@@ -65,6 +65,12 @@ class Cloudflare_Domain_Mapping extends Base_Capability_Module implements Domain
 
 		$explainer_lines['will_not']['send_domain'] = __('Add domain mappings as new CloudFlare zones', 'ultimate-multisite');
 
+		if ($this->get_cloudflare()->get_credential('WU_CLOUDFLARE_SAAS_ZONE_ID')) {
+			$explainer_lines['will']['custom_hostnames'] = __('Register custom domains as Custom Hostnames in your Cloudflare for SaaS zone, enabling automatic SSL provisioning for mapped domains', 'ultimate-multisite');
+		} else {
+			$explainer_lines['will_not']['custom_hostnames'] = __('Register custom domains as Cloudflare Custom Hostnames (requires SaaS Zone ID to be configured)', 'ultimate-multisite');
+		}
+
 		return $explainer_lines;
 	}
 
@@ -93,33 +99,113 @@ class Cloudflare_Domain_Mapping extends Base_Capability_Module implements Domain
 	}
 
 	/**
-	 * Handles adding a domain to Cloudflare.
+	 * Handles adding a custom domain via the Cloudflare for SaaS Custom Hostnames API.
 	 *
-	 * Cloudflare does not add domain mappings as zones.
+	 * When a SaaS Zone ID is configured, registers the domain as a Custom Hostname
+	 * in that zone so Cloudflare can provision an SSL certificate automatically.
+	 * Falls back silently when the SaaS Zone ID is not set.
 	 *
 	 * @since 2.5.0
 	 *
-	 * @param string $domain  The domain name.
-	 * @param int    $site_id The site ID.
+	 * @param string $domain  The domain name being mapped.
+	 * @param int    $site_id The site ID receiving the mapping.
 	 * @return void
 	 */
 	public function on_add_domain(string $domain, int $site_id): void {
-		// Cloudflare doesn't add domain mappings as zones.
+
+		$saas_zone_id = $this->get_cloudflare()->get_credential('WU_CLOUDFLARE_SAAS_ZONE_ID');
+
+		if ( ! $saas_zone_id) {
+			return;
+		}
+
+		$data = apply_filters(
+			'wu_cloudflare_custom_hostname_data',
+			[
+				'hostname' => $domain,
+				'ssl'      => [
+					'method' => 'http',
+					'type'   => 'dv',
+				],
+			],
+			$domain,
+			$site_id
+		);
+
+		$result = $this->get_cloudflare()->cloudflare_api_call(
+			"client/v4/zones/$saas_zone_id/custom_hostnames",
+			'POST',
+			$data
+		);
+
+		if (is_wp_error($result)) {
+			wu_log_add(
+				'integration-cloudflare',
+				sprintf('Failed to create Custom Hostname for "%s". Reason: %s', $domain, $result->get_error_message()),
+				LogLevel::ERROR
+			);
+
+			return;
+		}
+
+		wu_log_add('integration-cloudflare', sprintf('Created Custom Hostname for "%s" in Cloudflare SaaS zone.', $domain));
 	}
 
 	/**
-	 * Handles removing a domain from Cloudflare.
+	 * Handles removing a custom domain from the Cloudflare for SaaS Custom Hostnames API.
 	 *
-	 * Cloudflare does not manage domain mappings as zones.
+	 * Looks up the Custom Hostname by hostname and deletes it from the SaaS zone.
+	 * Falls back silently when the SaaS Zone ID is not set.
 	 *
 	 * @since 2.5.0
 	 *
-	 * @param string $domain  The domain name.
+	 * @param string $domain  The domain name being removed.
 	 * @param int    $site_id The site ID.
 	 * @return void
 	 */
 	public function on_remove_domain(string $domain, int $site_id): void {
-		// Cloudflare doesn't manage domain mappings as zones.
+
+		$saas_zone_id = $this->get_cloudflare()->get_credential('WU_CLOUDFLARE_SAAS_ZONE_ID');
+
+		if ( ! $saas_zone_id) {
+			return;
+		}
+
+		// Look up the Custom Hostname ID by hostname value.
+		$list_result = $this->get_cloudflare()->cloudflare_api_call(
+			"client/v4/zones/$saas_zone_id/custom_hostnames",
+			'GET',
+			['hostname' => $domain]
+		);
+
+		if (is_wp_error($list_result) || empty($list_result->result)) {
+			wu_log_add(
+				'integration-cloudflare',
+				sprintf('Could not find Custom Hostname for "%s" to delete. Skipping.', $domain),
+				LogLevel::WARNING
+			);
+
+			return;
+		}
+
+		$custom_hostname_id = $list_result->result[0]->id;
+
+		$delete_result = $this->get_cloudflare()->cloudflare_api_call(
+			"client/v4/zones/$saas_zone_id/custom_hostnames/$custom_hostname_id",
+			'DELETE'
+		);
+
+		if (is_wp_error($delete_result)) {
+			wu_log_add(
+				'integration-cloudflare',
+				sprintf('Failed to delete Custom Hostname for "%s". Reason: %s', $domain, $delete_result->get_error_message()),
+				LogLevel::ERROR
+			);
+
+			return;
+		}
+
+		wu_log_add('integration-cloudflare', sprintf('Deleted Custom Hostname for "%s" from Cloudflare SaaS zone.', $domain));
 	}
 
 	/**

--- a/inc/integrations/providers/cloudflare/class-cloudflare-integration.php
+++ b/inc/integrations/providers/cloudflare/class-cloudflare-integration.php
@@ -36,6 +36,7 @@ class Cloudflare_Integration extends Integration {
 		$this->set_logo(function_exists('wu_get_asset') ? wu_get_asset('cloudflare.svg', 'img/hosts') : '');
 		$this->set_tutorial_link('https://ultimatemultisite.com/docs/user-guide/host-integrations/cloudflare');
 		$this->set_constants(['WU_CLOUDFLARE_API_KEY', 'WU_CLOUDFLARE_ZONE_ID']);
+		$this->set_optional_constants(['WU_CLOUDFLARE_SAAS_ZONE_ID']);
 		$this->set_supports(['autossl']);
 	}
 
@@ -79,17 +80,22 @@ class Cloudflare_Integration extends Integration {
 	public function get_fields(): array {
 
 		return [
-			'WU_CLOUDFLARE_ZONE_ID' => [
+			'WU_CLOUDFLARE_ZONE_ID'      => [
 				'title'       => __('Zone ID', 'ultimate-multisite'),
 				'placeholder' => __('e.g. 644c7705723d62e31f700bb798219c75', 'ultimate-multisite'),
 			],
-			'WU_CLOUDFLARE_API_KEY' => [
+			'WU_CLOUDFLARE_API_KEY'      => [
 				'title'       => __('API Key', 'ultimate-multisite'),
 				'placeholder' => __('e.g. xKGbxxVDpdcUv9dUzRf4i4ngv0QNf1wCtbehiec_o', 'ultimate-multisite'),
 				'type'        => 'password',
 				'html_attr'   => [
 					'autocomplete' => 'new-password',
 				],
+			],
+			'WU_CLOUDFLARE_SAAS_ZONE_ID' => [
+				'title'       => __('SaaS Zone ID (Custom Hostnames)', 'ultimate-multisite'),
+				'placeholder' => __('e.g. 644c7705723d62e31f700bb798219c75', 'ultimate-multisite'),
+				'desc'        => __('Optional. The Zone ID of your Cloudflare for SaaS zone. When set, custom domains added to subsites will be registered as Custom Hostnames in that zone, enabling automatic SSL via Cloudflare SaaS.', 'ultimate-multisite'),
 			],
 		];
 	}
@@ -135,9 +141,11 @@ class Cloudflare_Integration extends Integration {
 		);
 
 		if ( ! is_wp_error($response)) {
-			$body = wp_remote_retrieve_body($response);
+			$body        = wp_remote_retrieve_body($response);
+			$status_code = wp_remote_retrieve_response_code($response);
 
-			if (wp_remote_retrieve_response_code($response) === 200) {
+			// Accept 200 OK and 201 Created (returned by Custom Hostnames POST).
+			if (200 === $status_code || 201 === $status_code) {
 				return json_decode($body);
 			} else {
 				$error_message = wp_remote_retrieve_response_message($response);

--- a/views/wizards/host-integrations/cloudflare-instructions.php
+++ b/views/wizards/host-integrations/cloudflare-instructions.php
@@ -50,3 +50,31 @@ defined('ABSPATH') || exit;
 <p class="wu-text-sm"><?php esc_html_e('Copy the API Token (it won\'t be shown again, so you need to copy it now!). We will use it on the next step alongside with the Zone ID', 'ultimate-multisite'); ?></p>
 
 <p class="wu-text-center"><i><?php esc_html_e('Done!', 'ultimate-multisite'); ?></i></p>
+
+<hr class="wu-my-6">
+
+<h3 class="wu-m-0 wu-py-4 wu-text-lg" id="cloudflare-saas-custom-hostnames">
+	<?php esc_html_e('Cloudflare for SaaS — Custom Hostnames (Optional)', 'ultimate-multisite'); ?>
+</h3>
+
+<p class="wu-text-sm wu-bg-green-100 wu-p-4 wu-text-green-700 wu-rounded">
+	<strong><?php esc_html_e('What is this?', 'ultimate-multisite'); ?></strong><br>
+	<?php esc_html_e('Cloudflare for SaaS lets you issue SSL certificates for custom domains mapped to your multisite — without requiring each customer to add your IP to their DNS. When a new domain is added to a subsite, Ultimate Multisite will automatically register it as a Custom Hostname in your SaaS zone so Cloudflare can provision the SSL certificate.', 'ultimate-multisite'); ?>
+</p>
+
+<p class="wu-text-sm">
+	<?php esc_html_e('To enable this feature, you need a Cloudflare zone configured as a SaaS provider zone. This is separate from your main DNS zone. Follow these steps:', 'ultimate-multisite'); ?>
+</p>
+
+<ol class="wu-text-sm wu-list-decimal wu-pl-6 wu-space-y-2">
+	<li><?php esc_html_e('In your Cloudflare dashboard, open the zone you want to use as the SaaS provider zone (this is typically your main domain zone).', 'ultimate-multisite'); ?></li>
+	<li><?php esc_html_e('Go to SSL/TLS → Custom Hostnames and enable Cloudflare for SaaS for that zone.', 'ultimate-multisite'); ?></li>
+	<li><?php esc_html_e('Copy the Zone ID of that SaaS zone from the Overview sidebar — this is your SaaS Zone ID.', 'ultimate-multisite'); ?></li>
+	<li><?php esc_html_e('Ensure your API token has the "SSL and Certificates: Edit" permission in addition to "DNS: Edit" for the SaaS zone.', 'ultimate-multisite'); ?></li>
+	<li><?php esc_html_e('Paste the SaaS Zone ID into the SaaS Zone ID (Custom Hostnames) field on the next step.', 'ultimate-multisite'); ?></li>
+</ol>
+
+<p class="wu-text-sm wu-bg-yellow-100 wu-p-4 wu-text-yellow-700 wu-rounded wu-mt-4">
+	<strong><?php esc_html_e('Customer DNS requirement:', 'ultimate-multisite'); ?></strong><br>
+	<?php esc_html_e('Your customers must add a CNAME record pointing their custom domain to your fallback origin (e.g. your main domain or a dedicated CNAME target). Cloudflare will verify domain ownership via HTTP before issuing the certificate.', 'ultimate-multisite'); ?>
+</p>


### PR DESCRIPTION
## Summary

Implements Cloudflare for SaaS (Custom Hostnames) API integration so that when a custom domain is added to a multisite subsite, the system automatically registers it as a Custom Hostname in the configured Cloudflare SaaS zone — enabling automatic SSL certificate provisioning via Cloudflare.

This is distinct from the existing subdomain/DNS integration (which adds CNAME records for subdomains). This feature targets the **custom domain mapping** flow.

Closes #374

## Changes

### `class-cloudflare-integration.php`
- Added optional `WU_CLOUDFLARE_SAAS_ZONE_ID` credential field with descriptive help text in the setup wizard
- `cloudflare_api_call()` now accepts HTTP `201 Created` in addition to `200 OK` — the Custom Hostnames POST endpoint returns 201

### `class-cloudflare-domain-mapping.php`
- `on_add_domain()`: now POSTs to `/zones/{saas_zone_id}/custom_hostnames` with DV HTTP validation when `WU_CLOUDFLARE_SAAS_ZONE_ID` is configured; silently skips if not set (backwards compatible)
- `on_remove_domain()`: looks up the Custom Hostname by hostname value then DELETEs it; logs a warning if not found
- `get_explainer_lines()`: dynamically shows whether Custom Hostnames are active based on whether the SaaS Zone ID is configured
- Filter hook `wu_cloudflare_custom_hostname_data` allows customising the Custom Hostname payload (e.g. switching to `email` or `alpn` SSL validation method)

### `cloudflare-instructions.php`
- Added a new "Cloudflare for SaaS — Custom Hostnames (Optional)" section explaining the feature, required API token permissions, and the customer DNS CNAME requirement

## How it works

1. Admin configures `WU_CLOUDFLARE_SAAS_ZONE_ID` in the Cloudflare integration wizard (optional — existing behaviour unchanged if omitted)
2. When a subsite owner maps a custom domain, `wu_add_domain` fires
3. The integration POSTs to `https://api.cloudflare.com/client/v4/zones/{saas_zone_id}/custom_hostnames` with `{"hostname": "example.com", "ssl": {"method": "http", "type": "dv"}}`
4. Cloudflare provisions a DV SSL certificate via HTTP validation
5. When the domain is removed, the Custom Hostname is looked up by hostname and deleted

## Backwards compatibility

- No breaking changes. The SaaS Zone ID field is optional.
- If `WU_CLOUDFLARE_SAAS_ZONE_ID` is not set, `on_add_domain` and `on_remove_domain` return immediately — identical to the previous stub behaviour.
- The existing subdomain CNAME flow (`on_add_subdomain` / `on_remove_subdomain`) is unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Cloudflare for SaaS Custom Hostnames support added, enabling automatic custom domain registration and SSL provisioning via optional SaaS zone configuration

* **Documentation**
  * Added comprehensive setup instructions for Cloudflare SaaS integration, including required API token permissions and customer DNS configuration steps

<!-- end of auto-generated comment: release notes by coderabbit.ai -->