### PR TITLE
fix: repair admin list table search for hashes and site titles

### DIFF
--- a/inc/functions/site.php
+++ b/inc/functions/site.php
@@ -57,6 +57,58 @@ function wu_get_site_by_hash($hash) {
 }
 
 /**
+ * Returns blog IDs that match a search term via mapped domain or site title.
+ *
+ * BerlinDB's schema-based search only covers the columns defined in
+ * Sites_Schema (blog_id, domain, path). Mapped domains and site titles
+ * (blogname) live outside that schema, so we collect their IDs here and
+ * merge them into the main query in wu_get_sites().
+ *
+ * @since 2.5.0
+ *
+ * @param string       $search      The search term.
+ * @param array|false  $blog_id__in Optional array of blog IDs to restrict the search to.
+ * @param int          $limit       Maximum number of IDs to return.
+ * @return int[]
+ */
+function wu_get_sites_extra_ids_for_search($search, $blog_id__in = false, $limit = 100) {
+
+	// Find sites with a matching mapped domain.
+	$domain_ids = wu_get_domains(
+		[
+			'number'      => $limit,
+			'search'      => '*' . $search . '*',
+			'fields'      => ['blog_id'],
+			'blog_id__in' => $blog_id__in,
+		]
+	);
+
+	$domain_ids = array_column($domain_ids, 'blog_id');
+
+	/*
+	 * Find sites whose title (blogname) matches the search term.
+	 * The title is stored in wp_blogmeta and is not part of the BerlinDB
+	 * sites schema, so we query it directly.
+	 */
+	global $wpdb;
+
+	$title_search_like = '%' . $wpdb->esc_like($search) . '%';
+
+	// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+	$title_ids = $wpdb->get_col(
+		$wpdb->prepare(
+			"SELECT blog_id FROM {$wpdb->blogmeta} WHERE meta_key = 'blogname' AND meta_value LIKE %s",
+			$title_search_like
+		)
+	);
+
+	$title_ids = array_map('intval', (array) $title_ids);
+
+	// Merge and deduplicate.
+	return array_values(array_unique(array_merge($domain_ids, $title_ids)));
+}
+
+/**
  * Queries sites.
  *
  * @since 2.0.0
@@ -69,44 +121,54 @@ function wu_get_sites($query = []) {
 		$query['number'] = 100;
 	}
 
-	// If we're just counting, skip the domain search merge logic
-	// and do a simple count query.
-
+	// If we're just counting, do a simple count query.
 	if ( ! empty($query['count'])) {
+		if ( ! empty($query['search'])) {
+			/*
+			 * When counting with a search term we need to account for sites
+			 * matched by mapped domain or by title (blogname), neither of which
+			 * is in the BerlinDB schema.  Collect the extra IDs, exclude them
+			 * from the schema count, and add them back in.
+			 */
+			$extra_ids = wu_get_sites_extra_ids_for_search($query['search'], $query['blog_id__in'] ?? false, $query['number']);
+
+			if ( ! empty($extra_ids)) {
+				$count_query                    = $query;
+				$existing_not_in                = isset($count_query['blog_id__not_in']) ? (array) $count_query['blog_id__not_in'] : [];
+				$count_query['blog_id__not_in'] = array_unique(array_merge($existing_not_in, $extra_ids));
+				unset($count_query['search']);
+
+				$schema_count = (int) \WP_Ultimo\Models\Site::query($count_query);
+
+				return $schema_count + count($extra_ids);
+			}
+		}
+
 		return \WP_Ultimo\Models\Site::query($query);
 	}
 
 	if ( ! empty($query['search'])) {
-		// We also want to find sites with a matching mapped domain.
-		$domain_ids = wu_get_domains(
-			[
-				'number'      => $query['number'],
-				'search'      => '*' . $query['search'] . '*',
-				'fields'      => ['blog_id'],
-				'blog_id__in' => $query['blog_id__in'] ?? false,
-			]
-		);
+		// We also want to find sites with a matching mapped domain or title.
+		$extra_ids = wu_get_sites_extra_ids_for_search($query['search'], $query['blog_id__in'] ?? false, $query['number']);
 
-		$domain_ids = array_column($domain_ids, 'blog_id');
+		if ( ! empty($extra_ids)) {
+			$sites_with_extra_query                = $query;
+			$sites_with_extra_query['blog_id__in'] = $extra_ids;
 
-		if ( ! empty($domain_ids)) {
-			$sites_with_domain_query                = $query;
-			$sites_with_domain_query['blog_id__in'] = $domain_ids;
+			unset($sites_with_extra_query['search']);
+			$sites_by_extra = \WP_Ultimo\Models\Site::query($sites_with_extra_query);
 
-			unset($sites_with_domain_query['search']);
-			$sites_by_domain = \WP_Ultimo\Models\Site::query($sites_with_domain_query);
-
-			$query['number']         -= count($sites_by_domain);
+			$query['number']         -= count($sites_by_extra);
 			$existing_not_in          = isset($query['blog_id__not_in']) ? (array) $query['blog_id__not_in'] : [];
-			$query['blog_id__not_in'] = array_unique(array_merge($existing_not_in, $domain_ids));
+			$query['blog_id__not_in'] = array_unique(array_merge($existing_not_in, $extra_ids));
 
 			if ($query['number'] <= 0) {
 				// We reached the limit already.
-				return $sites_by_domain;
+				return $sites_by_extra;
 			}
 			$sites = \WP_Ultimo\Models\Site::query($query);
-			// return matches by domain first.
-			return array_merge($sites_by_domain, $sites);
+			// Return matches by domain/title first.
+			return array_merge($sites_by_extra, $sites);
 		}
 	}
 

--- a/inc/list-tables/class-base-list-table.php
+++ b/inc/list-tables/class-base-list-table.php
@@ -251,12 +251,17 @@ class Base_List_Table extends \WP_List_Table {
 		}
 
 		/**
-		 * Accounts for hashes
+		 * Accounts for hashes.
+		 *
+		 * Models encode hashes with an empty group string (the default $model value).
+		 * We must decode with the same empty group so the ID round-trips correctly.
+		 * We also use strict `!== false` instead of a truthy check so that a decoded
+		 * value of 0 (which is falsy) is still treated as a valid ID.
 		 */
 		if (isset($query_args['search']) && strlen((string) $query_args['search']) === Hash::LENGTH) {
-			$item_id = Hash::decode($query_args['search']);
+			$item_id = Hash::decode($query_args['search'], '');
 
-			if ($item_id) {
+			if ($item_id !== false) {
 				unset($query_args['search']);
 
 				$query_args['id'] = $item_id;

--- a/inc/list-tables/class-membership-list-table-widget.php
+++ b/inc/list-tables/class-membership-list-table-widget.php
@@ -69,12 +69,16 @@ class Membership_List_Table_Widget extends Base_List_Table {
 		];
 
 		/**
-		 * Accounts for hashes
+		 * Accounts for hashes.
+		 *
+		 * Models encode hashes with an empty group string (the default $model value).
+		 * Decode with the same empty group and use strict !== false so a decoded
+		 * value of 0 is still treated as a valid ID.
 		 */
 		if (isset($query_args['search']) && strlen((string) $query_args['search']) === Hash::LENGTH) {
-			$item_id = Hash::decode($query_args['search']);
+			$item_id = Hash::decode($query_args['search'], '');
 
-			if ($item_id) {
+			if ($item_id !== false) {
 				unset($query_args['search']);
 
 				$query_args['id'] = $item_id;

--- a/inc/list-tables/class-payment-list-table-widget.php
+++ b/inc/list-tables/class-payment-list-table-widget.php
@@ -69,12 +69,16 @@ class Payment_List_Table_Widget extends Base_List_Table {
 		];
 
 		/**
-		 * Accounts for hashes
+		 * Accounts for hashes.
+		 *
+		 * Models encode hashes with an empty group string (the default $model value).
+		 * Decode with the same empty group and use strict !== false so a decoded
+		 * value of 0 is still treated as a valid ID.
 		 */
 		if (isset($query_args['search']) && strlen((string) $query_args['search']) === Hash::LENGTH) {
-			$item_id = Hash::decode($query_args['search']);
+			$item_id = Hash::decode($query_args['search'], '');
 
-			if ($item_id) {
+			if ($item_id !== false) {
 				unset($query_args['search']);
 
 				$query_args['id'] = $item_id;


### PR DESCRIPTION
## Summary

Fixes two root causes behind broken admin search (issue #174):

### 1. Hash decode group mismatch (payments, memberships, all list tables)

`Base_List_Table::get_items()` decoded hashes with the default group `'ultimate-multisite'`, but `Base_Model::get_hash()` encodes with `$this->model` which defaults to `''` (empty string) for most models (Payment, Membership, Customer, etc.). The mismatched groups produced wrong IDs, so searching by reference code (e.g. `PR1QGNYWO9`) returned no results.

**Fix:** Decode with `''` to match the encoding group. Also changed the truthy `if ($item_id)` check to strict `!== false` so a decoded ID of `0` is not incorrectly skipped.

Same fix applied to `class-membership-list-table-widget.php` and `class-payment-list-table-widget.php` which had identical logic.

### 2. Site title search

`wu_get_sites()` searched by domain and path (the BerlinDB schema columns) but not by site title. The title (`blogname`) is stored in `wp_blogmeta`, outside the schema.

**Fix:** Added `wu_get_sites_extra_ids_for_search()` helper that queries `wp_blogmeta` for matching `blogname` values and merges those blog IDs with the domain matches. The count path is also updated to include title-matched sites so pagination is correct.

## Files changed

- `inc/list-tables/class-base-list-table.php` — fix hash decode group + strict check
- `inc/list-tables/class-membership-list-table-widget.php` — same fix
- `inc/list-tables/class-payment-list-table-widget.php` — same fix
- `inc/functions/site.php` — add title search via blogmeta

Closes #174