### PR TITLE
fix: bypass enableMultisite port check in WP Performance blueprint

### DIFF
--- a/.github/performance-blueprint.json
+++ b/.github/performance-blueprint.json
@@ -8,10 +8,6 @@
 			}
 		},
 		{
-			"step": "runPHP",
-			"code": "<?php $p='/wordpress/wp-config.php'; $c=file_get_contents($p); if(strpos($c,'HTTP_HOST')===false){$c=str_replace('<?php',\"<?php\\n\\$_SERVER['HTTP_HOST']='127.0.0.1';\",$c);file_put_contents($p,$c);} echo 'done';"
-		},
-		{
 			"step": "wp-cli",
 			"command": "wp core multisite-convert --base=/ --skip-plugins --skip-themes"
 		},


### PR DESCRIPTION
## Summary

- Replaces the `enableMultisite` blueprint step with equivalent `wp-cli` steps that bypass the port check
- Adds `extraLibraries: ["wp-cli"]` so wp-cli.phar is available during blueprint execution
- Network-activates the plugin after multisite conversion

## Root cause

The `swissspidy/wp-performance-action` runs WP Playground on `127.0.0.1:9400`. The WP Playground `enableMultisite` blueprint step explicitly throws when the site URL has a custom port:

```
The current host is 127.0.0.1:9400, but WordPress multisites do not support custom ports.
```

This crash happens during blueprint execution, leaving the server unresponsive. Playwright then fails with `ECONNREFUSED 127.0.0.1:9400` because the server never finished starting.

The fix replaces `enableMultisite` with three equivalent steps:
1. `defineWpConfigConsts` — sets `WP_ALLOW_MULTISITE=1` in wp-config.php
2. `wp-cli: wp core multisite-convert --base=/` — converts the site to multisite (bypasses the TypeScript port check)
3. `wp-cli: wp plugin activate ultimate-multisite --network` — network-activates the plugin (required because `Network: true` in plugin header)

## Evidence

From the failing CI run on PR #444 (job 68482602203):
- Blueprint was applied correctly (merged blueprint shown in logs)
- WordPress downloaded to 85% then server became unresponsive
- Playwright immediately got `ECONNREFUSED 127.0.0.1:9400` on first test

The `enableMultisite` step source confirms the port check:
```typescript
if (url.port !== '') {
  throw new Error(`The current host is ${url.host}, but WordPress multisites do not support custom ports.`);
}
```

Closes #445

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Configuration & Setup**
  * Enhanced automatic WordPress multisite initialization for faster, more reliable environment setup.
  * Automatic network creation and standardized multisite constants ensure consistent multisite behavior.
  * Network-wide activation of the core multisite plugin during setup for immediate multisite functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->