### PR TITLE
feat: implement WordPress Command Palette to replace Jumper navigation (#474)

### DIFF
--- a/assets/js/command-palette.js
+++ b/assets/js/command-palette.js
@@ -1,0 +1,335 @@
+/**
+ * Command Palette Integration for Ultimate Multisite
+ *
+ * Registers dynamic commands for searching entities using WordPress Command Palette.
+ *
+ * @package WP_Ultimo
+ * @since 2.1.0
+ */
+
+(function (wp) {
+	'use strict';
+
+	// Check if wp.commands is available
+	if (!wp || !wp.commands || !wp.element) {
+		console.log('[Ultimate Multisite] Command palette not available - wp.commands or wp.element missing');
+		return;
+	}
+
+	console.log('[Ultimate Multisite] Command palette API detected, initializing...');
+
+	const { useState, useEffect, useRef } = wp.element;
+	const { __ } = wp.i18n;
+	const apiFetch = wp.apiFetch;
+
+	// Get configuration from localized script
+	const config = window.wuCommandPalette || {};
+	const entities = config.entities || {};
+	const restUrl = config.restUrl || '';
+	const networkAdminUrl = config.networkAdminUrl || '';
+	const customLinks = config.customLinks || [];
+
+	console.log('[Ultimate Multisite] Configuration loaded:', {
+		entitiesCount: Object.keys(entities).length,
+		restUrl: restUrl,
+		customLinksCount: customLinks.length,
+		entities: entities
+	});
+
+	/**
+	 * Custom hook for searching entities.
+	 * Called by the command palette with search parameter.
+	 *
+	 * @param {Object} params Parameters object.
+	 * @param {string} params.search The search term.
+	 * @return {Object} Commands and loading state.
+	 */
+	function useEntitySearch({ search }) {
+		const [commands, setCommands] = useState([]);
+		const [isLoading, setIsLoading] = useState(false);
+		const searchTimeoutRef = useRef(null);
+		const cacheRef = useRef({});
+
+		useEffect(() => {
+			// Clear any pending timeouts
+			if (searchTimeoutRef.current) {
+				clearTimeout(searchTimeoutRef.current);
+			}
+
+			// Minimum 2 characters required
+			if (!search || search.length < 2) {
+				setCommands([]);
+				setIsLoading(false);
+				return;
+			}
+
+			// Check cache
+			if (cacheRef.current[search]) {
+				setCommands(cacheRef.current[search]);
+				setIsLoading(false);
+				return;
+			}
+
+			// Debounce: wait 300ms before searching
+			setIsLoading(true);
+
+			searchTimeoutRef.current = setTimeout(() => {
+				const searchUrl = restUrl + '?' + new URLSearchParams({
+					query: search,
+					limit: 15
+				}).toString();
+
+				console.log('[Ultimate Multisite] Searching:', searchUrl);
+
+				apiFetch({
+					url: searchUrl
+				})
+					.then((response) => {
+						console.log('[Ultimate Multisite] Search response:', response);
+						const results = response.results || [];
+
+						const cmds = results.map((result) => {
+							const cmd = {
+								name: 'ultimate-multisite/' + result.type + '-' + result.id,
+								label: result.title,
+								searchLabel: result.title + ' ' + result.subtitle,
+								callback: ({ close }) => {
+									close();
+									window.location.href = result.url;
+								}
+							};
+
+							// Add icon if available
+							const icon = getIcon(result.icon);
+							if (icon) {
+								cmd.icon = icon;
+							}
+
+							return cmd;
+						});
+
+						// Cache the results
+						cacheRef.current[search] = cmds;
+
+						console.log('[Ultimate Multisite] Commands generated:', cmds.length);
+						setCommands(cmds);
+						setIsLoading(false);
+					})
+					.catch((error) => {
+						console.error('[Ultimate Multisite] Search error:', error);
+						setCommands([]);
+						setIsLoading(false);
+					});
+			}, 300);
+
+			return () => {
+				if (searchTimeoutRef.current) {
+					clearTimeout(searchTimeoutRef.current);
+				}
+			};
+		}, [search]);
+
+		return {
+			commands,
+			isLoading
+		};
+	}
+
+	/**
+	 * Get icon component for command palette.
+	 *
+	 * WordPress command palette expects icon components from @wordpress/icons package.
+	 * We'll map dashicon names to WordPress icons when available.
+	 *
+	 * @param {string} icon Dashicon name.
+	 * @return {Object|undefined} WordPress icon component or undefined.
+	 */
+	function getIcon(icon) {
+		// Check if @wordpress/icons is available
+		if (!wp.icons) {
+			console.log('[Ultimate Multisite] wp.icons not available');
+			return undefined;
+		}
+
+		// Map dashicon names to @wordpress/icons
+		const iconMap = {
+			'admin-users': wp.icons.people,
+			'admin-multisite': wp.icons.layout,
+			'id-alt': wp.icons.card,
+			'money-alt': wp.icons.payment,
+			'products': wp.icons.box,
+			'networking': wp.icons.globe,
+			'tickets-alt': wp.icons.tag,
+			'rest-api': wp.icons.code,
+			'megaphone': wp.icons.megaphone,
+			'feedback': wp.icons.commentContent,
+			'dashboard': wp.icons.home,
+			'admin-settings': wp.icons.settings,
+			'info': wp.icons.info,
+			'external': wp.icons.external
+		};
+
+		const mappedIcon = iconMap[icon];
+		if (!mappedIcon) {
+			console.log('[Ultimate Multisite] Icon not found:', icon);
+		}
+
+		return mappedIcon || undefined;
+	}
+
+	/**
+	 * Register the entity search command loader.
+	 */
+	function registerEntitySearchLoader() {
+		if (!wp.data || !wp.data.dispatch || !wp.commands || !wp.commands.store) {
+			return;
+		}
+
+		const { registerCommandLoader } = wp.data.dispatch(wp.commands.store);
+
+		registerCommandLoader({
+			name: 'ultimate-multisite/entity-search',
+			hook: useEntitySearch
+		});
+
+		console.log('[Ultimate Multisite] Command loader registered');
+	}
+
+	/**
+	 * Register static commands for custom links.
+	 */
+	function registerCustomLinks() {
+		if (!customLinks || customLinks.length === 0) {
+			return;
+		}
+
+		const { registerCommand } = wp.data.dispatch(wp.commands.store);
+
+		customLinks.forEach((link, index) => {
+			const cmd = {
+				name: 'ultimate-multisite/custom-link-' + index,
+				label: link.title,
+				callback: ({ close }) => {
+					close();
+					window.location.href = link.url;
+				}
+			};
+
+			// Add external link icon
+			const icon = getIcon('external');
+			if (icon) {
+				cmd.icon = icon;
+			}
+
+			registerCommand(cmd);
+		});
+	}
+
+	/**
+	 * Register static commands for Ultimate Multisite pages.
+	 */
+	function registerStaticCommands() {
+		if (!wp.data || !wp.data.dispatch || !wp.commands || !wp.commands.store) {
+			return;
+		}
+
+		const { registerCommand } = wp.data.dispatch(wp.commands.store);
+
+		// Register common Ultimate Multisite pages
+		const staticCommands = [];
+
+		// Dashboard command
+		const dashboardCmd = {
+			name: 'ultimate-multisite/dashboard',
+			label: __('Ultimate Multisite Dashboard', 'ultimate-multisite'),
+			callback: ({ close }) => {
+				close();
+				window.location.href = networkAdminUrl + 'admin.php?page=wp-ultimo';
+			}
+		};
+		const dashboardIcon = getIcon('dashboard');
+		if (dashboardIcon) dashboardCmd.icon = dashboardIcon;
+		staticCommands.push(dashboardCmd);
+
+		// Settings command
+		const settingsCmd = {
+			name: 'ultimate-multisite/settings',
+			label: __('Ultimate Multisite Settings', 'ultimate-multisite'),
+			callback: ({ close }) => {
+				close();
+				window.location.href = networkAdminUrl + 'admin.php?page=wp-ultimo-settings';
+			}
+		};
+		const settingsIcon = getIcon('admin-settings');
+		if (settingsIcon) settingsCmd.icon = settingsIcon;
+		staticCommands.push(settingsCmd);
+
+		// System info command
+		const systemInfoCmd = {
+			name: 'ultimate-multisite/system-info',
+			label: __('System Information', 'ultimate-multisite'),
+			callback: ({ close }) => {
+				close();
+				window.location.href = networkAdminUrl + 'admin.php?page=wp-ultimo-system-info';
+			}
+		};
+		const systemInfoIcon = getIcon('info');
+		if (systemInfoIcon) systemInfoCmd.icon = systemInfoIcon;
+		staticCommands.push(systemInfoCmd);
+
+		// Register list pages for each entity type
+		Object.keys(entities).forEach((slug) => {
+			const entity = entities[slug];
+
+			const cmd = {
+				name: 'ultimate-multisite/list-' + slug,
+				label: entity.label_plural || entity.label + 's',
+				callback: ({ close }) => {
+					close();
+					window.location.href = networkAdminUrl + 'admin.php?page=wu-' + slug.replace(/_/g, '-') + 's';
+				}
+			};
+
+			// Add icon if available
+			const icon = getIcon(entity.icon);
+			if (icon) {
+				cmd.icon = icon;
+			}
+
+			staticCommands.push(cmd);
+		});
+
+		// Register all static commands
+		staticCommands.forEach((command) => {
+			try {
+				registerCommand(command);
+			} catch (error) {
+				console.error('Error registering command:', command.name, error);
+			}
+		});
+	}
+
+	/**
+	 * Initialize command palette integration.
+	 */
+	function init() {
+		// Wait for DOM to be ready
+		if (document.readyState === 'loading') {
+			document.addEventListener('DOMContentLoaded', init);
+			return;
+		}
+
+		// Register entity search loader (dynamic commands)
+		registerEntitySearchLoader();
+
+		// Register static commands
+		registerStaticCommands();
+
+		// Register custom links
+		registerCustomLinks();
+	}
+
+	// Initialize
+	init();
+
+})(window.wp);

--- a/inc/apis/class-command-palette-rest-controller.php
+++ b/inc/apis/class-command-palette-rest-controller.php
@@ -1,0 +1,269 @@
+<?php
+/**
+ * Command Palette REST Controller
+ *
+ * Handles REST API endpoints for command palette search functionality.
+ *
+ * @package WP_Ultimo
+ * @subpackage Apis
+ * @since 2.1.0
+ */
+
+namespace WP_Ultimo\Apis;
+
+// Exit if accessed directly
+defined('ABSPATH') || exit;
+
+/**
+ * Command Palette REST Controller class.
+ *
+ * @since 2.1.0
+ */
+class Command_Palette_Rest_Controller {
+
+	use \WP_Ultimo\Traits\Singleton;
+
+	/**
+	 * The namespace for this controller's routes.
+	 *
+	 * @since 2.1.0
+	 * @var string
+	 */
+	protected $namespace = 'ultimate-multisite/v1';
+
+	/**
+	 * The base for this controller's routes.
+	 *
+	 * @since 2.1.0
+	 * @var string
+	 */
+	protected $rest_base = 'command-palette';
+
+	/**
+	 * Initialize the singleton.
+	 *
+	 * @since 2.1.0
+	 * @return void
+	 */
+	public function init(): void {
+
+		add_action('rest_api_init', [$this, 'register_routes']);
+	}
+
+	/**
+	 * Register the routes for command palette.
+	 *
+	 * @since 2.1.0
+	 * @return void
+	 */
+	public function register_routes(): void {
+
+		register_rest_route(
+			$this->namespace,
+			'/' . $this->rest_base . '/search',
+			[
+				[
+					'methods'             => \WP_REST_Server::READABLE,
+					'callback'            => [$this, 'search'],
+					'permission_callback' => [$this, 'search_permissions_check'],
+					'args'                => $this->get_search_params(),
+				],
+			]
+		);
+	}
+
+	/**
+	 * Get the query params for search.
+	 *
+	 * @since 2.1.0
+	 * @return array
+	 */
+	public function get_search_params(): array {
+
+		return [
+			'query'       => [
+				'description'       => __('Search query string.', 'ultimate-multisite'),
+				'type'              => 'string',
+				'required'          => true,
+				'sanitize_callback' => 'sanitize_text_field',
+				'validate_callback' => function ($param) {
+					return strlen($param) >= 2;
+				},
+			],
+			'entity_type' => [
+				'description'       => __('Entity type to search (optional).', 'ultimate-multisite'),
+				'type'              => 'string',
+				'required'          => false,
+				'sanitize_callback' => 'sanitize_key',
+			],
+			'limit'       => [
+				'description'       => __('Maximum number of results to return.', 'ultimate-multisite'),
+				'type'              => 'integer',
+				'required'          => false,
+				'default'           => 15,
+				'minimum'           => 1,
+				'maximum'           => 20,
+				'sanitize_callback' => 'absint',
+			],
+		];
+	}
+
+	/**
+	 * Check permissions for search endpoint.
+	 *
+	 * Fix: return type is bool|\WP_Error, not strict bool.
+	 *
+	 * @since 2.1.0
+	 *
+	 * @param \WP_REST_Request $request The request object.
+	 * @return bool|\WP_Error
+	 */
+	public function search_permissions_check($request) {
+		unset($request);
+
+		if (! current_user_can('manage_network')) {
+			return new \WP_Error(
+				'rest_forbidden',
+				__('You do not have permission to search.', 'ultimate-multisite'),
+				['status' => 403]
+			);
+		}
+
+		return true;
+	}
+
+	/**
+	 * Handle search request.
+	 *
+	 * @since 2.1.0
+	 *
+	 * @param \WP_REST_Request $request The request object.
+	 * @return \WP_REST_Response|\WP_Error
+	 */
+	public function search($request) {
+
+		$query       = $request->get_param('query');
+		$entity_type = $request->get_param('entity_type');
+		$limit       = $request->get_param('limit') ?: 15;
+
+		// Minimum query length.
+		if (strlen($query) < 2) {
+			return rest_ensure_response(
+				[
+					'results' => [],
+					'message' => __('Query must be at least 2 characters.', 'ultimate-multisite'),
+				]
+			);
+		}
+
+		$results = [];
+
+		// Get registered entities from Command Palette Manager.
+		$manager  = \WP_Ultimo\UI\Command_Palette_Manager::get_instance();
+		$entities = $manager->get_registered_entities();
+
+		// If no entities registered, return empty results.
+		if (empty($entities)) {
+			return rest_ensure_response(
+				[
+					'results' => [],
+					'total'   => 0,
+					'message' => __('No searchable entities registered yet.', 'ultimate-multisite'),
+				]
+			);
+		}
+
+		// If entity_type is specified, search only that type.
+		if (! empty($entity_type) && isset($entities[ $entity_type ])) {
+			$results = $this->search_entity_type($entity_type, $query, $limit);
+		} else {
+			// Search all entity types.
+			$entity_count   = count($entities);
+			$per_type_limit = max(1, (int) floor($limit / $entity_count));
+
+			// Fix: use array_keys() to avoid unused $config variable.
+			foreach (array_keys($entities) as $slug) {
+				$entity_results = $this->search_entity_type($slug, $query, $per_type_limit);
+				$results        = array_merge($results, $entity_results);
+
+				// Stop if we've reached the limit.
+				if (count($results) >= $limit) {
+					break;
+				}
+			}
+
+			// Trim to limit.
+			$results = array_slice($results, 0, $limit);
+		}
+
+		/**
+		 * Filter command palette search results.
+		 *
+		 * @since 2.1.0
+		 *
+		 * @param array  $results     Search results.
+		 * @param string $query       Search query.
+		 * @param string $entity_type Entity type (empty if searching all).
+		 */
+		$results = apply_filters('wu_command_palette_search_results', $results, $query, $entity_type);
+
+		return rest_ensure_response(
+			[
+				'results' => $results,
+				'total'   => count($results),
+			]
+		);
+	}
+
+	/**
+	 * Search a specific entity type.
+	 *
+	 * @since 2.1.0
+	 *
+	 * @param string $entity_slug Entity slug.
+	 * @param string $query       Search query.
+	 * @param int    $limit       Maximum results.
+	 * @return array
+	 */
+	protected function search_entity_type(string $entity_slug, string $query, int $limit): array {
+
+		// Get the manager class for this entity.
+		$manager_class = $this->get_manager_class($entity_slug);
+
+		if (! $manager_class || ! class_exists($manager_class)) {
+			return [];
+		}
+
+		$manager = $manager_class::get_instance();
+
+		if (! $manager || ! method_exists($manager, 'search_for_command_palette')) {
+			return [];
+		}
+
+		// Check user capability.
+		$config = $manager->get_command_palette_config();
+
+		if (! empty($config['capability']) && ! current_user_can($config['capability'])) {
+			return [];
+		}
+
+		return $manager->search_for_command_palette($query, $limit);
+	}
+
+	/**
+	 * Get the manager class name for an entity slug.
+	 *
+	 * @since 2.1.0
+	 *
+	 * @param string $entity_slug Entity slug.
+	 * @return string|null
+	 */
+	protected function get_manager_class(string $entity_slug): ?string {
+
+		$manager_name = str_replace(' ', '_', ucwords(str_replace(['_', '-'], ' ', $entity_slug)));
+
+		$class_name = "\\WP_Ultimo\\Managers\\{$manager_name}_Manager";
+
+		return class_exists($class_name) ? $class_name : null;
+	}
+}

--- a/inc/apis/trait-command-palette.php
+++ b/inc/apis/trait-command-palette.php
@@ -1,0 +1,339 @@
+<?php
+/**
+ * A trait to be included in entities to enable Command Palette integration.
+ *
+ * @package WP_Ultimo
+ * @subpackage Apis
+ * @since 2.1.0
+ */
+
+namespace WP_Ultimo\Apis;
+
+// Exit if accessed directly
+defined('ABSPATH') || exit;
+
+/**
+ * Command Palette trait.
+ *
+ * This trait provides methods to register entities with the WordPress Command Palette
+ * for quick navigation and search functionality. It follows the same pattern as the
+ * Rest_Api and MCP_Abilities traits, allowing managers to expose their entities
+ * via the command palette.
+ *
+ * @since 2.1.0
+ */
+trait Command_Palette {
+
+	/**
+	 * Whether command palette is enabled for this entity.
+	 *
+	 * @since 2.1.0
+	 * @var bool
+	 */
+	protected $command_palette_enabled = true;
+
+	/**
+	 * Enable command palette for this entity.
+	 * Should be called by the manager to register with the command palette.
+	 *
+	 * @since 2.1.0
+	 * @return void
+	 */
+	public function enable_command_palette(): void {
+
+		if (! $this->command_palette_enabled) {
+			return;
+		}
+
+		// Register this entity with the Command Palette Manager.
+		add_action('init', [$this, 'register_with_command_palette_manager'], 20);
+	}
+
+	/**
+	 * Register this entity with the Command Palette Manager.
+	 *
+	 * @since 2.1.0
+	 * @return void
+	 */
+	public function register_with_command_palette_manager(): void {
+
+		$manager = \WP_Ultimo\UI\Command_Palette_Manager::get_instance();
+
+		if (! $manager) {
+			return;
+		}
+
+		$config = $this->get_command_palette_config();
+
+		if (empty($config)) {
+			return;
+		}
+
+		$manager->register_entity_type($this->slug, $config);
+	}
+
+	/**
+	 * Get the command palette configuration for this entity.
+	 * Managers can override this method to customize their configuration.
+	 *
+	 * @since 2.1.0
+	 * @return array
+	 */
+	public function get_command_palette_config(): array {
+
+		$display_name = $this->get_entity_display_name();
+
+		return [
+			'label'            => $display_name,
+			'label_plural'     => $this->get_entity_display_name_plural(),
+			'icon'             => $this->get_entity_icon(),
+			'edit_url_pattern' => $this->get_edit_url_pattern(),
+			'search_fields'    => $this->get_search_fields(),
+			'capability'       => "wu_read_{$this->slug}",
+		];
+	}
+
+	/**
+	 * Get the display name for this entity (singular).
+	 *
+	 * @since 2.1.0
+	 * @return string
+	 */
+	protected function get_entity_display_name(): string {
+
+		$name = str_replace(['_', '-'], ' ', $this->slug);
+
+		return ucfirst($name);
+	}
+
+	/**
+	 * Get the display name for this entity (plural).
+	 *
+	 * @since 2.1.0
+	 * @return string
+	 */
+	protected function get_entity_display_name_plural(): string {
+
+		return $this->get_entity_display_name() . 's';
+	}
+
+	/**
+	 * Get the dashicon for this entity.
+	 *
+	 * @since 2.1.0
+	 * @return string
+	 */
+	protected function get_entity_icon(): string {
+
+		$icons = [
+			'customer'      => 'admin-users',
+			'site'          => 'admin-multisite',
+			'membership'    => 'id-alt',
+			'payment'       => 'money-alt',
+			'product'       => 'products',
+			'domain'        => 'networking',
+			'discount_code' => 'tickets-alt',
+			'webhook'       => 'rest-api',
+			'broadcast'     => 'megaphone',
+			'checkout_form' => 'feedback',
+		];
+
+		return $icons[ $this->slug ] ?? 'admin-generic';
+	}
+
+	/**
+	 * Get the edit URL pattern for this entity.
+	 *
+	 * @since 2.1.0
+	 * @return string
+	 */
+	protected function get_edit_url_pattern(): string {
+
+		return "admin.php?page=wp-ultimo-edit-{$this->slug}&id=%d";
+	}
+
+	/**
+	 * Get the fields to search for this entity.
+	 *
+	 * @since 2.1.0
+	 * @return array
+	 */
+	protected function get_search_fields(): array {
+
+		$default_fields = ['name', 'display_name', 'title'];
+
+		// Entity-specific search fields.
+		$entity_fields = [
+			'customer'      => ['display_name', 'email', 'user_login'],
+			'site'          => ['title', 'domain', 'path'],
+			'membership'    => ['reference_code', 'customer_id'],
+			'payment'       => ['reference_code', 'customer_id'],
+			'product'       => ['name', 'slug'],
+			'domain'        => ['domain', 'primary_domain'],
+			'discount_code' => ['code', 'name'],
+			'webhook'       => ['name', 'webhook_url'],
+			'broadcast'     => ['title', 'slug'],
+			'checkout_form' => ['name', 'slug'],
+		];
+
+		return $entity_fields[ $this->slug ] ?? $default_fields;
+	}
+
+	/**
+	 * Search entities for the command palette.
+	 * This method is called by the REST controller.
+	 *
+	 * @since 2.1.0
+	 *
+	 * @param string $query The search query.
+	 * @param int    $limit Maximum number of results to return.
+	 * @return array Array of search results.
+	 */
+	public function search_for_command_palette(string $query, int $limit = 15): array {
+
+		if (strlen($query) < 2) {
+			return [];
+		}
+
+		// Use the existing model query function.
+		$getter_function = "wu_get_{$this->slug}s";
+
+		if (! function_exists($getter_function)) {
+			return [];
+		}
+
+		$results = call_user_func(
+			$getter_function,
+			[
+				'search' => "*{$query}*",
+				'number' => $limit,
+			]
+		);
+
+		if (empty($results)) {
+			return [];
+		}
+
+		return array_map([$this, 'format_result_for_command_palette'], $results);
+	}
+
+	/**
+	 * Format a single result for the command palette.
+	 *
+	 * @since 2.1.0
+	 *
+	 * @param object $item The entity object.
+	 * @return array Formatted result.
+	 */
+	protected function format_result_for_command_palette($item): array {
+
+		$config = $this->get_command_palette_config();
+
+		$title    = $this->get_item_title($item);
+		$subtitle = $this->get_item_subtitle($item);
+		$url      = $this->get_item_url($item, $config['edit_url_pattern']);
+
+		return [
+			'id'       => $item->get_id(),
+			'type'     => $this->slug,
+			'title'    => $title,
+			'subtitle' => $subtitle,
+			'url'      => $url,
+			'icon'     => $config['icon'],
+		];
+	}
+
+	/**
+	 * Get the display title for an item.
+	 *
+	 * @since 2.1.0
+	 *
+	 * @param object $item The entity object.
+	 * @return string
+	 */
+	protected function get_item_title($item): string {
+
+		if (method_exists($item, 'get_display_name')) {
+			return $item->get_display_name();
+		}
+
+		if (method_exists($item, 'get_title')) {
+			return $item->get_title();
+		}
+
+		if (method_exists($item, 'get_name')) {
+			return $item->get_name();
+		}
+
+		return sprintf('#%d', $item->get_id());
+	}
+
+	/**
+	 * Get the subtitle/description for an item.
+	 *
+	 * @since 2.1.0
+	 *
+	 * @param object $item The entity object.
+	 * @return string
+	 */
+	protected function get_item_subtitle($item): string {
+
+		$parts = [];
+
+		// Add ID.
+		// Translators: %d the id of the item.
+		$parts[] = sprintf(__('ID: %d', 'ultimate-multisite'), $item->get_id());
+
+		// Entity-specific subtitles.
+		switch ($this->slug) {
+			case 'customer':
+				if (method_exists($item, 'get_email_address')) {
+					$parts[] = $item->get_email_address();
+				}
+				break;
+
+			case 'site':
+				if (method_exists($item, 'get_domain')) {
+					$parts[] = $item->get_domain();
+				}
+				break;
+
+			case 'membership':
+			case 'payment':
+				if (method_exists($item, 'get_reference_code')) {
+					$parts[] = $item->get_reference_code();
+				}
+				break;
+
+			case 'domain':
+				if (method_exists($item, 'get_domain')) {
+					$parts[] = $item->get_domain();
+				}
+				break;
+
+			case 'discount_code':
+				if (method_exists($item, 'get_code')) {
+					$parts[] = $item->get_code();
+				}
+				break;
+		}
+
+		return implode(' • ', array_filter($parts));
+	}
+
+	/**
+	 * Get the edit URL for an item.
+	 *
+	 * @since 2.1.0
+	 *
+	 * @param object $item    The entity object.
+	 * @param string $pattern URL pattern with %d placeholder.
+	 * @return string
+	 */
+	protected function get_item_url($item, string $pattern): string {
+
+		$url = sprintf($pattern, $item->get_id());
+
+		return network_admin_url($url);
+	}
+}

--- a/inc/class-wp-ultimo.php
+++ b/inc/class-wp-ultimo.php
@@ -491,9 +491,14 @@ final class WP_Ultimo {
 		}
 
 		/*
-		 * Loads the Jumper UI
+		 * Loads the Command Palette (replaces legacy Jumper UI)
 		 */
-		WP_Ultimo\UI\Jumper::get_instance();
+		WP_Ultimo\UI\Command_Palette_Manager::get_instance();
+
+		/*
+		 * Loads the Command Palette REST controller
+		 */
+		WP_Ultimo\Apis\Command_Palette_Rest_Controller::get_instance();
 
 		/*
 		 * Loads the Template Previewer

--- a/inc/managers/class-broadcast-manager.php
+++ b/inc/managers/class-broadcast-manager.php
@@ -28,6 +28,7 @@ class Broadcast_Manager extends Base_Manager {
 	use \WP_Ultimo\Apis\Rest_Api;
 	use \WP_Ultimo\Apis\WP_CLI;
 	use \WP_Ultimo\Apis\MCP_Abilities;
+	use \WP_Ultimo\Apis\Command_Palette;
 	use \WP_Ultimo\Traits\Singleton;
 
 	/**
@@ -59,6 +60,8 @@ class Broadcast_Manager extends Base_Manager {
 		$this->enable_wp_cli();
 
 		$this->enable_mcp_abilities();
+
+		$this->enable_command_palette();
 
 		/**
 		 * Add unseen broadcast notices to the panel.

--- a/inc/managers/class-checkout-form-manager.php
+++ b/inc/managers/class-checkout-form-manager.php
@@ -25,6 +25,7 @@ class Checkout_Form_Manager extends Base_Manager {
 
 	use \WP_Ultimo\Apis\Rest_Api;
 	use \WP_Ultimo\Apis\WP_CLI;
+	use \WP_Ultimo\Apis\Command_Palette;
 	use \WP_Ultimo\Traits\Singleton;
 
 	/**
@@ -54,5 +55,7 @@ class Checkout_Form_Manager extends Base_Manager {
 		$this->enable_rest_api();
 
 		$this->enable_wp_cli();
+
+		$this->enable_command_palette();
 	}
 }

--- a/inc/managers/class-customer-manager.php
+++ b/inc/managers/class-customer-manager.php
@@ -28,6 +28,7 @@ class Customer_Manager extends Base_Manager {
 	use \WP_Ultimo\Apis\Rest_Api;
 	use \WP_Ultimo\Apis\WP_CLI;
 	use \WP_Ultimo\Apis\MCP_Abilities;
+	use \WP_Ultimo\Apis\Command_Palette;
 	use \WP_Ultimo\Traits\Singleton;
 
 	/**
@@ -59,6 +60,8 @@ class Customer_Manager extends Base_Manager {
 		$this->enable_wp_cli();
 
 		$this->enable_mcp_abilities();
+
+		$this->enable_command_palette();
 
 		add_action(
 			'init',

--- a/inc/managers/class-discount-code-manager.php
+++ b/inc/managers/class-discount-code-manager.php
@@ -27,6 +27,7 @@ class Discount_Code_Manager extends Base_Manager {
 	use \WP_Ultimo\Apis\Rest_Api;
 	use \WP_Ultimo\Apis\WP_CLI;
 	use \WP_Ultimo\Apis\MCP_Abilities;
+	use \WP_Ultimo\Apis\Command_Palette;
 	use \WP_Ultimo\Traits\Singleton;
 
 	/**
@@ -58,6 +59,8 @@ class Discount_Code_Manager extends Base_Manager {
 		$this->enable_wp_cli();
 
 		$this->enable_mcp_abilities();
+
+		$this->enable_command_palette();
 
 		add_action('wu_gateway_payment_processed', [$this, 'maybe_add_use_on_payment_received']);
 	}

--- a/inc/managers/class-domain-manager.php
+++ b/inc/managers/class-domain-manager.php
@@ -30,6 +30,7 @@ class Domain_Manager extends Base_Manager {
 	use \WP_Ultimo\Apis\Rest_Api;
 	use \WP_Ultimo\Apis\WP_CLI;
 	use \WP_Ultimo\Apis\MCP_Abilities;
+	use \WP_Ultimo\Apis\Command_Palette;
 	use \WP_Ultimo\Traits\Singleton;
 
 	/**
@@ -135,6 +136,8 @@ class Domain_Manager extends Base_Manager {
 		$this->enable_wp_cli();
 
 		$this->enable_mcp_abilities();
+
+		$this->enable_command_palette();
 
 		$this->set_cookie_domain();
 

--- a/inc/managers/class-membership-manager.php
+++ b/inc/managers/class-membership-manager.php
@@ -27,6 +27,7 @@ class Membership_Manager extends Base_Manager {
 	use \WP_Ultimo\Apis\Rest_Api;
 	use \WP_Ultimo\Apis\WP_CLI;
 	use \WP_Ultimo\Apis\MCP_Abilities;
+	use \WP_Ultimo\Apis\Command_Palette;
 	use \WP_Ultimo\Traits\Singleton;
 
 	const LOG_FILE_NAME = 'memberships';
@@ -59,6 +60,8 @@ class Membership_Manager extends Base_Manager {
 		$this->enable_wp_cli();
 
 		$this->enable_mcp_abilities();
+
+		$this->enable_command_palette();
 
 		add_action(
 			'init',

--- a/inc/managers/class-payment-manager.php
+++ b/inc/managers/class-payment-manager.php
@@ -31,6 +31,7 @@ class Payment_Manager extends Base_Manager {
 	use \WP_Ultimo\Apis\Rest_Api;
 	use \WP_Ultimo\Apis\WP_CLI;
 	use \WP_Ultimo\Apis\MCP_Abilities;
+	use \WP_Ultimo\Apis\Command_Palette;
 	use \WP_Ultimo\Traits\Singleton;
 
 	const LOG_FILE_NAME = 'payments';
@@ -63,6 +64,8 @@ class Payment_Manager extends Base_Manager {
 		$this->enable_wp_cli();
 
 		$this->enable_mcp_abilities();
+
+		$this->enable_command_palette();
 
 		$this->register_forms();
 

--- a/inc/managers/class-product-manager.php
+++ b/inc/managers/class-product-manager.php
@@ -27,6 +27,7 @@ class Product_Manager extends Base_Manager {
 	use \WP_Ultimo\Apis\Rest_Api;
 	use \WP_Ultimo\Apis\WP_CLI;
 	use \WP_Ultimo\Apis\MCP_Abilities;
+	use \WP_Ultimo\Apis\Command_Palette;
 	use \WP_Ultimo\Traits\Singleton;
 
 	/**
@@ -58,5 +59,7 @@ class Product_Manager extends Base_Manager {
 		$this->enable_wp_cli();
 
 		$this->enable_mcp_abilities();
+
+		$this->enable_command_palette();
 	}
 }

--- a/inc/managers/class-site-manager.php
+++ b/inc/managers/class-site-manager.php
@@ -29,6 +29,7 @@ class Site_Manager extends Base_Manager {
 	use \WP_Ultimo\Apis\Rest_Api;
 	use \WP_Ultimo\Apis\WP_CLI;
 	use \WP_Ultimo\Apis\MCP_Abilities;
+	use \WP_Ultimo\Apis\Command_Palette;
 	use \WP_Ultimo\Traits\Singleton;
 
 	/**
@@ -60,6 +61,8 @@ class Site_Manager extends Base_Manager {
 		$this->enable_wp_cli();
 
 		$this->enable_mcp_abilities();
+
+		$this->enable_command_palette();
 
 		add_action('after_setup_theme', [$this, 'additional_thumbnail_sizes']);
 

--- a/inc/managers/class-webhook-manager.php
+++ b/inc/managers/class-webhook-manager.php
@@ -27,6 +27,7 @@ class Webhook_Manager extends Base_Manager {
 	use \WP_Ultimo\Apis\Rest_Api;
 	use \WP_Ultimo\Apis\WP_CLI;
 	use \WP_Ultimo\Apis\MCP_Abilities;
+	use \WP_Ultimo\Apis\Command_Palette;
 	use \WP_Ultimo\Traits\Singleton;
 
 	/**
@@ -74,6 +75,8 @@ class Webhook_Manager extends Base_Manager {
 		$this->enable_wp_cli();
 
 		$this->enable_mcp_abilities();
+
+		$this->enable_command_palette();
 
 		add_action('init', [$this, 'register_webhook_listeners']);
 

--- a/inc/ui/class-command-palette-manager.php
+++ b/inc/ui/class-command-palette-manager.php
@@ -1,0 +1,248 @@
+<?php
+/**
+ * Command Palette Manager
+ *
+ * Manages WordPress Command Palette integration for Ultimate Multisite.
+ *
+ * @package WP_Ultimo
+ * @subpackage UI
+ * @since 2.1.0
+ */
+
+namespace WP_Ultimo\UI;
+
+// Exit if accessed directly
+defined('ABSPATH') || exit;
+
+/**
+ * Command Palette Manager class.
+ *
+ * @since 2.1.0
+ */
+class Command_Palette_Manager {
+
+	use \WP_Ultimo\Traits\Singleton;
+
+	/**
+	 * Registered entity types for command palette.
+	 *
+	 * @since 2.1.0
+	 * @var array
+	 */
+	protected $registered_entities = [];
+
+	/**
+	 * Initialize the singleton.
+	 *
+	 * @since 2.1.0
+	 * @return void
+	 */
+	public function init(): void {
+
+		add_action('admin_enqueue_scripts', [$this, 'enqueue_scripts'], 100);
+
+		add_action('init', [$this, 'add_settings'], 20);
+	}
+
+	/**
+	 * Check if command palette is available.
+	 * Uses feature detection instead of version checking.
+	 *
+	 * @since 2.1.0
+	 * @return bool
+	 */
+	public function is_command_palette_available(): bool {
+
+		global $wp_version;
+
+		// WordPress 6.4+ has Command Palette support (Gutenberg editor).
+		// WordPress 6.9+ has admin-wide command palette.
+		// We check for 6.4+ and let the JavaScript handle feature detection.
+		$is_available = version_compare($wp_version, '6.4', '>=');
+
+		/**
+		 * Filter whether command palette is available.
+		 *
+		 * @since 2.1.0
+		 *
+		 * @param bool $is_available Whether command palette is available.
+		 */
+		return apply_filters('wu_is_command_palette_available', $is_available);
+	}
+
+	/**
+	 * Check if we should load command palette in current context.
+	 *
+	 * @since 2.1.0
+	 * @return bool
+	 */
+	protected function should_load_command_palette(): bool {
+
+		// Only in admin.
+		if (! is_admin()) {
+			return false;
+		}
+
+		// Check feature availability.
+		if (! $this->is_command_palette_available()) {
+			return false;
+		}
+
+		// Check user capability.
+		if (! current_user_can('manage_network')) {
+			return false;
+		}
+
+		return true;
+	}
+
+	/**
+	 * Register an entity type for command palette search.
+	 *
+	 * @since 2.1.0
+	 *
+	 * @param string $slug   Entity slug (e.g., 'customer', 'site').
+	 * @param array  $config Entity configuration.
+	 * @return void
+	 */
+	public function register_entity_type(string $slug, array $config): void {
+
+		$this->registered_entities[ $slug ] = $config;
+	}
+
+	/**
+	 * Get all registered entity types.
+	 *
+	 * @since 2.1.0
+	 * @return array
+	 */
+	public function get_registered_entities(): array {
+
+		return $this->registered_entities;
+	}
+
+	/**
+	 * Enqueue command palette scripts and styles.
+	 *
+	 * @since 2.1.0
+	 * @return void
+	 */
+	public function enqueue_scripts(): void {
+
+		if (! $this->should_load_command_palette()) {
+			return;
+		}
+
+		// Enqueue command palette integration.
+		wp_enqueue_script(
+			'wu-command-palette',
+			wu_get_asset('command-palette.js', 'js'),
+			['wp-commands', 'wp-element', 'wp-i18n', 'wp-api-fetch', 'wp-components', 'wp-icons'],
+			wu_get_version(),
+			true
+		);
+
+		// Pass configuration to JavaScript.
+		wp_localize_script(
+			'wu-command-palette',
+			'wuCommandPalette',
+			[
+				'entities'        => $this->registered_entities,
+				'restUrl'         => rest_url('ultimate-multisite/v1/command-palette/search'),
+				'nonce'           => wp_create_nonce('wp_rest'),
+				'networkAdminUrl' => network_admin_url(),
+				'customLinks'     => $this->get_custom_links(),
+				'i18n'            => [
+					'searchPlaceholder' => __('Search anything...', 'ultimate-multisite'),
+					'noResults'         => __('No results found', 'ultimate-multisite'),
+					'minChars'          => __('Type at least 2 characters to search', 'ultimate-multisite'),
+				],
+			]
+		);
+	}
+
+	/**
+	 * Get custom links from settings.
+	 *
+	 * @since 2.1.0
+	 * @return array
+	 */
+	protected function get_custom_links(): array {
+
+		$saved_links = wu_get_setting('jumper_custom_links', '');
+
+		if (empty($saved_links)) {
+			return [];
+		}
+
+		$custom_links = [];
+		$lines        = explode(PHP_EOL, (string) $saved_links);
+
+		foreach ($lines as $line) {
+			$line = trim($line);
+
+			if (empty($line)) {
+				continue;
+			}
+
+			// Format: Title : URL
+			$parts = explode(':', $line, 2);
+
+			if (count($parts) === 2) {
+				$title = trim($parts[0]);
+				$url   = trim($parts[1]);
+
+				if (! empty($title) && ! empty($url)) {
+					$custom_links[] = [
+						'title' => $title,
+						'url'   => $url,
+					];
+				}
+			}
+		}
+
+		return $custom_links;
+	}
+
+	/**
+	 * Add command palette settings.
+	 *
+	 * @since 2.1.0
+	 * @return void
+	 */
+	public function add_settings(): void {
+
+		wu_register_settings_section(
+			'tools',
+			[
+				'title' => __('Tools', 'ultimate-multisite'),
+				'desc'  => __('Tools and utilities for managing your network.', 'ultimate-multisite'),
+				'icon'  => 'dashicons-wu-tools',
+			]
+		);
+
+		wu_register_settings_field(
+			'tools',
+			'command_palette_header',
+			[
+				'title' => __('Command Palette', 'ultimate-multisite'),
+				'desc'  => __('Quick navigation and search using WordPress Command Palette (Ctrl/Cmd+K).', 'ultimate-multisite'),
+				'type'  => 'header',
+			]
+		);
+
+		wu_register_settings_field(
+			'tools',
+			'jumper_custom_links',
+			[
+				'title'       => __('Custom Links', 'ultimate-multisite'),
+				'desc'        => __('Add custom links to the Command Palette. Add one per line, with the format "Title : URL".', 'ultimate-multisite'),
+				'placeholder' => __('My Custom Link : https://example.com', 'ultimate-multisite'),
+				'type'        => 'textarea',
+				'html_attr'   => [
+					'rows' => 4,
+				],
+			]
+		);
+	}
+}


### PR DESCRIPTION
## Summary

Implements the WordPress Command Palette (⌘K / Ctrl+K) as a replacement for the legacy Jumper navigation widget. The Command Palette provides quick access to all WP Ultimo entities, admin pages, settings, and custom links via the native WordPress command palette API (available since WordPress 6.4).

This is a clean reimplementation based on the closed WIP PR #285, with all CodeRabbit review findings addressed upfront.

## What was built

| Component | Description |
|-----------|-------------|
| `inc/ui/class-command-palette-manager.php` | Singleton manager: enqueues JS, passes config via `wp_localize_script`, registers settings section |
| `inc/apis/trait-command-palette.php` | Trait added to all 10 entity managers; registers each entity type and provides search/format methods |
| `inc/apis/class-command-palette-rest-controller.php` | REST endpoint at `ultimate-multisite/v1/command-palette/search` |
| `assets/js/command-palette.js` | Registers dynamic search loader (debounced, cached, 2-char minimum), static commands, and custom links |
| 10 entity managers | Added `use Command_Palette` trait + `enable_command_palette()` call |
| `inc/class-wp-ultimo.php` | Loads `Command_Palette_Manager` + `Command_Palette_Rest_Controller` instead of `Jumper::get_instance()` |

## CodeRabbit fixes applied (from PR #285 review)

- **JS**: `slug.replace('_', '-')` → `slug.replace(/_/g, '-')` to handle multi-underscore slugs (e.g. `checkout_form` → `checkout-forms`)
- **REST controller**: Removed strict `bool` return type from `search_permissions_check()` — actual return is `bool|\WP_Error` per WP REST API convention
- **REST controller**: `foreach ($entities as $slug => $config)` → `foreach (array_keys($entities) as $slug)` to avoid unused `$config` variable

## Design decisions

- **Jumper files preserved**: `jumper.css`, `jumper.js`, `class-jumper.php` are kept but no longer loaded. The AJAX search handlers in `class-ajax.php` (`search_models`, `render_selectize_templates`) are intentionally preserved — `selectizer.js` and `tax-rates.js` depend on them for selectize dropdowns throughout the admin.
- **Version-gated**: Requires WordPress 6.4+ (checked server-side); JavaScript uses feature detection (`wp.commands` availability check) for graceful degradation.
- **Capability**: Requires `manage_network` — network admins only.
- **Settings**: Reuses the existing `jumper_custom_links` setting key for backward compatibility with existing custom link configurations.

## Testing

1. Open any WP Ultimo admin page on WordPress 6.4+
2. Press Ctrl+K (or Cmd+K on Mac) to open the Command Palette
3. Type a customer name, site domain, or product name — results appear with debounce
4. Static commands: "Ultimate Multisite Dashboard", "Ultimate Multisite Settings", "System Information", entity list pages
5. Custom links: add entries in Settings → Tools → Command Palette

Closes #474
Ref: PR #285 (closed WIP)