### PR TITLE
feat(tax): salvage universal tax fallback from closed PR #277

### DIFF
--- a/inc/checkout/class-cart.php
+++ b/inc/checkout/class-cart.php
@@ -2792,6 +2792,23 @@ class Cart implements \JsonSerializable {
 			return $line_item;
 		}
 
+		/**
+		 * Filters the applicable tax rates for a cart line item.
+		 *
+		 * Rates with country set to '*' (Apply to all countries) act as a universal
+		 * fallback and are applied when no country-specific rate matches the customer's
+		 * country. Country-specific rates always take precedence.
+		 *
+		 * To configure a universal fallback rate, go to Tax Rates and select
+		 * 'Apply to all countries' from the country dropdown on any rate row.
+		 *
+		 * @since 2.0.0
+		 *
+		 * @param array  $tax_rates    The applicable tax rates.
+		 * @param string $country      The customer's country code.
+		 * @param string $tax_category The tax category slug.
+		 * @param Cart   $cart         The current cart object.
+		 */
 		$tax_rates = apply_filters('wu_cart_applicable_tax_rates', wu_get_applicable_tax_rates($this->country, $tax_category, $this->state, $this->city), $this->country, $tax_category, $this);
 
 		if (empty($tax_rates)) {


### PR DESCRIPTION
## Summary

Closes #521

Cherry-picked commits `a3f97e82` and `7738dce8` from closed PR #277 onto a new branch. Both cherry-picks produced **empty commits** — the universal tax fallback feature is already fully implemented in `main` via PR #506.

This PR adds a docblock to the `wu_cart_applicable_tax_rates` filter in `class-cart.php`, documenting the filter's parameters and the universal fallback mechanism for developers.

## Feature Status: Complete

All acceptance criteria from issue #521 are met:

| Requirement | Status | Implementation |
|---|---|---|
| `enable_universal_tax` setting toggle | ✅ Superseded | Maintainer requested UI approach instead (see PR #277 review) |
| `universal_tax_rate` setting (0-100%) | ✅ Superseded | Configured via Tax Rates UI, not settings |
| `apply_universal_tax_rate` filter | ✅ Present | `wu_cart_applicable_tax_rates` filter in `class-cart.php:2795` |
| Translation updates | ✅ Done | "Apply to all countries" string in `lang/ultimate-multisite.pot` |
| Apply universal rate when no country-specific rates match | ✅ Done | Wildcard `*` fallback in `wu_get_applicable_tax_rates()` |

## How the Feature Works

The maintainer (@superdav42) requested a different approach than the original PR #277 settings-based implementation. The implemented approach:

1. **Tax Rates UI** (`views/taxes/list.php`): Select **"Apply to all countries"** (`*`) from the country dropdown on any tax rate row
2. **Fallback logic** (`inc/functions/tax.php`): `wu_get_applicable_tax_rates()` returns rates with `country='*'` only when no country-specific rate matches
3. **Filter hook** (`inc/checkout/class-cart.php`): `wu_cart_applicable_tax_rates` allows developers to further customise applicable rates

## Cherry-pick Resolution

- `a3f97e82` (settings-based approach): Conflicted with current code; resolved by keeping HEAD — the settings-based approach was superseded by the wildcard UI approach per maintainer feedback
- `7738dce8` (wildcard refactor): Conflicted with current code; resolved by keeping HEAD — the wildcard approach was already implemented in PR #506

## Runtime Testing

- **Risk classification**: Low (docs-only change — docblock addition)
- **Testing level**: `self-assessed`
- **Test coverage**: `tests/WP_Ultimo/Functions/Tax_Functions_Test.php` has 5 tests covering wildcard fallback behaviour
- **Behaviour verified**: Feature fully functional in main; this PR adds documentation only

## Files Changed

| File | Change |
|---|---|
| `inc/checkout/class-cart.php` | Added docblock to `wu_cart_applicable_tax_rates` filter documenting parameters and universal fallback behaviour |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced internal documentation for tax rate filtering logic, clarifying how universal fallback rates and country-specific rates are applied.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->