### PR TITLE
feat(tests): add unit tests for admin pages, admin classes, template library, and SSO

### DIFF
--- a/tests/WP_Ultimo/Admin/Configuration_Checker_Test.php
+++ b/tests/WP_Ultimo/Admin/Configuration_Checker_Test.php
@@ -1,0 +1,57 @@
+<?php
+/**
+ * Tests for Configuration_Checker class.
+ *
+ * @package WP_Ultimo\Tests
+ */
+
+namespace WP_Ultimo\Admin;
+
+use WP_UnitTestCase;
+
+/**
+ * Test class for Configuration_Checker.
+ */
+class Configuration_Checker_Test extends WP_UnitTestCase {
+
+	/**
+	 * @var Configuration_Checker
+	 */
+	private $checker;
+
+	/**
+	 * Set up test fixtures.
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+		$this->checker = Configuration_Checker::get_instance();
+	}
+
+	/**
+	 * Test get_instance returns a Configuration_Checker instance.
+	 */
+	public function test_get_instance_returns_instance(): void {
+		$this->assertInstanceOf(Configuration_Checker::class, $this->checker);
+	}
+
+	/**
+	 * Test get_instance returns the same instance (singleton).
+	 */
+	public function test_get_instance_is_singleton(): void {
+		$instance1 = Configuration_Checker::get_instance();
+		$instance2 = Configuration_Checker::get_instance();
+
+		$this->assertSame($instance1, $instance2);
+	}
+
+	/**
+	 * Test check_cookie_domain_configuration does not add notice when not network admin.
+	 */
+	public function test_check_cookie_domain_no_notice_outside_network_admin(): void {
+		// Not in network admin context — method should return early.
+		// We just verify it doesn't throw.
+		$this->checker->check_cookie_domain_configuration();
+
+		$this->assertTrue(true); // No exception thrown.
+	}
+}

--- a/tests/WP_Ultimo/Admin/Network_Usage_Columns_Test.php
+++ b/tests/WP_Ultimo/Admin/Network_Usage_Columns_Test.php
@@ -1,0 +1,109 @@
+<?php
+/**
+ * Tests for Network_Usage_Columns class.
+ *
+ * @package WP_Ultimo\Tests
+ */
+
+namespace WP_Ultimo\Admin;
+
+use WP_UnitTestCase;
+
+/**
+ * Test class for Network_Usage_Columns.
+ */
+class Network_Usage_Columns_Test extends WP_UnitTestCase {
+
+	/**
+	 * @var Network_Usage_Columns
+	 */
+	private $columns;
+
+	/**
+	 * Set up test fixtures.
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+		$this->columns = Network_Usage_Columns::get_instance();
+	}
+
+	/**
+	 * Test get_instance returns a Network_Usage_Columns instance.
+	 */
+	public function test_get_instance_returns_instance(): void {
+		$this->assertInstanceOf(Network_Usage_Columns::class, $this->columns);
+	}
+
+	/**
+	 * Test get_instance returns the same instance (singleton).
+	 */
+	public function test_get_instance_is_singleton(): void {
+		$instance1 = Network_Usage_Columns::get_instance();
+		$instance2 = Network_Usage_Columns::get_instance();
+
+		$this->assertSame($instance1, $instance2);
+	}
+
+	/**
+	 * Test SITE_TRANSIENT_BLOGS_PLUGINS constant value.
+	 */
+	public function test_site_transient_constant(): void {
+		$this->assertEquals('wu_blogs_data_plugins', Network_Usage_Columns::SITE_TRANSIENT_BLOGS_PLUGINS);
+	}
+
+	/**
+	 * Test add_plugins_column adds a 'sites' column.
+	 */
+	public function test_add_plugins_column(): void {
+		$columns = $this->columns->add_plugins_column([]);
+
+		$this->assertIsArray($columns);
+		$this->assertArrayHasKey('sites', $columns);
+	}
+
+	/**
+	 * Test add_themes_column adds a 'sites' column.
+	 */
+	public function test_add_themes_column(): void {
+		$columns = $this->columns->add_themes_column([]);
+
+		$this->assertIsArray($columns);
+		$this->assertArrayHasKey('sites', $columns);
+	}
+
+	/**
+	 * Test get_blogs_with_plugin returns an array.
+	 */
+	public function test_get_blogs_with_plugin_returns_array(): void {
+		$result = $this->columns->get_blogs_with_plugin('hello.php');
+
+		$this->assertIsArray($result);
+	}
+
+	/**
+	 * Test get_blogs_with_theme returns an array.
+	 */
+	public function test_get_blogs_with_theme_returns_array(): void {
+		$result = $this->columns->get_blogs_with_theme('twentytwentyfour');
+
+		$this->assertIsArray($result);
+	}
+
+	/**
+	 * Test get_blogs_data returns an array.
+	 */
+	public function test_get_blogs_data_returns_array(): void {
+		$result = $this->columns->get_blogs_data();
+
+		$this->assertIsArray($result);
+	}
+
+	/**
+	 * Test clear_site_transient does not throw.
+	 */
+	public function test_clear_site_transient_does_not_throw(): void {
+		$this->columns->clear_site_transient('hello.php', false);
+
+		$this->assertTrue(true); // No exception thrown.
+	}
+}

--- a/tests/WP_Ultimo/Admin_Pages/Broadcast_Edit_Admin_Page_Test.php
+++ b/tests/WP_Ultimo/Admin_Pages/Broadcast_Edit_Admin_Page_Test.php
@@ -1,0 +1,125 @@
+<?php
+/**
+ * Tests for Broadcast_Edit_Admin_Page class.
+ *
+ * @package WP_Ultimo\Tests
+ */
+
+namespace WP_Ultimo\Admin_Pages;
+
+use WP_UnitTestCase;
+
+/**
+ * Test class for Broadcast_Edit_Admin_Page.
+ */
+class Broadcast_Edit_Admin_Page_Test extends WP_UnitTestCase {
+
+	/**
+	 * @var Broadcast_Edit_Admin_Page
+	 */
+	private $page;
+
+	/**
+	 * Set up test fixtures.
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+		$this->page = new Broadcast_Edit_Admin_Page();
+	}
+
+	/**
+	 * Test page id is correct.
+	 */
+	public function test_page_id(): void {
+		$reflection = new \ReflectionClass($this->page);
+		$property   = $reflection->getProperty('id');
+		$property->setAccessible(true);
+
+		$this->assertEquals('wp-ultimo-edit-broadcast', $property->getValue($this->page));
+	}
+
+	/**
+	 * Test page type is submenu.
+	 */
+	public function test_page_type(): void {
+		$reflection = new \ReflectionClass($this->page);
+		$property   = $reflection->getProperty('type');
+		$property->setAccessible(true);
+
+		$this->assertEquals('submenu', $property->getValue($this->page));
+	}
+
+	/**
+	 * Test get_title returns add new string when not in edit mode.
+	 */
+	public function test_get_title_add_new(): void {
+		$reflection = new \ReflectionClass($this->page);
+		$property   = $reflection->getProperty('edit');
+		$property->setAccessible(true);
+		$property->setValue($this->page, false);
+
+		$title = $this->page->get_title();
+
+		$this->assertIsString($title);
+		$this->assertEquals('Add new Broadcast', $title);
+	}
+
+	/**
+	 * Test get_title returns edit string when in edit mode.
+	 */
+	public function test_get_title_edit(): void {
+		$reflection = new \ReflectionClass($this->page);
+		$property   = $reflection->getProperty('edit');
+		$property->setAccessible(true);
+		$property->setValue($this->page, true);
+
+		$title = $this->page->get_title();
+
+		$this->assertIsString($title);
+		$this->assertEquals('Edit Broadcast', $title);
+	}
+
+	/**
+	 * Test get_menu_title returns string.
+	 */
+	public function test_get_menu_title(): void {
+		$title = $this->page->get_menu_title();
+
+		$this->assertIsString($title);
+		$this->assertEquals('Edit Broadcast', $title);
+	}
+
+	/**
+	 * Test action_links returns empty array.
+	 */
+	public function test_action_links(): void {
+		$links = $this->page->action_links();
+
+		$this->assertIsArray($links);
+		$this->assertEmpty($links);
+	}
+
+	/**
+	 * Test supported_panels contains network_admin_menu.
+	 */
+	public function test_supported_panels(): void {
+		$reflection = new \ReflectionClass($this->page);
+		$property   = $reflection->getProperty('supported_panels');
+		$property->setAccessible(true);
+
+		$panels = $property->getValue($this->page);
+		$this->assertArrayHasKey('network_admin_menu', $panels);
+		$this->assertEquals('wu_edit_broadcasts', $panels['network_admin_menu']);
+	}
+
+	/**
+	 * Test badge_count is zero.
+	 */
+	public function test_badge_count(): void {
+		$reflection = new \ReflectionClass($this->page);
+		$property   = $reflection->getProperty('badge_count');
+		$property->setAccessible(true);
+
+		$this->assertEquals(0, $property->getValue($this->page));
+	}
+}

--- a/tests/WP_Ultimo/Admin_Pages/Broadcast_List_Admin_Page_Test.php
+++ b/tests/WP_Ultimo/Admin_Pages/Broadcast_List_Admin_Page_Test.php
@@ -1,0 +1,146 @@
+<?php
+/**
+ * Tests for Broadcast_List_Admin_Page class.
+ *
+ * @package WP_Ultimo\Tests
+ */
+
+namespace WP_Ultimo\Admin_Pages;
+
+use WP_UnitTestCase;
+
+/**
+ * Test class for Broadcast_List_Admin_Page.
+ */
+class Broadcast_List_Admin_Page_Test extends WP_UnitTestCase {
+
+	/**
+	 * @var Broadcast_List_Admin_Page
+	 */
+	private $page;
+
+	/**
+	 * Set up test fixtures.
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+		$this->page = new Broadcast_List_Admin_Page();
+	}
+
+	/**
+	 * Test page id is correct.
+	 */
+	public function test_page_id(): void {
+		$reflection = new \ReflectionClass($this->page);
+		$property   = $reflection->getProperty('id');
+		$property->setAccessible(true);
+
+		$this->assertEquals('wp-ultimo-broadcasts', $property->getValue($this->page));
+	}
+
+	/**
+	 * Test page type is submenu.
+	 */
+	public function test_page_type(): void {
+		$reflection = new \ReflectionClass($this->page);
+		$property   = $reflection->getProperty('type');
+		$property->setAccessible(true);
+
+		$this->assertEquals('submenu', $property->getValue($this->page));
+	}
+
+	/**
+	 * Test get_title returns string.
+	 */
+	public function test_get_title(): void {
+		$title = $this->page->get_title();
+
+		$this->assertIsString($title);
+		$this->assertEquals('Broadcast', $title);
+	}
+
+	/**
+	 * Test get_menu_title returns string.
+	 */
+	public function test_get_menu_title(): void {
+		$title = $this->page->get_menu_title();
+
+		$this->assertIsString($title);
+		$this->assertEquals('Broadcasts', $title);
+	}
+
+	/**
+	 * Test get_submenu_title returns string.
+	 */
+	public function test_get_submenu_title(): void {
+		$title = $this->page->get_submenu_title();
+
+		$this->assertIsString($title);
+		$this->assertEquals('Broadcasts', $title);
+	}
+
+	/**
+	 * Test get_labels returns array.
+	 */
+	public function test_get_labels(): void {
+		$labels = $this->page->get_labels();
+
+		$this->assertIsArray($labels);
+		$this->assertArrayHasKey('deleted_message', $labels);
+		$this->assertArrayHasKey('search_label', $labels);
+	}
+
+	/**
+	 * Test action_links returns array.
+	 */
+	public function test_action_links(): void {
+		$links = $this->page->action_links();
+
+		$this->assertIsArray($links);
+		$this->assertGreaterThanOrEqual(1, count($links));
+	}
+
+	/**
+	 * Test action_links has add broadcast link.
+	 */
+	public function test_action_links_add_broadcast(): void {
+		$links = $this->page->action_links();
+
+		$this->assertEquals('Add Broadcast', $links[0]['label']);
+		$this->assertArrayHasKey('url', $links[0]);
+		$this->assertArrayHasKey('icon', $links[0]);
+	}
+
+	/**
+	 * Test table returns list table instance.
+	 */
+	public function test_table(): void {
+		$table = $this->page->table();
+
+		$this->assertInstanceOf(\WP_Ultimo\List_Tables\Broadcast_List_Table::class, $table);
+	}
+
+	/**
+	 * Test supported_panels contains network_admin_menu.
+	 */
+	public function test_supported_panels(): void {
+		$reflection = new \ReflectionClass($this->page);
+		$property   = $reflection->getProperty('supported_panels');
+		$property->setAccessible(true);
+
+		$panels = $property->getValue($this->page);
+		$this->assertArrayHasKey('network_admin_menu', $panels);
+		$this->assertEquals('wu_read_broadcasts', $panels['network_admin_menu']);
+	}
+
+	/**
+	 * Test badge_count is zero.
+	 */
+	public function test_badge_count(): void {
+		$reflection = new \ReflectionClass($this->page);
+		$property   = $reflection->getProperty('badge_count');
+		$property->setAccessible(true);
+
+		$this->assertEquals(0, $property->getValue($this->page));
+	}
+}

--- a/tests/WP_Ultimo/Admin_Pages/Discount_Code_Edit_Admin_Page_Test.php
+++ b/tests/WP_Ultimo/Admin_Pages/Discount_Code_Edit_Admin_Page_Test.php
@@ -1,0 +1,125 @@
+<?php
+/**
+ * Tests for Discount_Code_Edit_Admin_Page class.
+ *
+ * @package WP_Ultimo\Tests
+ */
+
+namespace WP_Ultimo\Admin_Pages;
+
+use WP_UnitTestCase;
+
+/**
+ * Test class for Discount_Code_Edit_Admin_Page.
+ */
+class Discount_Code_Edit_Admin_Page_Test extends WP_UnitTestCase {
+
+	/**
+	 * @var Discount_Code_Edit_Admin_Page
+	 */
+	private $page;
+
+	/**
+	 * Set up test fixtures.
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+		$this->page = new Discount_Code_Edit_Admin_Page();
+	}
+
+	/**
+	 * Test page id is correct.
+	 */
+	public function test_page_id(): void {
+		$reflection = new \ReflectionClass($this->page);
+		$property   = $reflection->getProperty('id');
+		$property->setAccessible(true);
+
+		$this->assertEquals('wp-ultimo-edit-discount-code', $property->getValue($this->page));
+	}
+
+	/**
+	 * Test page type is submenu.
+	 */
+	public function test_page_type(): void {
+		$reflection = new \ReflectionClass($this->page);
+		$property   = $reflection->getProperty('type');
+		$property->setAccessible(true);
+
+		$this->assertEquals('submenu', $property->getValue($this->page));
+	}
+
+	/**
+	 * Test get_title returns add new string when not in edit mode.
+	 */
+	public function test_get_title_add_new(): void {
+		$reflection = new \ReflectionClass($this->page);
+		$property   = $reflection->getProperty('edit');
+		$property->setAccessible(true);
+		$property->setValue($this->page, false);
+
+		$title = $this->page->get_title();
+
+		$this->assertIsString($title);
+		$this->assertEquals('Add new Discount Code', $title);
+	}
+
+	/**
+	 * Test get_title returns edit string when in edit mode.
+	 */
+	public function test_get_title_edit(): void {
+		$reflection = new \ReflectionClass($this->page);
+		$property   = $reflection->getProperty('edit');
+		$property->setAccessible(true);
+		$property->setValue($this->page, true);
+
+		$title = $this->page->get_title();
+
+		$this->assertIsString($title);
+		$this->assertEquals('Edit Discount Code', $title);
+	}
+
+	/**
+	 * Test get_menu_title returns string.
+	 */
+	public function test_get_menu_title(): void {
+		$title = $this->page->get_menu_title();
+
+		$this->assertIsString($title);
+		$this->assertEquals('Edit Discount Code', $title);
+	}
+
+	/**
+	 * Test action_links returns empty array.
+	 */
+	public function test_action_links(): void {
+		$links = $this->page->action_links();
+
+		$this->assertIsArray($links);
+		$this->assertEmpty($links);
+	}
+
+	/**
+	 * Test supported_panels contains network_admin_menu.
+	 */
+	public function test_supported_panels(): void {
+		$reflection = new \ReflectionClass($this->page);
+		$property   = $reflection->getProperty('supported_panels');
+		$property->setAccessible(true);
+
+		$panels = $property->getValue($this->page);
+		$this->assertArrayHasKey('network_admin_menu', $panels);
+		$this->assertEquals('wu_edit_discount_codes', $panels['network_admin_menu']);
+	}
+
+	/**
+	 * Test badge_count is zero.
+	 */
+	public function test_badge_count(): void {
+		$reflection = new \ReflectionClass($this->page);
+		$property   = $reflection->getProperty('badge_count');
+		$property->setAccessible(true);
+
+		$this->assertEquals(0, $property->getValue($this->page));
+	}
+}

--- a/tests/WP_Ultimo/Admin_Pages/Discount_Code_List_Admin_Page_Test.php
+++ b/tests/WP_Ultimo/Admin_Pages/Discount_Code_List_Admin_Page_Test.php
@@ -1,0 +1,146 @@
+<?php
+/**
+ * Tests for Discount_Code_List_Admin_Page class.
+ *
+ * @package WP_Ultimo\Tests
+ */
+
+namespace WP_Ultimo\Admin_Pages;
+
+use WP_UnitTestCase;
+
+/**
+ * Test class for Discount_Code_List_Admin_Page.
+ */
+class Discount_Code_List_Admin_Page_Test extends WP_UnitTestCase {
+
+	/**
+	 * @var Discount_Code_List_Admin_Page
+	 */
+	private $page;
+
+	/**
+	 * Set up test fixtures.
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+		$this->page = new Discount_Code_List_Admin_Page();
+	}
+
+	/**
+	 * Test page id is correct.
+	 */
+	public function test_page_id(): void {
+		$reflection = new \ReflectionClass($this->page);
+		$property   = $reflection->getProperty('id');
+		$property->setAccessible(true);
+
+		$this->assertEquals('wp-ultimo-discount-codes', $property->getValue($this->page));
+	}
+
+	/**
+	 * Test page type is submenu.
+	 */
+	public function test_page_type(): void {
+		$reflection = new \ReflectionClass($this->page);
+		$property   = $reflection->getProperty('type');
+		$property->setAccessible(true);
+
+		$this->assertEquals('submenu', $property->getValue($this->page));
+	}
+
+	/**
+	 * Test get_title returns string.
+	 */
+	public function test_get_title(): void {
+		$title = $this->page->get_title();
+
+		$this->assertIsString($title);
+		$this->assertEquals('Discount Codes', $title);
+	}
+
+	/**
+	 * Test get_menu_title returns string.
+	 */
+	public function test_get_menu_title(): void {
+		$title = $this->page->get_menu_title();
+
+		$this->assertIsString($title);
+		$this->assertEquals('Discount Codes', $title);
+	}
+
+	/**
+	 * Test get_submenu_title returns string.
+	 */
+	public function test_get_submenu_title(): void {
+		$title = $this->page->get_submenu_title();
+
+		$this->assertIsString($title);
+		$this->assertEquals('Discount Codes', $title);
+	}
+
+	/**
+	 * Test get_labels returns array.
+	 */
+	public function test_get_labels(): void {
+		$labels = $this->page->get_labels();
+
+		$this->assertIsArray($labels);
+		$this->assertArrayHasKey('deleted_message', $labels);
+		$this->assertArrayHasKey('search_label', $labels);
+	}
+
+	/**
+	 * Test action_links returns array.
+	 */
+	public function test_action_links(): void {
+		$links = $this->page->action_links();
+
+		$this->assertIsArray($links);
+		$this->assertCount(1, $links);
+	}
+
+	/**
+	 * Test action_links has add discount code link.
+	 */
+	public function test_action_links_add_discount_code(): void {
+		$links = $this->page->action_links();
+
+		$this->assertEquals('Add Discount Code', $links[0]['label']);
+		$this->assertArrayHasKey('url', $links[0]);
+		$this->assertArrayHasKey('icon', $links[0]);
+	}
+
+	/**
+	 * Test table returns list table instance.
+	 */
+	public function test_table(): void {
+		$table = $this->page->table();
+
+		$this->assertInstanceOf(\WP_Ultimo\List_Tables\Discount_Code_List_Table::class, $table);
+	}
+
+	/**
+	 * Test supported_panels contains network_admin_menu.
+	 */
+	public function test_supported_panels(): void {
+		$reflection = new \ReflectionClass($this->page);
+		$property   = $reflection->getProperty('supported_panels');
+		$property->setAccessible(true);
+
+		$panels = $property->getValue($this->page);
+		$this->assertArrayHasKey('network_admin_menu', $panels);
+		$this->assertEquals('wu_read_discount_codes', $panels['network_admin_menu']);
+	}
+
+	/**
+	 * Test badge_count is zero.
+	 */
+	public function test_badge_count(): void {
+		$reflection = new \ReflectionClass($this->page);
+		$property   = $reflection->getProperty('badge_count');
+		$property->setAccessible(true);
+
+		$this->assertEquals(0, $property->getValue($this->page));
+	}
+}

--- a/tests/WP_Ultimo/Admin_Pages/Domain_Edit_Admin_Page_Test.php
+++ b/tests/WP_Ultimo/Admin_Pages/Domain_Edit_Admin_Page_Test.php
@@ -1,0 +1,125 @@
+<?php
+/**
+ * Tests for Domain_Edit_Admin_Page class.
+ *
+ * @package WP_Ultimo\Tests
+ */
+
+namespace WP_Ultimo\Admin_Pages;
+
+use WP_UnitTestCase;
+
+/**
+ * Test class for Domain_Edit_Admin_Page.
+ */
+class Domain_Edit_Admin_Page_Test extends WP_UnitTestCase {
+
+	/**
+	 * @var Domain_Edit_Admin_Page
+	 */
+	private $page;
+
+	/**
+	 * Set up test fixtures.
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+		$this->page = new Domain_Edit_Admin_Page();
+	}
+
+	/**
+	 * Test page id is correct.
+	 */
+	public function test_page_id(): void {
+		$reflection = new \ReflectionClass($this->page);
+		$property   = $reflection->getProperty('id');
+		$property->setAccessible(true);
+
+		$this->assertEquals('wp-ultimo-edit-domain', $property->getValue($this->page));
+	}
+
+	/**
+	 * Test page type is submenu.
+	 */
+	public function test_page_type(): void {
+		$reflection = new \ReflectionClass($this->page);
+		$property   = $reflection->getProperty('type');
+		$property->setAccessible(true);
+
+		$this->assertEquals('submenu', $property->getValue($this->page));
+	}
+
+	/**
+	 * Test get_title returns add new string when not in edit mode.
+	 */
+	public function test_get_title_add_new(): void {
+		$reflection = new \ReflectionClass($this->page);
+		$property   = $reflection->getProperty('edit');
+		$property->setAccessible(true);
+		$property->setValue($this->page, false);
+
+		$title = $this->page->get_title();
+
+		$this->assertIsString($title);
+		$this->assertEquals('Add new Domain', $title);
+	}
+
+	/**
+	 * Test get_title returns edit string when in edit mode.
+	 */
+	public function test_get_title_edit(): void {
+		$reflection = new \ReflectionClass($this->page);
+		$property   = $reflection->getProperty('edit');
+		$property->setAccessible(true);
+		$property->setValue($this->page, true);
+
+		$title = $this->page->get_title();
+
+		$this->assertIsString($title);
+		$this->assertEquals('Edit Domain', $title);
+	}
+
+	/**
+	 * Test get_menu_title returns string.
+	 */
+	public function test_get_menu_title(): void {
+		$title = $this->page->get_menu_title();
+
+		$this->assertIsString($title);
+		$this->assertEquals('Edit Domain', $title);
+	}
+
+	/**
+	 * Test action_links returns empty array.
+	 */
+	public function test_action_links(): void {
+		$links = $this->page->action_links();
+
+		$this->assertIsArray($links);
+		$this->assertEmpty($links);
+	}
+
+	/**
+	 * Test supported_panels contains network_admin_menu.
+	 */
+	public function test_supported_panels(): void {
+		$reflection = new \ReflectionClass($this->page);
+		$property   = $reflection->getProperty('supported_panels');
+		$property->setAccessible(true);
+
+		$panels = $property->getValue($this->page);
+		$this->assertArrayHasKey('network_admin_menu', $panels);
+		$this->assertEquals('wu_edit_domains', $panels['network_admin_menu']);
+	}
+
+	/**
+	 * Test badge_count is zero.
+	 */
+	public function test_badge_count(): void {
+		$reflection = new \ReflectionClass($this->page);
+		$property   = $reflection->getProperty('badge_count');
+		$property->setAccessible(true);
+
+		$this->assertEquals(0, $property->getValue($this->page));
+	}
+}

--- a/tests/WP_Ultimo/Admin_Pages/Domain_List_Admin_Page_Test.php
+++ b/tests/WP_Ultimo/Admin_Pages/Domain_List_Admin_Page_Test.php
@@ -1,0 +1,146 @@
+<?php
+/**
+ * Tests for Domain_List_Admin_Page class.
+ *
+ * @package WP_Ultimo\Tests
+ */
+
+namespace WP_Ultimo\Admin_Pages;
+
+use WP_UnitTestCase;
+
+/**
+ * Test class for Domain_List_Admin_Page.
+ */
+class Domain_List_Admin_Page_Test extends WP_UnitTestCase {
+
+	/**
+	 * @var Domain_List_Admin_Page
+	 */
+	private $page;
+
+	/**
+	 * Set up test fixtures.
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+		$this->page = new Domain_List_Admin_Page();
+	}
+
+	/**
+	 * Test page id is correct.
+	 */
+	public function test_page_id(): void {
+		$reflection = new \ReflectionClass($this->page);
+		$property   = $reflection->getProperty('id');
+		$property->setAccessible(true);
+
+		$this->assertEquals('wp-ultimo-domains', $property->getValue($this->page));
+	}
+
+	/**
+	 * Test page type is submenu.
+	 */
+	public function test_page_type(): void {
+		$reflection = new \ReflectionClass($this->page);
+		$property   = $reflection->getProperty('type');
+		$property->setAccessible(true);
+
+		$this->assertEquals('submenu', $property->getValue($this->page));
+	}
+
+	/**
+	 * Test get_title returns string.
+	 */
+	public function test_get_title(): void {
+		$title = $this->page->get_title();
+
+		$this->assertIsString($title);
+		$this->assertEquals('Domains', $title);
+	}
+
+	/**
+	 * Test get_menu_title returns string.
+	 */
+	public function test_get_menu_title(): void {
+		$title = $this->page->get_menu_title();
+
+		$this->assertIsString($title);
+		$this->assertEquals('Domains', $title);
+	}
+
+	/**
+	 * Test get_submenu_title returns string.
+	 */
+	public function test_get_submenu_title(): void {
+		$title = $this->page->get_submenu_title();
+
+		$this->assertIsString($title);
+		$this->assertEquals('Domains', $title);
+	}
+
+	/**
+	 * Test get_labels returns array.
+	 */
+	public function test_get_labels(): void {
+		$labels = $this->page->get_labels();
+
+		$this->assertIsArray($labels);
+		$this->assertArrayHasKey('deleted_message', $labels);
+		$this->assertArrayHasKey('search_label', $labels);
+	}
+
+	/**
+	 * Test action_links returns array.
+	 */
+	public function test_action_links(): void {
+		$links = $this->page->action_links();
+
+		$this->assertIsArray($links);
+		$this->assertCount(1, $links);
+	}
+
+	/**
+	 * Test action_links has add domain link.
+	 */
+	public function test_action_links_add_domain(): void {
+		$links = $this->page->action_links();
+
+		$this->assertEquals('Add Domain', $links[0]['label']);
+		$this->assertArrayHasKey('url', $links[0]);
+		$this->assertArrayHasKey('icon', $links[0]);
+	}
+
+	/**
+	 * Test table returns list table instance.
+	 */
+	public function test_table(): void {
+		$table = $this->page->table();
+
+		$this->assertInstanceOf(\WP_Ultimo\List_Tables\Domain_List_Table::class, $table);
+	}
+
+	/**
+	 * Test supported_panels contains network_admin_menu.
+	 */
+	public function test_supported_panels(): void {
+		$reflection = new \ReflectionClass($this->page);
+		$property   = $reflection->getProperty('supported_panels');
+		$property->setAccessible(true);
+
+		$panels = $property->getValue($this->page);
+		$this->assertArrayHasKey('network_admin_menu', $panels);
+		$this->assertEquals('wu_read_domains', $panels['network_admin_menu']);
+	}
+
+	/**
+	 * Test badge_count is zero.
+	 */
+	public function test_badge_count(): void {
+		$reflection = new \ReflectionClass($this->page);
+		$property   = $reflection->getProperty('badge_count');
+		$property->setAccessible(true);
+
+		$this->assertEquals(0, $property->getValue($this->page));
+	}
+}

--- a/tests/WP_Ultimo/Admin_Pages/Email_Edit_Admin_Page_Test.php
+++ b/tests/WP_Ultimo/Admin_Pages/Email_Edit_Admin_Page_Test.php
@@ -1,0 +1,115 @@
+<?php
+/**
+ * Tests for Email_Edit_Admin_Page class.
+ *
+ * @package WP_Ultimo\Tests
+ */
+
+namespace WP_Ultimo\Admin_Pages;
+
+use WP_UnitTestCase;
+
+/**
+ * Test class for Email_Edit_Admin_Page.
+ */
+class Email_Edit_Admin_Page_Test extends WP_UnitTestCase {
+
+	/**
+	 * @var Email_Edit_Admin_Page
+	 */
+	private $page;
+
+	/**
+	 * Set up test fixtures.
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+		$this->page = new Email_Edit_Admin_Page();
+	}
+
+	/**
+	 * Test page id is correct.
+	 */
+	public function test_page_id(): void {
+		$reflection = new \ReflectionClass($this->page);
+		$property   = $reflection->getProperty('id');
+		$property->setAccessible(true);
+
+		$this->assertEquals('wp-ultimo-edit-email', $property->getValue($this->page));
+	}
+
+	/**
+	 * Test page type is submenu.
+	 */
+	public function test_page_type(): void {
+		$reflection = new \ReflectionClass($this->page);
+		$property   = $reflection->getProperty('type');
+		$property->setAccessible(true);
+
+		$this->assertEquals('submenu', $property->getValue($this->page));
+	}
+
+	/**
+	 * Test get_title returns add new string when not in edit mode.
+	 */
+	public function test_get_title_add_new(): void {
+		$reflection = new \ReflectionClass($this->page);
+		$property   = $reflection->getProperty('edit');
+		$property->setAccessible(true);
+		$property->setValue($this->page, false);
+
+		$title = $this->page->get_title();
+
+		$this->assertIsString($title);
+		$this->assertEquals('Add new Email', $title);
+	}
+
+	/**
+	 * Test get_title returns edit string when in edit mode.
+	 */
+	public function test_get_title_edit(): void {
+		$reflection = new \ReflectionClass($this->page);
+		$property   = $reflection->getProperty('edit');
+		$property->setAccessible(true);
+		$property->setValue($this->page, true);
+
+		$title = $this->page->get_title();
+
+		$this->assertIsString($title);
+		$this->assertEquals('Edit Email', $title);
+	}
+
+	/**
+	 * Test get_menu_title returns string.
+	 */
+	public function test_get_menu_title(): void {
+		$title = $this->page->get_menu_title();
+
+		$this->assertIsString($title);
+		$this->assertEquals('Edit Email', $title);
+	}
+
+	/**
+	 * Test supported_panels contains network_admin_menu.
+	 */
+	public function test_supported_panels(): void {
+		$reflection = new \ReflectionClass($this->page);
+		$property   = $reflection->getProperty('supported_panels');
+		$property->setAccessible(true);
+
+		$panels = $property->getValue($this->page);
+		$this->assertArrayHasKey('network_admin_menu', $panels);
+		$this->assertEquals('wu_edit_emails', $panels['network_admin_menu']);
+	}
+
+	/**
+	 * Test badge_count is zero.
+	 */
+	public function test_badge_count(): void {
+		$reflection = new \ReflectionClass($this->page);
+		$property   = $reflection->getProperty('badge_count');
+		$property->setAccessible(true);
+
+		$this->assertEquals(0, $property->getValue($this->page));
+	}
+}

--- a/tests/WP_Ultimo/Admin_Pages/Email_List_Admin_Page_Test.php
+++ b/tests/WP_Ultimo/Admin_Pages/Email_List_Admin_Page_Test.php
@@ -1,0 +1,124 @@
+<?php
+/**
+ * Tests for Email_List_Admin_Page class.
+ *
+ * @package WP_Ultimo\Tests
+ */
+
+namespace WP_Ultimo\Admin_Pages;
+
+use WP_UnitTestCase;
+
+/**
+ * Test class for Email_List_Admin_Page.
+ */
+class Email_List_Admin_Page_Test extends WP_UnitTestCase {
+
+	/**
+	 * @var Email_List_Admin_Page
+	 */
+	private $page;
+
+	/**
+	 * Set up test fixtures.
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+		$this->page = new Email_List_Admin_Page();
+	}
+
+	/**
+	 * Test page id is correct.
+	 */
+	public function test_page_id(): void {
+		$reflection = new \ReflectionClass($this->page);
+		$property   = $reflection->getProperty('id');
+		$property->setAccessible(true);
+
+		$this->assertEquals('wp-ultimo-emails', $property->getValue($this->page));
+	}
+
+	/**
+	 * Test page type is submenu.
+	 */
+	public function test_page_type(): void {
+		$reflection = new \ReflectionClass($this->page);
+		$property   = $reflection->getProperty('type');
+		$property->setAccessible(true);
+
+		$this->assertEquals('submenu', $property->getValue($this->page));
+	}
+
+	/**
+	 * Test get_title returns string.
+	 */
+	public function test_get_title(): void {
+		$title = $this->page->get_title();
+
+		$this->assertIsString($title);
+		$this->assertEquals('System Emails', $title);
+	}
+
+	/**
+	 * Test get_menu_title returns string.
+	 */
+	public function test_get_menu_title(): void {
+		$title = $this->page->get_menu_title();
+
+		$this->assertIsString($title);
+		$this->assertEquals('System Emails', $title);
+	}
+
+	/**
+	 * Test get_submenu_title returns string.
+	 */
+	public function test_get_submenu_title(): void {
+		$title = $this->page->get_submenu_title();
+
+		$this->assertIsString($title);
+		$this->assertEquals('System Emails', $title);
+	}
+
+	/**
+	 * Test action_links returns array.
+	 */
+	public function test_action_links(): void {
+		$links = $this->page->action_links();
+
+		$this->assertIsArray($links);
+		$this->assertGreaterThanOrEqual(1, count($links));
+	}
+
+	/**
+	 * Test table returns list table instance.
+	 */
+	public function test_table(): void {
+		$table = $this->page->table();
+
+		$this->assertInstanceOf(\WP_Ultimo\List_Tables\Email_List_Table::class, $table);
+	}
+
+	/**
+	 * Test supported_panels contains network_admin_menu.
+	 */
+	public function test_supported_panels(): void {
+		$reflection = new \ReflectionClass($this->page);
+		$property   = $reflection->getProperty('supported_panels');
+		$property->setAccessible(true);
+
+		$panels = $property->getValue($this->page);
+		$this->assertArrayHasKey('network_admin_menu', $panels);
+		$this->assertEquals('wu_read_emails', $panels['network_admin_menu']);
+	}
+
+	/**
+	 * Test badge_count is zero.
+	 */
+	public function test_badge_count(): void {
+		$reflection = new \ReflectionClass($this->page);
+		$property   = $reflection->getProperty('badge_count');
+		$property->setAccessible(true);
+
+		$this->assertEquals(0, $property->getValue($this->page));
+	}
+}

--- a/tests/WP_Ultimo/Admin_Pages/Event_List_Admin_Page_Test.php
+++ b/tests/WP_Ultimo/Admin_Pages/Event_List_Admin_Page_Test.php
@@ -1,0 +1,135 @@
+<?php
+/**
+ * Tests for Event_List_Admin_Page class.
+ *
+ * @package WP_Ultimo\Tests
+ */
+
+namespace WP_Ultimo\Admin_Pages;
+
+use WP_UnitTestCase;
+
+/**
+ * Test class for Event_List_Admin_Page.
+ */
+class Event_List_Admin_Page_Test extends WP_UnitTestCase {
+
+	/**
+	 * @var Event_List_Admin_Page
+	 */
+	private $page;
+
+	/**
+	 * Set up test fixtures.
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+		$this->page = new Event_List_Admin_Page();
+	}
+
+	/**
+	 * Test page id is correct.
+	 */
+	public function test_page_id(): void {
+		$reflection = new \ReflectionClass($this->page);
+		$property   = $reflection->getProperty('id');
+		$property->setAccessible(true);
+
+		$this->assertEquals('wp-ultimo-events', $property->getValue($this->page));
+	}
+
+	/**
+	 * Test page type is submenu.
+	 */
+	public function test_page_type(): void {
+		$reflection = new \ReflectionClass($this->page);
+		$property   = $reflection->getProperty('type');
+		$property->setAccessible(true);
+
+		$this->assertEquals('submenu', $property->getValue($this->page));
+	}
+
+	/**
+	 * Test get_title returns string.
+	 */
+	public function test_get_title(): void {
+		$title = $this->page->get_title();
+
+		$this->assertIsString($title);
+		$this->assertEquals('Events', $title);
+	}
+
+	/**
+	 * Test get_menu_title returns string.
+	 */
+	public function test_get_menu_title(): void {
+		$title = $this->page->get_menu_title();
+
+		$this->assertIsString($title);
+		$this->assertEquals('Events', $title);
+	}
+
+	/**
+	 * Test get_submenu_title returns string.
+	 */
+	public function test_get_submenu_title(): void {
+		$title = $this->page->get_submenu_title();
+
+		$this->assertIsString($title);
+		$this->assertEquals('Events', $title);
+	}
+
+	/**
+	 * Test get_labels returns array.
+	 */
+	public function test_get_labels(): void {
+		$labels = $this->page->get_labels();
+
+		$this->assertIsArray($labels);
+		$this->assertArrayHasKey('deleted_message', $labels);
+		$this->assertArrayHasKey('search_label', $labels);
+	}
+
+	/**
+	 * Test action_links returns array.
+	 */
+	public function test_action_links(): void {
+		$links = $this->page->action_links();
+
+		$this->assertIsArray($links);
+		$this->assertCount(1, $links);
+	}
+
+	/**
+	 * Test action_links has view logs link.
+	 */
+	public function test_action_links_view_logs(): void {
+		$links = $this->page->action_links();
+
+		$this->assertEquals('View Logs', $links[0]['label']);
+		$this->assertArrayHasKey('url', $links[0]);
+		$this->assertArrayHasKey('icon', $links[0]);
+	}
+
+	/**
+	 * Test table returns list table instance.
+	 */
+	public function test_table(): void {
+		$table = $this->page->table();
+
+		$this->assertInstanceOf(\WP_Ultimo\List_Tables\Event_List_Table::class, $table);
+	}
+
+	/**
+	 * Test supported_panels contains network_admin_menu.
+	 */
+	public function test_supported_panels(): void {
+		$reflection = new \ReflectionClass($this->page);
+		$property   = $reflection->getProperty('supported_panels');
+		$property->setAccessible(true);
+
+		$panels = $property->getValue($this->page);
+		$this->assertArrayHasKey('network_admin_menu', $panels);
+		$this->assertEquals('wu_read_events', $panels['network_admin_menu']);
+	}
+}

--- a/tests/WP_Ultimo/Admin_Pages/Membership_List_Admin_Page_Test.php
+++ b/tests/WP_Ultimo/Admin_Pages/Membership_List_Admin_Page_Test.php
@@ -1,0 +1,146 @@
+<?php
+/**
+ * Tests for Membership_List_Admin_Page class.
+ *
+ * @package WP_Ultimo\Tests
+ */
+
+namespace WP_Ultimo\Admin_Pages;
+
+use WP_UnitTestCase;
+
+/**
+ * Test class for Membership_List_Admin_Page.
+ */
+class Membership_List_Admin_Page_Test extends WP_UnitTestCase {
+
+	/**
+	 * @var Membership_List_Admin_Page
+	 */
+	private $page;
+
+	/**
+	 * Set up test fixtures.
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+		$this->page = new Membership_List_Admin_Page();
+	}
+
+	/**
+	 * Test page id is correct.
+	 */
+	public function test_page_id(): void {
+		$reflection = new \ReflectionClass($this->page);
+		$property   = $reflection->getProperty('id');
+		$property->setAccessible(true);
+
+		$this->assertEquals('wp-ultimo-memberships', $property->getValue($this->page));
+	}
+
+	/**
+	 * Test page type is submenu.
+	 */
+	public function test_page_type(): void {
+		$reflection = new \ReflectionClass($this->page);
+		$property   = $reflection->getProperty('type');
+		$property->setAccessible(true);
+
+		$this->assertEquals('submenu', $property->getValue($this->page));
+	}
+
+	/**
+	 * Test get_title returns string.
+	 */
+	public function test_get_title(): void {
+		$title = $this->page->get_title();
+
+		$this->assertIsString($title);
+		$this->assertEquals('Memberships', $title);
+	}
+
+	/**
+	 * Test get_menu_title returns string.
+	 */
+	public function test_get_menu_title(): void {
+		$title = $this->page->get_menu_title();
+
+		$this->assertIsString($title);
+		$this->assertEquals('Memberships', $title);
+	}
+
+	/**
+	 * Test get_submenu_title returns string.
+	 */
+	public function test_get_submenu_title(): void {
+		$title = $this->page->get_submenu_title();
+
+		$this->assertIsString($title);
+		$this->assertEquals('Memberships', $title);
+	}
+
+	/**
+	 * Test get_labels returns array.
+	 */
+	public function test_get_labels(): void {
+		$labels = $this->page->get_labels();
+
+		$this->assertIsArray($labels);
+		$this->assertArrayHasKey('deleted_message', $labels);
+		$this->assertArrayHasKey('search_label', $labels);
+	}
+
+	/**
+	 * Test action_links returns array.
+	 */
+	public function test_action_links(): void {
+		$links = $this->page->action_links();
+
+		$this->assertIsArray($links);
+		$this->assertCount(1, $links);
+	}
+
+	/**
+	 * Test action_links has add membership link.
+	 */
+	public function test_action_links_add_membership(): void {
+		$links = $this->page->action_links();
+
+		$this->assertEquals('Add Membership', $links[0]['label']);
+		$this->assertArrayHasKey('url', $links[0]);
+		$this->assertArrayHasKey('icon', $links[0]);
+	}
+
+	/**
+	 * Test table returns list table instance.
+	 */
+	public function test_table(): void {
+		$table = $this->page->table();
+
+		$this->assertInstanceOf(\WP_Ultimo\List_Tables\Membership_List_Table::class, $table);
+	}
+
+	/**
+	 * Test supported_panels contains network_admin_menu.
+	 */
+	public function test_supported_panels(): void {
+		$reflection = new \ReflectionClass($this->page);
+		$property   = $reflection->getProperty('supported_panels');
+		$property->setAccessible(true);
+
+		$panels = $property->getValue($this->page);
+		$this->assertArrayHasKey('network_admin_menu', $panels);
+		$this->assertEquals('wu_read_memberships', $panels['network_admin_menu']);
+	}
+
+	/**
+	 * Test badge_count is zero.
+	 */
+	public function test_badge_count(): void {
+		$reflection = new \ReflectionClass($this->page);
+		$property   = $reflection->getProperty('badge_count');
+		$property->setAccessible(true);
+
+		$this->assertEquals(0, $property->getValue($this->page));
+	}
+}

--- a/tests/WP_Ultimo/Admin_Pages/Site_Edit_Admin_Page_Test.php
+++ b/tests/WP_Ultimo/Admin_Pages/Site_Edit_Admin_Page_Test.php
@@ -1,0 +1,115 @@
+<?php
+/**
+ * Tests for Site_Edit_Admin_Page class.
+ *
+ * @package WP_Ultimo\Tests
+ */
+
+namespace WP_Ultimo\Admin_Pages;
+
+use WP_UnitTestCase;
+
+/**
+ * Test class for Site_Edit_Admin_Page.
+ */
+class Site_Edit_Admin_Page_Test extends WP_UnitTestCase {
+
+	/**
+	 * @var Site_Edit_Admin_Page
+	 */
+	private $page;
+
+	/**
+	 * Set up test fixtures.
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+		$this->page = new Site_Edit_Admin_Page();
+	}
+
+	/**
+	 * Test page id is correct.
+	 */
+	public function test_page_id(): void {
+		$reflection = new \ReflectionClass($this->page);
+		$property   = $reflection->getProperty('id');
+		$property->setAccessible(true);
+
+		$this->assertEquals('wp-ultimo-edit-site', $property->getValue($this->page));
+	}
+
+	/**
+	 * Test page type is submenu.
+	 */
+	public function test_page_type(): void {
+		$reflection = new \ReflectionClass($this->page);
+		$property   = $reflection->getProperty('type');
+		$property->setAccessible(true);
+
+		$this->assertEquals('submenu', $property->getValue($this->page));
+	}
+
+	/**
+	 * Test get_title returns add new string when not in edit mode.
+	 */
+	public function test_get_title_add_new(): void {
+		$reflection = new \ReflectionClass($this->page);
+		$property   = $reflection->getProperty('edit');
+		$property->setAccessible(true);
+		$property->setValue($this->page, false);
+
+		$title = $this->page->get_title();
+
+		$this->assertIsString($title);
+		$this->assertEquals('Add new Site', $title);
+	}
+
+	/**
+	 * Test get_title returns edit string when in edit mode.
+	 */
+	public function test_get_title_edit(): void {
+		$reflection = new \ReflectionClass($this->page);
+		$property   = $reflection->getProperty('edit');
+		$property->setAccessible(true);
+		$property->setValue($this->page, true);
+
+		$title = $this->page->get_title();
+
+		$this->assertIsString($title);
+		$this->assertEquals('Edit Site', $title);
+	}
+
+	/**
+	 * Test get_menu_title returns string.
+	 */
+	public function test_get_menu_title(): void {
+		$title = $this->page->get_menu_title();
+
+		$this->assertIsString($title);
+		$this->assertEquals('Edit Site', $title);
+	}
+
+	/**
+	 * Test supported_panels contains network_admin_menu.
+	 */
+	public function test_supported_panels(): void {
+		$reflection = new \ReflectionClass($this->page);
+		$property   = $reflection->getProperty('supported_panels');
+		$property->setAccessible(true);
+
+		$panels = $property->getValue($this->page);
+		$this->assertArrayHasKey('network_admin_menu', $panels);
+		$this->assertEquals('wu_edit_sites', $panels['network_admin_menu']);
+	}
+
+	/**
+	 * Test badge_count is zero.
+	 */
+	public function test_badge_count(): void {
+		$reflection = new \ReflectionClass($this->page);
+		$property   = $reflection->getProperty('badge_count');
+		$property->setAccessible(true);
+
+		$this->assertEquals(0, $property->getValue($this->page));
+	}
+}

--- a/tests/WP_Ultimo/Admin_Pages/Site_List_Admin_Page_Test.php
+++ b/tests/WP_Ultimo/Admin_Pages/Site_List_Admin_Page_Test.php
@@ -1,0 +1,146 @@
+<?php
+/**
+ * Tests for Site_List_Admin_Page class.
+ *
+ * @package WP_Ultimo\Tests
+ */
+
+namespace WP_Ultimo\Admin_Pages;
+
+use WP_UnitTestCase;
+
+/**
+ * Test class for Site_List_Admin_Page.
+ */
+class Site_List_Admin_Page_Test extends WP_UnitTestCase {
+
+	/**
+	 * @var Site_List_Admin_Page
+	 */
+	private $page;
+
+	/**
+	 * Set up test fixtures.
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+		$this->page = new Site_List_Admin_Page();
+	}
+
+	/**
+	 * Test page id is correct.
+	 */
+	public function test_page_id(): void {
+		$reflection = new \ReflectionClass($this->page);
+		$property   = $reflection->getProperty('id');
+		$property->setAccessible(true);
+
+		$this->assertEquals('wp-ultimo-sites', $property->getValue($this->page));
+	}
+
+	/**
+	 * Test page type is submenu.
+	 */
+	public function test_page_type(): void {
+		$reflection = new \ReflectionClass($this->page);
+		$property   = $reflection->getProperty('type');
+		$property->setAccessible(true);
+
+		$this->assertEquals('submenu', $property->getValue($this->page));
+	}
+
+	/**
+	 * Test get_title returns string.
+	 */
+	public function test_get_title(): void {
+		$title = $this->page->get_title();
+
+		$this->assertIsString($title);
+		$this->assertEquals('Sites', $title);
+	}
+
+	/**
+	 * Test get_menu_title returns string.
+	 */
+	public function test_get_menu_title(): void {
+		$title = $this->page->get_menu_title();
+
+		$this->assertIsString($title);
+		$this->assertEquals('Sites', $title);
+	}
+
+	/**
+	 * Test get_submenu_title returns string.
+	 */
+	public function test_get_submenu_title(): void {
+		$title = $this->page->get_submenu_title();
+
+		$this->assertIsString($title);
+		$this->assertEquals('Sites', $title);
+	}
+
+	/**
+	 * Test get_labels returns array.
+	 */
+	public function test_get_labels(): void {
+		$labels = $this->page->get_labels();
+
+		$this->assertIsArray($labels);
+		$this->assertArrayHasKey('deleted_message', $labels);
+		$this->assertArrayHasKey('search_label', $labels);
+	}
+
+	/**
+	 * Test action_links returns array.
+	 */
+	public function test_action_links(): void {
+		$links = $this->page->action_links();
+
+		$this->assertIsArray($links);
+		$this->assertGreaterThanOrEqual(1, count($links));
+	}
+
+	/**
+	 * Test action_links has add site link.
+	 */
+	public function test_action_links_add_site(): void {
+		$links = $this->page->action_links();
+
+		$this->assertEquals('Add Site', $links[0]['label']);
+		$this->assertArrayHasKey('url', $links[0]);
+		$this->assertArrayHasKey('icon', $links[0]);
+	}
+
+	/**
+	 * Test table returns list table instance.
+	 */
+	public function test_table(): void {
+		$table = $this->page->table();
+
+		$this->assertInstanceOf(\WP_Ultimo\List_Tables\Site_List_Table::class, $table);
+	}
+
+	/**
+	 * Test supported_panels contains network_admin_menu.
+	 */
+	public function test_supported_panels(): void {
+		$reflection = new \ReflectionClass($this->page);
+		$property   = $reflection->getProperty('supported_panels');
+		$property->setAccessible(true);
+
+		$panels = $property->getValue($this->page);
+		$this->assertArrayHasKey('network_admin_menu', $panels);
+		$this->assertEquals('wu_read_sites', $panels['network_admin_menu']);
+	}
+
+	/**
+	 * Test badge_count is zero.
+	 */
+	public function test_badge_count(): void {
+		$reflection = new \ReflectionClass($this->page);
+		$property   = $reflection->getProperty('badge_count');
+		$property->setAccessible(true);
+
+		$this->assertEquals(0, $property->getValue($this->page));
+	}
+}

--- a/tests/WP_Ultimo/Admin_Pages/Webhook_List_Admin_Page_Test.php
+++ b/tests/WP_Ultimo/Admin_Pages/Webhook_List_Admin_Page_Test.php
@@ -1,0 +1,146 @@
+<?php
+/**
+ * Tests for Webhook_List_Admin_Page class.
+ *
+ * @package WP_Ultimo\Tests
+ */
+
+namespace WP_Ultimo\Admin_Pages;
+
+use WP_UnitTestCase;
+
+/**
+ * Test class for Webhook_List_Admin_Page.
+ */
+class Webhook_List_Admin_Page_Test extends WP_UnitTestCase {
+
+	/**
+	 * @var Webhook_List_Admin_Page
+	 */
+	private $page;
+
+	/**
+	 * Set up test fixtures.
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+		$this->page = new Webhook_List_Admin_Page();
+	}
+
+	/**
+	 * Test page id is correct.
+	 */
+	public function test_page_id(): void {
+		$reflection = new \ReflectionClass($this->page);
+		$property   = $reflection->getProperty('id');
+		$property->setAccessible(true);
+
+		$this->assertEquals('wp-ultimo-webhooks', $property->getValue($this->page));
+	}
+
+	/**
+	 * Test page type is submenu.
+	 */
+	public function test_page_type(): void {
+		$reflection = new \ReflectionClass($this->page);
+		$property   = $reflection->getProperty('type');
+		$property->setAccessible(true);
+
+		$this->assertEquals('submenu', $property->getValue($this->page));
+	}
+
+	/**
+	 * Test get_title returns string.
+	 */
+	public function test_get_title(): void {
+		$title = $this->page->get_title();
+
+		$this->assertIsString($title);
+		$this->assertEquals('Webhooks', $title);
+	}
+
+	/**
+	 * Test get_menu_title returns string.
+	 */
+	public function test_get_menu_title(): void {
+		$title = $this->page->get_menu_title();
+
+		$this->assertIsString($title);
+		$this->assertEquals('Webhooks', $title);
+	}
+
+	/**
+	 * Test get_submenu_title returns string.
+	 */
+	public function test_get_submenu_title(): void {
+		$title = $this->page->get_submenu_title();
+
+		$this->assertIsString($title);
+		$this->assertEquals('Webhooks', $title);
+	}
+
+	/**
+	 * Test get_labels returns array.
+	 */
+	public function test_get_labels(): void {
+		$labels = $this->page->get_labels();
+
+		$this->assertIsArray($labels);
+		$this->assertArrayHasKey('deleted_message', $labels);
+		$this->assertArrayHasKey('search_label', $labels);
+	}
+
+	/**
+	 * Test action_links returns array.
+	 */
+	public function test_action_links(): void {
+		$links = $this->page->action_links();
+
+		$this->assertIsArray($links);
+		$this->assertCount(1, $links);
+	}
+
+	/**
+	 * Test action_links has add webhook link.
+	 */
+	public function test_action_links_add_webhook(): void {
+		$links = $this->page->action_links();
+
+		$this->assertEquals('Add New Webhook', $links[0]['label']);
+		$this->assertArrayHasKey('url', $links[0]);
+		$this->assertArrayHasKey('icon', $links[0]);
+	}
+
+	/**
+	 * Test table returns list table instance.
+	 */
+	public function test_table(): void {
+		$table = $this->page->table();
+
+		$this->assertInstanceOf(\WP_Ultimo\List_Tables\Webhook_List_Table::class, $table);
+	}
+
+	/**
+	 * Test supported_panels contains network_admin_menu.
+	 */
+	public function test_supported_panels(): void {
+		$reflection = new \ReflectionClass($this->page);
+		$property   = $reflection->getProperty('supported_panels');
+		$property->setAccessible(true);
+
+		$panels = $property->getValue($this->page);
+		$this->assertArrayHasKey('network_admin_menu', $panels);
+		$this->assertEquals('wu_read_webhooks', $panels['network_admin_menu']);
+	}
+
+	/**
+	 * Test badge_count is zero.
+	 */
+	public function test_badge_count(): void {
+		$reflection = new \ReflectionClass($this->page);
+		$property   = $reflection->getProperty('badge_count');
+		$property->setAccessible(true);
+
+		$this->assertEquals(0, $property->getValue($this->page));
+	}
+}

--- a/tests/WP_Ultimo/SSO/Admin_Bar_Magic_Links_Test.php
+++ b/tests/WP_Ultimo/SSO/Admin_Bar_Magic_Links_Test.php
@@ -1,0 +1,59 @@
+<?php
+/**
+ * Tests for Admin_Bar_Magic_Links class.
+ *
+ * @package WP_Ultimo\Tests
+ */
+
+namespace WP_Ultimo\SSO;
+
+use WP_UnitTestCase;
+
+/**
+ * Test class for Admin_Bar_Magic_Links.
+ */
+class Admin_Bar_Magic_Links_Test extends WP_UnitTestCase {
+
+	/**
+	 * @var Admin_Bar_Magic_Links
+	 */
+	private $magic_links;
+
+	/**
+	 * Set up test fixtures.
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+		$this->magic_links = Admin_Bar_Magic_Links::get_instance();
+	}
+
+	/**
+	 * Test get_instance returns an Admin_Bar_Magic_Links instance.
+	 */
+	public function test_get_instance_returns_instance(): void {
+		$this->assertInstanceOf(Admin_Bar_Magic_Links::class, $this->magic_links);
+	}
+
+	/**
+	 * Test get_instance returns the same instance (singleton).
+	 */
+	public function test_get_instance_is_singleton(): void {
+		$instance1 = Admin_Bar_Magic_Links::get_instance();
+		$instance2 = Admin_Bar_Magic_Links::get_instance();
+
+		$this->assertSame($instance1, $instance2);
+	}
+
+	/**
+	 * Test modify_my_sites_menu does not throw when user is not logged in.
+	 */
+	public function test_modify_my_sites_menu_no_user(): void {
+		// Ensure no user is logged in.
+		wp_set_current_user(0);
+
+		$admin_bar = new \WP_Admin_Bar();
+		$this->magic_links->modify_my_sites_menu($admin_bar);
+
+		$this->assertTrue(true); // No exception thrown.
+	}
+}

--- a/tests/WP_Ultimo/SSO/Nav_Menu_Subsite_Links_Test.php
+++ b/tests/WP_Ultimo/SSO/Nav_Menu_Subsite_Links_Test.php
@@ -1,0 +1,85 @@
+<?php
+/**
+ * Tests for Nav_Menu_Subsite_Links class.
+ *
+ * @package WP_Ultimo\Tests
+ */
+
+namespace WP_Ultimo\SSO;
+
+use WP_UnitTestCase;
+
+/**
+ * Test class for Nav_Menu_Subsite_Links.
+ */
+class Nav_Menu_Subsite_Links_Test extends WP_UnitTestCase {
+
+	/**
+	 * @var Nav_Menu_Subsite_Links
+	 */
+	private $nav_menu;
+
+	/**
+	 * Set up test fixtures.
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+		$this->nav_menu = Nav_Menu_Subsite_Links::get_instance();
+	}
+
+	/**
+	 * Test get_instance returns a Nav_Menu_Subsite_Links instance.
+	 */
+	public function test_get_instance_returns_instance(): void {
+		$this->assertInstanceOf(Nav_Menu_Subsite_Links::class, $this->nav_menu);
+	}
+
+	/**
+	 * Test get_instance returns the same instance (singleton).
+	 */
+	public function test_get_instance_is_singleton(): void {
+		$instance1 = Nav_Menu_Subsite_Links::get_instance();
+		$instance2 = Nav_Menu_Subsite_Links::get_instance();
+
+		$this->assertSame($instance1, $instance2);
+	}
+
+	/**
+	 * Test META_KEY_SUBSITE_ID constant value.
+	 */
+	public function test_meta_key_constant(): void {
+		$this->assertEquals('_wu_subsite_id', Nav_Menu_Subsite_Links::META_KEY_SUBSITE_ID);
+	}
+
+	/**
+	 * Test CLASS_PREFIX constant value.
+	 */
+	public function test_class_prefix_constant(): void {
+		$this->assertEquals('wu-subsite-', Nav_Menu_Subsite_Links::CLASS_PREFIX);
+	}
+
+	/**
+	 * Test filter_menu_item_urls returns array.
+	 */
+	public function test_filter_menu_item_urls_returns_array(): void {
+		$result = $this->nav_menu->filter_menu_item_urls([], new \stdClass());
+
+		$this->assertIsArray($result);
+	}
+
+	/**
+	 * Test filter_menu_item_urls passes through items unchanged when no subsite items.
+	 */
+	public function test_filter_menu_item_urls_passthrough(): void {
+		$item       = new \stdClass();
+		$item->ID   = 1;
+		$item->url  = 'https://example.com';
+		$item->classes = [];
+
+		$items  = [$item];
+		$result = $this->nav_menu->filter_menu_item_urls($items, new \stdClass());
+
+		$this->assertCount(1, $result);
+		$this->assertEquals('https://example.com', $result[0]->url);
+	}
+}

--- a/tests/WP_Ultimo/Template_Library/Template_Library_Test.php
+++ b/tests/WP_Ultimo/Template_Library/Template_Library_Test.php
@@ -1,0 +1,74 @@
+<?php
+/**
+ * Tests for Template_Library class.
+ *
+ * @package WP_Ultimo\Tests
+ */
+
+namespace WP_Ultimo\Template_Library;
+
+use WP_UnitTestCase;
+
+/**
+ * Test class for Template_Library.
+ */
+class Template_Library_Test extends WP_UnitTestCase {
+
+	/**
+	 * @var Template_Library
+	 */
+	private $library;
+
+	/**
+	 * Set up test fixtures.
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+		$this->library = Template_Library::get_instance();
+		$this->library->init();
+	}
+
+	/**
+	 * Test get_instance returns a Template_Library instance.
+	 */
+	public function test_get_instance_returns_instance(): void {
+		$this->assertInstanceOf(Template_Library::class, $this->library);
+	}
+
+	/**
+	 * Test get_instance returns the same instance (singleton).
+	 */
+	public function test_get_instance_is_singleton(): void {
+		$instance1 = Template_Library::get_instance();
+		$instance2 = Template_Library::get_instance();
+
+		$this->assertSame($instance1, $instance2);
+	}
+
+	/**
+	 * Test get_repository returns a Template_Repository instance.
+	 */
+	public function test_get_repository_returns_instance(): void {
+		$repository = $this->library->get_repository();
+
+		$this->assertInstanceOf(Template_Repository::class, $repository);
+	}
+
+	/**
+	 * Test is_template_installed returns false for unknown slug.
+	 */
+	public function test_is_template_installed_returns_false_for_unknown(): void {
+		$result = $this->library->is_template_installed('nonexistent-template-slug-xyz');
+
+		$this->assertFalse($result);
+	}
+
+	/**
+	 * Test clear_cache returns bool.
+	 */
+	public function test_clear_cache_returns_bool(): void {
+		$result = $this->library->clear_cache();
+
+		$this->assertIsBool($result);
+	}
+}

--- a/tests/WP_Ultimo/Template_Library/Template_Repository_Test.php
+++ b/tests/WP_Ultimo/Template_Library/Template_Repository_Test.php
@@ -1,0 +1,92 @@
+<?php
+/**
+ * Tests for Template_Repository class.
+ *
+ * @package WP_Ultimo\Tests
+ */
+
+namespace WP_Ultimo\Template_Library;
+
+use WP_UnitTestCase;
+
+/**
+ * Test class for Template_Repository.
+ */
+class Template_Repository_Test extends WP_UnitTestCase {
+
+	/**
+	 * @var Template_Repository
+	 */
+	private $repository;
+
+	/**
+	 * Set up test fixtures.
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+		$this->repository = new Template_Repository();
+	}
+
+	/**
+	 * Test get_installer returns a Template_Installer instance.
+	 */
+	public function test_get_installer_returns_instance(): void {
+		$installer = $this->repository->get_installer();
+
+		$this->assertInstanceOf(Template_Installer::class, $installer);
+	}
+
+	/**
+	 * Test get_api_client returns an API_Client instance.
+	 */
+	public function test_get_api_client_returns_instance(): void {
+		$client = $this->repository->get_api_client();
+
+		$this->assertInstanceOf(API_Client::class, $client);
+	}
+
+	/**
+	 * Test get_template returns null for unknown slug.
+	 */
+	public function test_get_template_returns_null_for_unknown(): void {
+		$result = $this->repository->get_template('nonexistent-template-slug-xyz');
+
+		$this->assertNull($result);
+	}
+
+	/**
+	 * Test get_templates_by_category returns array.
+	 */
+	public function test_get_templates_by_category_returns_array(): void {
+		$result = $this->repository->get_templates_by_category('nonexistent-category');
+
+		$this->assertIsArray($result);
+	}
+
+	/**
+	 * Test search_templates returns array.
+	 */
+	public function test_search_templates_returns_array(): void {
+		$result = $this->repository->search_templates('test');
+
+		$this->assertIsArray($result);
+	}
+
+	/**
+	 * Test get_categories returns array.
+	 */
+	public function test_get_categories_returns_array(): void {
+		$result = $this->repository->get_categories();
+
+		$this->assertIsArray($result);
+	}
+
+	/**
+	 * Test clear_cache returns bool.
+	 */
+	public function test_clear_cache_returns_bool(): void {
+		$result = $this->repository->clear_cache();
+
+		$this->assertIsBool($result);
+	}
+}


### PR DESCRIPTION
## Summary

- Adds 19 new test files covering previously untested classes to increase unit test coverage toward the 50% target
- Follows existing test patterns (`WP_UnitTestCase`, `ReflectionClass` for protected properties, standard assertion methods)
- Covers admin list pages, edit pages, admin utility classes, template library, and SSO classes

## New test files

**Admin list pages** (8 files):
- `Broadcast_List_Admin_Page_Test` — page id, type, title, labels, action_links, table, supported_panels
- `Discount_Code_List_Admin_Page_Test` — same pattern
- `Domain_List_Admin_Page_Test` — same pattern
- `Email_List_Admin_Page_Test` — same pattern
- `Event_List_Admin_Page_Test` — same pattern
- `Membership_List_Admin_Page_Test` — same pattern
- `Site_List_Admin_Page_Test` — same pattern
- `Webhook_List_Admin_Page_Test` — same pattern

**Admin edit pages** (5 files):
- `Broadcast_Edit_Admin_Page_Test` — page id, type, title (add/edit modes), menu_title, action_links, supported_panels
- `Discount_Code_Edit_Admin_Page_Test` — same pattern
- `Domain_Edit_Admin_Page_Test` — same pattern
- `Email_Edit_Admin_Page_Test` — same pattern
- `Site_Edit_Admin_Page_Test` — same pattern

**Admin utility classes** (2 files):
- `Configuration_Checker_Test` — singleton, check_cookie_domain_configuration
- `Network_Usage_Columns_Test` — singleton, constants, add_plugins_column, add_themes_column, get_blogs_with_plugin/theme, get_blogs_data, clear_site_transient

**Template library** (2 files):
- `Template_Library_Test` — singleton, get_repository, is_template_installed, clear_cache
- `Template_Repository_Test` — get_installer, get_api_client, get_template, get_templates_by_category, search_templates, get_categories, clear_cache

**SSO** (2 files):
- `Admin_Bar_Magic_Links_Test` — singleton, modify_my_sites_menu (no-user guard)
- `Nav_Menu_Subsite_Links_Test` — singleton, constants, filter_menu_item_urls passthrough

Closes #448