### PR TITLE
fix: REST API pagination - map per_page/page to BerlinDB, add X-WP-Total headers (#480)

### DIFF
--- a/inc/apis/trait-rest-api.php
+++ b/inc/apis/trait-rest-api.php
@@ -86,6 +86,7 @@ trait Rest_Api {
 					'methods'             => \WP_REST_Server::READABLE,
 					'callback'            => [$this, 'get_items_rest'],
 					'permission_callback' => [$this, 'get_items_permissions_check'],
+					'args'                => $this->get_collection_params(),
 				],
 			];
 		}
@@ -178,7 +179,10 @@ trait Rest_Api {
 	}
 
 	/**
-	 * Returns a list of items.
+	 * Returns a list of items with WP REST API standard pagination support.
+	 *
+	 * Supports `page` and `per_page` query parameters and sets the
+	 * `X-WP-Total` and `X-WP-TotalPages` response headers.
 	 *
 	 * @since 2.0.0
 	 *
@@ -187,9 +191,87 @@ trait Rest_Api {
 	 */
 	public function get_items_rest($request) {
 
-		$items = $this->model_class::query($request->get_params());
+		$params = $request->get_params();
 
-		return rest_ensure_response($items);
+		/*
+		 * Map WP REST API standard pagination params to BerlinDB query params.
+		 * `per_page` → `number` (items per page)
+		 * `page`     → `offset` (calculated from page number)
+		 */
+		$per_page = isset($params['per_page']) ? absint($params['per_page']) : 10;
+		$page     = isset($params['page']) ? absint($params['page']) : 1;
+
+		if ($per_page < 1) {
+			$per_page = 10;
+		}
+
+		if ($page < 1) {
+			$page = 1;
+		}
+
+		$offset = ($page - 1) * $per_page;
+
+		// Remove REST-specific params before passing to the query layer.
+		unset($params['page'], $params['per_page']);
+
+		// Set BerlinDB pagination params.
+		$params['number'] = $per_page;
+		$params['offset'] = $offset;
+
+		$items = $this->model_class::query($params);
+
+		/*
+		 * Get the total count for pagination headers.
+		 * BerlinDB returns an integer when `count` is set to true.
+		 */
+		$count_params          = $params;
+		$count_params['count'] = true;
+
+		unset($count_params['number'], $count_params['offset']);
+
+		$total = (int) $this->model_class::query($count_params);
+
+		$max_pages = $per_page > 0 ? (int) ceil($total / $per_page) : 1;
+
+		$response = rest_ensure_response($items);
+
+		$response->header('X-WP-Total', $total);
+		$response->header('X-WP-TotalPages', $max_pages);
+
+		return $response;
+	}
+
+	/**
+	 * Returns the query params for collections.
+	 *
+	 * Registers the standard WP REST API pagination parameters (`page` and
+	 * `per_page`) so they appear in the schema and are validated before the
+	 * callback fires.
+	 *
+	 * @since 2.0.0
+	 * @return array
+	 */
+	public function get_collection_params() {
+
+		return [
+			'page'     => [
+				'description'       => __('Current page of the collection.', 'ultimate-multisite'),
+				'type'              => 'integer',
+				'default'           => 1,
+				'sanitize_callback' => 'absint',
+				'validate_callback' => 'rest_validate_request_arg',
+				'minimum'           => 1,
+			],
+			'per_page' => [
+				'description'       => __('Maximum number of items to be returned in result set.', 'ultimate-multisite'),
+				'type'              => 'integer',
+				'default'           => 10,
+				'minimum'           => 1,
+				'maximum'           => 100,
+				'sanitize_callback' => 'absint',
+				'validate_callback' => 'rest_validate_request_arg',
+			],
+		];
 	}
 
 	/**


### PR DESCRIPTION
## Summary

- Maps WP REST API standard `per_page` parameter to BerlinDB `number` param
- Maps WP REST API standard `page` parameter to BerlinDB `offset` = (page - 1) × per_page
- Adds `X-WP-Total` response header (total matching items via count query)
- Adds `X-WP-TotalPages` response header (ceil(total / per_page))
- Adds `get_collection_params()` method for standard WP REST parameter registration

Closes #480

## Root Cause

In `inc/apis/trait-rest-api.php`, `get_items_rest()` passed all request parameters directly to `::query()` without converting WP REST conventions to BerlinDB conventions.

## Testing

- `GET /wp-json/wu/v2/site?per_page=2&page=1` returns 2 items
- `GET /wp-json/wu/v2/site?per_page=2&page=2` returns next 2 items
- Response headers include `X-WP-Total` and `X-WP-TotalPages`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced REST API pagination with standard WordPress implementation, including proper response headers and validation for pagination query parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->