### PR TITLE
feat: add success/error notices after orphaned tables/users deletion

### DIFF
--- a/inc/admin-pages/class-settings-admin-page.php
+++ b/inc/admin-pages/class-settings-admin-page.php
@@ -649,6 +649,7 @@ class Settings_Admin_Page extends Wizard_Admin_Page {
 
 		$this->handle_export();
 		$this->handle_import_redirect();
+		$this->handle_orphaned_delete_redirect();
 		$this->register_forms();
 
 		parent::page_loaded();
@@ -868,6 +869,78 @@ class Settings_Admin_Page extends Wizard_Admin_Page {
 				<p><?php esc_html_e('Settings successfully imported!', 'ultimate-multisite'); ?></p>
 			</div>
 				<?php
+			}
+		);
+	}
+
+	/**
+	 * Display a success or info message after orphaned tables/users deletion redirect.
+	 *
+	 * Handles the redirect from both the orphaned tables and orphaned users deletion
+	 * modals, showing the admin a notice with the number of items deleted.
+	 *
+	 * @since 2.0.0
+	 * @return void
+	 */
+	protected function handle_orphaned_delete_redirect() {
+
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		if ( ! isset($_GET['deleted']) || ! isset($_GET['type']) || 'other' !== wu_request('tab')) {
+			return;
+		}
+
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		$deleted_count = absint($_GET['deleted']);
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		$type = sanitize_key($_GET['type']);
+
+		add_action(
+			'wu_page_wizard_after_title',
+			function () use ($deleted_count, $type) {
+
+				if ('tables' === $type) {
+					if ($deleted_count > 0) {
+						$message = sprintf(
+							/* translators: %d: number of deleted tables */
+							_n(
+								'Successfully deleted %d orphaned database table.',
+								'Successfully deleted %d orphaned database tables.',
+								$deleted_count,
+								'ultimate-multisite'
+							),
+							$deleted_count
+						);
+						$notice_class = 'notice-success';
+					} else {
+						$message      = __('No orphaned database tables were found to delete.', 'ultimate-multisite');
+						$notice_class = 'notice-info';
+					}
+				} elseif ('users' === $type) {
+					if ($deleted_count > 0) {
+						$message = sprintf(
+							/* translators: %d: number of deleted users */
+							_n(
+								'Successfully deleted %d orphaned user account.',
+								'Successfully deleted %d orphaned user accounts.',
+								$deleted_count,
+								'ultimate-multisite'
+							),
+							$deleted_count
+						);
+						$notice_class = 'notice-success';
+					} else {
+						$message      = __('No orphaned user accounts were found to delete.', 'ultimate-multisite');
+						$notice_class = 'notice-info';
+					}
+				} else {
+					return;
+				}
+
+				printf(
+					'<div id="message" class="updated notice wu-admin-notice %s is-dismissible"><p>%s</p></div>',
+					esc_attr($notice_class),
+					esc_html($message)
+				);
 			}
 		);
 	}

--- a/inc/class-orphaned-tables-manager.php
+++ b/inc/class-orphaned-tables-manager.php
@@ -196,12 +196,18 @@ class Orphaned_Tables_Manager {
 			[
 				'tab'     => 'other',
 				'deleted' => $deleted_count,
+				'type'    => 'tables',
 			]
 		);
 
 		wp_send_json_success(
 			[
 				'redirect_url' => $redirect_to,
+				'message'      => sprintf(
+					/* translators: %d: number of deleted tables */
+					_n('Successfully deleted %d orphaned table.', 'Successfully deleted %d orphaned tables.', $deleted_count, 'ultimate-multisite'),
+					$deleted_count
+				),
 			]
 		);
 	}


### PR DESCRIPTION
## Summary

- After deleting orphaned database tables via the admin modal, the settings page now shows a dismissible success notice with the count of deleted tables (or an info notice if none were found)
- The orphaned users deletion flow (which already passed `type=users` in the redirect) now also benefits from the same notice handler
- Adds a `type=tables` query param to the orphaned tables redirect URL to distinguish it from other redirects

## Changes

**`inc/class-orphaned-tables-manager.php`**
- Adds `type=tables` to the redirect URL after deletion
- Includes a human-readable message in the JSON success response (used by the modal JS before redirect)

**`inc/admin-pages/class-settings-admin-page.php`**
- New `handle_orphaned_delete_redirect()` method called from `page_loaded()`
- Reads `deleted` count and `type` (tables/users) from query params
- Displays `notice-success` when items were deleted, `notice-info` when count is zero
- Uses `_n()` for proper singular/plural strings

## Testing

1. Go to **Network Admin → Settings → Other tab**
2. Click **Check for Orphaned Tables** — confirm and delete
3. After redirect, a green success notice should appear: _"Successfully deleted N orphaned database table(s)."_
4. Repeat with no orphaned tables present — an info notice should appear: _"No orphaned database tables were found to delete."_
5. Same flow applies to **Check for Orphaned Users**

Closes #176

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added post-deletion confirmation notices for orphaned tables and users with localized messages showing deletion counts.
  * Admin settings page now displays success messages after deletion or info notices when no orphaned items are found.
  * Deletion feedback includes proper singular and plural text formatting for better user clarity and experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->