### PR TITLE
fix: guard strtotime() false return in dashboard execution time display (#410)

### DIFF
--- a/views/external-cron/dashboard.php
+++ b/views/external-cron/dashboard.php
@@ -176,7 +176,10 @@ defined('ABSPATH') || exit;
 								<span class="<?php echo esc_attr($status_class); ?>"><?php echo esc_html(ucfirst($status)); ?></span>
 							</td>
 							<td><?php echo isset($log['duration_ms']) ? esc_html($log['duration_ms'] . 'ms') : '-'; ?></td>
-							<td><?php echo isset($log['execution_time']) ? esc_html(human_time_diff(strtotime($log['execution_time']), time()) . ' ' . __('ago', 'ultimate-multisite')) : '-'; ?></td>
+							<td><?php
+							$exec_time = isset($log['execution_time']) ? strtotime($log['execution_time']) : false;
+							echo $exec_time ? esc_html(human_time_diff($exec_time, time()) . ' ' . __('ago', 'ultimate-multisite')) : '-';
+						?></td>
 						</tr>
 					<?php endforeach; ?>
 				</tbody>


### PR DESCRIPTION
## Summary

Addresses the PR #324 CodeRabbit review feedback item scoped to `views/external-cron/dashboard.php`.

**Problem:** `strtotime()` returns `false` when `$log['execution_time']` is malformed or an unexpected format. Passing `false` directly to `human_time_diff()` produces incorrect output (treats `false` as `0`, showing a time relative to the Unix epoch).

**Fix:** Capture the `strtotime()` result in `$exec_time` and only call `human_time_diff()` when it is truthy. Falls back to `'-'` for absent or unparseable values — consistent with the existing `duration_ms` fallback pattern on the adjacent column.

## Changes

- `views/external-cron/dashboard.php` — 1 file, defensive `strtotime()` guard on execution time display

## Review feedback addressed

| File | Line | Severity | Finding |
|------|------|----------|---------|
| `views/external-cron/dashboard.php` | 181 | Minor | Add defensive check for `strtotime()` returning false |

Closes #410

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved execution time display in the dashboard's recent log entries. Missing or invalid execution times now display as '-' instead of potentially showing invalid data. Valid times are formatted with "ago" notation for better readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->