### PR TITLE
fix: remove duplicate jsonSerialize() in Limitations class

### DIFF
--- a/inc/objects/class-limitations.php
+++ b/inc/objects/class-limitations.php
@@ -106,21 +106,6 @@ class Limitations implements \JsonSerializable {
 	}
 
 	/**
-	 * Specify data which should be serialized to JSON.
-	 *
-	 * Ensures Limitations objects are properly serialized in REST API
-	 * responses instead of appearing as empty arrays.
-	 *
-	 * @since 2.0.0
-	 * @return array
-	 */
-	#[\ReturnTypeWillChange]
-	public function jsonSerialize() {
-
-		return $this->to_array();
-	}
-
-	/**
 	 * Prepare to serialization.
 	 *
 	 * @see requires php 7.3


### PR DESCRIPTION
## Problem

Commit bd384940 added a second `jsonSerialize()` method to `WP_Ultimo\Objects\Limitations` at line 118, after PR #503 (c0b1a630) had already added the canonical implementation at line 405.

This caused a PHP fatal error on every WP bootstrap:

```
Fatal error: Cannot redeclare WP_Ultimo\Objects\Limitations::jsonSerialize()
in inc/objects/class-limitations.php on line 412
```

This broke PHPUnit and E2E CI on the addon repo PR [Ultimate-Multisite/ultimate-multisite-woocommerce#5](https://github.com/Ultimate-Multisite/ultimate-multisite-woocommerce/pull/5).

## Fix

Remove the duplicate declaration (the one with `@since 2.0.0` / incorrect docblock added by bd384940). Keep the canonical implementation from PR #503 (`@since 2.0.11`, placed after `to_array()`).

## Verification

- `grep -n "jsonSerialize"` now returns exactly one result (line 397)
- Class still `implements \JsonSerializable`
- Both methods are identical (`return $this->to_array()`) so no behaviour change

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified internal serialization handling for improved code maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->