### PR TITLE
fix: read webhook URL from database in send_test_event

### DIFF
--- a/inc/managers/class-webhook-manager.php
+++ b/inc/managers/class-webhook-manager.php
@@ -207,20 +207,44 @@ class Webhook_Manager extends Base_Manager {
 		check_ajax_referer('wu_webhook_send_test', 'nonce');
 		$event = wu_get_event_type(sanitize_text_field(wp_unslash($_POST['webhook_event'] ?? '')));
 
-		$webhook_data = [
-			'active'      => true,
-			'id'          => wu_request('webhook_id'),
-			'webhook_url' => wu_request('webhook_url'),
-		];
+		$webhook_id = absint(wu_request('webhook_id'));
 
-		$webhook = new Webhook($webhook_data);
+		/*
+		 * Fetch the webhook from the database using the provided ID so that the
+		 * webhook URL is always read from the persisted record rather than relying
+		 * on the client to supply it.  This fixes the blank-URL bug reported in
+		 * issue #90 where the POST value could be empty.
+		 *
+		 * Fall back to constructing a transient Webhook from POST data only when
+		 * no valid ID is provided (e.g. during a preview before the record is saved).
+		 */
+		if ($webhook_id) {
+			$webhook = wu_get_webhook($webhook_id);
+
+			if ( ! $webhook) {
+				wp_send_json_error(
+					[
+						'message' => __('Webhook not found.', 'ultimate-multisite'),
+					]
+				);
+
+				return;
+			}
+		} else {
+			$webhook_data = [
+				'active'      => true,
+				'webhook_url' => wu_request('webhook_url'),
+			];
+
+			$webhook = new Webhook($webhook_data);
+		}
 
 		$response = $this->send_webhook($webhook, wu_maybe_lazy_load_payload($event['payload']), true, false);
 
 		wp_send_json(
 			[
 				'response' => htmlentities2($response),
-				'id'       => wu_request('webhook_id'),
+				'id'       => $webhook_id,
 			]
 		);
 	}


### PR DESCRIPTION
## Summary

- Fixes the blank webhook URL when sending a test webhook (issue #90)
- `send_test_event()` now fetches the `Webhook` record from the database by ID using `wu_get_webhook()`, so the URL is always sourced from the persisted record
- Falls back to the POST-supplied URL only when no valid `webhook_id` is provided (e.g. unsaved preview scenario)

## Root Cause

`send_test_event()` was constructing a transient `Webhook` object from POST data:

```php
$webhook_data = [
    'active'      => true,
    'id'          => wu_request('webhook_id'),
    'webhook_url' => wu_request('webhook_url'),  // relied on client sending this
];
$webhook = new Webhook($webhook_data);
```

When the client did not include `webhook_url` in the POST body (or sent it blank), the webhook URL was empty and the HTTP request to the target URL failed silently.

## Fix

When a `webhook_id` is present, look up the full `Webhook` record from the database:

```php
$webhook_id = absint(wu_request('webhook_id'));
if ($webhook_id) {
    $webhook = wu_get_webhook($webhook_id);
    // URL, event, and all other fields come from the database record
}
```

This also removes the security concern of a client being able to supply an arbitrary URL for the test send.

Closes #90