### PR TITLE
feat: add WP REST API standard pagination to wu/v2 collection endpoints

### DIFF
--- a/inc/apis/trait-rest-api.php
+++ b/inc/apis/trait-rest-api.php
@@ -86,6 +86,7 @@ trait Rest_Api {
 					'methods'             => \WP_REST_Server::READABLE,
 					'callback'            => [$this, 'get_items_rest'],
 					'permission_callback' => [$this, 'get_items_permissions_check'],
+					'args'                => $this->get_collection_params(),
 				],
 			];
 		}
@@ -178,7 +179,10 @@ trait Rest_Api {
 	}
 
 	/**
-	 * Returns a list of items.
+	 * Returns a list of items with WP REST API standard pagination support.
+	 *
+	 * Supports `page` and `per_page` query parameters and sets the
+	 * `X-WP-Total` and `X-WP-TotalPages` response headers.
 	 *
 	 * @since 2.0.0
 	 *
@@ -187,9 +191,87 @@ trait Rest_Api {
 	 */
 	public function get_items_rest($request) {
 
-		$items = $this->model_class::query($request->get_params());
+		$params = $request->get_params();
 
-		return rest_ensure_response($items);
+		/*
+		 * Map WP REST API standard pagination params to BerlinDB query params.
+		 * `per_page` → `number` (items per page)
+		 * `page`     → `offset` (calculated from page number)
+		 */
+		$per_page = isset($params['per_page']) ? absint($params['per_page']) : 10;
+		$page     = isset($params['page']) ? absint($params['page']) : 1;
+
+		if ($per_page < 1) {
+			$per_page = 10;
+		}
+
+		if ($page < 1) {
+			$page = 1;
+		}
+
+		$offset = ($page - 1) * $per_page;
+
+		// Remove REST-specific params before passing to the query layer.
+		unset($params['page'], $params['per_page']);
+
+		// Set BerlinDB pagination params.
+		$params['number'] = $per_page;
+		$params['offset'] = $offset;
+
+		$items = $this->model_class::query($params);
+
+		/*
+		 * Get the total count for pagination headers.
+		 * BerlinDB returns an integer when `count` is set to true.
+		 */
+		$count_params          = $params;
+		$count_params['count'] = true;
+
+		unset($count_params['number'], $count_params['offset']);
+
+		$total = (int) $this->model_class::query($count_params);
+
+		$max_pages = $per_page > 0 ? (int) ceil($total / $per_page) : 1;
+
+		$response = rest_ensure_response($items);
+
+		$response->header('X-WP-Total', $total);
+		$response->header('X-WP-TotalPages', $max_pages);
+
+		return $response;
+	}
+
+	/**
+	 * Returns the query params for collections.
+	 *
+	 * Registers the standard WP REST API pagination parameters (`page` and
+	 * `per_page`) so they appear in the schema and are validated before the
+	 * callback fires.
+	 *
+	 * @since 2.0.0
+	 * @return array
+	 */
+	public function get_collection_params() {
+
+		return [
+			'page'     => [
+				'description'       => __('Current page of the collection.', 'ultimate-multisite'),
+				'type'              => 'integer',
+				'default'           => 1,
+				'sanitize_callback' => 'absint',
+				'validate_callback' => 'rest_validate_request_arg',
+				'minimum'           => 1,
+			],
+			'per_page' => [
+				'description'       => __('Maximum number of items to be returned in result set.', 'ultimate-multisite'),
+				'type'              => 'integer',
+				'default'           => 10,
+				'minimum'           => 1,
+				'maximum'           => 100,
+				'sanitize_callback' => 'absint',
+				'validate_callback' => 'rest_validate_request_arg',
+			],
+		];
 	}
 
 	/**


### PR DESCRIPTION
## Summary

Fixes the missing pagination support on all `wu/v2` collection endpoints (site, customer, membership, payment, product, etc.).

## Changes

- **`get_items_rest()`** — maps `page`/`per_page` query params to BerlinDB's `number`/`offset` params; runs a count query and sets `X-WP-Total` and `X-WP-TotalPages` response headers
- **`get_collection_params()`** — new method that registers `page` and `per_page` as validated route args (type: integer, min: 1, max: 100 for per_page)
- **`register_routes_general()`** — passes `get_collection_params()` as `args` for the GET route so WP REST API validates and sanitizes the params before the callback fires

## Behaviour

| Parameter | Default | Description |
|-----------|---------|-------------|
| `page` | `1` | Current page (1-indexed) |
| `per_page` | `10` | Items per page (max 100) |

Response headers added to all collection endpoints:
- `X-WP-Total` — total number of matching items
- `X-WP-TotalPages` — total number of pages

## Example

```
GET /wp-json/wu/v2/site?page=2&per_page=5
→ X-WP-Total: 47
→ X-WP-TotalPages: 10
→ [ ...5 sites... ]
```

## Backward Compatibility

- Requests without `page`/`per_page` default to page 1, 10 items — same as before but now limited (previously returned all items)
- All other query params (filters, ordering) continue to work unchanged
- Single-item endpoints (`/wu/v2/site/{id}`) are unaffected

Closes #370