### PR TITLE
feat(ci): add PHP lint gate, pin all actions to commit SHAs, upgrade EOL PHP

### DIFF
--- a/.github/workflows/addon-integration-test.yml
+++ b/.github/workflows/addon-integration-test.yml
@@ -66,14 +66,14 @@ jobs:
       options: --user root
     steps:
       - name: Checkout core plugin
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           repository: Ultimate-Multisite/ultimate-multisite
           ref: ${{ inputs.core-ref }}
           path: core
 
       - name: Checkout addon
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           ref: ${{ inputs.addon-ref || github.ref }}
           path: addon
@@ -145,25 +145,25 @@ jobs:
           --health-retries=10
     steps:
       - name: Checkout core plugin
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           repository: Ultimate-Multisite/ultimate-multisite
           ref: ${{ inputs.core-ref }}
           path: core
 
       - name: Checkout addon
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           ref: ${{ inputs.addon-ref || github.ref }}
           path: addon
 
       - name: Setup Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 18
 
       - name: Cache NPM dependencies
-        uses: actions/cache@v3
+        uses: actions/cache@6f8efc29b200d32929f49075959781ed54ec270c # v3
         with:
           path: ~/.npm
           key: ${{ runner.os }}-npm-e2e
@@ -251,7 +251,7 @@ jobs:
       - name: Upload Cypress screenshots
         if: always()
         continue-on-error: true
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: cypress-screenshots-${{ inputs.addon-slug }}
           path: |
@@ -261,7 +261,7 @@ jobs:
       - name: Upload Cypress videos
         if: always()
         continue-on-error: true
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: cypress-videos-${{ inputs.addon-slug }}
           path: |

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -11,12 +11,12 @@ jobs:
     name: Code Quality Checks
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Setup PHP
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@accd6127cb78bee3e8082180cb391013d204ef9f # v2
         with:
-          php-version: '8.1'
+          php-version: '8.2'
           extensions: mysqli, gd, bcmath
           tools: composer
 
@@ -25,7 +25,7 @@ jobs:
 
       - name: Get changed PHP files
         id: changed-files
-        uses: tj-actions/changed-files@v44
+        uses: tj-actions/changed-files@2d756ea4c53f7f6b397767d8723b3a10a9f35bf2 # v44
         with:
           files: |
             **/*.php
@@ -45,7 +45,7 @@ jobs:
           [ -s phpstan-report.xml ] || echo '<?xml version="1.0" encoding="UTF-8"?><checkstyle></checkstyle>' > phpstan-report.xml
 
       - name: Annotate PR with PHPCS results
-        uses: staabm/annotate-pull-request-from-checkstyle-action@v1
+        uses: staabm/annotate-pull-request-from-checkstyle-action@a7dbcfcab1a6892dae7893a160cc87f23af94de4 # v1
         if: github.event_name == 'pull_request' && steps.changed-files.outputs.any_changed == 'true'
         with:
           files: phpcs-report.xml
@@ -53,7 +53,7 @@ jobs:
           errors-as-warnings: true
 
       - name: Annotate PR with PHPStan results
-        uses: staabm/annotate-pull-request-from-checkstyle-action@v1
+        uses: staabm/annotate-pull-request-from-checkstyle-action@a7dbcfcab1a6892dae7893a160cc87f23af94de4 # v1
         if: github.event_name == 'pull_request' && steps.changed-files.outputs.any_changed == 'true'
         with:
           files: phpstan-report.xml

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -31,15 +31,15 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Setup Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 18
 
       - name: Cache NPM dependencies
-        uses: actions/cache@v3
+        uses: actions/cache@6f8efc29b200d32929f49075959781ed54ec270c # v3
         with:
           path: ~/.npm
           key: ${{ runner.os }}-npm-cache
@@ -48,7 +48,7 @@ jobs:
         run: npm ci
 
       - name: Cache Composer dependencies
-        uses: actions/cache@v3
+        uses: actions/cache@6f8efc29b200d32929f49075959781ed54ec270c # v3
         with:
           path: vendor
           key: ${{ runner.os }}-composer-cache
@@ -245,7 +245,7 @@ jobs:
       - name: Upload Cypress screenshots
         if: always()
         continue-on-error: true
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: cypress-screenshots-${{ matrix.php }}-${{ matrix.browser }}
           path: tests/e2e/cypress/screenshots
@@ -253,7 +253,7 @@ jobs:
       - name: Upload Cypress videos
         if: always()
         continue-on-error: true
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: cypress-videos-${{ matrix.php }}-${{ matrix.browser }}
           path: tests/e2e/cypress/videos

--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -19,21 +19,21 @@ jobs:
 
     steps:
       - name: Checkout PR Branch
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 0
 
       - name: Checkout Base Branch
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           ref: ${{ github.base_ref }}
           path: baseline
           fetch-depth: 0
 
       - name: Setup PHP
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@accd6127cb78bee3e8082180cb391013d204ef9f # v2
         with:
-          php-version: '8.1'
+          php-version: '8.2'
 
       - name: Run Baseline Performance Tests
         run: |
@@ -58,7 +58,7 @@ jobs:
           cat performance-report.md
       
       - name: Upload Performance Results
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         if: always()
         with:
           name: performance-results-${{ github.run_number }}
@@ -69,7 +69,7 @@ jobs:
           retention-days: 30
       
       - name: Comment PR with Performance Results
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         if: github.event_name == 'pull_request'
         with:
           script: |

--- a/.github/workflows/pr-build-test.yml
+++ b/.github/workflows/pr-build-test.yml
@@ -18,17 +18,17 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: '20'
           cache: 'npm'
           cache-dependency-path: 'package-lock.json'
 
       - name: Setup PHP
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@accd6127cb78bee3e8082180cb391013d204ef9f # v2
         with:
           php-version: '8.2'
           extensions: mysqli, mbstring, xml, zip
@@ -64,7 +64,7 @@ jobs:
           echo "Prepared artifact: $PLUGIN_DIR as $ARCHIVE_NAME"
 
       - name: Upload build artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: ${{ steps.artifact.outputs.name }}
           path: ${{ steps.artifact.outputs.path }}
@@ -142,7 +142,7 @@ jobs:
         # Fork PRs don't have write access to the base repo — skip gracefully.
         # The build artifact is still uploaded and accessible via the Actions run URL.
         if: github.event.pull_request.head.repo.full_name == github.repository
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
           script: |
             const comment = `## 🔨 Build Complete - Ready for Testing!

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,12 +14,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 0
 
       - name: Setup PHP
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@accd6127cb78bee3e8082180cb391013d204ef9f # v2
         with:
           php-version: '7.4'
           extensions: mbstring, intl, curl
@@ -40,7 +40,7 @@ jobs:
           esac
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: '18'
           cache: 'npm'
@@ -91,7 +91,7 @@ jobs:
 
       - name: Create Release
         id: create_release
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@de2c0eb89ae2a093876385947365aca7b0e5f844 # v1
         with:
           files: |
             build/ultimate-multisite-${{ env.VERSION }}.zip

--- a/.github/workflows/sync-wiki.yml
+++ b/.github/workflows/sync-wiki.yml
@@ -16,7 +16,7 @@ jobs:
       contents: write
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 0
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,8 +7,38 @@ on:
     branches: [main]
 
 jobs:
+  php-lint:
+    name: PHP Lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@accd6127cb78bee3e8082180cb391013d204ef9f # v2
+        with:
+          php-version: '8.2'
+          tools: none
+
+      - name: Check PHP syntax
+        run: |
+          echo "Checking PHP syntax across the codebase..."
+          errors=0
+          while IFS= read -r file; do
+            if ! php -l "$file" 2>&1 | grep -q "No syntax errors"; then
+              php -l "$file"
+              errors=$((errors + 1))
+            fi
+          done < <(find inc/ -name '*.php' -type f)
+          if [ "$errors" -gt 0 ]; then
+            echo ""
+            echo "Found $errors file(s) with syntax errors."
+            exit 1
+          fi
+          echo "All PHP files passed syntax check."
+
   php-tests:
     name: PHP ${{ matrix.php-version }}
+    needs: php-lint
     runs-on: ubuntu-latest
     continue-on-error: ${{ matrix.php-version == '8.5' }}
     strategy:


### PR DESCRIPTION
## Summary

- Adds a PHP Lint fast-fail CI gate that catches syntax errors (like duplicate method declarations) in ~5 seconds, before the full PHPUnit suite runs
- Pins all GitHub Actions across all 8 workflows to immutable commit SHAs to prevent supply chain attacks
- Upgrades code-quality and performance workflows from EOL PHP 8.1 to 8.2

## Context

PR #507 fixes a `Cannot redeclare jsonSerialize()` fatal error that broke tests on PHP 8.2/8.4/8.5. The root cause was two PRs (#491 and #503) independently adding the same method, merged in sequence without rebasing.

This PR adds protections to prevent that class of bug from reaching `main` again, and hardens the CI pipeline more broadly.

## Changes

### 1. PHP Lint fast-fail gate (`tests.yml`)

New `PHP Lint` job runs `php -l` on all files in `inc/` **before** PHPUnit starts. This:
- Catches syntax errors, duplicate method declarations, and parse errors in ~5 seconds
- Blocks PHPUnit from running if lint fails (`needs: php-lint`)
- Would have caught the duplicate `jsonSerialize()` bug immediately, before any test infrastructure spun up

### 2. Pin all GitHub Actions to commit SHAs (all 8 workflows)

Every `uses:` directive now references an immutable commit SHA instead of a mutable tag. This prevents:
- Supply chain attacks where a compromised maintainer re-tags a malicious version
- Unexpected breakage from upstream action updates

| Workflow | Actions pinned |
|----------|---------------|
| `tests.yml` | Already pinned (PR #501) |
| `code-quality.yml` | checkout, setup-php, changed-files, annotate-pr (4) |
| `e2e.yml` | checkout, setup-node, cache, upload-artifact (4) |
| `performance.yml` | checkout, setup-php, upload-artifact, github-script (4) |
| `pr-build-test.yml` | checkout, setup-node, setup-php, upload-artifact, github-script (5) |
| `release.yml` | checkout, setup-php, setup-node, action-gh-release (4) |
| `sync-wiki.yml` | checkout (1) |
| `addon-integration-test.yml` | checkout, setup-node, cache, upload-artifact (4) |

Also upgraded `actions/checkout` from v2/v3 to v4 and `actions/setup-node` from v3 to v4 where outdated.

### 3. Upgrade EOL PHP versions

- `code-quality.yml`: PHP 8.1 -> 8.2 (PHP 8.1 reached EOL November 2024)
- `performance.yml`: PHP 8.1 -> 8.2

## Branch protection recommendations

The `main` branch now has protection rules (required status checks + required reviews). Additional hardening to consider:

| Setting | Current | Recommended | Why |
|---------|---------|-------------|-----|
| `enforce_admins` | `false` | `true` | Admins can currently bypass all protections |
| `dismiss_stale_reviews` | `false` | `true` | Approved reviews stay valid after new pushes |
| `require_last_push_approval` | `false` | `true` | Prevents the pusher from also being the approver |
| `PHP Lint` required check | not set | add it | Fast-fail gate for syntax errors |
| `Code Quality Checks` required check | not set | consider | PHPCS/PHPStan annotations |

## Note on PHP 8.5

PHP 8.5 has `continue-on-error: true` in the matrix (experimental/pre-release), but is also listed as a required status check in branch protection. This means:
- If PHP 8.5 fails, the **workflow** won't fail (continue-on-error)
- But the **branch protection** check will still show as failed and block merge

This is actually the correct behavior for now -- it means PHP 8.5 failures are visible but the workflow itself doesn't fail. If PHP 8.5 should truly be non-blocking, remove it from the required status checks in branch protection settings.