### PR TITLE
fix: resolve Jumper click handler and deprecated dynamic property warnings (#238)

### DIFF
--- a/inc/class-ajax.php
+++ b/inc/class-ajax.php
@@ -261,21 +261,23 @@ class Ajax implements \WP_Ultimo\Interfaces\Singleton {
 		foreach ($data_sources as $function) {
 			$results = call_user_func($function, $query);
 
-			array_map(
+			$results = array_map(
 				function ($item) {
 
-					$url = str_replace('_', '-', (string) $item->model);
+					$row = $item->to_array();
 
-					$item->value = wu_network_admin_url(
+					$url = str_replace('_', '-', (string) $row['model']);
+
+					$row['value'] = wu_network_admin_url(
 						"wp-ultimo-edit-{$url}",
 						[
 							'id' => $item->get_id(),
 						]
 					);
 
-					$item->group = ucwords((string) $item->model) . 's';
+					$row['group'] = ucwords((string) $row['model']) . 's';
 
-					return $item;
+					return $row;
 				},
 				$results
 			);


### PR DESCRIPTION
## Summary

Fixes two bugs in the Jumper feature reported in #238.

### Bug 1: Click handler does nothing / shows "undefined"

`search_all_models()` called `array_map()` but **discarded the return value** — the mapped items (with `value` and `group` keys added) were never assigned back to `$results`. The original unmodified `$results` was then merged into `$data`, so every model item reached the JS without a `value` field.

The Jumper JS click handler does `window.location.href = $(this).val()` where `.val()` maps to the selectize `value` field. With no `value` key in the data, this was `undefined`, so clicking did nothing.

### Bug 2: PHP deprecated dynamic property warnings

The same callback assigned `$item->value` and `$item->group` directly onto WP_Ultimo model objects (Domain, Site, Membership, etc.). These classes don't declare those properties, triggering PHP 8.2 deprecated warnings:

```
PHP Deprecated: Creation of dynamic property WP_Ultimo\Models\Domain::$value is deprecated
PHP Deprecated: Creation of dynamic property WP_Ultimo\Models\Domain::$group is deprecated
```

### Fix

- Assign the `array_map()` return value to `$results`
- Use `$item->to_array()` to convert each model to a plain array before adding `value` and `group` keys — matching the pattern already used for discount codes in the same loop

```php
// Before (broken)
array_map(function ($item) {
    $item->value = wu_network_admin_url(...);  // dynamic property, discarded
    $item->group = ...;
    return $item;
}, $results);  // return value thrown away

// After (fixed)
$results = array_map(function ($item) {
    $row = $item->to_array();
    $row['value'] = wu_network_admin_url(...);
    $row['group'] = ...;
    return $row;
}, $results);
```

## Testing

1. Open the Jumper (Ctrl+Alt+G or the trigger button)
2. Search for a domain, site, or membership
3. Click a result — should navigate to the edit page
4. Check PHP error logs — no deprecated dynamic property warnings

Closes #238