### PR TITLE
fix: enforce server-side confirmation check before destructive modal actions

### DIFF
--- a/inc/admin-pages/class-customer-edit-admin-page.php
+++ b/inc/admin-pages/class-customer-edit-admin-page.php
@@ -255,6 +255,10 @@ class Customer_Edit_Admin_Page extends Edit_Admin_Page {
 	 */
 	public function handle_transfer_customer_modal(): void {
 
+		if ( ! wu_request('confirm')) {
+			wp_send_json_error(new \WP_Error('not-confirmed', __('Please confirm the transfer.', 'ultimate-multisite')));
+		}
+
 		global $wpdb;
 
 		$customer    = wu_get_customer(wu_request('id'));

--- a/inc/admin-pages/class-membership-edit-admin-page.php
+++ b/inc/admin-pages/class-membership-edit-admin-page.php
@@ -280,6 +280,10 @@ class Membership_Edit_Admin_Page extends Edit_Admin_Page {
 	 */
 	public function handle_transfer_membership_modal(): void {
 
+		if ( ! wu_request('confirm')) {
+			wp_send_json_error(new \WP_Error('not-confirmed', __('Please confirm the transfer.', 'ultimate-multisite')));
+		}
+
 		$membership = wu_get_membership(wu_request('id'));
 
 		if ( ! $membership) {

--- a/inc/admin-pages/class-payment-edit-admin-page.php
+++ b/inc/admin-pages/class-payment-edit-admin-page.php
@@ -234,6 +234,10 @@ class Payment_Edit_Admin_Page extends Edit_Admin_Page {
 	 */
 	public function handle_delete_line_item_modal(): void {
 
+		if ( ! wu_request('confirm')) {
+			wp_send_json_error(new \WP_Error('not-confirmed', __('Please confirm the deletion.', 'ultimate-multisite')));
+		}
+
 		$payment = wu_get_payment(wu_request('id'));
 
 		$line_item = wu_get_line_item(wu_request('line_item_id'), $payment->get_id());
@@ -392,6 +396,10 @@ class Payment_Edit_Admin_Page extends Edit_Admin_Page {
 	 * @return void
 	 */
 	public function handle_refund_payment_modal(): void {
+
+		if ( ! wu_request('confirm')) {
+			wp_send_json_error(new \WP_Error('not-confirmed', __('Please confirm the refund.', 'ultimate-multisite')));
+		}
 
 		$amount = wu_to_float(wu_request('amount'));
 

--- a/inc/admin-pages/class-site-edit-admin-page.php
+++ b/inc/admin-pages/class-site-edit-admin-page.php
@@ -248,6 +248,10 @@ class Site_Edit_Admin_Page extends Edit_Admin_Page {
 	 */
 	public function handle_transfer_site_modal(): void {
 
+		if ( ! wu_request('confirm')) {
+			wp_send_json_error(new \WP_Error('not-confirmed', __('Please confirm the transfer.', 'ultimate-multisite')));
+		}
+
 		global $wpdb;
 
 		// phpcs:ignore WordPress.Security.NonceVerification.Missing -- Nonce verification happens in the form handler

--- a/inc/admin-pages/class-site-list-admin-page.php
+++ b/inc/admin-pages/class-site-list-admin-page.php
@@ -186,6 +186,10 @@ class Site_List_Admin_Page extends List_Admin_Page {
 	 */
 	public function handle_publish_pending_site_modal(): void {
 
+		if ( ! wu_request('confirm')) {
+			wp_send_json_error(new \WP_Error('not-confirmed', __('Please confirm the publication.', 'ultimate-multisite')));
+		}
+
 		$membership = wu_get_membership(wu_request('membership_id'));
 
 		if ( ! $membership) {

--- a/inc/managers/class-form-manager.php
+++ b/inc/managers/class-form-manager.php
@@ -447,6 +447,15 @@ class Form_Manager extends Base_Manager {
 
 		if ($model) {
 			/*
+			 * Require the confirmation toggle to be flipped before proceeding.
+			 * The submit button is disabled client-side via Vue, but we must
+			 * enforce this server-side as well to prevent bypasses.
+			 */
+			if ( ! wu_request('confirm')) {
+				wp_send_json_error(new \WP_Error('not-confirmed', __('Please confirm the deletion.', 'ultimate-multisite')));
+			}
+
+			/*
 			 * Handle meta key deletion
 			 */
 			if ($meta_key) {

--- a/inc/managers/class-limitation-manager.php
+++ b/inc/managers/class-limitation-manager.php
@@ -188,6 +188,10 @@ class Limitation_Manager {
 	 */
 	public function handle_confirm_limitations_reset(): void {
 
+		if ( ! wu_request('confirm')) {
+			wp_send_json_error(new \WP_Error('not-confirmed', __('Please confirm the limitations reset.', 'ultimate-multisite')));
+		}
+
 		$id = wu_request('id');
 
 		$model = wu_request('model');

--- a/inc/managers/class-notes-manager.php
+++ b/inc/managers/class-notes-manager.php
@@ -364,6 +364,10 @@ class Notes_Manager extends Base_Manager {
 	 */
 	public function handle_clear_notes_modal(): void {
 
+		if ( ! wu_request('confirm_clear_notes')) {
+			wp_send_json_error(new \WP_Error('not-confirmed', __('Please confirm clearing all notes.', 'ultimate-multisite')));
+		}
+
 		$model         = wu_request('model');
 		$function_name = "wu_get_{$model}";
 		$object        = $function_name(wu_request('object_id'));
@@ -462,6 +466,10 @@ class Notes_Manager extends Base_Manager {
 	 * @return void
 	 */
 	public function handle_delete_note_modal(): void {
+
+		if ( ! wu_request('confirm_delete_note')) {
+			wp_send_json_error(new \WP_Error('not-confirmed', __('Please confirm the note deletion.', 'ultimate-multisite')));
+		}
 
 		$model         = wu_request('model');
 		$function_name = "wu_get_{$model}";

--- a/inc/ui/class-domain-mapping-element.php
+++ b/inc/ui/class-domain-mapping-element.php
@@ -507,6 +507,10 @@ class Domain_Mapping_Element extends Base_Element {
 	 */
 	public function handle_user_delete_domain_modal(): void {
 
+		if ( ! wu_request('confirm')) {
+			wp_send_json_error(new \WP_Error('not-confirmed', __('Please confirm the deletion.', 'ultimate-multisite')));
+		}
+
 		if (wu_request('user_id')) {
 			$customer = wu_get_customer_by_user_id(wu_request('user_id'));
 		}
@@ -590,6 +594,10 @@ class Domain_Mapping_Element extends Base_Element {
 	 * @return void
 	 */
 	public function handle_user_make_domain_primary_modal(): void {
+
+		if ( ! wu_request('confirm')) {
+			wp_send_json_error(new \WP_Error('not-confirmed', __('Please confirm the action.', 'ultimate-multisite')));
+		}
 
 		$current_site = wu_request('current_site');
 

--- a/inc/ui/class-site-actions-element.php
+++ b/inc/ui/class-site-actions-element.php
@@ -618,6 +618,10 @@ class Site_Actions_Element extends Base_Element {
 	 */
 	public function handle_delete_site() {
 
+		if ( ! wu_request('confirm')) {
+			return new \WP_Error('not-confirmed', __('Please confirm the site deletion.', 'ultimate-multisite'));
+		}
+
 		global $wpdb;
 
 		$site = wu_get_site_by_hash(wu_request('site'));

--- a/tests/WP_Ultimo/Managers/Form_Manager_Test.php
+++ b/tests/WP_Ultimo/Managers/Form_Manager_Test.php
@@ -95,4 +95,23 @@ class Form_Manager_Test extends \WP_UnitTestCase {
 		$this->assertIsString($url);
 		$this->assertStringContainsString('url_test_form', $url);
 	}
+
+	/**
+	 * Test that handle_model_delete_form aborts when confirm is not set.
+	 *
+	 * @since 2.0.0
+	 */
+	public function test_handle_model_delete_form_requires_confirmation(): void {
+
+		$manager = $this->get_manager_instance();
+
+		// Ensure 'confirm' is not set in the request.
+		unset($_REQUEST['confirm']);
+		$_REQUEST['model'] = 'membership';
+		$_REQUEST['id']    = '1';
+
+		$this->expectException(\WPDieException::class);
+
+		$manager->handle_model_delete_form();
+	}
 }


### PR DESCRIPTION
## Summary

Closes #95

When a user is prompted to confirm a destructive action (deletion, transfer, refund, etc.) by flipping a toggle switch, the confirmation was only enforced client-side via Vue (`v-bind:disabled="!confirmed"`). The server-side handlers did not check the `confirm` field, so the action would proceed regardless of whether the toggle was flipped.

## Root cause

The submit button is disabled in the browser via Vue reactive state, but a direct POST request (or a browser with JavaScript disabled) bypasses this entirely. The server must independently verify the confirmation.

## Fix

Added a `wu_request('confirm')` check at the top of every handler that has a corresponding confirmation toggle in its render form. If the field is falsy, the handler returns a `not-confirmed` WP_Error immediately — matching the existing pattern already used in `handle_edit_membership_product_modal()`.

### Handlers fixed

| Handler | File |
|---------|------|
| `handle_model_delete_form()` | `inc/managers/class-form-manager.php` |
| `handle_transfer_membership_modal()` | `inc/admin-pages/class-membership-edit-admin-page.php` |
| `handle_transfer_customer_modal()` | `inc/admin-pages/class-customer-edit-admin-page.php` |
| `handle_transfer_site_modal()` | `inc/admin-pages/class-site-edit-admin-page.php` |
| `handle_delete_line_item_modal()` | `inc/admin-pages/class-payment-edit-admin-page.php` |
| `handle_refund_payment_modal()` | `inc/admin-pages/class-payment-edit-admin-page.php` |
| `handle_publish_pending_site_modal()` | `inc/admin-pages/class-site-list-admin-page.php` |
| `handle_user_delete_domain_modal()` | `inc/ui/class-domain-mapping-element.php` |
| `handle_user_make_domain_primary_modal()` | `inc/ui/class-domain-mapping-element.php` |
| `handle_confirm_limitations_reset()` | `inc/managers/class-limitation-manager.php` |
| `handle_clear_notes_modal()` | `inc/managers/class-notes-manager.php` |
| `handle_delete_note_modal()` | `inc/managers/class-notes-manager.php` |

The `handle_model_delete_form()` fix is the primary fix for issue #95 (membership deletion). The remaining handlers are the same class of bug across the codebase.

## Testing

- PHP syntax: all 10 modified files pass `php -l`
- Added `test_handle_model_delete_form_requires_confirmation()` to `Form_Manager_Test`
- The existing `handle_edit_membership_product_modal()` already had this pattern and serves as the reference implementation