### PR TITLE
#447: Use Gutenberg blocks for checkout page in setup wizard

### DIFF
--- a/inc/installers/class-default-content-installer.php
+++ b/inc/installers/class-default-content-installer.php
@@ -356,11 +356,25 @@ class Default_Content_Installer extends Base_Installer {
 			$status->save();
 		}
 
-		$post_content = '
-			<!-- wp:shortcode -->
-				[wu_checkout slug="%s"]
-			<!-- /wp:shortcode -->
-		';
+		/*
+		 * Build a Gutenberg block layout: three columns (25/50/25) with the
+		 * Ultimate Multisite checkout block centred in the middle column.
+		 * This gives site owners a clean starting point that is easy to
+		 * customise in the block editor without touching shortcode syntax.
+		 */
+		$post_content = '<!-- wp:columns {"align":"wide"} -->
+<div class="wp-block-columns alignwide"><!-- wp:column {"width":"25%"} -->
+<div class="wp-block-column" style="flex-basis:25%"></div>
+<!-- /wp:column -->
+
+<!-- wp:column {"width":"50%"} -->
+<div class="wp-block-column" style="flex-basis:50%"><!-- wp:wp-ultimo/checkout {"slug":"%s"} /--></div>
+<!-- /wp:column -->
+
+<!-- wp:column {"width":"25%"} -->
+<div class="wp-block-column" style="flex-basis:25%"></div>
+<!-- /wp:column --></div>
+<!-- /wp:columns -->';
 
 		/*
 		 * Create the page on the main site.


### PR DESCRIPTION
## Summary

Replaces the shortcode-based page content created by the setup wizard with a proper Gutenberg block layout.

**Before:** The wizard created a page containing a `<!-- wp:shortcode -->` block wrapping `[wu_checkout slug="main-form"]`.

**After:** The wizard creates a page with:
- A wide-aligned three-column layout (25% / 50% / 25%)
- The `wp-ultimo/checkout` block placed in the centre 50% column
- Empty spacer columns on each side for visual balance

## Why

The shortcode approach works but is opaque in the block editor — users see a raw shortcode string and must know the syntax to modify it. The Gutenberg block approach gives a visual, editable starting point that is easy to customise (resize columns, add content above/below, swap the block for a different form) without touching shortcode syntax.

The 25/50/25 column split centres the checkout form on the page, which is the most common layout for registration pages, while leaving the columns easy to adjust.

## Changes

- `inc/installers/class-default-content-installer.php`: Replace `$post_content` shortcode string with Gutenberg `wp:columns` / `wp:column` / `wp:wp-ultimo/checkout` block markup in `_install_create_checkout()`.

Closes #447

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Checkout page layout has been restructured with an enhanced multi-column design, featuring centered content placement for improved visual organization and better user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->