### PR TITLE
fix: gate demo-site cleanup on successful site deletion

### DIFF
--- a/inc/managers/class-site-manager.php
+++ b/inc/managers/class-site-manager.php
@@ -1119,13 +1119,21 @@ class Site_Manager extends Base_Manager {
 		// Fire pre-deletion hook for extensibility.
 		do_action('wu_before_demo_site_deleted', $site, $membership, $customer);
 
-		// Delete the WordPress blog if it exists.
-		if ($blog_id) {
-			wpmu_delete_blog($blog_id, true);
-		}
-
-		// Delete the WP Ultimo site record.
+		// Delete the site record (wp_delete_site handles the underlying blog removal).
 		$result = $site->delete();
+
+		if (true !== $result) {
+			wu_log_add(
+				'demo-cleanup',
+				sprintf(
+					// translators: %d is the site ID.
+					__('Failed to delete demo site #%d; skipping related cleanup.', 'ultimate-multisite'),
+					$site_id
+				)
+			);
+
+			return;
+		}
 
 		// Optionally delete the membership if it only has this demo site.
 		$delete_membership = apply_filters('wu_demo_site_delete_membership', true, $membership, $site);


### PR DESCRIPTION
## Summary

- Removes the redundant `wpmu_delete_blog()` call — `Site::delete()` calls `wp_delete_site()` internally which handles blog removal, so the prior code was deleting the blog twice.
- Checks the return value of `$site->delete()` and returns early (with a log entry) if deletion did not succeed.
- Membership, customer, and WP user cleanup now only runs when site deletion returned `true`, preventing orphaned records in partial-failure paths.

## Problem

`async_delete_demo_site()` ran two site-delete steps and then proceeded with membership/customer/user cleanup unconditionally. In a partial-failure path, the site could survive while its ownership and billing records were deleted, leaving it permanently orphaned.

## Fix

```diff
-		// Delete the WordPress blog if it exists.
-		if ($blog_id) {
-			wpmu_delete_blog($blog_id, true);
-		}
-
-		// Delete the WP Ultimo site record.
+		// Delete the site record (wp_delete_site handles the underlying blog removal).
 		$result = $site->delete();
+
+		if (true !== $result) {
+			wu_log_add('demo-cleanup', sprintf(
+				__('Failed to delete demo site #%d; skipping related cleanup.', 'ultimate-multisite'),
+				$site_id
+			));
+			return;
+		}
```

## Testing

- Verify happy path: demo site deletion still removes membership/customer/user as configured.
- Verify failure path: if `$site->delete()` returns non-`true`, the method returns early and logs the failure without touching membership/customer/user records.

Closes #406

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Refined demo site cleanup workflow with enhanced error detection and logging for failed removal operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->