### PR TITLE
fix(ci): skip PR comment steps for fork PRs

### DIFF
--- a/.github/workflows/pr-build-test.yml
+++ b/.github/workflows/pr-build-test.yml
@@ -139,6 +139,9 @@ jobs:
           echo "Playground URL generated"
 
       - name: Comment on PR
+        # Fork PRs don't have write access to the base repo — skip gracefully.
+        # The build artifact is still uploaded and accessible via the Actions run URL.
+        if: github.event.pull_request.head.repo.full_name == github.repository
         uses: actions/github-script@v7
         with:
           script: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -222,14 +222,16 @@ jobs:
 
       - name: Check if a comment was already made
         id: find-comment
-        if: github.event_name == 'pull_request'
+        # Fork PRs don't have write access to the base repo — skip comment steps.
+        # Performance results are still uploaded as artifacts and shown in the workflow summary.
+        if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
         uses: peter-evans/find-comment@b30e6a3c0ed37e7c023ccd3f1db5c6c0b0c23aad
         with:
           issue-number: ${{ github.event.pull_request.number }}
           body-includes: Performance test results for
 
       - name: Comment on PR with performance results
-        if: github.event_name == 'pull_request' && hashFiles('.wp-performance-action/env/artifacts/performance-results.md') != ''
+        if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && hashFiles('.wp-performance-action/env/artifacts/performance-results.md') != ''
         uses: peter-evans/create-or-update-comment@e8674b075228eee787fea43ef493e45ece1004c9
         with:
           issue-number: ${{ github.event.pull_request.number }}


### PR DESCRIPTION
## Summary

Fixes the 'Build Plugin for Testing' and 'WP Performance Metrics' CI failures that affect all external contributor (fork) PRs, including #491.

## Root Cause

GitHub restricts `GITHUB_TOKEN` write permissions for fork PRs — the token cannot write to the base repo's issues/PRs. Both failing jobs attempted to post PR comments using this token, resulting in HTTP 403 `Resource not accessible by integration`.

This is a standard GitHub security restriction: fork PRs run with a read-only token to prevent untrusted code from writing to the base repo.

## Fix

Added `github.event.pull_request.head.repo.full_name == github.repository` condition to all PR comment steps in both workflows. This skips the comment steps for fork PRs while keeping them active for PRs from the same repo.

- `pr-build-test.yml`: Comment on PR step now skipped for forks
- `tests.yml`: Both "Check if a comment was already made" and "Comment on PR with performance results" steps now skipped for forks

Build artifacts and performance results are still uploaded as GitHub Actions artifacts and shown in the workflow summary — they're just not posted as PR comments for fork PRs.

## Impact

- Fork PRs: CI passes (comment steps skipped gracefully)
- Same-repo PRs: No change in behaviour (comment steps still run)

Unblocks PR #491 and all future external contributor PRs.