### PR TITLE
feat: add addon management infrastructure (manifest, CI workflow, helper scripts)

### DIFF
--- a/.github/workflows/addon-integration-test.yml
+++ b/.github/workflows/addon-integration-test.yml
@@ -1,0 +1,274 @@
+name: Addon Integration Test
+
+# Reusable workflow for testing Ultimate Multisite addons.
+# Called by individual addon repos to run PHPUnit and E2E tests
+# against a full WordPress Multisite environment with the core plugin.
+#
+# Usage in addon repo (.github/workflows/ci.yml):
+#
+#   on: [push, pull_request]
+#   jobs:
+#     test:
+#       uses: Ultimate-Multisite/ultimate-multisite/.github/workflows/addon-integration-test.yml@main
+#       with:
+#         addon-slug: multisite-ultimate-plugin-and-theme-manager
+#       secrets: inherit
+
+on:
+  workflow_call:
+    inputs:
+      addon-slug:
+        description: "Addon directory name (e.g., multisite-ultimate-plugin-and-theme-manager)"
+        required: true
+        type: string
+      addon-ref:
+        description: "Git ref to checkout for the addon (default: triggering ref)"
+        required: false
+        type: string
+        default: ""
+      php-versions:
+        description: "JSON array of PHP versions to test"
+        required: false
+        type: string
+        default: '["8.2"]'
+      run-e2e:
+        description: "Whether to run E2E (Cypress) tests"
+        required: false
+        type: boolean
+        default: false
+      core-ref:
+        description: "Git ref for the core plugin (default: main)"
+        required: false
+        type: string
+        default: "main"
+
+jobs:
+  phpunit:
+    name: "PHPUnit (PHP ${{ matrix.php }})"
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        php: ${{ fromJson(inputs.php-versions) }}
+    services:
+      mysql:
+        image: mariadb:11.4
+        env:
+          MYSQL_ROOT_PASSWORD: root
+        ports: [3306]
+        options: >-
+          --health-cmd="healthcheck.sh --connect --innodb_initialized"
+          --health-interval=10s
+          --health-timeout=5s
+          --health-retries=5
+    container:
+      image: cimg/php:${{ matrix.php }}
+      options: --user root
+    steps:
+      - name: Checkout core plugin
+        uses: actions/checkout@v4
+        with:
+          repository: Ultimate-Multisite/ultimate-multisite
+          ref: ${{ inputs.core-ref }}
+          path: core
+
+      - name: Checkout addon
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.addon-ref || github.ref }}
+          path: addon
+
+      - name: Install system dependencies
+        run: apt-get update && apt-get install -y subversion mariadb-client
+
+      - name: Install PHP extensions
+        run: install-php-extensions mysqli gd bcmath || echo "Extensions may already be installed."
+
+      - name: Set up Composer global bin path
+        run: |
+          mkdir -p "$HOME/.config/composer/vendor/bin"
+          echo "PATH=$HOME/.config/composer/vendor/bin:$PATH" >> "$GITHUB_ENV"
+
+      - name: Install core Composer dependencies
+        working-directory: core
+        run: composer install --no-interaction --prefer-dist
+
+      - name: Install addon Composer dependencies
+        working-directory: addon
+        run: composer install --no-interaction --prefer-dist
+
+      - name: Wait for MySQL
+        run: |
+          for i in $(seq 1 30); do
+            if mysqladmin ping -h mysql --silent; then
+              echo "MySQL is up"
+              break
+            fi
+            echo "Waiting for MySQL... ($i/30)"
+            sleep 2
+          done
+
+      - name: Prepare WordPress test suite
+        working-directory: core
+        run: |
+          rm -rf /tmp/wordpress-tests-lib /tmp/wordpress/
+          bash bin/install-wp-tests.sh wordpress_test root root mysql latest
+          # Symlink core plugin into WP plugins dir
+          ln -s "$GITHUB_WORKSPACE/core" /tmp/wordpress/wp-content/plugins/ultimate-multisite
+          # Symlink addon into WP plugins dir
+          ln -s "$GITHUB_WORKSPACE/addon" "/tmp/wordpress/wp-content/plugins/${{ inputs.addon-slug }}"
+
+      - name: Run addon PHPUnit tests
+        working-directory: addon
+        run: |
+          if [[ -f phpunit.xml.dist ]] || [[ -f phpunit.xml ]]; then
+            vendor/bin/phpunit
+          else
+            echo "No phpunit.xml.dist found — skipping PHPUnit"
+          fi
+
+  e2e:
+    name: "E2E Tests"
+    if: inputs.run-e2e
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    services:
+      mailpit:
+        image: axllent/mailpit:latest
+        ports:
+          - 1025:1025
+          - 8025:8025
+        options: >-
+          --health-cmd="wget --spider -q http://localhost:8025 || exit 1"
+          --health-interval=2s
+          --health-timeout=2s
+          --health-retries=10
+    steps:
+      - name: Checkout core plugin
+        uses: actions/checkout@v4
+        with:
+          repository: Ultimate-Multisite/ultimate-multisite
+          ref: ${{ inputs.core-ref }}
+          path: core
+
+      - name: Checkout addon
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.addon-ref || github.ref }}
+          path: addon
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: 18
+
+      - name: Cache NPM dependencies
+        uses: actions/cache@v3
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-npm-e2e
+
+      - name: Install core NPM dependencies
+        working-directory: core
+        run: npm ci
+
+      - name: Install core Composer dependencies
+        working-directory: core
+        run: composer install --no-interaction --prefer-dist
+
+      - name: Install addon NPM dependencies
+        working-directory: addon
+        run: |
+          if [[ -f package.json ]]; then
+            npm ci
+          fi
+
+      - name: Install addon Composer dependencies
+        working-directory: addon
+        run: |
+          if [[ -f composer.json ]]; then
+            composer install --no-interaction --prefer-dist
+          fi
+
+      - name: Generate wp-env override for addon
+        working-directory: core
+        run: |
+          # Create override that includes core + this addon
+          cat > .wp-env.override.json <<ENDJSON
+          {
+            "env": {
+              "development": {
+                "plugins": [".", "../addon"]
+              },
+              "tests": {
+                "plugins": [".", "../addon"]
+              }
+            }
+          }
+          ENDJSON
+
+      - name: Start WordPress test environment
+        working-directory: core
+        run: npm run env:start:test
+
+      - name: Wait for WordPress to be ready
+        run: |
+          for i in $(seq 1 60); do
+            if curl -s http://localhost:8889 | grep -q "WordPress"; then
+              echo "WordPress is ready"
+              break
+            fi
+            echo "Waiting for WordPress... ($i/60)"
+            sleep 5
+          done
+
+      - name: Run core setup test (activates plugins)
+        working-directory: core
+        run: |
+          if [[ -f tests/e2e/cypress/integration/000-setup.spec.js ]]; then
+            npx cypress run \
+              --config-file cypress.config.test.js \
+              --spec "tests/e2e/cypress/integration/000-setup.spec.js" \
+              --browser chrome
+          fi
+
+      - name: Run addon E2E tests
+        working-directory: addon
+        run: |
+          if [[ -d tests/e2e ]] && [[ -f cypress.config.js ]]; then
+            npx cypress run --browser chrome
+          elif [[ -d tests/e2e ]]; then
+            # Use core's Cypress config with addon's test specs
+            cd "$GITHUB_WORKSPACE/core"
+            npx cypress run \
+              --config-file cypress.config.test.js \
+              --spec "$GITHUB_WORKSPACE/addon/tests/e2e/**/*.spec.js" \
+              --browser chrome
+          else
+            echo "No E2E tests found — skipping"
+          fi
+
+      - name: Upload Cypress screenshots
+        if: always()
+        continue-on-error: true
+        uses: actions/upload-artifact@v4
+        with:
+          name: cypress-screenshots-${{ inputs.addon-slug }}
+          path: |
+            core/tests/e2e/cypress/screenshots
+            addon/tests/e2e/cypress/screenshots
+
+      - name: Upload Cypress videos
+        if: always()
+        continue-on-error: true
+        uses: actions/upload-artifact@v4
+        with:
+          name: cypress-videos-${{ inputs.addon-slug }}
+          path: |
+            core/tests/e2e/cypress/videos
+            addon/tests/e2e/cypress/videos
+
+      - name: Stop WordPress environment
+        if: always()
+        working-directory: core
+        run: npm run env:stop

--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,6 @@ performance-report.md
 tests/simple-performance-results-*.json
 # AI agent loop state (framework artifacts)
 .agents/loop-state/
+
+# Generated wp-env override (addon-specific, not committed)
+.wp-env.override.json

--- a/.wp-env.json
+++ b/.wp-env.json
@@ -4,8 +4,7 @@
     "development": {
       "multisite": true,
       "plugins": [
-        ".",
-        "../addons/ultimate-multisite-domain-seller"
+        "."
       ],
       "mappings": {
         "wp-content/mu-plugins/email-smtp-dev.php": "./mu-plugins/email-smtp-dev/email-smtp-dev.php",
@@ -24,8 +23,7 @@
     "tests": {
       "multisite": true,
       "plugins": [
-        ".",
-        "../addons/ultimate-multisite-domain-seller"
+        "."
       ],
       "mappings": {
         "wp-content/mu-plugins/email-smtp-test.php": "./mu-plugins/email-smtp-test/email-smtp-test.php",

--- a/addons.json
+++ b/addons.json
@@ -1,0 +1,171 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "description": "Ultimate Multisite addon manifest. Used by bin/clone-addons.sh and CI workflows.",
+  "addons": [
+    {
+      "slug": "multisite-ultimate-admin-page-creator",
+      "description": "Admin page creator",
+      "active": true
+    },
+    {
+      "slug": "multisite-ultimate-affiliatewp",
+      "description": "AffiliateWP integration",
+      "active": true
+    },
+    {
+      "slug": "multisite-ultimate-ai-site-builder",
+      "description": "AI site builder",
+      "active": true
+    },
+    {
+      "slug": "multisite-ultimate-domain-seller",
+      "description": "Domain seller",
+      "active": true
+    },
+    {
+      "slug": "multisite-ultimate-gocardless",
+      "description": "GoCardless gateway",
+      "active": true
+    },
+    {
+      "slug": "multisite-ultimate-language-selector",
+      "description": "Language selector",
+      "active": true
+    },
+    {
+      "slug": "multisite-ultimate-mailchimp",
+      "description": "Mailchimp integration",
+      "active": true
+    },
+    {
+      "slug": "multisite-ultimate-metered-plans",
+      "description": "Metered plans",
+      "active": true
+    },
+    {
+      "slug": "multisite-ultimate-metrics-and-onboarding",
+      "description": "Metrics and onboarding",
+      "active": true
+    },
+    {
+      "slug": "multisite-ultimate-payfast",
+      "description": "Payfast gateway",
+      "active": true
+    },
+    {
+      "slug": "multisite-ultimate-plugin-and-theme-manager",
+      "description": "Plugin and theme manager",
+      "active": true
+    },
+    {
+      "slug": "multisite-ultimate-site-exporter",
+      "description": "Site exporter",
+      "active": true
+    },
+    {
+      "slug": "multisite-ultimate-support-agents",
+      "description": "Support agents",
+      "active": true
+    },
+    {
+      "slug": "multisite-ultimate-support-tickets",
+      "description": "Support tickets",
+      "active": true
+    },
+    {
+      "slug": "multisite-ultimate-vat",
+      "description": "Value added taxes",
+      "active": true
+    },
+    {
+      "slug": "ultimate-multisite-analytics",
+      "description": "Analytics",
+      "active": false
+    },
+    {
+      "slug": "ultimate-multisite-captcha",
+      "description": "Captcha",
+      "active": true
+    },
+    {
+      "slug": "ultimate-multisite-chuck-norris-facts",
+      "description": "Chuck Norris facts (example addon)",
+      "active": false
+    },
+    {
+      "slug": "ultimate-multisite-content-sync",
+      "description": "Content sync (Elementor templates)",
+      "active": true
+    },
+    {
+      "slug": "ultimate-multisite-emails",
+      "description": "Email account selling and provisioning",
+      "active": true
+    },
+    {
+      "slug": "ultimate-multisite-fluent-forms",
+      "description": "Fluent Forms checkout integration",
+      "active": true
+    },
+    {
+      "slug": "ultimate-multisite-gravity-forms",
+      "description": "Gravity Forms integration",
+      "active": false
+    },
+    {
+      "slug": "ultimate-multisite-loco-translate",
+      "description": "Loco Translate multisite features",
+      "active": true
+    },
+    {
+      "slug": "ultimate-multisite-mailster",
+      "description": "Mailster email marketing integration",
+      "active": true
+    },
+    {
+      "slug": "ultimate-multisite-multi-tenancy",
+      "description": "Multi-tenancy",
+      "active": false
+    },
+    {
+      "slug": "ultimate-multisite-multinetwork",
+      "description": "Create and sell whole networks",
+      "active": true
+    },
+    {
+      "slug": "ultimate-multisite-woocommerce",
+      "description": "WooCommerce integration",
+      "active": true
+    },
+    {
+      "slug": "multisite-ultimate-fluent-forms",
+      "description": "Fluent Forms (legacy, empty repo)",
+      "active": false
+    }
+  ],
+  "non_addon_repos": [
+    "ultimate-multisite",
+    "ultimate-multisite-addon-template",
+    "addon-deployment-tool",
+    "ultimate-update-server-plugin",
+    "hook-profiler",
+    "pro-themes",
+    "material-wp",
+    "tutor-multisite-compatibilty",
+    "wp-ultimo-v1",
+    "stripe-connect-proxy",
+    "wordpress-translated-tuned-llm",
+    "cron-service-plugin",
+    "opcache-preload-generator",
+    "gp-translate-with-openai",
+    "docs",
+    "the-perfect-wp-cron",
+    "ai-provider-for-any-compatible-endpoint",
+    "cli-abilities-bridge",
+    "gratis-ai-agent",
+    "trellis-cli",
+    "woocommerce-subscriptions-core",
+    "ultimate-ai-plugin-translations",
+    "ultimate-ai-translation-server"
+  ]
+}

--- a/bin/clone-addons.sh
+++ b/bin/clone-addons.sh
@@ -1,0 +1,159 @@
+#!/bin/bash
+# Clone or update all Ultimate Multisite addons into a sibling directory.
+#
+# Usage:
+#   bin/clone-addons.sh [--active-only] [--dir <path>] [--addon <slug>]
+#
+# Options:
+#   --active-only   Only clone addons marked "active": true in addons.json
+#   --dir <path>    Target directory (default: ../ultimate-multisite-addons)
+#   --addon <slug>  Clone/update a single addon by slug
+#
+# Requires: gh (GitHub CLI), jq
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+MANIFEST="$REPO_ROOT/addons.json"
+ORG="Ultimate-Multisite"
+
+# Defaults
+ADDONS_DIR=""
+ACTIVE_ONLY=false
+SINGLE_ADDON=""
+
+usage() {
+	echo "Usage: $0 [--active-only] [--dir <path>] [--addon <slug>]"
+	echo ""
+	echo "Options:"
+	echo "  --active-only   Only clone addons marked active in addons.json"
+	echo "  --dir <path>    Target directory (default: ../ultimate-multisite-addons)"
+	echo "  --addon <slug>  Clone/update a single addon by slug"
+	return 0
+}
+
+parse_args() {
+	while [[ $# -gt 0 ]]; do
+		case "$1" in
+		--active-only)
+			ACTIVE_ONLY=true
+			shift
+			;;
+		--dir)
+			ADDONS_DIR="$2"
+			shift 2
+			;;
+		--addon)
+			SINGLE_ADDON="$2"
+			shift 2
+			;;
+		-h | --help)
+			usage
+			exit 0
+			;;
+		*)
+			echo "Unknown option: $1" >&2
+			usage >&2
+			return 1
+			;;
+		esac
+	done
+	return 0
+}
+
+check_dependencies() {
+	local missing=false
+	if ! command -v gh >/dev/null 2>&1; then
+		echo "Error: gh (GitHub CLI) is required but not installed." >&2
+		missing=true
+	fi
+	if ! command -v jq >/dev/null 2>&1; then
+		echo "Error: jq is required but not installed." >&2
+		missing=true
+	fi
+	if [[ "$missing" == "true" ]]; then
+		return 1
+	fi
+	return 0
+}
+
+get_addon_slugs() {
+	local filter='.addons[].slug'
+	if [[ "$ACTIVE_ONLY" == "true" ]]; then
+		filter='.addons[] | select(.active == true) | .slug'
+	fi
+	if [[ -n "$SINGLE_ADDON" ]]; then
+		filter=".addons[] | select(.slug == \"$SINGLE_ADDON\") | .slug"
+	fi
+	jq -r "$filter" "$MANIFEST"
+}
+
+clone_or_update() {
+	local slug="$1"
+	local target="$ADDONS_DIR/$slug"
+
+	if [[ -d "$target/.git" ]]; then
+		echo "  Updating $slug..."
+		git -C "$target" fetch --quiet origin 2>/dev/null || true
+		local default_branch
+		default_branch=$(git -C "$target" symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's|refs/remotes/origin/||' || echo "main")
+		local current_branch
+		current_branch=$(git -C "$target" branch --show-current 2>/dev/null || echo "")
+		if [[ "$current_branch" == "$default_branch" ]]; then
+			git -C "$target" pull --quiet --ff-only origin "$default_branch" 2>/dev/null || true
+		fi
+		echo "  OK: $slug (existing)"
+	else
+		echo "  Cloning $slug..."
+		if gh repo clone "$ORG/$slug" "$target" -- --quiet 2>/dev/null; then
+			echo "  OK: $slug (cloned)"
+		else
+			echo "  SKIP: $slug (clone failed — repo may be empty)" >&2
+		fi
+	fi
+	return 0
+}
+
+main() {
+	parse_args "$@"
+	check_dependencies
+
+	if [[ -z "$ADDONS_DIR" ]]; then
+		ADDONS_DIR="$(cd "$REPO_ROOT/.." && pwd)/ultimate-multisite-addons"
+	fi
+
+	if [[ ! -f "$MANIFEST" ]]; then
+		echo "Error: Addon manifest not found at $MANIFEST" >&2
+		return 1
+	fi
+
+	echo "Addon directory: $ADDONS_DIR"
+	mkdir -p "$ADDONS_DIR"
+
+	local slugs
+	slugs=$(get_addon_slugs)
+
+	if [[ -z "$slugs" ]]; then
+		echo "No addons found matching criteria."
+		return 0
+	fi
+
+	local count=0
+	local total
+	total=$(echo "$slugs" | wc -l | tr -d ' ')
+	echo "Processing $total addon(s)..."
+	echo ""
+
+	while IFS= read -r slug; do
+		count=$((count + 1))
+		echo "[$count/$total] $slug"
+		clone_or_update "$slug"
+	done <<<"$slugs"
+
+	echo ""
+	echo "Done. $count addon(s) processed in $ADDONS_DIR"
+	return 0
+}
+
+main "$@"

--- a/bin/generate-wp-env-override.sh
+++ b/bin/generate-wp-env-override.sh
@@ -1,0 +1,178 @@
+#!/bin/bash
+# Generate .wp-env.override.json that includes discovered addons as plugins.
+#
+# Usage:
+#   bin/generate-wp-env-override.sh [--dir <addons-dir>] [--addon <slug>] [--php <version>]
+#
+# Options:
+#   --dir <path>      Addons directory (default: ../ultimate-multisite-addons)
+#   --addon <slug>    Include only this specific addon (plus core)
+#   --php <version>   Set PHP version in override (e.g., 8.1)
+#
+# Output: .wp-env.override.json in the repo root
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+# Defaults
+ADDONS_DIR=""
+SINGLE_ADDON=""
+PHP_VERSION=""
+
+parse_args() {
+	while [[ $# -gt 0 ]]; do
+		case "$1" in
+		--dir)
+			ADDONS_DIR="$2"
+			shift 2
+			;;
+		--addon)
+			SINGLE_ADDON="$2"
+			shift 2
+			;;
+		--php)
+			PHP_VERSION="$2"
+			shift 2
+			;;
+		-h | --help)
+			echo "Usage: $0 [--dir <addons-dir>] [--addon <slug>] [--php <version>]"
+			exit 0
+			;;
+		*)
+			echo "Unknown option: $1" >&2
+			return 1
+			;;
+		esac
+	done
+	return 0
+}
+
+find_plugin_dirs() {
+	local search_dir="$1"
+	local dirs=""
+
+	if [[ -n "$SINGLE_ADDON" ]]; then
+		local addon_path="$search_dir/$SINGLE_ADDON"
+		if [[ -d "$addon_path" ]]; then
+			# Verify it contains a PHP file with Plugin Name header
+			if grep -rl "Plugin Name:" "$addon_path"/*.php >/dev/null 2>&1; then
+				local rel_path
+				rel_path=$(python3 -c "import os.path; print(os.path.relpath('$addon_path', '$REPO_ROOT'))" 2>/dev/null || echo "../ultimate-multisite-addons/$SINGLE_ADDON")
+				dirs="$rel_path"
+			fi
+		fi
+	else
+		for addon_dir in "$search_dir"/*/; do
+			if [[ ! -d "$addon_dir" ]]; then
+				continue
+			fi
+			# Check for a main plugin file with Plugin Name header
+			if grep -rl "Plugin Name:" "$addon_dir"*.php >/dev/null 2>&1; then
+				local rel_path
+				rel_path=$(python3 -c "import os.path; print(os.path.relpath('${addon_dir%/}', '$REPO_ROOT'))" 2>/dev/null || echo "")
+				if [[ -n "$rel_path" ]]; then
+					if [[ -n "$dirs" ]]; then
+						dirs="$dirs"$'\n'"$rel_path"
+					else
+						dirs="$rel_path"
+					fi
+				fi
+			fi
+		done
+	fi
+
+	echo "$dirs"
+	return 0
+}
+
+generate_override() {
+	local plugin_paths="$1"
+
+	# Build the plugins JSON array: always starts with "." (core)
+	local plugins_json='["."'
+	while IFS= read -r path; do
+		if [[ -n "$path" ]]; then
+			plugins_json="$plugins_json, \"$path\""
+		fi
+	done <<<"$plugin_paths"
+	plugins_json="$plugins_json]"
+
+	# Build the full override JSON
+	local override
+	if [[ -n "$PHP_VERSION" ]]; then
+		override=$(
+			cat <<ENDJSON
+{
+  "config": {
+    "phpVersion": "$PHP_VERSION"
+  },
+  "env": {
+    "development": {
+      "plugins": $plugins_json
+    },
+    "tests": {
+      "plugins": $plugins_json
+    }
+  }
+}
+ENDJSON
+		)
+	else
+		override=$(
+			cat <<ENDJSON
+{
+  "env": {
+    "development": {
+      "plugins": $plugins_json
+    },
+    "tests": {
+      "plugins": $plugins_json
+    }
+  }
+}
+ENDJSON
+		)
+	fi
+
+	echo "$override"
+	return 0
+}
+
+main() {
+	parse_args "$@"
+
+	if [[ -z "$ADDONS_DIR" ]]; then
+		ADDONS_DIR="$(cd "$REPO_ROOT/.." && pwd)/ultimate-multisite-addons"
+	fi
+
+	if [[ ! -d "$ADDONS_DIR" ]]; then
+		echo "Warning: Addons directory not found at $ADDONS_DIR" >&2
+		echo "Run bin/clone-addons.sh first, or use --dir to specify the path." >&2
+		# Generate override with just core
+		generate_override "" >"$REPO_ROOT/.wp-env.override.json"
+		echo "Generated .wp-env.override.json (core only)"
+		return 0
+	fi
+
+	local plugin_dirs
+	plugin_dirs=$(find_plugin_dirs "$ADDONS_DIR")
+
+	local count=0
+	if [[ -n "$plugin_dirs" ]]; then
+		count=$(echo "$plugin_dirs" | wc -l | tr -d ' ')
+	fi
+
+	generate_override "$plugin_dirs" >"$REPO_ROOT/.wp-env.override.json"
+
+	echo "Generated .wp-env.override.json with $count addon(s)"
+	if [[ -n "$plugin_dirs" ]]; then
+		echo "$plugin_dirs" | while IFS= read -r p; do
+			echo "  + $p"
+		done
+	fi
+	return 0
+}
+
+main "$@"


### PR DESCRIPTION
## Summary

This PR introduces the foundational infrastructure for managing the Ultimate Multisite addon ecosystem. Previously, addon repos had no shared test infrastructure and the core repo had a hardcoded addon path in `.wp-env.json`. This replaces that with a data-driven, reusable system.

---

## What's included

### `addons.json` — Addon manifest

A central JSON manifest listing all 28 addon repos with three fields per entry:

- `slug` — the GitHub repo name under the `Ultimate-Multisite` org
- `description` — human-readable label
- `active` — whether the addon is actively maintained (used to filter operations)

A `non_addon_repos` array lists repos in the org that are not addons (tooling, themes, legacy), so scripts can skip them without hardcoding exclusions.

This manifest is the single source of truth for the addon set. Scripts and CI read from it rather than hardcoding slugs.

### `bin/clone-addons.sh` — Clone/update all addon repos

Clones or updates all addon repos into a sibling directory (`../ultimate-multisite-addons` by default). Handles both fresh clones and existing repos (fast-forward pull on default branch).

```bash
bin/clone-addons.sh                          # clone/update all addons
bin/clone-addons.sh --active-only            # only active addons
bin/clone-addons.sh --addon <slug>           # single addon
bin/clone-addons.sh --dir /path/to/addons    # custom target directory
```

Requires `gh` CLI and `jq`.

### `bin/generate-wp-env-override.sh` — Generate wp-env override

Scans the addons directory for valid WordPress plugin directories (checks for `Plugin Name:` header) and generates `.wp-env.override.json` with the core plugin plus all discovered addons as plugins. This file is gitignored — it's generated per-developer based on which addons they have cloned.

```bash
bin/generate-wp-env-override.sh              # all addons in default dir
bin/generate-wp-env-override.sh --addon <slug>   # single addon + core
bin/generate-wp-env-override.sh --php 8.1    # also set PHP version
```

Typical local dev workflow:
```bash
bin/clone-addons.sh --active-only
bin/generate-wp-env-override.sh
npm run env:start
```

### `.github/workflows/addon-integration-test.yml` — Reusable CI workflow

A `workflow_call` workflow that addon repos can call to run integration tests against a full WordPress Multisite environment with the core plugin installed alongside them.

**How addon repos use it** — add a `.github/workflows/ci.yml` in the addon repo:

```yaml
on: [push, pull_request]
jobs:
  test:
    uses: Ultimate-Multisite/ultimate-multisite/.github/workflows/addon-integration-test.yml@main
    with:
      addon-slug: multisite-ultimate-plugin-and-theme-manager
    secrets: inherit
```

**What it does:**

- `phpunit` job: spins up a MariaDB service, checks out core + addon side-by-side, installs Composer deps for both, bootstraps the WordPress test suite via `bin/install-wp-tests.sh`, symlinks both plugins into the WP plugins directory, and runs the addon's PHPUnit suite. Runs as a matrix over PHP versions (default: `["8.2"]`).
- `e2e` job (opt-in via `run-e2e: true`): starts a full `wp-env` environment with core + addon loaded, runs the core setup spec to activate plugins, then runs the addon's Cypress specs. Uploads screenshots and videos as artifacts.

**Inputs:**

| Input | Default | Description |
|-------|---------|-------------|
| `addon-slug` | required | Addon directory name |
| `addon-ref` | triggering ref | Git ref for the addon checkout |
| `php-versions` | `["8.2"]` | JSON array of PHP versions |
| `run-e2e` | `false` | Whether to run Cypress E2E tests |
| `core-ref` | `main` | Git ref for the core plugin |

This eliminates the need for each addon to maintain its own test infrastructure — they get PHPUnit + optional E2E against the real core plugin for free.

---

## Changes to existing files

- **`.wp-env.json`**: removed hardcoded `../addons/ultimate-multisite-domain-seller` path from both `development` and `tests` plugin lists. Addon loading is now handled by the generated `.wp-env.override.json`.
- **`.gitignore`**: added `.wp-env.override.json` (generated file, developer-specific).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Reusable GitHub Actions workflow for addon integration testing with PHPUnit and E2E test support
  * Addon manifest defining available addons and their configurations

* **Chores**
  * Added helper scripts for cloning addons and generating development environments
  * Updated build configuration to exclude generated environment files from version control

<!-- end of auto-generated comment: release notes by coderabbit.ai -->