### PR TITLE
#433: Scope admin asset enqueues to WP Ultimo pages only

### DIFF
--- a/inc/class-scripts.php
+++ b/inc/class-scripts.php
@@ -33,9 +33,9 @@ class Scripts {
 
 		add_action('init', [$this, 'register_default_styles']);
 
-		add_action('admin_init', [$this, 'enqueue_default_admin_styles']);
+		add_action('admin_enqueue_scripts', [$this, 'enqueue_default_admin_styles']);
 
-		add_action('admin_init', [$this, 'enqueue_default_admin_scripts']);
+		add_action('admin_enqueue_scripts', [$this, 'enqueue_default_admin_scripts']);
 
 		add_action('wp_ajax_wu_toggle_container', [$this, 'update_use_container']);
 
@@ -427,10 +427,19 @@ class Scripts {
 	/**
 	 * Loads the default admin styles.
 	 *
+	 * Only enqueued on WP Ultimo admin pages to avoid loading 150KB+ of CSS
+	 * on unrelated admin pages (e.g., Posts, Plugins, Settings).
+	 *
 	 * @since 2.0.0
+	 *
+	 * @param string $hook_suffix The current admin page hook suffix.
 	 * @return void
 	 */
-	public function enqueue_default_admin_styles(): void {
+	public function enqueue_default_admin_styles(string $hook_suffix): void {
+
+		if ( ! wu_is_wu_page($hook_suffix)) {
+			return;
+		}
 
 		wp_enqueue_style('wu-admin');
 
@@ -441,10 +450,19 @@ class Scripts {
 	/**
 	 * Loads the default admin scripts.
 	 *
+	 * Only enqueued on WP Ultimo admin pages to avoid loading scripts
+	 * on unrelated admin pages (e.g., Posts, Plugins, Settings).
+	 *
 	 * @since 2.0.0
+	 *
+	 * @param string $hook_suffix The current admin page hook suffix.
 	 * @return void
 	 */
-	public function enqueue_default_admin_scripts(): void {
+	public function enqueue_default_admin_scripts(string $hook_suffix): void {
+
+		if ( ! wu_is_wu_page($hook_suffix)) {
+			return;
+		}
 
 		wp_enqueue_script('wu-admin');
 

--- a/inc/functions/assets.php
+++ b/inc/functions/assets.php
@@ -27,3 +27,30 @@ function wu_get_asset($asset, $assets_dir = 'img', $base_dir = 'assets') {
 
 	return wu_url("$base_dir/$assets_dir/$asset");
 }
+
+/**
+ * Checks if the current admin page belongs to WP Ultimo.
+ *
+ * Used to guard asset enqueues so that WP Ultimo scripts and styles are only
+ * loaded on WP Ultimo admin pages, not on every page in the network admin.
+ *
+ * Detection relies on the hook suffix passed to `admin_enqueue_scripts`. All
+ * WP Ultimo admin pages register with an ID prefixed by `wp-ultimo`, which
+ * WordPress uses when generating the page hook (e.g., `toplevel_page_wp-ultimo`,
+ * `wp-ultimo_page_wp-ultimo-settings`). The hook suffix always contains the
+ * page slug, so checking for `wp-ultimo` is reliable.
+ *
+ * @since 2.4.2
+ *
+ * @param string $hook_suffix The hook suffix passed to `admin_enqueue_scripts`.
+ * @return bool True if the current page is a WP Ultimo admin page.
+ */
+function wu_is_wu_page(string $hook_suffix = ''): bool {
+
+	if ('' === $hook_suffix) {
+		$screen      = get_current_screen();
+		$hook_suffix = $screen ? (string) $screen->id : '';
+	}
+
+	return str_contains($hook_suffix, 'wp-ultimo');
+}


### PR DESCRIPTION
## Summary

Fixes the primary finding from the performance audit in issue #433: WP Ultimo was loading **151KB+ of CSS** and several JS files on **every admin page** in the network — including Posts, Plugins, Settings, and all third-party plugin pages.

## Root Cause

`class-scripts.php` hooked `enqueue_default_admin_styles()` and `enqueue_default_admin_scripts()` to `admin_init`, which fires on every admin page. This caused:

- `wu-admin.css` (114KB) + `wu-styling` / `framework.css` (37KB) = **151KB CSS** on every admin page
- `wu-admin.js` → `wu-functions.js` → tiptip, flatpicker, blockUI, accounting, clipboard chain on every admin page
- `wu-password-toggle.js` and `wu-password.css` on every admin page

## Fix

Two minimal changes, no new complexity:

1. **`inc/functions/assets.php`** — adds `wu_is_wu_page(string $hook_suffix)` helper. All WP Ultimo admin pages use IDs prefixed with `wp-ultimo`, which WordPress embeds in the generated page hook suffix (e.g. `toplevel_page_wp-ultimo`, `wp-ultimo_page_wp-ultimo-settings`). Checking for `wp-ultimo` in the hook suffix is reliable and requires no list maintenance.

2. **`inc/class-scripts.php`** — switches the two `admin_init` hooks to `admin_enqueue_scripts` (which receives the hook suffix as a parameter) and adds a `wu_is_wu_page()` guard to both enqueue methods.

## What Was Already Correct (No Changes)

- Admin pages in `inc/admin-pages/` use `load-{page_hook}` — already page-scoped ✓
- `class-dashboard-widgets.php` guards with `$pagenow === 'index.php'` ✓
- `class-site-exporter.php` guards with hook name check ✓
- `class-tours.php` only enqueues when `has_tours()` is true ✓
- `class-admin-notices.php` — legitimately global (WU notices can appear on any admin page) ✓
- `class-base-list-table.php` — constructor only runs inside `page_loaded()` which is already page-scoped ✓
- Frontend checkout, UI elements — all properly scoped ✓

## Impact

- **Before:** 151KB CSS + JS dependency chain loaded on every admin page
- **After:** Assets only loaded on WP Ultimo admin pages
- No behaviour change on WP Ultimo pages — all assets still load there

Closes #433