### PR TITLE
fix: allow all product types in pricing_table field autocomplete

### DIFF
--- a/inc/checkout/signup-fields/class-signup-field-pricing-table.php
+++ b/inc/checkout/signup-fields/class-signup-field-pricing-table.php
@@ -106,8 +106,22 @@ class Signup_Field_Pricing_Table extends Base_Signup_Field {
 	 */
 	public function defaults() {
 
+		$all_products = wu_get_products(
+			[
+				'order'   => 'ASC',
+				'orderby' => 'list_order',
+			]
+		);
+
+		$product_ids = array_map(
+			function ($product) {
+				return $product->get_id();
+			},
+			$all_products
+		);
+
 		return [
-			'pricing_table_products'               => implode(',', array_keys(wu_get_plans_as_options())),
+			'pricing_table_products'               => implode(',', $product_ids),
 			'pricing_table_template'               => 'list',
 			'force_different_durations'            => false,
 			'hide_pricing_table_when_pre_selected' => false,
@@ -177,7 +191,6 @@ class Signup_Field_Pricing_Table extends Base_Signup_Field {
 				'data-value-field'  => 'id',
 				'data-label-field'  => 'name',
 				'data-search-field' => 'name',
-				'data-include'      => implode(',', array_keys(wu_get_plans_as_options())),
 				'data-max-items'    => 999,
 			],
 		];


### PR DESCRIPTION
## Summary

Fixes the checkout form editor's `pricing_table` field, which incorrectly restricted the product autocomplete to only show products with **Type=Plan**. Products with **Type=Service** or **Type=Package** were not selectable.

## Root Cause

Two issues in `inc/checkout/signup-fields/class-signup-field-pricing-table.php`:

1. **`defaults()`** used `wu_get_plans_as_options()` — which only returns plans — so new pricing table fields defaulted to a plan-only product list.
2. **`get_fields()`** set `data-include` on the model autocomplete field to the list of plan IDs, which restricted the AJAX product search to only those IDs.

## Fix

- **Removed `data-include`** from the `pricing_table_products` model field in `get_fields()`. Without this restriction, the autocomplete searches all products (plans, services, packages) via the existing AJAX handler.
- **Updated `defaults()`** to use `wu_get_products()` (all products ordered by `list_order`) instead of `wu_get_plans_as_options()`, so new pricing table fields default to all active products.

## Comparison

The `order_bump` field (which the issue notes already allows any product type) has no `data-include` restriction — this fix brings `pricing_table` in line with that behaviour.

## Testing

1. Go to `/wp-admin/network/admin.php?page=wp-ultimo-edit-checkout-form&id=1`
2. Edit or add a `pricing_table` field
3. In the **Products** autocomplete, search for a product with Type=Service or Type=Package
4. Confirm it appears in the results and can be selected

Closes #80