### PR TITLE
fix: differentiate API errors from not-found in on_remove_domain

### DIFF
--- a/inc/integrations/providers/cloudflare/class-cloudflare-domain-mapping.php
+++ b/inc/integrations/providers/cloudflare/class-cloudflare-domain-mapping.php
@@ -160,7 +160,8 @@ class Cloudflare_Domain_Mapping extends Base_Capability_Module implements Domain
 	 * @since 2.5.0
 	 *
 	 * @param string $domain  The domain name being removed.
-	 * @param int    $site_id The site ID.
+	 * @param int    $site_id The site ID. Required by Domain_Mapping_Capability interface but unused here.
+	 *                        Unlike on_add_domain, no filter hook is applied before deletion.
 	 * @return void
 	 */
 	public function on_remove_domain(string $domain, int $site_id): void {
@@ -178,7 +179,17 @@ class Cloudflare_Domain_Mapping extends Base_Capability_Module implements Domain
 			['hostname' => $domain]
 		);
 
-		if (is_wp_error($list_result) || empty($list_result->result)) {
+		if (is_wp_error($list_result)) {
+			wu_log_add(
+				'integration-cloudflare',
+				sprintf('Failed to look up Custom Hostname for "%s". Reason: %s', $domain, $list_result->get_error_message()),
+				LogLevel::ERROR
+			);
+
+			return;
+		}
+
+		if (empty($list_result->result)) {
 			wu_log_add(
 				'integration-cloudflare',
 				sprintf('Could not find Custom Hostname for "%s" to delete. Skipping.', $domain),


### PR DESCRIPTION
## Summary

Addresses the CodeRabbit review feedback from PR #377 that was tracked in issue #405.

The `on_remove_domain` method in `class-cloudflare-domain-mapping.php` previously conflated two distinct failure cases in a single `if` branch:

1. **API failure** — `is_wp_error($list_result)` — a genuine Cloudflare API error
2. **Not found** — `empty($list_result->result)` — a successful API call that returned no matching Custom Hostname

Both were logged with the same WARNING-level "Could not find Custom Hostname" message, which masked real API errors.

## Changes

**`inc/integrations/providers/cloudflare/class-cloudflare-domain-mapping.php`**

- Split the combined `is_wp_error($list_result) || empty($list_result->result)` check into two separate branches:
  - API errors → `LogLevel::ERROR` with the `WP_Error` message via `$list_result->get_error_message()`
  - Not-found → `LogLevel::WARNING` with the existing "Could not find Custom Hostname" message (unchanged)
- Added a `@param` doc note for the `$site_id` parameter explaining it is required by the `Domain_Mapping_Capability` interface but unused in this method (unlike `on_add_domain` which passes it to a filter)

## Files changed

- `inc/integrations/providers/cloudflare/class-cloudflare-domain-mapping.php` (1 file, within the 5-file quality-debt cap)

Closes #405