### PR TITLE
fix: hide coupon banner via v-show when coupon is removed

### DIFF
--- a/views/legacy/signup/pricing-table/coupon-code.php
+++ b/views/legacy/signup/pricing-table/coupon-code.php
@@ -11,10 +11,10 @@ if (isset($_GET['coupon']) && wu_get_coupon(sanitize_text_field(wp_unslash($_GET
 	?>
 
 <div id="coupon-code-app" class="wu-mb-3">
-	<div class="wu-p-3 wu-bg-green-50 wu-border wu-border-solid wu-border-green-200 wu-rounded wu-flex wu-items-center wu-justify-between">
+	<div v-show="coupon" class="wu-p-3 wu-bg-green-50 wu-border wu-border-solid wu-border-green-200 wu-rounded wu-flex wu-items-center wu-justify-between">
 		<div class="wu-text-sm">
 			<strong><?php esc_html_e('Coupon applied', 'ultimate-multisite'); ?>:</strong>
-			<span>{{ coupon && coupon.code ? coupon.code : (coupon && coupon.id ? coupon.id : '') }}</span>
+			<span>{{ coupon.code || coupon.id }}</span>
 		</div>
 		<div>
 			<a href="#" class="wu-text-red-600 wu-text-sm wu-no-underline" v-on:click.prevent="remove_coupon">


### PR DESCRIPTION
## Summary

- Adds `v-show="coupon"` to the green coupon banner div so it is hidden when `remove_coupon()` sets `this.coupon = false`
- Simplifies the verbose Vue ternary `{{ coupon && coupon.code ? coupon.code : (coupon && coupon.id ? coupon.id : '') }}` to `{{ coupon.code || coupon.id }}` — safe because the parent is now hidden when coupon is falsy

## Problem

PR #489 added the coupon banner UI but omitted a Vue visibility directive. After clicking "Remove", `remove_coupon()` sets `this.coupon = false` but the banner had no conditional rendering — it stayed visible showing "Coupon applied:" with an empty code, confusing users.

## Fix

One-line change on line 14 of `views/legacy/signup/pricing-table/coupon-code.php`:

```diff
-<div class="wu-p-3 wu-bg-green-50 ...">
+<div v-show="coupon" class="wu-p-3 wu-bg-green-50 ...">
```

## Testing

1. Navigate to signup pricing table with a valid coupon (`?coupon=TESTCODE&step=plan`)
2. Confirm the green "Coupon applied: TESTCODE" banner renders
3. Click "Remove" — confirm the banner disappears (previously it stayed visible with empty code)

## Runtime Testing

- **Testing level:** self-assessed
- **Risk classification:** low (template-only change, single Vue directive addition)
- **Behaviour verified:** `v-show` is a standard Vue 2/3 directive that reactively hides the element when the bound expression is falsy; `remove_coupon()` already sets `this.coupon = false` per `assets/js/coupon-code.js`

## Files changed

- `views/legacy/signup/pricing-table/coupon-code.php` — adds `v-show="coupon"` to banner div; simplifies Vue interpolation

Closes #492

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the display behavior of applied coupons within the pricing table. Coupons will now appear only when they are actively applied to an order, eliminating unnecessary interface elements from displaying. The coupon code identifier logic has been refined to ensure accurate and reliable display of coupon information, improving overall user experience during checkout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->