### PR TITLE
feat: put External Cron Service behind WU_EXTERNAL_CRON_ENABLED feature flag

### DIFF
--- a/constants.php
+++ b/constants.php
@@ -37,3 +37,17 @@ if ( ! defined('WP_ULTIMO_PLUGIN_BASENAME')) {
 if ( ! defined('WU_TEMPLATE_LIBRARY_ENABLED')) {
 	define('WU_TEMPLATE_LIBRARY_ENABLED', false);
 }
+
+/**
+ * Feature flag: Enable External Cron Service.
+ *
+ * When set to true, enables the External Cron manager, admin page,
+ * and service integration. Server-side functionality is not complete,
+ * so this defaults to false. Developers can enable this by defining
+ * WU_EXTERNAL_CRON_ENABLED as true in wp-config.php before the plugin loads.
+ *
+ * @since 2.5.0
+ */
+if ( ! defined('WU_EXTERNAL_CRON_ENABLED')) {
+	define('WU_EXTERNAL_CRON_ENABLED', false);
+}

--- a/inc/class-wp-ultimo.php
+++ b/inc/class-wp-ultimo.php
@@ -1013,10 +1013,18 @@ final class WP_Ultimo {
 		 */
 		WP_Ultimo\Views::get_instance();
 
-		/*
+		/**
 		 * Loads the External Cron manager.
+		 *
+		 * This is behind a feature flag as server-side functionality
+		 * is not yet complete. Define WU_EXTERNAL_CRON_ENABLED as true
+		 * in wp-config.php to enable for development/testing.
+		 *
+		 * @since 2.5.0
 		 */
-		WP_Ultimo\External_Cron\External_Cron_Manager::get_instance();
+		if (defined('WU_EXTERNAL_CRON_ENABLED') && WU_EXTERNAL_CRON_ENABLED) {
+			WP_Ultimo\External_Cron\External_Cron_Manager::get_instance();
+		}
 	}
 
 	/**


### PR DESCRIPTION
## Summary

- Puts the External Cron manager, admin page, and service integration behind a `WU_EXTERNAL_CRON_ENABLED` PHP constant feature flag (defaults to `false`)
- Server-side functionality is not complete, so this hides it for the next release — same pattern as the Template Library flag in #599

## Changes

- **`constants.php`** — Added `WU_EXTERNAL_CRON_ENABLED` constant (defaults to `false`)
- **`inc/class-wp-ultimo.php`** — Wrapped `External_Cron_Manager::get_instance()` with feature flag check

## Usage

To enable for development/testing, add to `wp-config.php`:

```php
define('WU_EXTERNAL_CRON_ENABLED', true);
```

## Verification

- [ ] Without the constant defined, the External Cron admin page should not appear and no cron service hooks should fire
- [ ] With `WU_EXTERNAL_CRON_ENABLED` set to `true`, the External Cron admin page and service integration should work as before