### PR TITLE
feat: add client-side JS validation to checkout flow

### DIFF
--- a/assets/js/checkout.js
+++ b/assets/js/checkout.js
@@ -573,6 +573,238 @@
 					} // end if;
 
 				},
+				/**
+				 * Runs client-side validation against the rules exposed by PHP.
+				 *
+				 * Returns an array of error objects { code, message } for any
+				 * failing rules. An empty array means the form is valid client-side.
+				 * Server-side rules (uniqueness, DB lookups) are still checked via AJAX.
+				 *
+				 * @param {Object} values Key/value map of current form field values.
+				 * @return {Array} Array of { code, message } error objects.
+				 */
+				validate_client_side(values) {
+
+					const rules = (typeof wu_checkout !== 'undefined' && wu_checkout.validation_rules) ? wu_checkout.validation_rules : {};
+					const i18n = (typeof wu_checkout !== 'undefined' && wu_checkout.i18n) ? wu_checkout.i18n : {};
+					const errors = [];
+
+					/**
+					 * Retrieve a display label for a field, falling back to the field ID.
+					 *
+					 * @param {string} field Field ID.
+					 * @return {string} Human-readable label.
+					 */
+					function label(field) {
+
+						const labels = (typeof wu_checkout !== 'undefined' && wu_checkout.field_labels) ? wu_checkout.field_labels : {};
+
+						return labels[ field ] || field.replace(/_/g, ' ');
+
+					}
+
+					/**
+					 * Resolve the current value for a field from the values map.
+					 * Falls back to an empty string so rule checks are always safe.
+					 *
+					 * @param {string} field Field ID.
+					 * @return {string} Current field value as a string.
+					 */
+					function val(field) {
+
+						return (values[ field ] !== undefined && values[ field ] !== null) ? String(values[ field ]) : '';
+
+					}
+
+					/**
+					 * Add an error for a field if one does not already exist.
+					 *
+					 * @param {string} field
+					 * @param {string} message
+					 */
+					function addError(field, message) {
+
+						const alreadyHas = errors.some(function(e) {
+
+							return e.code === field;
+
+						});
+
+						if (! alreadyHas) {
+
+							errors.push({ code: field, message });
+
+						}
+
+					}
+
+					Object.keys(rules).forEach(function(field) {
+
+						const fieldRules = rules[ field ];
+						const fieldVal = val(field);
+
+						fieldRules.forEach(function(ruleObj) {
+
+							const rule = ruleObj.rule;
+							const param = ruleObj.param;
+
+							switch (rule) {
+
+								case 'required': {
+
+									if (fieldVal.trim() === '') {
+
+										// translators: %s is the field label.
+										addError(field, (i18n.field_required || '%s is required.').replace('%s', label(field)));
+
+									}
+
+									break;
+
+								}
+
+								case 'required_without': {
+
+									// Required when the referenced field is absent/empty.
+									if (val(param).trim() === '' && fieldVal.trim() === '') {
+
+										addError(field, (i18n.field_required || '%s is required.').replace('%s', label(field)));
+
+									}
+
+									break;
+
+								}
+
+								case 'required_with': {
+
+									// Required when the referenced field is present/non-empty.
+									if (val(param).trim() !== '' && fieldVal.trim() === '') {
+
+										addError(field, (i18n.field_required || '%s is required.').replace('%s', label(field)));
+
+									}
+
+									break;
+
+								}
+
+								case 'email': {
+
+									if (fieldVal.trim() !== '' && ! /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(fieldVal)) {
+
+										addError(field, (i18n.field_invalid_email || '%s must be a valid email address.').replace('%s', label(field)));
+
+									}
+
+									break;
+
+								}
+
+								case 'min': {
+
+									const minLen = parseInt(param, 10);
+
+									if (! isNaN(minLen) && fieldVal.length > 0 && fieldVal.length < minLen) {
+
+										addError(field, (i18n.field_min_length || '%s must be at least %d characters.').replace('%s', label(field)).replace('%d', minLen));
+
+									}
+
+									break;
+
+								}
+
+								case 'max': {
+
+									const maxLen = parseInt(param, 10);
+
+									if (! isNaN(maxLen) && fieldVal.length > maxLen) {
+
+										addError(field, (i18n.field_max_length || '%s must not exceed %d characters.').replace('%s', label(field)).replace('%d', maxLen));
+
+									}
+
+									break;
+
+								}
+
+								case 'alpha_dash': {
+
+									if (fieldVal.trim() !== '' && ! /^[a-zA-Z0-9_-]+$/.test(fieldVal)) {
+
+										addError(field, (i18n.field_alpha_dash || '%s may only contain letters, numbers, dashes, and underscores.').replace('%s', label(field)));
+
+									}
+
+									break;
+
+								}
+
+								case 'lowercase': {
+
+									if (fieldVal.trim() !== '' && fieldVal !== fieldVal.toLowerCase()) {
+
+										addError(field, (i18n.field_lowercase || '%s must be lowercase.').replace('%s', label(field)));
+
+									}
+
+									break;
+
+								}
+
+								case 'same': {
+
+									if (fieldVal !== val(param)) {
+
+										addError(field, (i18n.field_same || '%s must match %s.').replace('%s', label(field)).replace('%s', label(param)));
+
+									}
+
+									break;
+
+								}
+
+								case 'integer': {
+
+									if (fieldVal.trim() !== '' && ! /^\d+$/.test(fieldVal.trim())) {
+
+										addError(field, (i18n.field_integer || '%s must be a whole number.').replace('%s', label(field)));
+
+									}
+
+									break;
+
+								}
+
+								case 'accepted': {
+
+									// "accepted" means the value must be truthy (1, true, "on", "yes").
+									const accepted = [ '1', 'true', 'on', 'yes' ];
+
+									if (fieldVal.trim() !== '' && ! accepted.includes(fieldVal.toLowerCase())) {
+
+										addError(field, (i18n.field_accepted || '%s must be accepted.').replace('%s', label(field)));
+
+									}
+
+									break;
+
+								}
+
+								// Rules handled server-side only (unique, products, country, etc.) are skipped.
+								default:
+									break;
+
+							}
+
+						});
+
+					});
+
+					return errors;
+
+				},
 				validate_form() {
 
 					this.errors = [];
@@ -590,6 +822,37 @@
 
 					}, {});
 
+					/*
+				 * Run client-side validation first.
+				 *
+				 * Build a values map from the serialised form data plus Vue-managed
+				 * fields so the validator has the same picture as the server.
+				 * This gives instant feedback without a network round-trip.
+				 */
+					const form_values = Object.assign({}, form_data_obj, {
+						products: this.products,
+						membership_id: this.membership_id,
+						payment_id: this.payment_id,
+						valid_password: this.valid_password ? '1' : '',
+						user_id: form_data_obj.user_id || '',
+					});
+
+					const client_errors = this.validate_client_side(form_values);
+
+					if (client_errors.length) {
+
+						this.errors = client_errors;
+
+						this.unblock();
+
+						return;
+
+					}
+
+					/*
+				 * Client-side checks passed — proceed with the AJAX validation
+				 * which handles server-only rules (uniqueness, DB lookups, etc.).
+				 */
 					const form_data = jQuery.param({
 						...form_data_obj,
 						products: this.products,

--- a/inc/checkout/class-checkout.php
+++ b/inc/checkout/class-checkout.php
@@ -1912,6 +1912,25 @@ class Checkout {
 			'forgot_password'      => __('Forgot password?', 'ultimate-multisite'),
 			'cancel'               => __('Cancel', 'ultimate-multisite'),
 			'email_exists'         => __('A customer with the same email address or username already exists.', 'ultimate-multisite'),
+			// Client-side validation messages (%s = field label, %d = numeric limit).
+			/* translators: %s: field label */
+			'field_required'       => __('%s is required.', 'ultimate-multisite'),
+			/* translators: %s: field label */
+			'field_invalid_email'  => __('%s must be a valid email address.', 'ultimate-multisite'),
+			/* translators: 1: field label, 2: minimum character count */
+			'field_min_length'     => __('%s must be at least %d characters.', 'ultimate-multisite'),
+			/* translators: 1: field label, 2: maximum character count */
+			'field_max_length'     => __('%s must not exceed %d characters.', 'ultimate-multisite'),
+			/* translators: %s: field label */
+			'field_alpha_dash'     => __('%s may only contain letters, numbers, dashes, and underscores.', 'ultimate-multisite'),
+			/* translators: %s: field label */
+			'field_lowercase'      => __('%s must be lowercase.', 'ultimate-multisite'),
+			/* translators: 1: field label, 2: other field label */
+			'field_same'           => __('%s must match %s.', 'ultimate-multisite'),
+			/* translators: %s: field label */
+			'field_integer'        => __('%s must be a whole number.', 'ultimate-multisite'),
+			/* translators: %s: field label */
+			'field_accepted'       => __('%s must be accepted.', 'ultimate-multisite'),
 		];
 
 		/*
@@ -2037,6 +2056,41 @@ class Checkout {
 			$variables['discount_code'] = $variables['order']->discount_code->get_code();
 		}
 
+		/*
+		 * Expose validation rules and field labels to JS so client-side
+		 * validation stays in sync with the server-side rules without
+		 * duplicating logic.
+		 */
+		$variables['validation_rules'] = $this->get_js_validation_rules();
+
+		/*
+		 * Build a field_labels map (field_id => human-readable label) from the
+		 * checkout form fields so the JS validator can show friendly names.
+		 */
+		$field_labels = [
+			'email_address'              => __('Email address', 'ultimate-multisite'),
+			'email_address_confirmation' => __('Email address confirmation', 'ultimate-multisite'),
+			'username'                   => __('Username', 'ultimate-multisite'),
+			'password'                   => __('Password', 'ultimate-multisite'),
+			'password_conf'              => __('Password confirmation', 'ultimate-multisite'),
+			'site_title'                 => __('Site title', 'ultimate-multisite'),
+			'site_url'                   => __('Site URL', 'ultimate-multisite'),
+			'billing_country'            => __('Country', 'ultimate-multisite'),
+			'billing_zip_code'           => __('ZIP / Postal code', 'ultimate-multisite'),
+			'billing_state'              => __('State / Province', 'ultimate-multisite'),
+			'billing_city'               => __('City', 'ultimate-multisite'),
+		];
+
+		if ($this->checkout_form) {
+			foreach ($this->checkout_form->get_all_fields() as $field) {
+				if ( ! empty($field['id']) && ! empty($field['name'])) {
+					$field_labels[ $field['id'] ] = $field['name'];
+				}
+			}
+		}
+
+		$variables['field_labels'] = $field_labels;
+
 		/**
 		 * Allow plugin developers to filter the pre-sets of a checkout page.
 		 *
@@ -2049,6 +2103,94 @@ class Checkout {
 		 * @return array The new variables array.
 		 */
 		return apply_filters('wu_get_checkout_variables', $variables, $this);
+	}
+
+	/**
+	 * Converts the PHP validation rules into a JS-friendly structure.
+	 *
+	 * Each rule string (e.g. "required|min:4|email") is parsed into an array of
+	 * rule objects so the client-side validator can process them without
+	 * duplicating the rule definitions.
+	 *
+	 * Only rules that can be meaningfully evaluated client-side are included.
+	 * Server-only rules (unique_site, unique:\WP_User, products, country, state,
+	 * city, site_template) are intentionally omitted — the AJAX call still
+	 * validates those server-side.
+	 *
+	 * @since 2.1.0
+	 * @return array<string, array<array{rule: string, param: string|null}>>
+	 */
+	public function get_js_validation_rules(): array {
+
+		$raw_rules = $this->validation_rules();
+
+		/*
+		 * Rules that require a database lookup or complex server-side logic.
+		 * These are skipped for client-side validation.
+		 */
+		$server_only = [
+			'unique_site',
+			'site_template',
+			'products',
+			'country',
+			'state',
+			'city',
+		];
+
+		$js_rules = [];
+
+		foreach ($raw_rules as $field => $rule_string) {
+			if (empty($rule_string)) {
+				continue;
+			}
+
+			$parsed = [];
+
+			foreach (explode('|', $rule_string) as $rule_part) {
+				$rule_part = trim($rule_part);
+
+				if (empty($rule_part)) {
+					continue;
+				}
+
+				// Split "rule:param" into rule name and optional parameter.
+				if (strpos($rule_part, ':') !== false) {
+					[$rule_name, $rule_param] = explode(':', $rule_part, 2);
+				} else {
+					$rule_name  = $rule_part;
+					$rule_param = null;
+				}
+
+				// Skip rules that start with "unique:" (DB lookups).
+				if (strpos($rule_name, 'unique') === 0) {
+					continue;
+				}
+
+				// Skip server-only rules.
+				if (in_array($rule_name, $server_only, true)) {
+					continue;
+				}
+
+				$parsed[] = [
+					'rule'  => $rule_name,
+					'param' => $rule_param,
+				];
+			}
+
+			if ( ! empty($parsed)) {
+				$js_rules[ $field ] = $parsed;
+			}
+		}
+
+		/**
+		 * Allow plugin developers to modify the JS validation rules.
+		 *
+		 * @since 2.1.0
+		 * @param array    $js_rules  Field => parsed rule array.
+		 * @param Checkout $checkout  The checkout instance.
+		 * @return array
+		 */
+		return apply_filters('wu_checkout_js_validation_rules', $js_rules, $this);
 	}
 
 	/**


### PR DESCRIPTION
## Summary

- Exposes PHP validation rules to JavaScript via `wp_localize_script` (laravel-jsvalidation approach) so client-side and server-side rules stay in sync without duplication
- Adds `validate_client_side()` to the Vue checkout app that runs before the AJAX call, giving instant per-field error feedback
- Server-only rules (uniqueness checks, DB lookups) are intentionally skipped client-side and still validated via AJAX

## What changed

### PHP (`inc/checkout/class-checkout.php`)
- `get_js_validation_rules()` — new method that parses the PHP rule strings (`required`, `email`, `min:N`, `max:N`, `alpha_dash`, `lowercase`, `same:field`, `integer`, `accepted`) into a JS-friendly array; skips server-only rules (`unique_site`, `unique:\WP_User`, `products`, `country`, `state`, `city`)
- `get_checkout_variables()` — exposes `validation_rules` and `field_labels` to the `wu_checkout` JS object via `wp_localize_script`
- Added i18n strings for all new validation messages (translatable)

### JavaScript (`assets/js/checkout.js`)
- `validate_client_side(values)` — new Vue method that evaluates the exposed rules against current form values; uses the existing `errors` array and `get_error()` mechanism for per-field display (no new UI needed)
- `validate_form()` — calls `validate_client_side()` first; only proceeds to AJAX if client-side passes, avoiding unnecessary network round-trips

## Design decisions

- **No new UI**: reuses the existing `<span v-if="get_error(...)">` per-field error display already present in all field templates
- **No new library**: pure vanilla JS rule evaluation — no external dependency
- **Extensible**: `wu_checkout_js_validation_rules` filter lets plugins add/modify rules; `wu_checkout_validation_rules` filter already covers the PHP side
- **Graceful degradation**: if `wu_checkout.validation_rules` is absent (e.g. older cached page), the client-side check is a no-op and AJAX validation still runs

## Testing

1. Load a checkout form with required fields (email, username, password, site URL)
2. Submit without filling required fields — errors appear instantly without a network request
3. Fill fields with invalid data (bad email format, username with spaces, short password) — per-field errors appear immediately
4. Fill all fields correctly — form proceeds to AJAX validation as before

Closes #279