### PR TITLE
fix: REST API meta-stored field filters for Site endpoint (#479)

### DIFF
--- a/inc/database/sites/class-site-query.php
+++ b/inc/database/sites/class-site-query.php
@@ -15,7 +15,7 @@ use WP_Ultimo\Database\Engine\Query;
 defined('ABSPATH') || exit;
 
 /**
- * Class used for querying products.
+ * Class used for querying sites.
  *
  * @since 2.0.0
  */
@@ -105,16 +105,86 @@ class Site_Query extends Query {
 	protected $global_cache = true;
 
 	/**
-	 * We need to add the network_id if one is not set.
+	 * Maps convenience query params to their wp_blogmeta keys.
 	 *
-	 * @param array $query Query.
+	 * Fields like `type`, `customer_id`, `membership_id`, and `template_id`
+	 * are stored in wp_blogmeta, not as columns in wp_blogs. BerlinDB cannot
+	 * filter by them directly, so we convert them to meta_query clauses here.
 	 *
+	 * @since 2.5.0
+	 * @var array<string, string>
+	 */
+	protected $meta_filter_map = [
+		'type'          => \WP_Ultimo\Models\Site::META_TYPE,
+		'customer_id'   => \WP_Ultimo\Models\Site::META_CUSTOMER_ID,
+		'membership_id' => \WP_Ultimo\Models\Site::META_MEMBERSHIP_ID,
+		'template_id'   => \WP_Ultimo\Models\Site::META_TEMPLATE_ID,
+	];
+
+	/**
+	 * Converts meta-stored field params into meta_query clauses, then queries.
+	 *
+	 * BerlinDB can only filter by actual wp_blogs columns. Fields stored in
+	 * wp_blogmeta (type, customer_id, membership_id, template_id) must be
+	 * translated to meta_query clauses before the query is executed.
+	 *
+	 * Also ensures the current network's site_id is set when not provided.
+	 *
+	 * @since 2.0.0
+	 * @since 2.5.0 Added meta_query conversion for meta-stored fields.
+	 *
+	 * @param array $query Query parameters.
 	 * @return array|int
 	 */
 	public function query($query = array()) {
+
 		if (empty($query['site_id']) && empty($query['site_id__in'])) {
 			$query['site_id'] = get_current_network_id();
 		}
+
+		$extra_meta_clauses = [];
+
+		foreach ($this->meta_filter_map as $param => $meta_key) {
+			if ( ! isset($query[ $param ])) {
+				continue;
+			}
+
+			$value = $query[ $param ];
+
+			unset($query[ $param ]);
+
+			$extra_meta_clauses[] = [
+				'key'     => $meta_key,
+				'value'   => $value,
+				'compare' => '=',
+			];
+		}
+
+		if ( ! empty($extra_meta_clauses)) {
+			$existing = isset($query['meta_query']) && is_array($query['meta_query'])
+				? $query['meta_query']
+				: [];
+
+			/*
+			 * Preserve any existing relation key so callers can still pass
+			 * their own meta_query with a custom relation. The new clauses
+			 * are always ANDed together; if the caller already set a relation
+			 * we wrap both sets under a top-level AND.
+			 */
+			if ( ! empty($existing)) {
+				$query['meta_query'] = array_merge(
+					['relation' => 'AND'],
+					$existing,
+					$extra_meta_clauses
+				);
+			} else {
+				$query['meta_query'] = array_merge( // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query
+					['relation' => 'AND'],
+					$extra_meta_clauses
+				);
+			}
+		}
+
 		return parent::query($query);
 	}
 }

--- a/inc/managers/class-site-manager.php
+++ b/inc/managers/class-site-manager.php
@@ -123,6 +123,54 @@ class Site_Manager extends Base_Manager {
 	}
 
 	/**
+	 * Returns the query params for the site collection endpoint.
+	 *
+	 * Extends the base pagination params with site-specific filters for
+	 * meta-stored fields (type, customer_id, membership_id, template_id).
+	 * These params are converted to meta_query clauses by Site_Query::query().
+	 *
+	 * @since 2.5.0
+	 * @return array
+	 */
+	public function get_collection_params() {
+
+		$params = parent::get_collection_params();
+
+		$params['type'] = [
+			'description'       => __('Filter sites by type (e.g. customer_owned, site_template, pending, external).', 'ultimate-multisite'),
+			'type'              => 'string',
+			'sanitize_callback' => 'sanitize_text_field',
+			'validate_callback' => 'rest_validate_request_arg',
+		];
+
+		$params['customer_id'] = [
+			'description'       => __('Filter sites by the ID of the owning customer.', 'ultimate-multisite'),
+			'type'              => 'integer',
+			'sanitize_callback' => 'absint',
+			'validate_callback' => 'rest_validate_request_arg',
+			'minimum'           => 1,
+		];
+
+		$params['membership_id'] = [
+			'description'       => __('Filter sites by the ID of the associated membership.', 'ultimate-multisite'),
+			'type'              => 'integer',
+			'sanitize_callback' => 'absint',
+			'validate_callback' => 'rest_validate_request_arg',
+			'minimum'           => 1,
+		];
+
+		$params['template_id'] = [
+			'description'       => __('Filter sites by the ID of the template used to create them.', 'ultimate-multisite'),
+			'type'              => 'integer',
+			'sanitize_callback' => 'absint',
+			'validate_callback' => 'rest_validate_request_arg',
+			'minimum'           => 1,
+		];
+
+		return $params;
+	}
+
+	/**
 	 * Allows for hyphens to be used, since WordPress supports it.
 	 *
 	 * @since 2.1.3

--- a/tests/WP_Ultimo/Managers/Site_Manager_Test.php
+++ b/tests/WP_Ultimo/Managers/Site_Manager_Test.php
@@ -1977,4 +1977,208 @@ class Site_Manager_Test extends \WP_UnitTestCase {
 
 		$this->assertStringStartsWith('site', $slug);
 	}
+
+	// ========================================================================
+	// Site_Query meta-filter support (issue #479)
+	// ========================================================================
+
+	/**
+	 * Test querying sites by type via meta_query conversion.
+	 */
+	public function test_site_query_filter_by_type(): void {
+
+		$site_a = wu_create_site([
+			'domain' => 'filter-type-a.example.com',
+			'path'   => '/filter-type-a/',
+			'type'   => \WP_Ultimo\Database\Sites\Site_Type::CUSTOMER_OWNED,
+		]);
+
+		$site_b = wu_create_site([
+			'domain' => 'filter-type-b.example.com',
+			'path'   => '/filter-type-b/',
+			'type'   => \WP_Ultimo\Database\Sites\Site_Type::SITE_TEMPLATE,
+		]);
+
+		$this->assertNotWPError($site_a, 'site_a creation should succeed');
+		$this->assertNotWPError($site_b, 'site_b creation should succeed');
+
+		$results = \WP_Ultimo\Models\Site::query([
+			'type'   => \WP_Ultimo\Database\Sites\Site_Type::CUSTOMER_OWNED,
+			'fields' => 'ids',
+		]);
+
+		$ids = is_array($results) ? $results : [];
+
+		$this->assertContains(
+			$site_a->get_id(),
+			$ids,
+			'customer_owned site should appear in type=customer_owned query'
+		);
+
+		$this->assertNotContains(
+			$site_b->get_id(),
+			$ids,
+			'site_template site should NOT appear in type=customer_owned query'
+		);
+	}
+
+	/**
+	 * Test querying sites by customer_id via meta_query conversion.
+	 */
+	public function test_site_query_filter_by_customer_id(): void {
+
+		$site_a = wu_create_site([
+			'domain'      => 'filter-cust-a.example.com',
+			'path'        => '/filter-cust-a/',
+			'type'        => \WP_Ultimo\Database\Sites\Site_Type::CUSTOMER_OWNED,
+			'customer_id' => 101,
+		]);
+
+		$site_b = wu_create_site([
+			'domain'      => 'filter-cust-b.example.com',
+			'path'        => '/filter-cust-b/',
+			'type'        => \WP_Ultimo\Database\Sites\Site_Type::CUSTOMER_OWNED,
+			'customer_id' => 202,
+		]);
+
+		$this->assertNotWPError($site_a, 'site_a creation should succeed');
+		$this->assertNotWPError($site_b, 'site_b creation should succeed');
+
+		$results = \WP_Ultimo\Models\Site::query([
+			'customer_id' => 101,
+			'fields'      => 'ids',
+		]);
+
+		$ids = is_array($results) ? $results : [];
+
+		$this->assertContains(
+			$site_a->get_id(),
+			$ids,
+			'Site with customer_id=101 should appear in results'
+		);
+
+		$this->assertNotContains(
+			$site_b->get_id(),
+			$ids,
+			'Site with customer_id=202 should NOT appear in customer_id=101 results'
+		);
+	}
+
+	/**
+	 * Test querying sites by membership_id via meta_query conversion.
+	 */
+	public function test_site_query_filter_by_membership_id(): void {
+
+		$site_a = wu_create_site([
+			'domain'        => 'filter-mem-a.example.com',
+			'path'          => '/filter-mem-a/',
+			'type'          => \WP_Ultimo\Database\Sites\Site_Type::CUSTOMER_OWNED,
+			'membership_id' => 55,
+		]);
+
+		$site_b = wu_create_site([
+			'domain'        => 'filter-mem-b.example.com',
+			'path'          => '/filter-mem-b/',
+			'type'          => \WP_Ultimo\Database\Sites\Site_Type::CUSTOMER_OWNED,
+			'membership_id' => 66,
+		]);
+
+		$this->assertNotWPError($site_a, 'site_a creation should succeed');
+		$this->assertNotWPError($site_b, 'site_b creation should succeed');
+
+		$results = \WP_Ultimo\Models\Site::query([
+			'membership_id' => 55,
+			'fields'        => 'ids',
+		]);
+
+		$ids = is_array($results) ? $results : [];
+
+		$this->assertContains(
+			$site_a->get_id(),
+			$ids,
+			'Site with membership_id=55 should appear in results'
+		);
+
+		$this->assertNotContains(
+			$site_b->get_id(),
+			$ids,
+			'Site with membership_id=66 should NOT appear in membership_id=55 results'
+		);
+	}
+
+	/**
+	 * Test combining type and customer_id filters (AND logic).
+	 */
+	public function test_site_query_filter_by_type_and_customer_id(): void {
+
+		$site_match = wu_create_site([
+			'domain'      => 'filter-combo-match.example.com',
+			'path'        => '/filter-combo-match/',
+			'type'        => \WP_Ultimo\Database\Sites\Site_Type::CUSTOMER_OWNED,
+			'customer_id' => 77,
+		]);
+
+		$site_wrong_type = wu_create_site([
+			'domain'      => 'filter-combo-wrongtype.example.com',
+			'path'        => '/filter-combo-wrongtype/',
+			'type'        => \WP_Ultimo\Database\Sites\Site_Type::SITE_TEMPLATE,
+			'customer_id' => 77,
+		]);
+
+		$site_wrong_customer = wu_create_site([
+			'domain'      => 'filter-combo-wrongcust.example.com',
+			'path'        => '/filter-combo-wrongcust/',
+			'type'        => \WP_Ultimo\Database\Sites\Site_Type::CUSTOMER_OWNED,
+			'customer_id' => 88,
+		]);
+
+		$this->assertNotWPError($site_match, 'site_match creation should succeed');
+		$this->assertNotWPError($site_wrong_type, 'site_wrong_type creation should succeed');
+		$this->assertNotWPError($site_wrong_customer, 'site_wrong_customer creation should succeed');
+
+		$results = \WP_Ultimo\Models\Site::query([
+			'type'        => \WP_Ultimo\Database\Sites\Site_Type::CUSTOMER_OWNED,
+			'customer_id' => 77,
+			'fields'      => 'ids',
+		]);
+
+		$ids = is_array($results) ? $results : [];
+
+		$this->assertContains(
+			$site_match->get_id(),
+			$ids,
+			'Site matching both type and customer_id should appear'
+		);
+
+		$this->assertNotContains(
+			$site_wrong_type->get_id(),
+			$ids,
+			'Site with wrong type should NOT appear'
+		);
+
+		$this->assertNotContains(
+			$site_wrong_customer->get_id(),
+			$ids,
+			'Site with wrong customer_id should NOT appear'
+		);
+	}
+
+	/**
+	 * Test that get_collection_params() includes meta-filter params.
+	 */
+	public function test_get_collection_params_includes_meta_filters(): void {
+
+		$manager = $this->get_manager_instance();
+
+		$params = $manager->get_collection_params();
+
+		$this->assertArrayHasKey('type', $params, 'type param should be registered');
+		$this->assertArrayHasKey('customer_id', $params, 'customer_id param should be registered');
+		$this->assertArrayHasKey('membership_id', $params, 'membership_id param should be registered');
+		$this->assertArrayHasKey('template_id', $params, 'template_id param should be registered');
+
+		// Pagination params should still be present.
+		$this->assertArrayHasKey('page', $params, 'page param should still be registered');
+		$this->assertArrayHasKey('per_page', $params, 'per_page param should still be registered');
+	}
 }


### PR DESCRIPTION
## Summary

- Overrides `Site_Query::query()` to convert `type`, `customer_id`, `membership_id`, and `template_id` query params into `meta_query` clauses before delegating to BerlinDB, since these fields are stored in `wp_blogmeta` not `wp_blogs` columns
- Overrides `Site_Manager::get_collection_params()` to register those four params as valid REST API query parameters with proper sanitization
- Adds 5 integration tests covering each filter individually, combined AND filtering, and REST param registration

## Root Cause

BerlinDB can only filter by actual table columns. When `type`, `customer_id`, etc. were passed as query params, BerlinDB silently ignored them (no column match), returning all sites instead of filtered results.

## Solution

`Site_Query::query()` intercepts the meta-stored field params, removes them from the raw query array, and builds `meta_query` clauses using the `Site::META_*` constants (`wu_type`, `wu_customer_id`, `wu_membership_id`, `wu_template_id`). Multiple filters are ANDed. Any existing `meta_query` from the caller is preserved and merged.

## Files Changed

- `inc/database/sites/class-site-query.php` — added `$meta_filter_map` property and meta_query conversion logic in `query()`
- `inc/managers/class-site-manager.php` — added `get_collection_params()` override registering the four filter params
- `tests/WP_Ultimo/Managers/Site_Manager_Test.php` — 5 new tests

Closes #479