### PR TITLE
fix(tax): skip wu_get_country_states() for wildcard '*' country rates

### DIFF
--- a/inc/tax/class-tax.php
+++ b/inc/tax/class-tax.php
@@ -248,7 +248,14 @@ class Tax {
 				function ($rate) use ($fetch_state_options) {
 
 					if ($fetch_state_options) {
-						$rate['state_options'] = wu_get_country_states($rate['country'], 'slug', 'name');
+						/*
+						 * Rates with country='*' (Apply to all countries) are wildcard
+						 * fallbacks and have no meaningful state list — skip the lookup
+						 * to avoid passing '*' to wu_get_country_states().
+						 */
+						$rate['state_options'] = ('*' !== $rate['country'])
+							? wu_get_country_states($rate['country'], 'slug', 'name')
+							: [];
 					}
 
 					$rate['tax_rate'] = is_numeric($rate['tax_rate']) ? $rate['tax_rate'] : 0;


### PR DESCRIPTION
## Summary

Completes the universal tax fallback feature (issue #511) by fixing the one missing piece: when a tax rate has `country='*'` (Apply to all countries), `wu_get_country_states('*')` was being called unnecessarily. This guard ensures wildcard rates receive an empty `state_options` array instead.

## What was already in place on `main`

The bulk of the feature was already implemented across three prior PRs/branches:

- **`wu_get_applicable_tax_rates()`** (`inc/functions/tax.php`) — already returns `*` rates as a catch-all fallback when no country-specific rate matches the customer's country. Country-specific rates always take precedence.
- **Tax Rates UI** (`views/taxes/list.php`) — the country dropdown already includes `<option value="*">Apply to all countries</option>` as the first option.
- **Unit tests** (`tests/WP_Ultimo/Functions/Tax_Functions_Test.php`) — comprehensive tests for wildcard fallback behaviour already exist and pass.

## What this PR adds

**`inc/tax/class-tax.php` — `get_tax_rates()` method:**

```php
// Before
$rate['state_options'] = wu_get_country_states($rate['country'], 'slug', 'name');

// After
$rate['state_options'] = ('*' !== $rate['country'])
    ? wu_get_country_states($rate['country'], 'slug', 'name')
    : [];
```

When `$fetch_state_options = true` (called from the AJAX handler that serves the Tax Rates admin page), passing `'*'` to `wu_get_country_states()` would attempt to instantiate `Country_*` (which doesn't exist), fall back to `Country_Default`, and return an empty/meaningless result anyway. The guard makes this explicit and avoids the unnecessary lookup.

## Testing

- **PHP syntax:** `php -l` passes on all three tax files
- **Static review:** diff is 8 lines, single-purpose, no logic change to the fallback mechanism
- **Unit tests:** 6 wildcard-specific tests in `Tax_Functions_Test.php` cover the fallback behaviour end-to-end — CI will run these

## References

- Closes #511
- Original implementation context: PR #277 (closed, branch `feature/universal-tax-rate`)
- Maintainer spec: redesign as "Apply to all countries" option in the country dropdown, not a separate settings toggle