### PR TITLE
fix: add AnsPress compatibility guard for wu-ajax product search (issue #171)

### DIFF
--- a/.wiki/known-incompatibilities-with-other-plugins.md
+++ b/.wiki/known-incompatibilities-with-other-plugins.md
@@ -21,3 +21,5 @@ Here is a list of them and what you should do in these cases:
   * Anti-Splog: Although less powerful, this is also _built into Ultimate Multisite._
 
 **Note** : All other WPMU Dev plugins can be used normally alongside Ultimate Multisite. Examples include _Smush_ , _Forminator_ , _Defender,_ etc.
+
+**AnsPress – Question and Answer** AnsPress registers an AJAX dispatcher on the WordPress `init` hook that intercepts requests and calls `die()` after processing. This conflicts with Ultimate Multisite's Light Ajax system (which also fires on `init`) and causes a fatal error when selecting a product to add to a membership. As of Ultimate Multisite 2.4.3, a compatibility fix is included that automatically removes AnsPress's conflicting hook during Ultimate Multisite AJAX requests. No manual action is required — both plugins can be used together.

--- a/inc/class-wp-ultimo.php
+++ b/inc/class-wp-ultimo.php
@@ -662,6 +662,13 @@ final class WP_Ultimo {
 		\WP_Ultimo\Compat\Honeypot_Compat::get_instance();
 
 		/*
+		 * AnsPress compatibility — prevents AnsPress from intercepting
+		 * wu-ajax requests and causing a fatal error in the membership
+		 * product-selection modal.
+		 */
+		\WP_Ultimo\Compat\AnsPress_Compat::get_instance();
+
+		/*
 		 * WooCommerce Subscriptions compatibility
 		 */
 		\WP_Ultimo\Compat\WooCommerce_Subscriptions_Compat::get_instance();

--- a/inc/compat/class-anspress-compat.php
+++ b/inc/compat/class-anspress-compat.php
@@ -1,0 +1,173 @@
+<?php
+/**
+ * AnsPress Compatibility Layer
+ *
+ * Prevents AnsPress from intercepting Ultimate Multisite's Light Ajax
+ * requests and causing a fatal error when selecting a product to add
+ * to a membership.
+ *
+ * AnsPress hooks an AJAX dispatcher onto the `init` action (via
+ * AP_Ajax::init()) that calls die() after processing any request it
+ * recognises.  Ultimate Multisite's Light Ajax also fires on `init`
+ * (when wu-when=init) and relies on reaching its own action hooks
+ * without interference.  When both plugins are active, AnsPress's
+ * handler runs first and terminates the request before Ultimate
+ * Multisite can serve the product-search JSON, producing a fatal /
+ * empty-response error in the membership product-selection modal.
+ *
+ * The fix: when a wu-ajax request is detected, remove AnsPress's
+ * init-time AJAX handler so Ultimate Multisite can complete normally.
+ *
+ * @package WP_Ultimo
+ * @subpackage Compat/AnsPress_Compat
+ * @since 2.4.3
+ */
+
+namespace WP_Ultimo\Compat;
+
+// Exit if accessed directly
+defined('ABSPATH') || exit;
+
+/**
+ * AnsPress compatibility class.
+ *
+ * @since 2.4.3
+ */
+class AnsPress_Compat {
+
+	use \WP_Ultimo\Traits\Singleton;
+
+	/**
+	 * Instantiate the necessary hooks.
+	 *
+	 * We hook as early as possible (plugins_loaded priority 5) so we
+	 * can remove AnsPress's init handler before it fires.
+	 *
+	 * @since 2.4.3
+	 * @return void
+	 */
+	public function init(): void {
+
+		/*
+		 * Only act when this is a wu-ajax request.
+		 * phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		 */
+		if ( ! isset($_REQUEST['wu-ajax'])) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+			return;
+		}
+
+		/*
+		 * Guard: only apply the fix when AnsPress is actually active.
+		 * We check for the AP_Ajax class (present in all AnsPress
+		 * versions ≥ 4.x) and the legacy anspress_ajax() function
+		 * (versions < 4.x).
+		 */
+		if ( ! class_exists('AP_Ajax') && ! function_exists('anspress_ajax')) {
+			return;
+		}
+
+		/*
+		 * Remove AnsPress's init-time AJAX dispatcher so it cannot
+		 * intercept and terminate our wu-ajax request.
+		 *
+		 * AnsPress 4.x registers AP_Ajax::init() on `init` at
+		 * priority 1.  We remove it here (before `init` fires) so
+		 * Ultimate Multisite's Light Ajax handler can run cleanly.
+		 */
+		add_action(
+			'plugins_loaded',
+			[$this, 'remove_anspress_ajax_hooks'],
+			PHP_INT_MAX
+		);
+	}
+
+	/**
+	 * Removes AnsPress's AJAX hooks that conflict with wu-ajax requests.
+	 *
+	 * Called late on plugins_loaded (after AnsPress has registered its
+	 * own hooks) so we can safely remove them before `init` fires.
+	 *
+	 * @since 2.4.3
+	 * @return void
+	 */
+	public function remove_anspress_ajax_hooks(): void {
+
+		/*
+		 * AnsPress 4.x — class-based AJAX handler.
+		 *
+		 * AP_Ajax::init() is registered on `init` at priority 1.
+		 * It calls ap_send_json() / die() after handling any request
+		 * it recognises, which terminates our wu-ajax response early.
+		 */
+		if (class_exists('AP_Ajax')) {
+			$this->remove_class_action('init', 'AP_Ajax', 'init', 1);
+			$this->remove_class_action('init', 'AP_Ajax', 'init', 2);
+			$this->remove_class_action('init', 'AP_Ajax', 'init', 10);
+		}
+
+		/*
+		 * AnsPress < 4.x — function-based AJAX handler.
+		 *
+		 * Older versions registered a global anspress_ajax() function
+		 * directly on `init`.
+		 */
+		if (function_exists('anspress_ajax')) {
+			remove_action('init', 'anspress_ajax', 1);
+			remove_action('init', 'anspress_ajax', 2);
+			remove_action('init', 'anspress_ajax', 10);
+		}
+	}
+
+	/**
+	 * Removes an action registered by a class instance or statically.
+	 *
+	 * WordPress stores hook callbacks keyed by a string that includes
+	 * the class name and method.  When the callback was registered via
+	 * an instance (not a static call) we cannot use remove_action()
+	 * directly because we don't have the original instance.  This
+	 * helper iterates the global $wp_filter array to find and remove
+	 * the matching entry.
+	 *
+	 * @since 2.4.3
+	 *
+	 * @param string $tag       The action hook name.
+	 * @param string $class     The fully-qualified class name.
+	 * @param string $method    The method name.
+	 * @param int    $priority  The priority the action was registered at.
+	 * @return void
+	 */
+	protected function remove_class_action(string $tag, string $class, string $method, int $priority): void {
+
+		global $wp_filter;
+
+		if ( ! isset($wp_filter[ $tag ][ $priority ])) {
+			return;
+		}
+
+		foreach ($wp_filter[ $tag ][ $priority ] as $hook_key => $hook_data) {
+			$callback = $hook_data['function'];
+
+			// Static call: ['ClassName', 'method']
+			if (
+				is_array($callback)
+				&& is_string($callback[0])
+				&& $callback[0] === $class
+				&& $callback[1] === $method
+			) {
+				unset($wp_filter[ $tag ][ $priority ][ $hook_key ]);
+				return;
+			}
+
+			// Instance call: [$object, 'method']
+			if (
+				is_array($callback)
+				&& is_object($callback[0])
+				&& is_a($callback[0], $class)
+				&& $callback[1] === $method
+			) {
+				unset($wp_filter[ $tag ][ $priority ][ $hook_key ]);
+				return;
+			}
+		}
+	}
+}


### PR DESCRIPTION
## Summary

- Adds `WP_Ultimo\Compat\AnsPress_Compat` — a new compatibility class that prevents AnsPress from intercepting Ultimate Multisite's Light Ajax requests and causing a fatal error when selecting a product to add to a membership.
- Registers the compat class in `class-wp-ultimo.php` alongside the other compat layers.
- Updates the known-incompatibilities wiki page to document that this conflict is now automatically resolved (no manual action required).

## Root cause

AnsPress registers an AJAX dispatcher on the WordPress `init` hook (`AP_Ajax::init()` in v4.x, `anspress_ajax()` in older versions) that calls `die()` after processing any request it recognises.

Ultimate Multisite's Light Ajax system also fires on `init` (when `wu-when=init`) and relies on reaching its own `wu_ajax_*` action hooks without interference. When both plugins are active, AnsPress's handler runs first and terminates the request before Ultimate Multisite can serve the product-search JSON, producing a fatal/empty-response error in the membership product-selection modal.

## Fix

The compat class hooks into `plugins_loaded` at `PHP_INT_MAX` (after AnsPress has registered its own hooks) and removes AnsPress's `init`-time AJAX handlers before they can fire. The guard is a no-op when AnsPress is not active — no performance impact for sites that don't use AnsPress.

Covers both:
- **AnsPress 4.x** — class-based `AP_Ajax::init()` registered on `init` at priorities 1, 2, and 10
- **AnsPress < 4.x** — function-based `anspress_ajax()` registered on `init`

## Testing

1. Install and activate AnsPress alongside Ultimate Multisite.
2. Navigate to Network Admin → Memberships → Edit any membership.
3. Click "Add Product" — the product search modal should open and the selectize search should return results without a fatal error.
4. Confirm the product can be added successfully.

Without this fix, step 3 produces a fatal error / empty AJAX response.

Closes #171

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Resolved incompatibility with AnsPress – Question and Answer plugin that could trigger fatal errors when selecting products for membership creation.
  * Ultimate Multisite 2.4.3+ includes an automatic compatibility fix that seamlessly resolves conflicts without requiring manual user intervention.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->