### PR TITLE
fix: add defensive validation before accessing API response keys in external cron registration

### DIFF
--- a/inc/external-cron/class-external-cron-registration.php
+++ b/inc/external-cron/class-external-cron-registration.php
@@ -64,6 +64,19 @@ class External_Cron_Registration {
 			return $result;
 		}
 
+		// Validate required fields in response.
+		if (
+			! is_array($result) ||
+			empty($result['site_id']) ||
+			empty($result['api_key']) ||
+			empty($result['api_secret'])
+		) {
+			return new \WP_Error(
+				'invalid_response',
+				__('Invalid registration response from service.', 'ultimate-multisite')
+			);
+		}
+
 		// Save credentials.
 		wu_save_setting('external_cron_site_id', $result['site_id']);
 		wu_save_setting('external_cron_api_key', $result['api_key']);
@@ -110,6 +123,14 @@ class External_Cron_Registration {
 
 		if (is_wp_error($result)) {
 			return $result;
+		}
+
+		// Validate required field in response.
+		if (! is_array($result) || empty($result['site_id'])) {
+			return new \WP_Error(
+				'invalid_response',
+				__('Invalid registration response from service.', 'ultimate-multisite')
+			);
 		}
 
 		// Save site ID for this blog.


### PR DESCRIPTION
## Summary

- Adds `is_array()` + `empty()` validation for `site_id`, `api_key`, and `api_secret` in `register_network()` before persisting credentials or calling `set_credentials()`
- Adds `is_array()` + `empty()` validation for `site_id` in `register_subsite()` before calling `update_blog_option()`
- Returns a `WP_Error('invalid_response', ...)` if any required field is missing or empty, preventing PHP notices and invalid state from a malformed API response

## Changes

- `inc/external-cron/class-external-cron-registration.php` — 1 file, 21 lines added

## Motivation

CodeRabbit flagged in PR #324 that `register_network()` accessed `$result['site_id']`, `$result['api_key']`, and `$result['api_secret']` directly after the `is_wp_error()` check, without confirming the response is a valid array with those keys present. A malformed or partial API response would cause PHP notices and leave the plugin in an inconsistent state (partial credentials saved).

The same pattern existed in `register_subsite()` for `$result['site_id']`.

Closes #409