### PR TITLE
feat(tax): implement universal tax as 'Apply to all countries' option in Tax Rates page

### DIFF
--- a/tests/WP_Ultimo/Functions/Tax_Functions_Test.php
+++ b/tests/WP_Ultimo/Functions/Tax_Functions_Test.php
@@ -177,4 +177,187 @@ class Tax_Functions_Test extends WP_UnitTestCase {
 
 		$this->assertIsArray($result);
 	}
+
+	/**
+	 * Test wu_get_applicable_tax_rates returns '*' rate as fallback when no country match.
+	 *
+	 * When a tax rate has country='*' (Apply to all countries) and no per-country
+	 * rate matches the customer's country, the '*' rate should be returned as a fallback.
+	 */
+	public function test_get_applicable_tax_rates_returns_wildcard_as_fallback(): void {
+
+		$tax_rates = [
+			'default' => [
+				'name'  => 'Default',
+				'rates' => [
+					[
+						'id'       => 'rate-wildcard',
+						'title'    => 'Universal Rate',
+						'country'  => '*',
+						'state'    => '',
+						'city'     => '',
+						'tax_rate' => 20,
+					],
+				],
+			],
+		];
+
+		wu_save_option('tax_rates', $tax_rates);
+
+		// Customer is in Germany — no per-country rate exists, so '*' should apply.
+		$result = wu_get_applicable_tax_rates('DE');
+
+		$this->assertIsArray($result);
+		$this->assertNotEmpty($result);
+		$this->assertEquals('Universal Rate', $result[0]['title']);
+		$this->assertEquals('*', $result[0]['country']);
+	}
+
+	/**
+	 * Test per-country rates take precedence over '*' (Apply to all countries) rate.
+	 *
+	 * When both a per-country rate and a '*' rate exist, the per-country rate
+	 * should be returned and the '*' rate should NOT be included.
+	 */
+	public function test_get_applicable_tax_rates_country_specific_takes_precedence_over_wildcard(): void {
+
+		$tax_rates = [
+			'default' => [
+				'name'  => 'Default',
+				'rates' => [
+					[
+						'id'       => 'rate-us',
+						'title'    => 'US Rate',
+						'country'  => 'US',
+						'state'    => '',
+						'city'     => '',
+						'tax_rate' => 10,
+					],
+					[
+						'id'       => 'rate-wildcard',
+						'title'    => 'Universal Rate',
+						'country'  => '*',
+						'state'    => '',
+						'city'     => '',
+						'tax_rate' => 20,
+					],
+				],
+			],
+		];
+
+		wu_save_option('tax_rates', $tax_rates);
+
+		// Customer is in the US — the per-country US rate should apply, not the wildcard.
+		$result = wu_get_applicable_tax_rates('US');
+
+		$this->assertIsArray($result);
+		$this->assertNotEmpty($result);
+		$this->assertEquals('US Rate', $result[0]['title']);
+		$this->assertEquals('US', $result[0]['country']);
+
+		// Wildcard should NOT be in the results when a country-specific rate matched.
+		$countries = array_column($result, 'country');
+		$this->assertNotContains('*', $countries);
+	}
+
+	/**
+	 * Test '*' rate is not returned when a per-country rate matches.
+	 *
+	 * Verifies the fallback-only nature: '*' only applies when no country-specific
+	 * rate exists for the customer's country.
+	 */
+	public function test_get_applicable_tax_rates_wildcard_not_returned_when_country_matches(): void {
+
+		$tax_rates = [
+			'default' => [
+				'name'  => 'Default',
+				'rates' => [
+					[
+						'id'       => 'rate-de',
+						'title'    => 'Germany Rate',
+						'country'  => 'DE',
+						'state'    => '',
+						'city'     => '',
+						'tax_rate' => 19,
+					],
+					[
+						'id'       => 'rate-wildcard',
+						'title'    => 'Universal Rate',
+						'country'  => '*',
+						'state'    => '',
+						'city'     => '',
+						'tax_rate' => 15,
+					],
+				],
+			],
+		];
+
+		wu_save_option('tax_rates', $tax_rates);
+
+		$result = wu_get_applicable_tax_rates('DE');
+
+		$this->assertCount(1, $result);
+		$this->assertEquals('Germany Rate', $result[0]['title']);
+	}
+
+	/**
+	 * Test '*' rate applies to any country with no specific rate configured.
+	 */
+	public function test_get_applicable_tax_rates_wildcard_applies_to_any_unmatched_country(): void {
+
+		$tax_rates = [
+			'default' => [
+				'name'  => 'Default',
+				'rates' => [
+					[
+						'id'       => 'rate-wildcard',
+						'title'    => 'Universal Rate',
+						'country'  => '*',
+						'state'    => '',
+						'city'     => '',
+						'tax_rate' => 10,
+					],
+				],
+			],
+		];
+
+		wu_save_option('tax_rates', $tax_rates);
+
+		foreach (['BR', 'JP', 'AU', 'CA'] as $country) {
+			$result = wu_get_applicable_tax_rates($country);
+
+			$this->assertNotEmpty($result, "Expected wildcard rate to apply for country: $country");
+			$this->assertEquals('*', $result[0]['country'], "Expected '*' country for: $country");
+		}
+	}
+
+	/**
+	 * Test no rates returned when no country match and no '*' rate configured.
+	 */
+	public function test_get_applicable_tax_rates_empty_when_no_match_and_no_wildcard(): void {
+
+		$tax_rates = [
+			'default' => [
+				'name'  => 'Default',
+				'rates' => [
+					[
+						'id'       => 'rate-us',
+						'title'    => 'US Rate',
+						'country'  => 'US',
+						'state'    => '',
+						'city'     => '',
+						'tax_rate' => 10,
+					],
+				],
+			],
+		];
+
+		wu_save_option('tax_rates', $tax_rates);
+
+		// Customer is in Germany — no US rate applies, no wildcard configured.
+		$result = wu_get_applicable_tax_rates('DE');
+
+		$this->assertIsArray($result);
+		$this->assertEmpty($result);
+	}
 }


### PR DESCRIPTION
## Summary

Implements the 'Apply to all countries' universal tax fallback feature requested in issue #455.

## What was already implemented

After reviewing the codebase, the core feature was already present:

- **`views/taxes/list.php`** — Country dropdown already includes `<option value="*">Apply to all countries</option>` as the first option
- **`inc/functions/tax.php`** — `wu_get_applicable_tax_rates()` already has fallback logic: when no country-specific rate matches, any rate with `country='*'` is applied as a universal fallback
- **`lang/ultimate-multisite.pot`** — "Apply to all countries" string already present at line 22517

This is the correct dropdown-option approach requested by the maintainer (not the separate settings toggle approach from closed PR #277).

## What this PR adds

**Tests** (`tests/WP_Ultimo/Functions/Tax_Functions_Test.php`) — 5 new test cases covering the `'*'` wildcard country behavior:

1. `test_get_applicable_tax_rates_returns_wildcard_as_fallback` — wildcard rate returned when no country-specific match
2. `test_get_applicable_tax_rates_country_specific_takes_precedence_over_wildcard` — per-country rates take precedence
3. `test_get_applicable_tax_rates_wildcard_not_returned_when_country_matches` — wildcard excluded when country matches
4. `test_get_applicable_tax_rates_wildcard_applies_to_any_unmatched_country` — wildcard applies to any unmatched country (BR, JP, AU, CA)
5. `test_get_applicable_tax_rates_empty_when_no_match_and_no_wildcard` — empty result when no match and no wildcard

## Acceptance criteria

- [x] 'Apply to all countries' option appears in country dropdown on Tax Rates page
- [x] Selecting it applies the rate universally as a fallback
- [x] Existing per-country rates still take precedence
- [x] Translations updated for new strings (already in POT file)

## Reference

- Closes #455
- Supersedes closed PR #277 (separate settings toggle approach — rejected by maintainer)