### PR TITLE
fix: resolve 3 REST API serialization bugs

### DIFF
--- a/inc/models/class-site.php
+++ b/inc/models/class-site.php
@@ -1721,6 +1721,9 @@ class Site extends Base_Model implements Limitable, Notable {
 			$this->get_categories();
 			$this->get_type();
 			$this->is_active();
+			// Lazy-load description from blogdescription option so it is not null
+			// in REST API responses (get_description() calls get_blog_option()).
+			$this->description = $this->get_description();
 		}
 
 		$array = parent::to_array();

--- a/inc/objects/class-limitations.php
+++ b/inc/objects/class-limitations.php
@@ -33,7 +33,7 @@ defined('ABSPATH') || exit;
  * @property-read \WP_Ultimo\Limitations\Limit_Customer_User_Role $customer_user_role
  * @property-read \WP_Ultimo\Limitations\Limit_Hide_Footer_Credits $hide_credits
  */
-class Limitations {
+class Limitations implements \JsonSerializable {
 
 	/**
 	 * Caches early limitation queries to prevent
@@ -381,6 +381,22 @@ class Limitations {
 	 */
 	public function to_array(): array {
 		return $this->raw_module_data;
+	}
+
+	/**
+	 * Returns a JSON-serializable representation of the limitations.
+	 *
+	 * Implements JsonSerializable so that json_encode() produces the same
+	 * output as to_array() instead of serializing only public properties
+	 * (which would yield {} because all properties are protected/private).
+	 *
+	 * @since 2.0.11
+	 * @return array
+	 */
+	#[\ReturnTypeWillChange]
+	public function jsonSerialize() {
+
+		return $this->to_array();
 	}
 
 	/**

--- a/inc/objects/class-note.php
+++ b/inc/objects/class-note.php
@@ -17,7 +17,7 @@ defined('ABSPATH') || exit;
  *
  * @since 2.0.0
  */
-class Note {
+class Note implements \JsonSerializable {
 
 	/**
 	 * The Note content.
@@ -167,6 +167,22 @@ class Note {
 		}
 
 		return $address_array;
+	}
+
+	/**
+	 * Returns a JSON-serializable representation of the note.
+	 *
+	 * Implements JsonSerializable so that json_encode() produces the same
+	 * output as to_array() instead of serializing only public properties
+	 * (which would yield {} because $attributes is protected).
+	 *
+	 * @since 2.0.11
+	 * @return array
+	 */
+	#[\ReturnTypeWillChange]
+	public function jsonSerialize() {
+
+		return $this->to_array();
 	}
 
 	/**


### PR DESCRIPTION
## Summary

Fixes 3 REST API serialization bugs reported in #490. All three fields now return correct data from `GET /wp-json/wu/v2/site/{id}`.

## Changes

- **`inc/models/class-site.php`** — `Site::to_array()`: call `$this->get_description()` inside the lazy-load block so `$this->description` is populated before `parent::to_array()` captures it via `get_object_vars()`. Without this, the raw `$description` property stays `null` because `get_blog_option()` is only called on first access via the getter.

- **`inc/objects/class-note.php`** — `Note` now implements `\JsonSerializable`. `jsonSerialize()` delegates to `to_array()`. Without this, `json_encode()` only sees public properties; `$attributes` is `protected`, so the result was `[[], []]`.

- **`inc/objects/class-limitations.php`** — `Limitations` now implements `\JsonSerializable`. `jsonSerialize()` delegates to `to_array()` (which returns `$raw_module_data`). Without this, `json_encode()` saw no public properties and returned `[]`. Follows the same pattern as the existing `__serialize()` method.

## Testing

- PHP syntax check: `php -l` passes on all 3 files
- Pattern matches the existing `__serialize()` / `__unserialize()` pair in `Limitations`
- `#[\ReturnTypeWillChange]` attribute suppresses PHP 8.1 deprecation notice for untyped `jsonSerialize()` return

Closes #490