### PR TITLE
fix: guard cron disable/sync/heartbeat on registration status

### DIFF
--- a/inc/external-cron/class-external-cron-manager.php
+++ b/inc/external-cron/class-external-cron-manager.php
@@ -99,13 +99,13 @@ class External_Cron_Manager {
 	}
 
 	/**
-	 * Maybe disable WordPress cron if service is active.
+	 * Maybe disable WordPress cron if service is active and site is registered.
 	 *
 	 * @since 2.3.0
 	 */
 	public function maybe_disable_wp_cron(): void {
 
-		if ( ! $this->is_service_active()) {
+		if ( ! $this->is_service_ready()) {
 			return;
 		}
 
@@ -139,13 +139,27 @@ class External_Cron_Manager {
 	}
 
 	/**
+	 * Check if service is enabled and the site is registered.
+	 *
+	 * Guards disable/sync/heartbeat paths so WP-Cron is not disabled and
+	 * scheduled actions are not sent until the site has a valid site ID.
+	 *
+	 * @since 2.3.0
+	 * @return bool
+	 */
+	private function is_service_ready(): bool {
+
+		return $this->is_service_active() && $this->is_registered();
+	}
+
+	/**
 	 * Schedule the sync action.
 	 *
 	 * @since 2.3.0
 	 */
 	private function schedule_sync(): void {
 
-		if ( ! $this->is_service_active()) {
+		if ( ! $this->is_service_ready()) {
 			return;
 		}
 
@@ -161,7 +175,7 @@ class External_Cron_Manager {
 	 */
 	private function schedule_heartbeat(): void {
 
-		if ( ! $this->is_service_active()) {
+		if ( ! $this->is_service_ready()) {
 			return;
 		}
 
@@ -177,7 +191,7 @@ class External_Cron_Manager {
 	 */
 	public function sync_schedules(): void {
 
-		if ( ! $this->is_service_active()) {
+		if ( ! $this->is_service_ready()) {
 			return;
 		}
 
@@ -193,7 +207,7 @@ class External_Cron_Manager {
 	 */
 	public function send_heartbeat(): void {
 
-		if ( ! $this->is_service_active()) {
+		if ( ! $this->is_service_ready()) {
 			return;
 		}
 


### PR DESCRIPTION
## Summary

- Adds private `is_service_ready()` helper combining `is_service_active() && is_registered()`
- Gates `maybe_disable_wp_cron()`, `schedule_sync()`, `schedule_heartbeat()`, `sync_schedules()`, and `send_heartbeat()` on the new combined check
- Prevents WP-Cron from being disabled and stops sync/heartbeat from firing before the site has a valid site ID

## Problem

Before this fix, enabling the external cron service (setting `external_cron_enabled = true`) was sufficient to disable WP-Cron and schedule sync/heartbeat actions — even if the site had never registered and had no `site_id`. This meant:
- WP-Cron would stop running, breaking all scheduled tasks
- Sync and heartbeat calls would hit the service without a valid site ID

## Fix

A single `is_service_ready()` guard replaces the five individual `is_service_active()` checks. The helper is `private` since it is only needed internally.

## Files changed

- `inc/external-cron/class-external-cron-manager.php` (1 file, within the 5-file quality-debt cap)

Closes #408