### PR TITLE
fix(tax): redesign universal tax as 'Apply to all countries' dropdown option

### DIFF
--- a/inc/functions/tax.php
+++ b/inc/functions/tax.php
@@ -201,6 +201,20 @@ function wu_get_applicable_tax_rates($country, $tax_category = 'default', $state
 		}
 	}
 
+	/*
+	 * If no country-specific rates matched, apply any rates configured
+	 * with '*' (Apply to all countries) as a fallback.
+	 */
+	if (empty($results)) {
+		foreach ($tax_category['rates'] as $rate) {
+			if ('*' === $rate['country']) {
+				$rate['order'] = 1;
+
+				$results[ $rate['id'] ] = $rate;
+			}
+		}
+	}
+
 	uasort($results, 'wu_sort_by_order');
 
 	return array_values($results);

--- a/lang/ultimate-multisite.pot
+++ b/lang/ultimate-multisite.pot
@@ -22513,8 +22513,12 @@ msgstr ""
 msgid "Loading Tax Rates..."
 msgstr ""
 
-#: views/taxes/list.php:266
-#: views/taxes/list.php:281
+#: views/taxes/list.php:243
+msgid "Apply to all countries"
+msgstr ""
+
+#: views/taxes/list.php:270
+#: views/taxes/list.php:285
 msgid "Leave blank to apply to all"
 msgstr ""
 

--- a/views/taxes/list.php
+++ b/views/taxes/list.php
@@ -239,6 +239,10 @@ $taxes_enabled = wu_get_setting('enable_taxes', false);
 
 			<select v-cloak v-model="item.<?php echo esc_attr($key); ?>" style="width: 100%;">
 
+						<option value="*">
+							<?php esc_html_e('Apply to all countries', 'ultimate-multisite'); ?>
+						</option>
+
 						<?php foreach (wu_get_countries_as_options() as $country_code => $country_name) : ?>
 
 				<option value="<?php echo esc_attr($country_code); ?>">


### PR DESCRIPTION
## Summary

Implements the maintainer's preferred approach from PR #277 review feedback: add an **'Apply to all countries'** option to the country dropdown on the Tax Rates configuration page, rather than using new settings fields.

Supersedes PR #277 (closed with explanation).

## Changes

- **`views/taxes/list.php`**: Add `*` option at the top of the country dropdown in the Tax Rates UI — labelled "Apply to all countries"
- **`inc/functions/tax.php`**: In `wu_get_applicable_tax_rates()`, after the main scoring loop, apply any rates with `country = '*'` as a fallback when no country-specific rates matched
- **`lang/ultimate-multisite.pot`**: Add "Apply to all countries" translation string; update line number references for "Leave blank to apply to all"

## How it works

1. Admin creates a tax rate and selects **"Apply to all countries"** from the country dropdown — this stores `country = '*'` on the rate
2. When a customer checks out, `wu_get_applicable_tax_rates()` runs the normal country-matching logic
3. If no country-specific rates match (score < 10), the fallback loop applies any `*`-country rates
4. This is consistent with how state and city already use blank/wildcard to mean "apply to all"

## Why this approach

- No new settings fields required (simpler, less UI surface)
- Consistent with existing wildcard patterns for state/city
- Directly addresses @superdav42's review feedback: _"I think I'd rather implement this by adding a new option to the country drop down, 'Apply to all countries'"_

Closes #426