### PR TITLE
fix: coupon removal button and duplicate field ID on checkout form (#76)

### DIFF
--- a/inc/checkout/signup-fields/class-signup-field-discount-code.php
+++ b/inc/checkout/signup-fields/class-signup-field-discount-code.php
@@ -166,7 +166,7 @@ class Signup_Field_Discount_Code extends Base_Signup_Field {
 		$checkout_fields = [];
 
 		$checkout_fields['discount_code_checkbox'] = [
-			'id'        => 'discount_code',
+			'id'        => 'discount_code_checkbox',
 			'type'      => 'toggle',
 			'name'      => __('Have a coupon code?', 'ultimate-multisite'),
 			'class'     => 'wu-w-auto',

--- a/views/checkout/templates/order-summary/simple.php
+++ b/views/checkout/templates/order-summary/simple.php
@@ -259,7 +259,7 @@ defined('ABSPATH') || exit;
 		printf(esc_html__('Discount applied: %1$s - %2$s (%3$s) %4$s', 'ultimate-multisite'), '{{ order.discount_code.name }}', '{{ order.discount_code.code }}', '{{ order.discount_code.discount_description }}', '{{ wu_format_money(-order.totals.total_discounts) }}');
 		?>
 
-		<a class="wu-no-underline wu-ml-2" href="#" v-on:click.prevent="discount_code = ''">
+		<a class="wu-no-underline wu-ml-2" href="#" v-on:click.prevent="discount_code = ''; toggle_discount_code = false">
 
 			<?php esc_html_e('Remove', 'ultimate-multisite'); ?>
 


### PR DESCRIPTION
## Summary

Fixes two bugs reported in issue #76:

1. **Remove button does nothing** — The "Remove" link in the order summary only set `discount_code = ''` but did not reset `toggle_discount_code`. This left the coupon input field visible and in an inconsistent state. The fix adds `toggle_discount_code = false` to the click handler so the coupon field collapses and the Vue watcher correctly triggers `create_order()` to recalculate totals.

2. **Coupon code does not render correctly** — The toggle checkbox (`discount_code_checkbox`) had `id = 'discount_code'`, the same as the text input field. This produced a duplicate `id="field-discount_code"` in the rendered HTML, breaking the `<label for="...">` association and causing rendering issues. Fixed by giving the toggle its own unique id: `discount_code_checkbox`.

## Changes

- `views/checkout/templates/order-summary/simple.php` — extend click handler to also reset `toggle_discount_code`
- `inc/checkout/signup-fields/class-signup-field-discount-code.php` — fix duplicate HTML id on the toggle checkbox

Closes #76