### PR TITLE
fix: suppress login account notice in WP admin dashboard

### DIFF
--- a/inc/ui/class-login-form-element.php
+++ b/inc/ui/class-login-form-element.php
@@ -886,6 +886,16 @@ class Login_Form_Element extends Base_Element {
 		$atts['login_url'] = $this->get_logout_url();
 		$atts['form']      = $form;
 
+		/*
+		 * Only show the "Not you?" notice when the login form is rendered
+		 * in a front-end context. In the WP admin dashboard the user is
+		 * already authenticated and the notice is unnecessary noise.
+		 *
+		 * @since 2.3.0
+		 * @see https://github.com/Ultimate-Multisite/ultimate-multisite/issues/93
+		 */
+		$atts['show_logged_in_notice'] = ! is_admin();
+
 		wu_get_template($view, $atts);
 	}
 }

--- a/views/dashboard-widgets/login-form.php
+++ b/views/dashboard-widgets/login-form.php
@@ -9,9 +9,11 @@ defined('ABSPATH') || exit;
 ?>
 <div class="wu-styling <?php echo esc_attr($className); ?>">
 
-	<?php if ($logged) : ?>
+	<?php if ($logged && ! empty($show_logged_in_notice)) : ?>
 
 	<!-- Already Logged Block -->
+	<!-- Only shown on front-end login pages, not in the WP admin dashboard. -->
+	<!-- @see https://github.com/Ultimate-Multisite/ultimate-multisite/issues/93 -->
 
 	<div class="wu-p-4 wu-bg-yellow-200 wu-rounded <?php echo esc_attr(wu_env_picker('wu-mb-4', 'wu-mt-2 wu-shadow-sm')); ?>">
 
@@ -26,7 +28,7 @@ defined('ABSPATH') || exit;
 
 	<!-- Already Logged Block - End -->
 
-	<?php else : ?>
+	<?php elseif (! $logged) : ?>
 
 	<!-- Title Element -->
 	<div class="wu-pb-4 wu-flex wu-items-center">


### PR DESCRIPTION
## Summary

The "Not [USERNAME]? Log in using your account." alert was rendered unconditionally whenever a user was logged in, including on every plugin page in the WP admin dashboard. This is noise — the notice is only meaningful on front-end login pages where a visitor might be logged in as the wrong account.

## Root Cause

`Login_Form_Element::output()` passed `$logged = true` to the view whenever any user was logged in, with no context check. The view then rendered the yellow alert block unconditionally. The element is embedded in admin dashboard pages (Account, My Sites) via `as_inline_content()`, so the alert appeared on every admin page load.

## Fix

- Added `show_logged_in_notice` flag to `output()` — set to `true` only when `!is_admin()`
- Updated `views/dashboard-widgets/login-form.php` to gate the alert block on `$logged && !empty($show_logged_in_notice)`
- Changed the `else` branch to `elseif (!$logged)` so the login form only renders when the user is not logged in (unchanged behaviour on front-end)

## Behaviour

| Context | Logged in | Before | After |
|---------|-----------|--------|-------|
| WP admin dashboard | Yes | Shows yellow alert | No output (correct) |
| Front-end login page | Yes | Shows yellow alert | Shows yellow alert (unchanged) |
| Front-end login page | No | Shows login form | Shows login form (unchanged) |

## Files Changed

- `inc/ui/class-login-form-element.php` — adds `show_logged_in_notice` to view attrs
- `views/dashboard-widgets/login-form.php` — gates alert on `show_logged_in_notice`

Closes #93