### PR TITLE
fix: add pull-requests:write permission to WP Performance Metrics job

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -101,6 +101,9 @@ jobs:
     name: WP Performance Metrics
     runs-on: ubuntu-latest
     continue-on-error: true
+    permissions:
+      contents: read
+      pull-requests: write
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
## Summary

- Adds `permissions` block to the `wp-performance` job in `.github/workflows/tests.yml`
- Grants `pull-requests: write` so the `swissspidy/wp-performance-action@v2` action can post PR comments
- Grants `contents: read` (least-privilege, required for `actions/checkout`)

## Root Cause

The `wp-performance` job runs `swissspidy/wp-performance-action@v2` with `create-comment: ${{ github.event_name == 'pull_request' }}`. On PR events the action attempts to post a comment via the GitHub Issues API. Without an explicit `pull-requests: write` permission the default restricted token scope causes:

```
RequestError [HttpError]: Resource not accessible by integration
URL: https://api.github.com/repos/Ultimate-Multisite/ultimate-multisite/issues/470/comments
```

## Fix

```yaml
permissions:
  contents: read
  pull-requests: write
```

Added at job level (not workflow level) to keep the scope minimal — only the `wp-performance` job needs write access.

## Testing

The fix will be verified by the next PR run: the `WP Performance Metrics` job should complete without the `Resource not accessible by integration` error and successfully post its comment.

Closes #471