### PR TITLE
fix: resolve fatal error in Site_Manager::get_collection_params() calling non-existent parent method

### DIFF
--- a/inc/managers/class-site-manager.php
+++ b/inc/managers/class-site-manager.php
@@ -26,11 +26,13 @@ defined('ABSPATH') || exit;
  */
 class Site_Manager extends Base_Manager {
 
-	use \WP_Ultimo\Apis\Rest_Api;
 	use \WP_Ultimo\Apis\WP_CLI;
 	use \WP_Ultimo\Apis\MCP_Abilities;
 	use \WP_Ultimo\Apis\Command_Palette;
 	use \WP_Ultimo\Traits\Singleton;
+	use \WP_Ultimo\Apis\Rest_Api {
+		\WP_Ultimo\Apis\Rest_Api::get_collection_params as trait_get_collection_params;
+	}
 
 	/**
 	 * The manager slug.
@@ -134,7 +136,7 @@ class Site_Manager extends Base_Manager {
 	 */
 	public function get_collection_params() {
 
-		$params = parent::get_collection_params();
+		$params = $this->trait_get_collection_params();
 
 		$params['type'] = [
 			'description'       => __('Filter sites by type (e.g. customer_owned, site_template, pending, external).', 'ultimate-multisite'),


### PR DESCRIPTION
## Summary

- Fixes a fatal PHP error introduced in PR #479/#481 that crashes WordPress whenever the REST API is initialised
- `Site_Manager::get_collection_params()` was calling `parent::get_collection_params()` which resolves to `Base_Manager::get_collection_params()` — a method that does not exist
- Uses a PHP trait alias (`trait_get_collection_params`) to correctly call the `Rest_Api` trait's base implementation

## Root Cause

In PHP, `parent::method()` inside a class that uses a trait calls the **parent class** method, not the trait method. `get_collection_params()` is defined in the `Rest_Api` trait, not in `Base_Manager`. So `parent::get_collection_params()` throws:

```
Fatal Error: Uncaught Error: Call to undefined method WP_Ultimo\Managers\Base_Manager::get_collection_params()
  in inc/managers/class-site-manager.php:137
```

This error fires on `rest_api_init`, crashing the entire WordPress page load for any request that touches the REST API — including the checkout flow's AJAX calls, causing all E2E tests to fail.

## Fix

Use a trait alias to expose the trait's `get_collection_params()` under a different name, then call that alias from the override:

```php
use \WP_Ultimo\Apis\Rest_Api {
    \WP_Ultimo\Apis\Rest_Api::get_collection_params as trait_get_collection_params;
}

public function get_collection_params() {
    $params = $this->trait_get_collection_params(); // calls trait method, not parent class
    // ... add site-specific params
    return $params;
}
```

## Testing

- PHP syntax check: `php -l inc/managers/class-site-manager.php` → no errors
- Existing unit test `test_get_collection_params_includes_meta_filters()` validates the override still returns all expected params (type, customer_id, membership_id, template_id, page, per_page)
- E2E CI will verify the REST API no longer crashes on `rest_api_init`

Closes #483

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Internal code organization improvements to enhance maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->