### PR TITLE
feat: improve onboarding UX for subdomain choice and cPanel setup (#140)

### DIFF
--- a/inc/admin-pages/class-multisite-setup-admin-page.php
+++ b/inc/admin-pages/class-multisite-setup-admin-page.php
@@ -214,6 +214,20 @@ class Multisite_Setup_Admin_Page extends Wizard_Admin_Page {
 				],
 				'default' => '1',
 			],
+			'subdomain_recommendation' => [
+				'type' => 'note',
+				'desc' => '<div class="wu-bg-blue-50 wu-border wu-border-blue-200 wu-rounded-lg wu-p-4">
+					<div class="wu-flex">
+						<div class="wu-flex-shrink-0">
+							<span class="dashicons dashicons-info wu-text-blue-500"></span>
+						</div>
+						<div class="wu-ml-3">
+							<h4 class="wu-text-sm wu-font-medium wu-text-blue-800">' . esc_html__('Sub-domains are recommended for most businesses', 'multisite-ultimate') . '</h4>
+							<p class="wu-text-sm wu-text-blue-700 wu-mt-1">' . esc_html__('Sub-domains (e.g. site1.yourdomain.com) allow custom domain mapping and look more professional. Sub-directories (e.g. yourdomain.com/site1) are simpler to set up but cannot be changed later without rebuilding your network.', 'multisite-ultimate') . '</p>
+						</div>
+					</div>
+				</div>',
+			],
 			'network_details_header'   => [
 				'type'  => 'header',
 				'title' => __('Network Details', 'multisite-ultimate'),

--- a/inc/admin-pages/class-setup-wizard-admin-page.php
+++ b/inc/admin-pages/class-setup-wizard-admin-page.php
@@ -466,7 +466,25 @@ class Setup_Wizard_Admin_Page extends Wizard_Admin_Page {
 				'next_label'   => Default_Content_Installer::get_instance()->all_done() ? __('Go to the Next Step &rarr;', 'ultimate-multisite') : __('Install', 'ultimate-multisite'),
 				'disable_next' => true,
 				'fields'       => [
-					'terms' => [
+					'hosting_tip' => [
+						'type' => 'note',
+						'desc' => sprintf(
+							'<div class="wu-bg-yellow-50 wu-border wu-border-yellow-200 wu-rounded-lg wu-p-4 wu-mb-4">
+								<div class="wu-flex">
+									<div class="wu-flex-shrink-0">
+										<span class="dashicons dashicons-warning wu-text-yellow-500"></span>
+									</div>
+									<div class="wu-ml-3">
+										<h4 class="wu-text-sm wu-font-medium wu-text-yellow-800">%s</h4>
+										<p class="wu-text-sm wu-text-yellow-700 wu-mt-1">%s</p>
+									</div>
+								</div>
+							</div>',
+							esc_html__('Using cPanel or another hosting integration?', 'ultimate-multisite'),
+							esc_html__('If your host uses cPanel (or another supported integration), configure it before creating template sites. This ensures subdomains are automatically created when template sites are added. You can set up hosting integrations after this wizard completes, under Settings → Integrations.', 'ultimate-multisite')
+						),
+					],
+					'terms'       => [
 						'type' => 'note',
 						'desc' => fn() => $this->render_installation_steps(Default_Content_Installer::get_instance()->get_steps()),
 					],

--- a/inc/integrations/providers/cpanel/class-cpanel-integration.php
+++ b/inc/integrations/providers/cpanel/class-cpanel-integration.php
@@ -122,7 +122,7 @@ class CPanel_Integration extends Integration {
 			],
 			'WU_CPANEL_HOST'      => [
 				'title'       => __('cPanel Host', 'ultimate-multisite'),
-				'desc'        => __('Your server hostname, typically your domain or a server address like server123.hostingprovider.com.', 'ultimate-multisite'),
+				'desc'        => __('Your domain or server hostname — without the port number or trailing characters. Example: yourdomain.com or server123.hostingprovider.com', 'ultimate-multisite'),
 				'placeholder' => __('e.g. yourdomain.com', 'ultimate-multisite'),
 			],
 			'WU_CPANEL_PORT'      => [
@@ -166,10 +166,20 @@ class CPanel_Integration extends Integration {
 			$host      = $this->get_credential('WU_CPANEL_HOST');
 			$port      = (int) ($this->get_credential('WU_CPANEL_PORT') ?: 2083);
 
+			/*
+			 * Sanitize the host value to handle common user input errors:
+			 * - Strip protocol prefix (https://, http://)
+			 * - Strip trailing semicolons, slashes, and whitespace
+			 * - Strip port number if accidentally included (e.g. yourdomain.com:2083)
+			 */
+			$clean_host = preg_replace('#^https?://#', '', (string) $host);
+			$clean_host = rtrim($clean_host, "; \t\n\r\0\x0B/");
+			$clean_host = preg_replace('#:\d+$#', '', $clean_host);
+
 			$this->api = new CPanel_API(
 				$username,
 				$password ?: null,
-				preg_replace('#^https?://#', '', (string) $host),
+				$clean_host,
 				$port,
 				false,
 				$api_token ?: null

--- a/views/wizards/setup/ready.php
+++ b/views/wizards/setup/ready.php
@@ -36,6 +36,20 @@ defined('ABSPATH') || exit;
 		<?php esc_html_e('You now have everything you need in place to start building your Website as a Service business!', 'ultimate-multisite'); ?>
 	</p>
 
+	<p class="wu-text-sm wu-text-gray-500 wu-my-4">
+		<?php
+		printf(
+			/* translators: %s is a link to the hosting integrations setup page */
+			esc_html__('If you use cPanel or another hosting provider, configure the integration under %s before creating template sites to ensure subdomains are automatically provisioned.', 'ultimate-multisite'),
+			sprintf(
+				'<a href="%s" class="wu-text-blue-600 hover:wu-underline">%s</a>',
+				esc_url(wu_network_admin_url('wp-ultimo-hosting-integration-wizard')),
+				esc_html__('Settings → Hosting Integrations', 'ultimate-multisite')
+			)
+		);
+		?>
+	</p>
+
 	</div>
 
 </div>


### PR DESCRIPTION
## Summary

Implements the onboarding UX improvements requested in issue #140. All changes are low-risk UI/copy additions with no breaking changes.

### Changes

**1. Subdomain recommendation note (multisite setup wizard)**
- Added an informational blue notice below the Site Structure selector explaining the trade-offs between sub-domains and sub-directories
- Explicitly states that sub-domains are recommended for most businesses and that the choice cannot be changed later without rebuilding the network
- Addresses the user's pain point of deleting and reinstalling because they didn't know subdirectories were suboptimal

**2. Hosting integration warning before template site creation (setup wizard)**
- Added a yellow warning notice in the Default Content step prompting users to configure cPanel (or other hosting integrations) before creating template sites
- Explains that this ensures subdomains are automatically provisioned when template sites are added
- Addresses the user's pain point of broken template subdomains because cPanel wasn't configured first

**3. Hosting integration reminder on Ready screen**
- Added a small reminder paragraph on the final "Ready!" screen with a direct link to the hosting integrations wizard
- Reinforces the message at the point where users are about to start using the plugin

**4. Improved cPanel Host field description**
- Updated the field description to explicitly say "without the port number or trailing characters"
- Addresses the user's confusion about whether to include the port in the host field

**5. cPanel Host input sanitization**
- Added sanitization in `CPanel_Integration::load_api()` to strip common user input errors from the host value:
  - Protocol prefix (`https://`, `http://`)
  - Trailing semicolons, slashes, and whitespace
  - Accidental port numbers (e.g. `yourdomain.com:2083`)
- Addresses the user's pain point of a trailing semicolon causing configuration failure

### Files changed

- `inc/admin-pages/class-multisite-setup-admin-page.php` — subdomain recommendation note
- `inc/admin-pages/class-setup-wizard-admin-page.php` — hosting integration warning in defaults step
- `inc/integrations/providers/cpanel/class-cpanel-integration.php` — host field description + sanitization
- `views/wizards/setup/ready.php` — hosting integration reminder on ready screen

Closes #140