### PR TITLE
fix: address PR #324 review feedback in class-external-cron-admin-page.php

### DIFF
--- a/inc/admin-pages/class-external-cron-admin-page.php
+++ b/inc/admin-pages/class-external-cron-admin-page.php
@@ -286,8 +286,8 @@ class External_Cron_Admin_Page extends Base_Admin_Page {
 		return add_query_arg(
 			[
 				'action'     => 'external_cron_connect',
-				'site_url'   => rawurlencode(network_site_url()),
-				'return_url' => rawurlencode($return_url),
+				'site_url'   => network_site_url(),
+				'return_url' => $return_url,
 			],
 			self::SERVICE_URL . '/wp-json/cron-service/v1/oauth/authorize'
 		);
@@ -399,7 +399,7 @@ class External_Cron_Admin_Page extends Base_Admin_Page {
 			wp_send_json_error(['message' => __('Permission denied.', 'ultimate-multisite')]);
 		}
 
-		$enabled = (bool) wu_request('enabled', false);
+		$enabled = filter_var(wu_request('enabled', false), FILTER_VALIDATE_BOOLEAN);
 
 		wu_save_setting('external_cron_enabled', $enabled);
 


### PR DESCRIPTION
## Summary

Addresses the two HIGH-severity CodeRabbit findings from PR #324 that were deferred as quality-debt (issue #407). Changes are limited to `inc/admin-pages/class-external-cron-admin-page.php` (1 file).

## Changes

### Fix 1: Remove `rawurlencode()` double-encoding in `get_connect_url()`

`add_query_arg()` encodes values internally via `build_query()` (confirmed in WordPress core `wp-includes/functions.php`). Pre-encoding with `rawurlencode()` causes double-encoding — `%` becomes `%25` — which breaks the OAuth callback redirect URL.

```diff
-  'site_url'   => rawurlencode(network_site_url()),
-  'return_url' => rawurlencode($return_url),
+  'site_url'   => network_site_url(),
+  'return_url' => $return_url,
```

### Fix 2: Replace `(bool)` cast with `filter_var(FILTER_VALIDATE_BOOLEAN)` in `ajax_toggle()`

In PHP, `(bool)"false"` returns `true` because any non-empty string is truthy. `FILTER_VALIDATE_BOOLEAN` correctly maps the strings `"false"`, `"0"`, `"off"`, `"no"` to `false`, matching expected toggle behaviour when the JS client sends a string value.

```diff
-  $enabled = (bool) wu_request('enabled', false);
+  $enabled = filter_var(wu_request('enabled', false), FILTER_VALIDATE_BOOLEAN);
```

## Quality-debt blast radius

- Files changed: **1** (well within the 5-file cap)
- Source: PR #324 CodeRabbit review, line 294 and line 415

Closes #407