### PR TITLE
fix: pin all GitHub Actions to immutable commit SHAs in tests.yml

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -30,7 +30,7 @@ jobs:
       image: cimg/php:${{ matrix.php-version }}
       options: --user root
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Set up Composer global bin path
         run: |
@@ -88,7 +88,7 @@ jobs:
 
       - name: Upload coverage to Codecov
         if: matrix.php-version == '8.3'
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@1af58845a975a7985b0beb0cbe6fbbb71a41dbad # v5
         with:
           file: ./coverage.xml
           flags: unittests
@@ -106,10 +106,10 @@ jobs:
       pull-requests: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Setup PHP
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@accd6127cb78bee3e8082180cb391013d204ef9f # v2
         with:
           php-version: "8.2"
 
@@ -117,12 +117,12 @@ jobs:
         run: composer install --no-dev --no-interaction --prefer-dist --optimize-autoloader
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: lts/*
 
       - name: Checkout wp-performance-action
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           repository: swissspidy/wp-performance-action
           ref: b7e3ffcf0fc4a48b62492e021e0ebeb51430ff11
@@ -214,7 +214,7 @@ jobs:
 
       - name: Upload performance results
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: performance-results-${{ github.run_number }}
           path: .wp-performance-action/env/artifacts/


### PR DESCRIPTION
## Summary

Addresses the high-priority CodeRabbit supply-chain security finding from PR #422 review (issue #495).

All mutable `@vN` action references in `.github/workflows/tests.yml` have been replaced with full immutable commit SHAs. Version tags are retained as inline comments for readability.

## Changes

| Action | Before | After |
|--------|--------|-------|
| `actions/checkout` | `@v4` | `@34e114876b0b11c390a56381ad16ebd13914f8d5` |
| `codecov/codecov-action` | `@v5` | `@1af58845a975a7985b0beb0cbe6fbbb71a41dbad` |
| `shivammathur/setup-php` | `@v2` | `@accd6127cb78bee3e8082180cb391013d204ef9f` |
| `actions/setup-node` | `@v4` | `@49933ea5288caeca8642d1e84afbd3f7d6820020` |
| `actions/upload-artifact` | `@v4` | `@ea165f8d65b6e75b540449e92b4886f43607fa02` |

The `peter-evans/find-comment` and `peter-evans/create-or-update-comment` actions were already pinned to SHAs.

## Why

Mutable version tags (`@v4`, `@v2`, etc.) can be silently redirected to a different commit by a compromised or malicious maintainer. Pinning to a full SHA ensures the exact code that was reviewed is what runs in CI — a core supply-chain integrity control.

## Testing Evidence

- **Testing level:** `untested` — CI config only, no executable application code changed
- **Stability results:** N/A — workflow YAML syntax verified by inspection
- **Smoke pages/endpoints checked:** N/A

## Files changed

- `.github/workflows/tests.yml` — pinned 5 mutable action references to commit SHAs

Closes #495