### PR TITLE
fix: remove duplicate jsonSerialize() in Note class

### DIFF
--- a/inc/objects/class-note.php
+++ b/inc/objects/class-note.php
@@ -145,21 +145,6 @@ class Note implements \JsonSerializable {
 	}
 
 	/**
-	 * Specify data which should be serialized to JSON.
-	 *
-	 * Ensures Note objects are properly serialized in REST API responses
-	 * instead of appearing as empty arrays.
-	 *
-	 * @since 2.0.0
-	 * @return array
-	 */
-	#[\ReturnTypeWillChange]
-	public function jsonSerialize() {
-
-		return $this->to_array();
-	}
-
-	/**
 	 * Returns a key => value representation of the notes fields.
 	 *
 	 * @since 2.0.0


### PR DESCRIPTION
## Summary

- Removes duplicate `jsonSerialize()` method in `Note` class that causes `PHP Fatal: Cannot redeclare WP_Ultimo\Objects\Note::jsonSerialize()` on PHP 8.2, 8.4, and 8.5
- Same root cause as the Limitations fix in 7c66017e — two PRs (#491 and #503) both solving issue #490 were merged in sequence without rebasing, each adding their own `jsonSerialize()`

## Root Cause Analysis

1. **PR #503** (`c0b1a630`) added `jsonSerialize()` after `to_array()` with `@since 2.0.11`
2. **PR #491** (`bd384940`) added a **second** `jsonSerialize()` before `to_array()` with `@since 2.0.0`
3. PR #491 was merged ~30 minutes after PR #503, creating the duplicate
4. Commit `7c66017e` fixed the identical issue in `Limitations` but missed `Note`
5. PHP 8.3 happens to pass (likely due to test ordering/coverage), while 8.2, 8.4, and 8.5 fatal

## Why This Wasn't Caught

**The `main` branch has no branch protection rules.** This means:
- PRs can be merged without passing CI status checks
- Direct pushes to `main` are allowed
- No required reviews before merge

## Recommended Protections

To prevent this class of bug from reaching `main`:

1. **Enable branch protection on `main`** with:
   - Require status checks to pass before merging (specifically the `PHP 8.2`, `PHP 8.4`, `PHP 8.5` jobs from `tests.yml`)
   - Require branches to be up to date before merging (this would have caught the conflict between #491 and #503)
   - Require at least 1 approving review
2. **Consider adding a PHP lint CI step** (`php -l`) that catches syntax/redeclaration errors before the full test suite runs

## Testing

- `php -l inc/objects/class-note.php` passes
- No other duplicate `jsonSerialize()` methods exist in the codebase
- CI should now pass on all PHP versions (8.2, 8.3, 8.4, 8.5)