### PR TITLE
fix: correct typo in addons.json (tutor-multisite-compatibilty → tutor-multisite-compatibility)

### DIFF
--- a/addons.json
+++ b/addons.json
@@ -151,7 +151,7 @@
     "hook-profiler",
     "pro-themes",
     "material-wp",
-    "tutor-multisite-compatibilty",
+    "tutor-multisite-compatibility",
     "wp-ultimo-v1",
     "stripe-connect-proxy",
     "wordpress-translated-tuned-llm",


### PR DESCRIPTION
## Summary

- Fixes a typo in `addons.json` line 154: `tutor-multisite-compatibilty` → `tutor-multisite-compatibility`
- Flagged as high-priority by CodeRabbit in PR #478 review

Closes #493

## Changes

- `addons.json` — corrected misspelled slug in `non_addon_repos` array

## Testing Evidence

- **Testing level:** self-assessed
- **Risk classification:** low (single character typo fix in a JSON data file, no executable code)
- **Stability results:** N/A — docs/data only
- **Smoke pages/endpoints checked:** N/A

## Quality-Debt Blast Radius

Files changed: 1 (well within the 5-file cap for quality-debt PRs per t1422)