### PR TITLE
fix(api): serialize Notes, Limitations, description, Membership meta + fix admin fatal error + CI for fork PRs

### DIFF
--- a/.github/workflows/pr-build-test.yml
+++ b/.github/workflows/pr-build-test.yml
@@ -139,6 +139,9 @@ jobs:
           echo "Playground URL generated"
 
       - name: Comment on PR
+        # Fork PRs don't have write access to the base repo — skip gracefully.
+        # The build artifact is still uploaded and accessible via the Actions run URL.
+        if: github.event.pull_request.head.repo.full_name == github.repository
         uses: actions/github-script@v7
         with:
           script: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -222,14 +222,16 @@ jobs:
 
       - name: Check if a comment was already made
         id: find-comment
-        if: github.event_name == 'pull_request'
+        # Fork PRs don't have write access to the base repo — skip comment steps.
+        # Performance results are still uploaded as artifacts and shown in the workflow summary.
+        if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
         uses: peter-evans/find-comment@b30e6a3c0ed37e7c023ccd3f1db5c6c0b0c23aad
         with:
           issue-number: ${{ github.event.pull_request.number }}
           body-includes: Performance test results for
 
       - name: Comment on PR with performance results
-        if: github.event_name == 'pull_request' && hashFiles('.wp-performance-action/env/artifacts/performance-results.md') != ''
+        if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && hashFiles('.wp-performance-action/env/artifacts/performance-results.md') != ''
         uses: peter-evans/create-or-update-comment@e8674b075228eee787fea43ef493e45ece1004c9
         with:
           issue-number: ${{ github.event.pull_request.number }}

--- a/encrypt-secrets.php
+++ b/encrypt-secrets.php
@@ -8,8 +8,9 @@ $client_id     = getenv('MU_CLIENT_ID') ?: '';
 $client_secret = getenv('MU_CLIENT_SECRET') ?: '';
 
 if (!$client_id || !$client_secret) {
-	echo "Missing MU_CLIENT_ID or MU_CLIENT_SECRET env vars\n";
-	exit(1);
+	echo "Missing MU_CLIENT_ID or MU_CLIENT_SECRET env vars — writing placeholder\n";
+	file_put_contents('inc/stuff.php', "<?php\nreturn " . var_export(['', ''], true) . ';');
+	exit(0);
 }
 
 function encryptValue($plaintext, $key) {

--- a/encrypt-secrets.php
+++ b/encrypt-secrets.php
@@ -8,8 +8,10 @@ $client_id     = getenv('MU_CLIENT_ID') ?: '';
 $client_secret = getenv('MU_CLIENT_SECRET') ?: '';
 
 if (!$client_id || !$client_secret) {
-	echo "Missing MU_CLIENT_ID or MU_CLIENT_SECRET env vars — writing placeholder\n";
-	file_put_contents('inc/stuff.php', "<?php\nreturn " . var_export(['', ''], true) . ';');
+	fwrite(STDERR, "Missing MU_CLIENT_ID or MU_CLIENT_SECRET env vars\n");
+	if (!file_exists('inc/stuff.php')) {
+		file_put_contents('inc/stuff.php', "<?php\nreturn " . var_export(['', ''], true) . ';');
+	}
 	exit(0);
 }
 

--- a/inc/admin-pages/class-edit-admin-page.php
+++ b/inc/admin-pages/class-edit-admin-page.php
@@ -460,7 +460,7 @@ abstract class Edit_Admin_Page extends Base_Admin_Page {
 	 * @param array  $atts Array of attributes to pass to the form.
 	 * @return void
 	 */
-	protected function add_fields_widget($id, $atts = []) {
+	public function add_fields_widget($id, $atts = []) {
 
 		$atts = wp_parse_args(
 			$atts,

--- a/inc/models/class-customer.php
+++ b/inc/models/class-customer.php
@@ -980,6 +980,8 @@ class Customer extends Base_Model implements Billable, Notable {
 		if ($this->get_id()) {
 			$this->has_trialed();
 			$this->get_extra_information();
+			$this->get_billing_address();
+			$this->get_notes();
 		}
 
 		return parent::to_array();

--- a/inc/models/class-membership.php
+++ b/inc/models/class-membership.php
@@ -2196,6 +2196,22 @@ class Membership extends Base_Model implements Limitable, Billable, Notable {
 	}
 
 	/**
+	 * Serialize model to array, ensuring meta-stored fields are loaded.
+	 *
+	 * @since 2.0.0
+	 * @return array
+	 */
+	public function to_array() {
+
+		if ($this->get_id()) {
+			$this->get_cancellation_reason();
+			$this->get_discount_code();
+		}
+
+		return parent::to_array();
+	}
+
+	/**
 	 * By default, we just use the to_array method, but you can rewrite this.
 	 *
 	 * @since 2.0.0

--- a/inc/models/class-site.php
+++ b/inc/models/class-site.php
@@ -1728,6 +1728,9 @@ class Site extends Base_Model implements Limitable, Notable {
 		// Expose blog_id as id so callers get the correct non-zero value.
 		$array['id'] = $this->get_id();
 
+		// Description is lazy-loaded from wp_options (blogdescription), not a column.
+		$array['description'] = $this->get_description();
+
 		return $array;
 	}
 

--- a/inc/models/class-site.php
+++ b/inc/models/class-site.php
@@ -1731,6 +1731,12 @@ class Site extends Base_Model implements Limitable, Notable {
 		// Description is lazy-loaded from wp_options (blogdescription), not a column.
 		$array['description'] = $this->get_description();
 
+		// Notes are lazy-loaded from metadata via the Notable trait.
+		$array['notes'] = $this->get_notes();
+
+		// Limitations are lazy-loaded from metadata via the Limitable trait.
+		$array['limitations'] = $this->get_limitations();
+
 		return $array;
 	}
 

--- a/inc/objects/class-billing-address.php
+++ b/inc/objects/class-billing-address.php
@@ -26,7 +26,7 @@ defined('ABSPATH') || exit;
  * @property string $billing_city City or town.
  * @property string $billing_zip_code ZIP or postal code.
  */
-class Billing_Address {
+class Billing_Address implements \JsonSerializable {
 
 	/**
 	 * The Billing Address content.
@@ -196,6 +196,18 @@ class Billing_Address {
 		}
 
 		return $address_array;
+	}
+
+	/**
+	 * Serialize billing address for JSON encoding.
+	 *
+	 * @since 2.0.0
+	 * @return array
+	 */
+	#[\ReturnTypeWillChange]
+	public function jsonSerialize() {
+
+		return $this->to_array();
 	}
 
 	/**

--- a/inc/objects/class-limitations.php
+++ b/inc/objects/class-limitations.php
@@ -33,7 +33,7 @@ defined('ABSPATH') || exit;
  * @property-read \WP_Ultimo\Limitations\Limit_Customer_User_Role $customer_user_role
  * @property-read \WP_Ultimo\Limitations\Limit_Hide_Footer_Credits $hide_credits
  */
-class Limitations {
+class Limitations implements \JsonSerializable {
 
 	/**
 	 * Caches early limitation queries to prevent
@@ -103,6 +103,21 @@ class Limitations {
 		}
 
 		return $module;
+	}
+
+	/**
+	 * Specify data which should be serialized to JSON.
+	 *
+	 * Ensures Limitations objects are properly serialized in REST API
+	 * responses instead of appearing as empty arrays.
+	 *
+	 * @since 2.0.0
+	 * @return array
+	 */
+	#[\ReturnTypeWillChange]
+	public function jsonSerialize() {
+
+		return $this->to_array();
 	}
 
 	/**

--- a/inc/objects/class-note.php
+++ b/inc/objects/class-note.php
@@ -17,7 +17,7 @@ defined('ABSPATH') || exit;
  *
  * @since 2.0.0
  */
-class Note {
+class Note implements \JsonSerializable {
 
 	/**
 	 * The Note content.
@@ -142,6 +142,21 @@ class Note {
 		}
 
 		return true;
+	}
+
+	/**
+	 * Specify data which should be serialized to JSON.
+	 *
+	 * Ensures Note objects are properly serialized in REST API responses
+	 * instead of appearing as empty arrays.
+	 *
+	 * @since 2.0.0
+	 * @return array
+	 */
+	#[\ReturnTypeWillChange]
+	public function jsonSerialize() {
+
+		return $this->to_array();
 	}
 
 	/**


### PR DESCRIPTION
## Summary

Fixes several remaining REST API serialization issues not covered by PR #470, plus a fatal error on the site edit page and CI failures for fork PRs.

### API Serialization Fixes

- **Notes** return `null` or `[[], []]` — `Note` objects lack `JsonSerializable`, so `json_encode()` can't see `protected $attributes`
- **Limitations** return `[]` — `Limitations` objects have `__serialize()` (for PHP `serialize()`) but not `JsonSerializable`
- **Description** returns `null` on Site — loaded from `wp_options` (blogdescription) via `get_description()`, never called in `to_array()`
- **Membership** meta fields (`cancellation_reason`, `discount_code`) return `null` — missing `to_array()` override

### Admin Fix

- **Site edit page fatal error** — `Site_Exporter` calls `$page->add_fields_widget()` externally via hook but method was `protected`

### CI Fix

- **Build fails on fork PRs** — `encrypt-secrets.php` exits with error when GitHub secrets are unavailable (standard GitHub security for fork PRs)

## Changes

| File | Change |
|------|--------|
| `inc/objects/class-note.php` | Add `JsonSerializable` interface + `jsonSerialize()` |
| `inc/objects/class-limitations.php` | Add `JsonSerializable` interface + `jsonSerialize()` |
| `inc/models/class-site.php` | Add `description` to `to_array()`, load notes/limitations |
| `inc/models/class-membership.php` | Add `to_array()` override for `cancellation_reason`, `discount_code` |
| `inc/admin-pages/class-edit-admin-page.php` | Change `add_fields_widget()` from `protected` to `public` |
| `encrypt-secrets.php` | Write placeholder instead of `exit(1)` when secrets are missing |

## Testing

Verified on local WordPress multisite (localhost:10023):

```
GET /wp-json/wu/v2/site/3
✅ description: "Description du site" (was null)
✅ notes: [{"text": "Note client", "author_id": 1, ...}] (was null/[[],[]])
✅ limitations: {post_types: {...}, users: {...}, ...} (was [])
✅ customer_id: "1", membership_id: "1", id: 3

GET /wp-json/wu/v2/membership/1
✅ discount_code: false (was null)
✅ cancellation_reason: null (correct — status is active)

Admin: /wp-admin/network/admin.php?page=wp-ultimo-edit-site&id=3
✅ No more fatal error (was: Call to protected method add_fields_widget)
```

Closes #490

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed incomplete data serialization in API responses for sites, customers, and memberships—descriptions, notes, limitations, billing addresses, and discount information now properly included.
  * Improved JSON encoding support for related data objects to ensure complete information delivery in integrations.

* **Chores**
  * Enhanced backend data loading mechanisms for better consistency in serialized outputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->