### PR TITLE
fix: apply wu_checkout_template_id filter in all site creation paths

### DIFF
--- a/inc/managers/class-site-manager.php
+++ b/inc/managers/class-site-manager.php
@@ -189,11 +189,25 @@ class Site_Manager extends Base_Manager {
 				if ($errors->has_errors() === false) {
 					$d = wu_get_site_domain_and_path(wu_request('site_url', ''), $checkout->request_or_session('site_domain'));
 
+					/*
+					 * Apply the wu_checkout_template_id filter so that
+					 * "Assign Site Template" mode is honoured when adding
+					 * a new site to an existing membership.
+					 *
+					 * @since 2.5.0
+					 */
+					$template_id = apply_filters(
+						'wu_checkout_template_id',
+						(int) $checkout->request_or_session('template_id'),
+						$membership,
+						$checkout
+					);
+
 					$pending_site = $membership->create_pending_site(
 						[
 							'domain'        => $d->domain,
 							'path'          => $d->path,
-							'template_id'   => $checkout->request_or_session('template_id'),
+							'template_id'   => $template_id,
 							'title'         => $checkout->request_or_session('site_title'),
 							'customer_id'   => $customer->get_id(),
 							'membership_id' => $membership->get_id(),

--- a/inc/models/class-membership.php
+++ b/inc/models/class-membership.php
@@ -2046,6 +2046,23 @@ class Membership extends Base_Model implements Limitable, Billable, Notable {
 
 		$pending_site->set_type('customer_owned');
 
+		/*
+		 * Ensure the template ID is set when the product uses
+		 * "Assign Site Template" mode. During checkout the
+		 * wu_checkout_template_id filter sets this on the pending
+		 * site data, but if the checkout form has no template
+		 * selection field the value may still be empty. Re-apply
+		 * the filter here as a safety net so the assigned template
+		 * is always honoured.
+		 *
+		 * @since 2.5.0
+		 */
+		$template_id = apply_filters('wu_checkout_template_id', (int) $pending_site->get_template_id(), $this, null);
+
+		if ($template_id && $template_id !== (int) $pending_site->get_template_id()) {
+			$pending_site->set_template_id($template_id);
+		}
+
 		try {
 			$saved = $pending_site->save();
 		} catch (\Throwable $e) {

--- a/tests/WP_Ultimo/Limits/Site_Template_Limits_Test.php
+++ b/tests/WP_Ultimo/Limits/Site_Template_Limits_Test.php
@@ -1,0 +1,267 @@
+<?php
+
+namespace WP_Ultimo\Limits;
+
+use WP_Ultimo\Limitations\Limit_Site_Templates;
+use WP_Ultimo\Objects\Limitations;
+
+/**
+ * Tests for the Site_Template_Limits class.
+ *
+ * @covers \WP_Ultimo\Limits\Site_Template_Limits
+ */
+class Site_Template_Limits_Test extends \WP_UnitTestCase {
+
+	/**
+	 * Get a fresh Site_Template_Limits instance via reflection.
+	 *
+	 * @return Site_Template_Limits
+	 */
+	private function get_instance() {
+
+		$ref      = new \ReflectionClass(Site_Template_Limits::class);
+		$instance = $ref->newInstanceWithoutConstructor();
+
+		return $instance;
+	}
+
+	/**
+	 * Test class exists.
+	 */
+	public function test_class_exists(): void {
+
+		$this->assertTrue(class_exists(Site_Template_Limits::class));
+	}
+
+	/**
+	 * Test maybe_force_template_selection overrides template_id when mode is assign_template.
+	 */
+	public function test_maybe_force_template_selection_assign_mode(): void {
+
+		$instance = $this->get_instance();
+
+		$product = wu_create_product(
+			[
+				'name'  => 'Test Plan',
+				'slug'  => 'test-plan-tpl-' . wp_rand(),
+				'type'  => 'plan',
+				'price' => 10,
+			]
+		);
+
+		$this->assertNotWPError($product);
+
+		// Create a template site.
+		$template = wu_create_site(
+			[
+				'title'  => 'Template Site',
+				'domain' => 'tpl-assign-' . wp_rand() . '.example.com',
+				'path'   => '/',
+				'type'   => 'site_template',
+			]
+		);
+
+		$this->assertNotWPError($template);
+
+		$template_id = $template->get_id();
+
+		// Save limitations on the product with assign_template mode.
+		$product->update_meta(
+			'wu_limitations',
+			[
+				'site_templates' => [
+					'enabled' => true,
+					'mode'    => 'assign_template',
+					'limit'   => [
+						(string) $template_id => [
+							'behavior' => 'pre_selected',
+						],
+					],
+				],
+			]
+		);
+
+		// Create a membership linked to this product.
+		$customer = wu_create_customer(
+			[
+				'user_id' => self::factory()->user->create(),
+			]
+		);
+
+		$this->assertNotWPError($customer);
+
+		$membership = wu_create_membership(
+			[
+				'customer_id' => $customer->get_id(),
+				'plan_id'     => $product->get_id(),
+				'status'      => 'active',
+			]
+		);
+
+		$this->assertNotWPError($membership);
+
+		// Call the filter handler with template_id = 0 (no selection).
+		$result = $instance->maybe_force_template_selection(0, $membership);
+
+		$this->assertEquals($template_id, $result, 'Assign template mode should override template_id to the pre-selected template.');
+	}
+
+	/**
+	 * Test maybe_force_template_selection does NOT override when mode is default.
+	 */
+	public function test_maybe_force_template_selection_default_mode(): void {
+
+		$instance = $this->get_instance();
+
+		$product = wu_create_product(
+			[
+				'name'  => 'Default Plan',
+				'slug'  => 'default-plan-tpl-' . wp_rand(),
+				'type'  => 'plan',
+				'price' => 10,
+			]
+		);
+
+		$this->assertNotWPError($product);
+
+		// No site_templates limitations — mode defaults to 'default'.
+
+		$customer = wu_create_customer(
+			[
+				'user_id' => self::factory()->user->create(),
+			]
+		);
+
+		$this->assertNotWPError($customer);
+
+		$membership = wu_create_membership(
+			[
+				'customer_id' => $customer->get_id(),
+				'plan_id'     => $product->get_id(),
+				'status'      => 'active',
+			]
+		);
+
+		$this->assertNotWPError($membership);
+
+		// Call the filter handler with template_id = 42.
+		$result = $instance->maybe_force_template_selection(42, $membership);
+
+		$this->assertEquals(42, $result, 'Default mode should not override the template_id.');
+	}
+
+	/**
+	 * Test maybe_force_template_selection returns false when assign mode has no pre-selected template.
+	 */
+	public function test_maybe_force_template_selection_assign_mode_no_preselected(): void {
+
+		$instance = $this->get_instance();
+
+		$product = wu_create_product(
+			[
+				'name'  => 'Empty Assign Plan',
+				'slug'  => 'empty-assign-plan-' . wp_rand(),
+				'type'  => 'plan',
+				'price' => 10,
+			]
+		);
+
+		$this->assertNotWPError($product);
+
+		// Save limitations with assign_template mode but no pre-selected template.
+		$product->update_meta(
+			'wu_limitations',
+			[
+				'site_templates' => [
+					'enabled' => true,
+					'mode'    => 'assign_template',
+					'limit'   => null,
+				],
+			]
+		);
+
+		$customer = wu_create_customer(
+			[
+				'user_id' => self::factory()->user->create(),
+			]
+		);
+
+		$this->assertNotWPError($customer);
+
+		$membership = wu_create_membership(
+			[
+				'customer_id' => $customer->get_id(),
+				'plan_id'     => $product->get_id(),
+				'status'      => 'active',
+			]
+		);
+
+		$this->assertNotWPError($membership);
+
+		// Call the filter handler with template_id = 0.
+		$result = $instance->maybe_force_template_selection(0, $membership);
+
+		$this->assertFalse($result, 'Assign mode with no pre-selected template should return false.');
+	}
+
+	/**
+	 * Test maybe_force_template_selection_on_cart sets template_id in extra params.
+	 */
+	public function test_maybe_force_template_selection_on_cart_assign_mode(): void {
+
+		$instance = $this->get_instance();
+
+		$product = wu_create_product(
+			[
+				'name'  => 'Cart Plan',
+				'slug'  => 'cart-plan-tpl-' . wp_rand(),
+				'type'  => 'plan',
+				'price' => 10,
+			]
+		);
+
+		$this->assertNotWPError($product);
+
+		$template = wu_create_site(
+			[
+				'title'  => 'Cart Template Site',
+				'domain' => 'tpl-cart-' . wp_rand() . '.example.com',
+				'path'   => '/',
+				'type'   => 'site_template',
+			]
+		);
+
+		$this->assertNotWPError($template);
+
+		$template_id = $template->get_id();
+
+		$product->update_meta(
+			'wu_limitations',
+			[
+				'site_templates' => [
+					'enabled' => true,
+					'mode'    => 'assign_template',
+					'limit'   => [
+						(string) $template_id => [
+							'behavior' => 'pre_selected',
+						],
+					],
+				],
+			]
+		);
+
+		// Build a minimal cart mock with the product.
+		$cart = $this->getMockBuilder(\WP_Ultimo\Checkout\Cart::class)
+			->disableOriginalConstructor()
+			->onlyMethods(['get_all_products'])
+			->getMock();
+
+		$cart->method('get_all_products')->willReturn([$product]);
+
+		$extra  = [];
+		$result = $instance->maybe_force_template_selection_on_cart($extra, $cart);
+
+		$this->assertArrayHasKey('template_id', $result, 'Cart extra params should include template_id in assign mode.');
+		$this->assertEquals($template_id, $result['template_id'], 'Cart template_id should match the pre-selected template.');
+	}
+}


### PR DESCRIPTION
## Summary

Fixes the "Assign Site Template" product mode not working — new sites were created with a default WordPress install instead of copying the assigned template site.

**Root cause:** Two site creation code paths bypassed the `wu_checkout_template_id` filter that enforces the assigned template:

1. **`Membership::publish_pending_site()`** — When the pending site is published (async via cron/AJAX or sync), the template_id stored on the pending site could be `0` if the checkout form had no template selection field. The `wu_checkout_template_id` filter was only applied during checkout form processing, not during publication. Added a safety-net filter call before `save()` so the membership's "Assign Site Template" limitation is always honoured.

2. **`Site_Manager::maybe_validate_add_new_site()`** — When adding a new site to an existing membership (e.g. from the customer dashboard), the template_id was taken directly from the request without applying the `wu_checkout_template_id` filter. Now applies the filter so the product's template assignment is respected.

## Changes

- `inc/models/class-membership.php` — Re-apply `wu_checkout_template_id` filter in `publish_pending_site()` before saving, ensuring the assigned template is used even when the pending site data lacks it.
- `inc/managers/class-site-manager.php` — Apply `wu_checkout_template_id` filter in `maybe_validate_add_new_site()` before creating the pending site.
- `tests/WP_Ultimo/Limits/Site_Template_Limits_Test.php` — New test class covering `maybe_force_template_selection` and `maybe_force_template_selection_on_cart` for assign_template mode, default mode, and edge cases.

## Testing

1. Create a product (plan) with "Assign Site Template" mode and select a template site
2. Create a checkout form (with or without a template selection field)
3. Sign up as a new customer with that product
4. Verify the new site is created from the assigned template (not a blank WordPress install)
5. Also test adding a new site to an existing membership from the customer dashboard

Closes #259