### PR TITLE
fix(membership): reset is_publishing on thrown exceptions in publish_pending_site

### DIFF
--- a/inc/models/class-membership.php
+++ b/inc/models/class-membership.php
@@ -2046,7 +2046,21 @@ class Membership extends Base_Model implements Limitable, Billable, Notable {
 
 		$pending_site->set_type('customer_owned');
 
-		$saved = $pending_site->save();
+		try {
+			$saved = $pending_site->save();
+		} catch (\Throwable $e) {
+			/*
+			 * Reset is_publishing when Site::save() or a downstream hook throws,
+			 * so the cron/manual retry path is not stuck in "Creating" state.
+			 *
+			 * @since 2.4.13
+			 */
+			$pending_site->set_publishing(false);
+
+			$this->update_pending_site($pending_site);
+
+			return new \WP_Error('pending_site_publish_failed', $e->getMessage());
+		}
 
 		if (is_wp_error($saved)) {
 			if ($saved->get_error_code() === 'site_taken') {


### PR DESCRIPTION
## Summary

Addresses the unactioned CodeRabbit review feedback from PR #372, tracked in issue #412.

**Finding (medium severity):** The rollback that clears the pending site's `is_publishing` flag only ran when `Site::save()` returned a `WP_Error`. If `Site::save()` or a downstream hook threw a `Throwable` (PHP exception or `Error`), the pending site remained stuck in the `"Creating"` state and the cron/manual retry path could not recover.

**Fix:** Wrap the `Site::save()` call in `try/catch(\Throwable $e)` so that both `WP_Error` returns and thrown exceptions reset `is_publishing` and return a `WP_Error` to the caller.

## Changes

- `inc/models/class-membership.php` — wrap `$pending_site->save()` in `try/catch(\Throwable)` in `publish_pending_site()` (1 file, 15 lines added)

## Blast radius

1 file changed. Well within the 5-file quality-debt cap.

Closes #412