### PR TITLE
t516: test(list-tables): write unit tests for remaining list table classes

### DIFF
--- a/tests/WP_Ultimo/List_Tables/Broadcast_List_Table_Test.php
+++ b/tests/WP_Ultimo/List_Tables/Broadcast_List_Table_Test.php
@@ -1,0 +1,336 @@
+<?php
+/**
+ * Tests for Broadcast_List_Table class.
+ *
+ * @package WP_Ultimo\Tests
+ */
+
+namespace WP_Ultimo\List_Tables;
+
+use WP_UnitTestCase;
+
+/**
+ * Test class for Broadcast_List_Table.
+ *
+ * @group list-tables
+ */
+class Broadcast_List_Table_Test extends WP_UnitTestCase {
+
+	/**
+	 * @var Broadcast_List_Table
+	 */
+	private Broadcast_List_Table $table;
+
+	/**
+	 * Set up test fixtures.
+	 */
+	public function set_up(): void {
+
+		parent::set_up();
+
+		$this->table = new Broadcast_List_Table();
+	}
+
+	/**
+	 * Tear down after each test.
+	 */
+	public function tear_down(): void {
+
+		unset( $_REQUEST['type'], $_REQUEST['status'] );
+
+		parent::tear_down();
+	}
+
+	// =========================================================================
+	// Constructor & Labels
+	// =========================================================================
+
+	/**
+	 * Test constructor sets singular label.
+	 */
+	public function test_constructor_sets_singular_label(): void {
+
+		$this->assertStringContainsString( 'Broadcast', $this->table->get_label( 'singular' ) );
+	}
+
+	/**
+	 * Test constructor sets plural label.
+	 */
+	public function test_constructor_sets_plural_label(): void {
+
+		$this->assertStringContainsString( 'Broadcasts', $this->table->get_label( 'plural' ) );
+	}
+
+	// =========================================================================
+	// get_columns()
+	// =========================================================================
+
+	/**
+	 * Test get_columns returns array with expected keys.
+	 */
+	public function test_get_columns_returns_expected_keys(): void {
+
+		$columns = $this->table->get_columns();
+
+		$this->assertIsArray( $columns );
+		$this->assertArrayHasKey( 'cb', $columns );
+		$this->assertArrayHasKey( 'type', $columns );
+		$this->assertArrayHasKey( 'the_content', $columns );
+		$this->assertArrayHasKey( 'target_customers', $columns );
+		$this->assertArrayHasKey( 'target_products', $columns );
+		$this->assertArrayHasKey( 'date_created', $columns );
+		$this->assertArrayHasKey( 'id', $columns );
+	}
+
+	/**
+	 * Test get_columns returns 7 columns.
+	 */
+	public function test_get_columns_returns_seven_columns(): void {
+
+		$columns = $this->table->get_columns();
+
+		$this->assertCount( 7, $columns );
+	}
+
+	// =========================================================================
+	// get_sortable_columns()
+	// =========================================================================
+
+	/**
+	 * Test get_sortable_columns returns array.
+	 */
+	public function test_get_sortable_columns_returns_array(): void {
+
+		$columns = $this->table->get_sortable_columns();
+
+		$this->assertIsArray( $columns );
+	}
+
+	// =========================================================================
+	// column_cb()
+	// =========================================================================
+
+	/**
+	 * Test column_cb returns disabled checkbox for broadcast_email type.
+	 */
+	public function test_column_cb_returns_disabled_for_broadcast_email(): void {
+
+		$item = $this->getMockBuilder( \stdClass::class )
+			->addMethods( [ 'get_type', 'get_id' ] )
+			->getMock();
+		$item->method( 'get_type' )->willReturn( 'broadcast_email' );
+		$item->method( 'get_id' )->willReturn( 1 );
+
+		$output = $this->table->column_cb( $item );
+
+		$this->assertStringContainsString( 'disabled', $output );
+	}
+
+	/**
+	 * Test column_cb returns normal checkbox for broadcast_notice type.
+	 */
+	public function test_column_cb_returns_normal_for_broadcast_notice(): void {
+
+		$item = $this->getMockBuilder( \stdClass::class )
+			->addMethods( [ 'get_type', 'get_id' ] )
+			->getMock();
+		$item->method( 'get_type' )->willReturn( 'broadcast_notice' );
+		$item->method( 'get_id' )->willReturn( 5 );
+
+		$output = $this->table->column_cb( $item );
+
+		$this->assertStringContainsString( 'type="checkbox"', $output );
+		$this->assertStringNotContainsString( 'disabled', $output );
+		$this->assertStringContainsString( '5', $output );
+	}
+
+	// =========================================================================
+	// column_type()
+	// =========================================================================
+
+	/**
+	 * Test column_type returns Email label for broadcast_email.
+	 */
+	public function test_column_type_returns_email_label_for_broadcast_email(): void {
+
+		$item = $this->getMockBuilder( \stdClass::class )
+			->addMethods( [ 'get_type', 'get_notice_type' ] )
+			->getMock();
+		$item->method( 'get_type' )->willReturn( 'broadcast_email' );
+
+		$output = $this->table->column_type( $item );
+
+		$this->assertStringContainsString( 'Email', $output );
+	}
+
+	/**
+	 * Test column_type returns Notice label for broadcast_notice.
+	 */
+	public function test_column_type_returns_notice_label_for_broadcast_notice(): void {
+
+		$item = $this->getMockBuilder( \stdClass::class )
+			->addMethods( [ 'get_type', 'get_notice_type' ] )
+			->getMock();
+		$item->method( 'get_type' )->willReturn( 'broadcast_notice' );
+		$item->method( 'get_notice_type' )->willReturn( 'info' );
+
+		$output = $this->table->column_type( $item );
+
+		$this->assertStringContainsString( 'Notice', $output );
+	}
+
+	/**
+	 * Test column_type applies correct CSS class for info notice.
+	 */
+	public function test_column_type_applies_blue_class_for_info_notice(): void {
+
+		$item = $this->getMockBuilder( \stdClass::class )
+			->addMethods( [ 'get_type', 'get_notice_type' ] )
+			->getMock();
+		$item->method( 'get_type' )->willReturn( 'broadcast_notice' );
+		$item->method( 'get_notice_type' )->willReturn( 'info' );
+
+		$output = $this->table->column_type( $item );
+
+		$this->assertStringContainsString( 'wu-bg-blue-200', $output );
+	}
+
+	/**
+	 * Test column_type applies correct CSS class for success notice.
+	 */
+	public function test_column_type_applies_green_class_for_success_notice(): void {
+
+		$item = $this->getMockBuilder( \stdClass::class )
+			->addMethods( [ 'get_type', 'get_notice_type' ] )
+			->getMock();
+		$item->method( 'get_type' )->willReturn( 'broadcast_notice' );
+		$item->method( 'get_notice_type' )->willReturn( 'success' );
+
+		$output = $this->table->column_type( $item );
+
+		$this->assertStringContainsString( 'wu-bg-green-200', $output );
+	}
+
+	/**
+	 * Test column_type applies correct CSS class for warning notice.
+	 */
+	public function test_column_type_applies_orange_class_for_warning_notice(): void {
+
+		$item = $this->getMockBuilder( \stdClass::class )
+			->addMethods( [ 'get_type', 'get_notice_type' ] )
+			->getMock();
+		$item->method( 'get_type' )->willReturn( 'broadcast_notice' );
+		$item->method( 'get_notice_type' )->willReturn( 'warning' );
+
+		$output = $this->table->column_type( $item );
+
+		$this->assertStringContainsString( 'wu-bg-orange-200', $output );
+	}
+
+	/**
+	 * Test column_type applies correct CSS class for error notice.
+	 */
+	public function test_column_type_applies_red_class_for_error_notice(): void {
+
+		$item = $this->getMockBuilder( \stdClass::class )
+			->addMethods( [ 'get_type', 'get_notice_type' ] )
+			->getMock();
+		$item->method( 'get_type' )->willReturn( 'broadcast_notice' );
+		$item->method( 'get_notice_type' )->willReturn( 'error' );
+
+		$output = $this->table->column_type( $item );
+
+		$this->assertStringContainsString( 'wu-bg-red-200', $output );
+	}
+
+	// =========================================================================
+	// get_filters()
+	// =========================================================================
+
+	/**
+	 * Test get_filters returns correct structure.
+	 */
+	public function test_get_filters_returns_correct_structure(): void {
+
+		$filters = $this->table->get_filters();
+
+		$this->assertIsArray( $filters );
+		$this->assertArrayHasKey( 'filters', $filters );
+		$this->assertArrayHasKey( 'date_filters', $filters );
+	}
+
+	/**
+	 * Test get_filters has type and status filters.
+	 */
+	public function test_get_filters_has_type_and_status(): void {
+
+		$filters = $this->table->get_filters();
+
+		$this->assertArrayHasKey( 'type', $filters['filters'] );
+		$this->assertArrayHasKey( 'status', $filters['filters'] );
+	}
+
+	/**
+	 * Test get_filters has date_created date filter.
+	 */
+	public function test_get_filters_has_date_created_date_filter(): void {
+
+		$filters = $this->table->get_filters();
+
+		$this->assertArrayHasKey( 'date_created', $filters['date_filters'] );
+	}
+
+	// =========================================================================
+	// get_views()
+	// =========================================================================
+
+	/**
+	 * Test get_views returns all, broadcast_email, broadcast_notice keys.
+	 */
+	public function test_get_views_returns_expected_keys(): void {
+
+		$views = $this->table->get_views();
+
+		$this->assertArrayHasKey( 'all', $views );
+		$this->assertArrayHasKey( 'broadcast_email', $views );
+		$this->assertArrayHasKey( 'broadcast_notice', $views );
+	}
+
+	/**
+	 * Test get_views each entry has required keys.
+	 */
+	public function test_get_views_entries_have_required_keys(): void {
+
+		$views = $this->table->get_views();
+
+		foreach ( $views as $key => $view ) {
+			$this->assertArrayHasKey( 'field', $view, "Missing 'field' in {$key}" );
+			$this->assertArrayHasKey( 'url', $view, "Missing 'url' in {$key}" );
+			$this->assertArrayHasKey( 'label', $view, "Missing 'label' in {$key}" );
+			$this->assertArrayHasKey( 'count', $view, "Missing 'count' in {$key}" );
+		}
+	}
+
+	// =========================================================================
+	// column_the_content()
+	// =========================================================================
+
+	/**
+	 * Test column_the_content returns string with title.
+	 */
+	public function test_column_the_content_returns_string_with_title(): void {
+
+		$item = $this->getMockBuilder( \stdClass::class )
+			->addMethods( [ 'get_id', 'get_slug', 'get_title', 'get_content' ] )
+			->getMock();
+		$item->method( 'get_id' )->willReturn( 1 );
+		$item->method( 'get_slug' )->willReturn( 'test-broadcast' );
+		$item->method( 'get_title' )->willReturn( 'Test Broadcast Title' );
+		$item->method( 'get_content' )->willReturn( 'Some broadcast content here.' );
+
+		$output = $this->table->column_the_content( $item );
+
+		$this->assertIsString( $output );
+		$this->assertStringContainsString( 'Test Broadcast Title', $output );
+	}
+}

--- a/tests/WP_Ultimo/List_Tables/Checkout_Form_List_Table_Test.php
+++ b/tests/WP_Ultimo/List_Tables/Checkout_Form_List_Table_Test.php
@@ -1,0 +1,180 @@
+<?php
+/**
+ * Tests for Checkout_Form_List_Table class.
+ *
+ * @package WP_Ultimo\Tests
+ */
+
+namespace WP_Ultimo\List_Tables;
+
+use WP_UnitTestCase;
+
+/**
+ * Test class for Checkout_Form_List_Table.
+ *
+ * @group list-tables
+ */
+class Checkout_Form_List_Table_Test extends WP_UnitTestCase {
+
+	/**
+	 * @var Checkout_Form_List_Table
+	 */
+	private Checkout_Form_List_Table $table;
+
+	/**
+	 * Set up test fixtures.
+	 */
+	public function set_up(): void {
+
+		parent::set_up();
+
+		$this->table = new Checkout_Form_List_Table();
+	}
+
+	// =========================================================================
+	// Constructor & Labels
+	// =========================================================================
+
+	/**
+	 * Test constructor sets singular label.
+	 */
+	public function test_constructor_sets_singular_label(): void {
+
+		$this->assertStringContainsString( 'Checkout Form', $this->table->get_label( 'singular' ) );
+	}
+
+	/**
+	 * Test constructor sets plural label.
+	 */
+	public function test_constructor_sets_plural_label(): void {
+
+		$this->assertStringContainsString( 'Checkout Forms', $this->table->get_label( 'plural' ) );
+	}
+
+	// =========================================================================
+	// get_columns()
+	// =========================================================================
+
+	/**
+	 * Test get_columns returns expected keys.
+	 */
+	public function test_get_columns_returns_expected_keys(): void {
+
+		$columns = $this->table->get_columns();
+
+		$this->assertIsArray( $columns );
+		$this->assertArrayHasKey( 'cb', $columns );
+		$this->assertArrayHasKey( 'name', $columns );
+		$this->assertArrayHasKey( 'slug', $columns );
+		$this->assertArrayHasKey( 'steps', $columns );
+		$this->assertArrayHasKey( 'id', $columns );
+	}
+
+	/**
+	 * Test get_columns returns 5 columns.
+	 */
+	public function test_get_columns_returns_five_columns(): void {
+
+		$columns = $this->table->get_columns();
+
+		$this->assertCount( 5, $columns );
+	}
+
+	// =========================================================================
+	// get_sortable_columns()
+	// =========================================================================
+
+	/**
+	 * Test get_sortable_columns returns array.
+	 */
+	public function test_get_sortable_columns_returns_array(): void {
+
+		$columns = $this->table->get_sortable_columns();
+
+		$this->assertIsArray( $columns );
+	}
+
+	// =========================================================================
+	// column_slug()
+	// =========================================================================
+
+	/**
+	 * Test column_slug returns slug wrapped in span.
+	 */
+	public function test_column_slug_returns_slug_in_span(): void {
+
+		$item = $this->getMockBuilder( \stdClass::class )
+			->addMethods( [ 'get_slug' ] )
+			->getMock();
+		$item->method( 'get_slug' )->willReturn( 'my-checkout-form' );
+
+		$output = $this->table->column_slug( $item );
+
+		$this->assertStringContainsString( 'my-checkout-form', $output );
+		$this->assertStringContainsString( '<span', $output );
+		$this->assertStringContainsString( 'wu-font-mono', $output );
+	}
+
+	// =========================================================================
+	// column_steps()
+	// =========================================================================
+
+	/**
+	 * Test column_steps returns step and field count.
+	 */
+	public function test_column_steps_returns_step_and_field_count(): void {
+
+		$item = $this->getMockBuilder( \stdClass::class )
+			->addMethods( [ 'get_step_count', 'get_field_count' ] )
+			->getMock();
+		$item->method( 'get_step_count' )->willReturn( 3 );
+		$item->method( 'get_field_count' )->willReturn( 12 );
+
+		$output = $this->table->column_steps( $item );
+
+		$this->assertStringContainsString( '3', $output );
+		$this->assertStringContainsString( '12', $output );
+	}
+
+	// =========================================================================
+	// column_shortcode()
+	// =========================================================================
+
+	/**
+	 * Test column_shortcode returns input with shortcode value.
+	 */
+	public function test_column_shortcode_returns_input_with_shortcode(): void {
+
+		$item = $this->getMockBuilder( \stdClass::class )
+			->addMethods( [ 'get_shortcode' ] )
+			->getMock();
+		$item->method( 'get_shortcode' )->willReturn( '[wu_checkout slug="my-form"]' );
+
+		$output = $this->table->column_shortcode( $item );
+
+		$this->assertStringContainsString( '<input', $output );
+		$this->assertStringContainsString( 'wu_checkout', $output );
+	}
+
+	// =========================================================================
+	// column_name()
+	// =========================================================================
+
+	/**
+	 * Test column_name returns string with form name.
+	 */
+	public function test_column_name_returns_string_with_form_name(): void {
+
+		$item = $this->getMockBuilder( \stdClass::class )
+			->addMethods( [ 'get_id', 'get_slug', 'get_name' ] )
+			->getMock();
+		$item->method( 'get_id' )->willReturn( 1 );
+		$item->method( 'get_slug' )->willReturn( 'my-form' );
+		$item->method( 'get_name' )->willReturn( 'My Checkout Form' );
+
+		$output = $this->table->column_name( $item );
+
+		$this->assertIsString( $output );
+		$this->assertStringContainsString( 'My Checkout Form', $output );
+	}
+}

--- a/tests/WP_Ultimo/List_Tables/Customer_List_Table_Test.php
+++ b/tests/WP_Ultimo/List_Tables/Customer_List_Table_Test.php
@@ -1,0 +1,280 @@
+<?php
+/**
+ * Tests for Customer_List_Table class.
+ *
+ * @package WP_Ultimo\Tests
+ */
+
+namespace WP_Ultimo\List_Tables;
+
+use WP_UnitTestCase;
+
+/**
+ * Test class for Customer_List_Table.
+ *
+ * @group list-tables
+ */
+class Customer_List_Table_Test extends WP_UnitTestCase {
+
+	/**
+	 * @var Customer_List_Table
+	 */
+	private Customer_List_Table $table;
+
+	/**
+	 * Set up test fixtures.
+	 */
+	public function set_up(): void {
+
+		parent::set_up();
+
+		$this->table = new Customer_List_Table();
+	}
+
+	/**
+	 * Tear down after each test.
+	 */
+	public function tear_down(): void {
+
+		unset( $_GET['s'], $_REQUEST['filter'] );
+
+		parent::tear_down();
+	}
+
+	// =========================================================================
+	// Constructor & Labels
+	// =========================================================================
+
+	/**
+	 * Test constructor sets singular label.
+	 */
+	public function test_constructor_sets_singular_label(): void {
+
+		$this->assertStringContainsString( 'Customer', $this->table->get_label( 'singular' ) );
+	}
+
+	/**
+	 * Test constructor sets plural label.
+	 */
+	public function test_constructor_sets_plural_label(): void {
+
+		$this->assertStringContainsString( 'Customers', $this->table->get_label( 'plural' ) );
+	}
+
+	/**
+	 * Test constructor sets grid and list modes.
+	 */
+	public function test_constructor_sets_grid_and_list_modes(): void {
+
+		$this->assertArrayHasKey( 'grid', $this->table->modes );
+		$this->assertArrayHasKey( 'list', $this->table->modes );
+	}
+
+	// =========================================================================
+	// get_columns()
+	// =========================================================================
+
+	/**
+	 * Test get_columns returns expected keys.
+	 */
+	public function test_get_columns_returns_expected_keys(): void {
+
+		$columns = $this->table->get_columns();
+
+		$this->assertIsArray( $columns );
+		$this->assertArrayHasKey( 'cb', $columns );
+		$this->assertArrayHasKey( 'customer_status', $columns );
+		$this->assertArrayHasKey( 'name', $columns );
+		$this->assertArrayHasKey( 'last_login', $columns );
+		$this->assertArrayHasKey( 'date_registered', $columns );
+		$this->assertArrayHasKey( 'memberships', $columns );
+		$this->assertArrayHasKey( 'id', $columns );
+	}
+
+	/**
+	 * Test get_columns returns 7 columns.
+	 */
+	public function test_get_columns_returns_seven_columns(): void {
+
+		$columns = $this->table->get_columns();
+
+		$this->assertCount( 7, $columns );
+	}
+
+	// =========================================================================
+	// get_sortable_columns()
+	// =========================================================================
+
+	/**
+	 * Test get_sortable_columns returns array.
+	 */
+	public function test_get_sortable_columns_returns_array(): void {
+
+		$columns = $this->table->get_sortable_columns();
+
+		$this->assertIsArray( $columns );
+	}
+
+	// =========================================================================
+	// get_filters()
+	// =========================================================================
+
+	/**
+	 * Test get_filters returns array (Customer uses schema-based filters).
+	 */
+	public function test_get_filters_returns_array(): void {
+
+		$filters = $this->table->get_filters();
+
+		$this->assertIsArray( $filters );
+	}
+
+	// =========================================================================
+	// get_views()
+	// =========================================================================
+
+	/**
+	 * Test get_views returns all, vip, online keys.
+	 */
+	public function test_get_views_returns_expected_keys(): void {
+
+		$views = $this->table->get_views();
+
+		$this->assertArrayHasKey( 'all', $views );
+		$this->assertArrayHasKey( 'vip', $views );
+		$this->assertArrayHasKey( 'online', $views );
+	}
+
+	/**
+	 * Test get_views entries have required keys.
+	 */
+	public function test_get_views_entries_have_required_keys(): void {
+
+		$views = $this->table->get_views();
+
+		foreach ( $views as $key => $view ) {
+			$this->assertArrayHasKey( 'field', $view, "Missing 'field' in {$key}" );
+			$this->assertArrayHasKey( 'url', $view, "Missing 'url' in {$key}" );
+			$this->assertArrayHasKey( 'label', $view, "Missing 'label' in {$key}" );
+			$this->assertArrayHasKey( 'count', $view, "Missing 'count' in {$key}" );
+		}
+	}
+
+	// =========================================================================
+	// get_extra_query_fields()
+	// =========================================================================
+
+	/**
+	 * Test get_extra_query_fields includes type=customer.
+	 */
+	public function test_get_extra_query_fields_includes_customer_type(): void {
+
+		$fields = $this->table->get_extra_query_fields();
+
+		$this->assertIsArray( $fields );
+		$this->assertArrayHasKey( 'type', $fields );
+		$this->assertEquals( 'customer', $fields['type'] );
+	}
+
+	/**
+	 * Test get_extra_query_fields adds vip filter when filter=vip.
+	 */
+	public function test_get_extra_query_fields_adds_vip_filter(): void {
+
+		$_REQUEST['filter'] = 'vip';
+
+		$fields = $this->table->get_extra_query_fields();
+
+		$this->assertArrayHasKey( 'vip', $fields );
+		$this->assertEquals( 1, $fields['vip'] );
+
+		unset( $_REQUEST['filter'] );
+	}
+
+	/**
+	 * Test get_extra_query_fields adds last_login_query for online filter.
+	 */
+	public function test_get_extra_query_fields_adds_last_login_for_online(): void {
+
+		$_REQUEST['filter'] = 'online';
+
+		$fields = $this->table->get_extra_query_fields();
+
+		$this->assertArrayHasKey( 'last_login_query', $fields );
+
+		unset( $_REQUEST['filter'] );
+	}
+
+	// =========================================================================
+	// column_customer_status()
+	// =========================================================================
+
+	/**
+	 * Test column_customer_status returns HTML with avatar.
+	 */
+	public function test_column_customer_status_returns_html(): void {
+
+		$item = $this->getMockBuilder( \stdClass::class )
+			->addMethods( [ 'is_vip', 'get_user_id' ] )
+			->getMock();
+		$item->method( 'is_vip' )->willReturn( false );
+		$item->method( 'get_user_id' )->willReturn( 1 );
+
+		$output = $this->table->column_customer_status( $item );
+
+		$this->assertIsString( $output );
+		$this->assertStringContainsString( 'wu-status-container', $output );
+	}
+
+	/**
+	 * Test column_customer_status includes VIP tag for VIP customers.
+	 */
+	public function test_column_customer_status_includes_vip_tag(): void {
+
+		$item = $this->getMockBuilder( \stdClass::class )
+			->addMethods( [ 'is_vip', 'get_user_id' ] )
+			->getMock();
+		$item->method( 'is_vip' )->willReturn( true );
+		$item->method( 'get_user_id' )->willReturn( 1 );
+
+		$output = $this->table->column_customer_status( $item );
+
+		$this->assertStringContainsString( 'VIP', $output );
+	}
+
+	// =========================================================================
+	// column_last_login()
+	// =========================================================================
+
+	/**
+	 * Test column_last_login returns Online for online customers.
+	 */
+	public function test_column_last_login_returns_online_for_online_customer(): void {
+
+		$item = $this->getMockBuilder( \stdClass::class )
+			->addMethods( [ 'is_online', 'get_last_login' ] )
+			->getMock();
+		$item->method( 'is_online' )->willReturn( true );
+
+		$output = $this->table->column_last_login( $item );
+
+		$this->assertStringContainsString( 'Online', $output );
+	}
+
+	/**
+	 * Test column_last_login returns datetime for offline customers.
+	 */
+	public function test_column_last_login_returns_datetime_for_offline_customer(): void {
+
+		$item = $this->getMockBuilder( \stdClass::class )
+			->addMethods( [ 'is_online', 'get_last_login' ] )
+			->getMock();
+		$item->method( 'is_online' )->willReturn( false );
+		$item->method( 'get_last_login' )->willReturn( '2024-01-15 10:00:00' );
+
+		$output = $this->table->column_last_login( $item );
+
+		// Should return datetime HTML (span with role=tooltip) or '--' for invalid date.
+		$this->assertIsString( $output );
+	}
+}

--- a/tests/WP_Ultimo/List_Tables/Customers_Membership_List_Table_Test.php
+++ b/tests/WP_Ultimo/List_Tables/Customers_Membership_List_Table_Test.php
@@ -1,0 +1,140 @@
+<?php
+/**
+ * Tests for Customers_Membership_List_Table class.
+ *
+ * @package WP_Ultimo\Tests
+ */
+
+namespace WP_Ultimo\List_Tables;
+
+use WP_UnitTestCase;
+
+/**
+ * Test class for Customers_Membership_List_Table.
+ *
+ * @group list-tables
+ */
+class Customers_Membership_List_Table_Test extends WP_UnitTestCase {
+
+	/**
+	 * @var Customers_Membership_List_Table
+	 */
+	private Customers_Membership_List_Table $table;
+
+	/**
+	 * Set up test fixtures.
+	 */
+	public function set_up(): void {
+
+		parent::set_up();
+
+		$this->table = new Customers_Membership_List_Table();
+	}
+
+	// =========================================================================
+	// Constructor & Inheritance
+	// =========================================================================
+
+	/**
+	 * Test table extends Membership_List_Table.
+	 */
+	public function test_table_extends_membership_list_table(): void {
+
+		$this->assertInstanceOf( Membership_List_Table::class, $this->table );
+	}
+
+	/**
+	 * Test table inherits singular label from parent.
+	 */
+	public function test_table_inherits_singular_label(): void {
+
+		$this->assertStringContainsString( 'Membership', $this->table->get_label( 'singular' ) );
+	}
+
+	// =========================================================================
+	// get_columns()
+	// =========================================================================
+
+	/**
+	 * Test get_columns returns only responsive column.
+	 */
+	public function test_get_columns_returns_only_responsive(): void {
+
+		$columns = $this->table->get_columns();
+
+		$this->assertIsArray( $columns );
+		$this->assertArrayHasKey( 'responsive', $columns );
+		$this->assertCount( 1, $columns );
+	}
+
+	// =========================================================================
+	// get_sortable_columns()
+	// =========================================================================
+
+	/**
+	 * Test get_sortable_columns returns array.
+	 */
+	public function test_get_sortable_columns_returns_array(): void {
+
+		$columns = $this->table->get_sortable_columns();
+
+		$this->assertIsArray( $columns );
+	}
+
+	// =========================================================================
+	// get_filters() — inherited from Membership_List_Table
+	// =========================================================================
+
+	/**
+	 * Test get_filters returns correct structure (inherited).
+	 */
+	public function test_get_filters_returns_correct_structure(): void {
+
+		$filters = $this->table->get_filters();
+
+		$this->assertIsArray( $filters );
+		$this->assertArrayHasKey( 'filters', $filters );
+		$this->assertArrayHasKey( 'date_filters', $filters );
+	}
+
+	// =========================================================================
+	// get_views() — inherited from Membership_List_Table
+	// =========================================================================
+
+	/**
+	 * Test get_views returns all key (inherited).
+	 */
+	public function test_get_views_returns_all_key(): void {
+
+		$views = $this->table->get_views();
+
+		$this->assertIsArray( $views );
+		$this->assertArrayHasKey( 'all', $views );
+	}
+
+	// =========================================================================
+	// column_responsive()
+	// =========================================================================
+
+	/**
+	 * Test column_responsive outputs HTML without throwing.
+	 *
+	 * Note: wu_responsive_table_row() is a template helper not available in unit
+	 * test environment. We verify the method is callable and the item getters are
+	 * invoked correctly by checking the method exists and the column is defined.
+	 */
+	public function test_column_responsive_method_exists(): void {
+
+		$this->assertTrue( method_exists( $this->table, 'column_responsive' ) );
+	}
+
+	/**
+	 * Test column_responsive is defined in get_columns.
+	 */
+	public function test_column_responsive_is_in_get_columns(): void {
+
+		$columns = $this->table->get_columns();
+
+		$this->assertArrayHasKey( 'responsive', $columns );
+	}
+}

--- a/tests/WP_Ultimo/List_Tables/Customers_Payment_List_Table_Test.php
+++ b/tests/WP_Ultimo/List_Tables/Customers_Payment_List_Table_Test.php
@@ -1,0 +1,139 @@
+<?php
+/**
+ * Tests for Customers_Payment_List_Table class.
+ *
+ * @package WP_Ultimo\Tests
+ */
+
+namespace WP_Ultimo\List_Tables;
+
+use WP_UnitTestCase;
+
+/**
+ * Test class for Customers_Payment_List_Table.
+ *
+ * @group list-tables
+ */
+class Customers_Payment_List_Table_Test extends WP_UnitTestCase {
+
+	/**
+	 * @var Customers_Payment_List_Table
+	 */
+	private Customers_Payment_List_Table $table;
+
+	/**
+	 * Set up test fixtures.
+	 */
+	public function set_up(): void {
+
+		parent::set_up();
+
+		$this->table = new Customers_Payment_List_Table();
+	}
+
+	// =========================================================================
+	// Constructor & Inheritance
+	// =========================================================================
+
+	/**
+	 * Test table extends Payment_List_Table.
+	 */
+	public function test_table_extends_payment_list_table(): void {
+
+		$this->assertInstanceOf( Payment_List_Table::class, $this->table );
+	}
+
+	/**
+	 * Test table inherits singular label from parent.
+	 */
+	public function test_table_inherits_singular_label(): void {
+
+		$this->assertStringContainsString( 'Payment', $this->table->get_label( 'singular' ) );
+	}
+
+	// =========================================================================
+	// get_columns()
+	// =========================================================================
+
+	/**
+	 * Test get_columns returns only responsive column.
+	 */
+	public function test_get_columns_returns_only_responsive(): void {
+
+		$columns = $this->table->get_columns();
+
+		$this->assertIsArray( $columns );
+		$this->assertArrayHasKey( 'responsive', $columns );
+		$this->assertCount( 1, $columns );
+	}
+
+	// =========================================================================
+	// get_sortable_columns()
+	// =========================================================================
+
+	/**
+	 * Test get_sortable_columns returns array.
+	 */
+	public function test_get_sortable_columns_returns_array(): void {
+
+		$columns = $this->table->get_sortable_columns();
+
+		$this->assertIsArray( $columns );
+	}
+
+	// =========================================================================
+	// get_filters() — inherited from Payment_List_Table
+	// =========================================================================
+
+	/**
+	 * Test get_filters returns correct structure (inherited).
+	 */
+	public function test_get_filters_returns_correct_structure(): void {
+
+		$filters = $this->table->get_filters();
+
+		$this->assertIsArray( $filters );
+		$this->assertArrayHasKey( 'filters', $filters );
+		$this->assertArrayHasKey( 'date_filters', $filters );
+	}
+
+	// =========================================================================
+	// get_views() — inherited from Payment_List_Table
+	// =========================================================================
+
+	/**
+	 * Test get_views returns all key (inherited).
+	 */
+	public function test_get_views_returns_all_key(): void {
+
+		$views = $this->table->get_views();
+
+		$this->assertIsArray( $views );
+		$this->assertArrayHasKey( 'all', $views );
+	}
+
+	// =========================================================================
+	// column_responsive()
+	// =========================================================================
+
+	/**
+	 * Test column_responsive method exists.
+	 *
+	 * Note: wu_responsive_table_row() is a template helper not available in unit
+	 * test environment. We verify the method is callable and the column is defined.
+	 */
+	public function test_column_responsive_method_exists(): void {
+
+		$this->assertTrue( method_exists( $this->table, 'column_responsive' ) );
+	}
+
+	/**
+	 * Test column_responsive is defined in get_columns.
+	 */
+	public function test_column_responsive_is_in_get_columns(): void {
+
+		$columns = $this->table->get_columns();
+
+		$this->assertArrayHasKey( 'responsive', $columns );
+	}
+}

--- a/tests/WP_Ultimo/List_Tables/Customers_Site_List_Table_Test.php
+++ b/tests/WP_Ultimo/List_Tables/Customers_Site_List_Table_Test.php
@@ -1,0 +1,129 @@
+<?php
+/**
+ * Tests for Customers_Site_List_Table class.
+ *
+ * @package WP_Ultimo\Tests
+ */
+
+namespace WP_Ultimo\List_Tables;
+
+use WP_UnitTestCase;
+
+/**
+ * Test class for Customers_Site_List_Table.
+ *
+ * @group list-tables
+ */
+class Customers_Site_List_Table_Test extends WP_UnitTestCase {
+
+	/**
+	 * @var Customers_Site_List_Table
+	 */
+	private Customers_Site_List_Table $table;
+
+	/**
+	 * Set up test fixtures.
+	 */
+	public function set_up(): void {
+
+		parent::set_up();
+
+		$this->table = new Customers_Site_List_Table();
+	}
+
+	/**
+	 * Tear down after each test.
+	 */
+	public function tear_down(): void {
+
+		unset( $_REQUEST['page'], $_REQUEST['id'] );
+
+		parent::tear_down();
+	}
+
+	// =========================================================================
+	// Constructor & Inheritance
+	// =========================================================================
+
+	/**
+	 * Test table extends Site_List_Table.
+	 */
+	public function test_table_extends_site_list_table(): void {
+
+		$this->assertInstanceOf( Site_List_Table::class, $this->table );
+	}
+
+	/**
+	 * Test constructor forces list mode.
+	 */
+	public function test_constructor_forces_list_mode(): void {
+
+		$this->assertEquals( 'list', $this->table->current_mode );
+	}
+
+	// =========================================================================
+	// get_columns()
+	// =========================================================================
+
+	/**
+	 * Test get_columns returns only responsive column.
+	 */
+	public function test_get_columns_returns_only_responsive(): void {
+
+		$columns = $this->table->get_columns();
+
+		$this->assertIsArray( $columns );
+		$this->assertArrayHasKey( 'responsive', $columns );
+		$this->assertCount( 1, $columns );
+	}
+
+	// =========================================================================
+	// get_sortable_columns()
+	// =========================================================================
+
+	/**
+	 * Test get_sortable_columns returns array.
+	 */
+	public function test_get_sortable_columns_returns_array(): void {
+
+		$columns = $this->table->get_sortable_columns();
+
+		$this->assertIsArray( $columns );
+	}
+
+	// =========================================================================
+	// get_items() — overrides parent to add pending sites
+	// =========================================================================
+
+	/**
+	 * Test get_items with count=true returns numeric.
+	 */
+	public function test_get_items_count_returns_numeric(): void {
+
+		$result = $this->table->get_items( 5, 1, true );
+
+		$this->assertIsNumeric( $result );
+	}
+
+	/**
+	 * Test get_items with count=false returns array.
+	 */
+	public function test_get_items_returns_array(): void {
+
+		$result = $this->table->get_items( 5, 1, false );
+
+		$this->assertIsArray( $result );
+	}
+
+	/**
+	 * Test get_items without id returns sites without pending.
+	 */
+	public function test_get_items_without_id_returns_sites(): void {
+
+		unset( $_REQUEST['id'] );
+
+		$result = $this->table->get_items( 5, 1, false );
+
+		$this->assertIsArray( $result );
+	}
+}

--- a/tests/WP_Ultimo/List_Tables/Discount_Code_List_Table_Test.php
+++ b/tests/WP_Ultimo/List_Tables/Discount_Code_List_Table_Test.php
@@ -1,0 +1,264 @@
+<?php
+/**
+ * Tests for Discount_Code_List_Table class.
+ *
+ * @package WP_Ultimo\Tests
+ */
+
+namespace WP_Ultimo\List_Tables;
+
+use WP_UnitTestCase;
+
+/**
+ * Test class for Discount_Code_List_Table.
+ *
+ * @group list-tables
+ */
+class Discount_Code_List_Table_Test extends WP_UnitTestCase {
+
+	/**
+	 * @var Discount_Code_List_Table
+	 */
+	private Discount_Code_List_Table $table;
+
+	/**
+	 * Set up test fixtures.
+	 */
+	public function set_up(): void {
+
+		parent::set_up();
+
+		$this->table = new Discount_Code_List_Table();
+	}
+
+	// =========================================================================
+	// Constructor & Labels
+	// =========================================================================
+
+	/**
+	 * Test constructor sets singular label.
+	 */
+	public function test_constructor_sets_singular_label(): void {
+
+		$this->assertStringContainsString( 'Discount Code', $this->table->get_label( 'singular' ) );
+	}
+
+	/**
+	 * Test constructor sets plural label.
+	 */
+	public function test_constructor_sets_plural_label(): void {
+
+		$this->assertStringContainsString( 'Discount Codes', $this->table->get_label( 'plural' ) );
+	}
+
+	// =========================================================================
+	// get_columns()
+	// =========================================================================
+
+	/**
+	 * Test get_columns returns expected keys.
+	 */
+	public function test_get_columns_returns_expected_keys(): void {
+
+		$columns = $this->table->get_columns();
+
+		$this->assertIsArray( $columns );
+		$this->assertArrayHasKey( 'cb', $columns );
+		$this->assertArrayHasKey( 'name', $columns );
+		$this->assertArrayHasKey( 'coupon_code', $columns );
+		$this->assertArrayHasKey( 'uses', $columns );
+		$this->assertArrayHasKey( 'value', $columns );
+		$this->assertArrayHasKey( 'setup_fee_value', $columns );
+		$this->assertArrayHasKey( 'date_expiration', $columns );
+	}
+
+	/**
+	 * Test get_columns returns 7 columns.
+	 */
+	public function test_get_columns_returns_seven_columns(): void {
+
+		$columns = $this->table->get_columns();
+
+		$this->assertCount( 7, $columns );
+	}
+
+	// =========================================================================
+	// get_sortable_columns()
+	// =========================================================================
+
+	/**
+	 * Test get_sortable_columns returns array.
+	 */
+	public function test_get_sortable_columns_returns_array(): void {
+
+		$columns = $this->table->get_sortable_columns();
+
+		$this->assertIsArray( $columns );
+	}
+
+	// =========================================================================
+	// column_default()
+	// =========================================================================
+
+	/**
+	 * Test column_default returns value from getter.
+	 */
+	public function test_column_default_returns_value_from_getter(): void {
+
+		$item = $this->getMockBuilder( \stdClass::class )
+			->addMethods( [ 'get_name' ] )
+			->getMock();
+		$item->method( 'get_name' )->willReturn( 'Summer Sale' );
+
+		$output = $this->table->column_default( $item, 'name' );
+
+		$this->assertEquals( 'Summer Sale', $output );
+	}
+
+	// =========================================================================
+	// column_value()
+	// =========================================================================
+
+	/**
+	 * Test column_value returns 'No Discount' when value is 0.
+	 */
+	public function test_column_value_returns_no_discount_when_zero(): void {
+
+		$item = $this->getMockBuilder( \stdClass::class )
+			->addMethods( [ 'get_value', 'get_type' ] )
+			->getMock();
+		$item->method( 'get_value' )->willReturn( 0 );
+
+		$output = $this->table->column_value( $item );
+
+		$this->assertStringContainsString( 'No Discount', $output );
+	}
+
+	/**
+	 * Test column_value returns percentage format for percentage type.
+	 */
+	public function test_column_value_returns_percentage_for_percentage_type(): void {
+
+		$item = $this->getMockBuilder( \stdClass::class )
+			->addMethods( [ 'get_value', 'get_type' ] )
+			->getMock();
+		$item->method( 'get_value' )->willReturn( 20 );
+		$item->method( 'get_type' )->willReturn( 'percentage' );
+
+		$output = $this->table->column_value( $item );
+
+		$this->assertStringContainsString( '%', $output );
+		$this->assertStringContainsString( 'OFF', $output );
+	}
+
+	/**
+	 * Test column_value returns currency format for flat type.
+	 */
+	public function test_column_value_returns_currency_for_flat_type(): void {
+
+		$item = $this->getMockBuilder( \stdClass::class )
+			->addMethods( [ 'get_value', 'get_type' ] )
+			->getMock();
+		$item->method( 'get_value' )->willReturn( 10 );
+		$item->method( 'get_type' )->willReturn( 'flat' );
+
+		$output = $this->table->column_value( $item );
+
+		$this->assertStringContainsString( 'OFF', $output );
+	}
+
+	// =========================================================================
+	// column_setup_fee_value()
+	// =========================================================================
+
+	/**
+	 * Test column_setup_fee_value returns 'No Discount' when value is 0.
+	 */
+	public function test_column_setup_fee_value_returns_no_discount_when_zero(): void {
+
+		$item = $this->getMockBuilder( \stdClass::class )
+			->addMethods( [ 'get_setup_fee_value', 'get_setup_fee_type' ] )
+			->getMock();
+		$item->method( 'get_setup_fee_value' )->willReturn( 0 );
+
+		$output = $this->table->column_setup_fee_value( $item );
+
+		$this->assertStringContainsString( 'No Discount', $output );
+	}
+
+	/**
+	 * Test column_setup_fee_value returns percentage for percentage type.
+	 */
+	public function test_column_setup_fee_value_returns_percentage_for_percentage_type(): void {
+
+		$item = $this->getMockBuilder( \stdClass::class )
+			->addMethods( [ 'get_setup_fee_value', 'get_setup_fee_type' ] )
+			->getMock();
+		$item->method( 'get_setup_fee_value' )->willReturn( 15 );
+		$item->method( 'get_setup_fee_type' )->willReturn( 'percentage' );
+
+		$output = $this->table->column_setup_fee_value( $item );
+
+		$this->assertStringContainsString( '%', $output );
+	}
+
+	// =========================================================================
+	// column_uses()
+	// =========================================================================
+
+	/**
+	 * Test column_uses returns usage count.
+	 */
+	public function test_column_uses_returns_usage_count(): void {
+
+		$item = $this->getMockBuilder( \stdClass::class )
+			->addMethods( [ 'get_uses', 'get_max_uses' ] )
+			->getMock();
+		$item->method( 'get_uses' )->willReturn( 5 );
+		$item->method( 'get_max_uses' )->willReturn( 0 );
+
+		$output = $this->table->column_uses( $item );
+
+		$this->assertStringContainsString( '5', $output );
+		$this->assertStringContainsString( 'No Limits', $output );
+	}
+
+	/**
+	 * Test column_uses shows max uses when set.
+	 */
+	public function test_column_uses_shows_max_uses_when_set(): void {
+
+		$item = $this->getMockBuilder( \stdClass::class )
+			->addMethods( [ 'get_uses', 'get_max_uses' ] )
+			->getMock();
+		$item->method( 'get_uses' )->willReturn( 3 );
+		$item->method( 'get_max_uses' )->willReturn( 10 );
+
+		$output = $this->table->column_uses( $item );
+
+		$this->assertStringContainsString( '10', $output );
+	}
+
+	// =========================================================================
+	// column_coupon_code()
+	// =========================================================================
+
+	/**
+	 * Test column_coupon_code returns code in uppercase span.
+	 */
+	public function test_column_coupon_code_returns_uppercase_code(): void {
+
+		$valid_mock = true; // not a WP_Error
+
+		$item = $this->getMockBuilder( \stdClass::class )
+			->addMethods( [ 'get_code', 'is_valid' ] )
+			->getMock();
+		$item->method( 'get_code' )->willReturn( 'summer20' );
+		$item->method( 'is_valid' )->willReturn( true );
+
+		$output = $this->table->column_coupon_code( $item );
+
+		$this->assertStringContainsString( 'SUMMER20', $output );
+		$this->assertStringContainsString( 'wu-font-mono', $output );
+	}
+}

--- a/tests/WP_Ultimo/List_Tables/Domain_List_Table_Test.php
+++ b/tests/WP_Ultimo/List_Tables/Domain_List_Table_Test.php
@@ -1,0 +1,293 @@
+<?php
+/**
+ * Tests for Domain_List_Table class.
+ *
+ * @package WP_Ultimo\Tests
+ */
+
+namespace WP_Ultimo\List_Tables;
+
+use WP_UnitTestCase;
+
+/**
+ * Test class for Domain_List_Table.
+ *
+ * @group list-tables
+ */
+class Domain_List_Table_Test extends WP_UnitTestCase {
+
+	/**
+	 * @var Domain_List_Table
+	 */
+	private Domain_List_Table $table;
+
+	/**
+	 * Set up test fixtures.
+	 */
+	public function set_up(): void {
+
+		parent::set_up();
+
+		$this->table = new Domain_List_Table();
+	}
+
+	/**
+	 * Tear down after each test.
+	 */
+	public function tear_down(): void {
+
+		unset( $_REQUEST['blog_id'] );
+
+		parent::tear_down();
+	}
+
+	// =========================================================================
+	// Constructor & Labels
+	// =========================================================================
+
+	/**
+	 * Test constructor sets singular label.
+	 */
+	public function test_constructor_sets_singular_label(): void {
+
+		$this->assertStringContainsString( 'Domain', $this->table->get_label( 'singular' ) );
+	}
+
+	/**
+	 * Test constructor sets plural label.
+	 */
+	public function test_constructor_sets_plural_label(): void {
+
+		$this->assertStringContainsString( 'Domains', $this->table->get_label( 'plural' ) );
+	}
+
+	// =========================================================================
+	// get_columns()
+	// =========================================================================
+
+	/**
+	 * Test get_columns returns expected keys.
+	 */
+	public function test_get_columns_returns_expected_keys(): void {
+
+		$columns = $this->table->get_columns();
+
+		$this->assertIsArray( $columns );
+		$this->assertArrayHasKey( 'cb', $columns );
+		$this->assertArrayHasKey( 'domain', $columns );
+		$this->assertArrayHasKey( 'stage', $columns );
+		$this->assertArrayHasKey( 'blog_id', $columns );
+		$this->assertArrayHasKey( 'active', $columns );
+		$this->assertArrayHasKey( 'primary_domain', $columns );
+		$this->assertArrayHasKey( 'secure', $columns );
+		$this->assertArrayHasKey( 'id', $columns );
+	}
+
+	/**
+	 * Test get_columns returns 8 columns.
+	 */
+	public function test_get_columns_returns_eight_columns(): void {
+
+		$columns = $this->table->get_columns();
+
+		$this->assertCount( 8, $columns );
+	}
+
+	// =========================================================================
+	// get_sortable_columns()
+	// =========================================================================
+
+	/**
+	 * Test get_sortable_columns returns array.
+	 */
+	public function test_get_sortable_columns_returns_array(): void {
+
+		$columns = $this->table->get_sortable_columns();
+
+		$this->assertIsArray( $columns );
+	}
+
+	// =========================================================================
+	// get_filters()
+	// =========================================================================
+
+	/**
+	 * Test get_filters returns correct structure.
+	 */
+	public function test_get_filters_returns_correct_structure(): void {
+
+		$filters = $this->table->get_filters();
+
+		$this->assertIsArray( $filters );
+		$this->assertArrayHasKey( 'filters', $filters );
+		$this->assertArrayHasKey( 'date_filters', $filters );
+	}
+
+	/**
+	 * Test get_filters has active, primary_domain, secure, stage filters.
+	 */
+	public function test_get_filters_has_expected_filter_keys(): void {
+
+		$filters = $this->table->get_filters();
+
+		$this->assertArrayHasKey( 'active', $filters['filters'] );
+		$this->assertArrayHasKey( 'primary_domain', $filters['filters'] );
+		$this->assertArrayHasKey( 'secure', $filters['filters'] );
+		$this->assertArrayHasKey( 'stage', $filters['filters'] );
+	}
+
+	// =========================================================================
+	// get_extra_query_fields()
+	// =========================================================================
+
+	/**
+	 * Test get_extra_query_fields adds blog_id when present in request.
+	 */
+	public function test_get_extra_query_fields_adds_blog_id(): void {
+
+		$_REQUEST['blog_id'] = '5';
+
+		$fields = $this->table->get_extra_query_fields();
+
+		$this->assertArrayHasKey( 'blog_id', $fields );
+		$this->assertEquals( '5', $fields['blog_id'] );
+
+		unset( $_REQUEST['blog_id'] );
+	}
+
+	/**
+	 * Test get_extra_query_fields returns empty when no blog_id.
+	 */
+	public function test_get_extra_query_fields_empty_without_blog_id(): void {
+
+		unset( $_REQUEST['blog_id'] );
+
+		$fields = $this->table->get_extra_query_fields();
+
+		$this->assertArrayNotHasKey( 'blog_id', $fields );
+	}
+
+	// =========================================================================
+	// column_active()
+	// =========================================================================
+
+	/**
+	 * Test column_active returns 'Yes' for active domain.
+	 */
+	public function test_column_active_returns_yes_for_active(): void {
+
+		$item = $this->getMockBuilder( \stdClass::class )
+			->addMethods( [ 'is_active' ] )
+			->getMock();
+		$item->method( 'is_active' )->willReturn( true );
+
+		$output = $this->table->column_active( $item );
+
+		$this->assertStringContainsString( 'Yes', $output );
+	}
+
+	/**
+	 * Test column_active returns 'No' for inactive domain.
+	 */
+	public function test_column_active_returns_no_for_inactive(): void {
+
+		$item = $this->getMockBuilder( \stdClass::class )
+			->addMethods( [ 'is_active' ] )
+			->getMock();
+		$item->method( 'is_active' )->willReturn( false );
+
+		$output = $this->table->column_active( $item );
+
+		$this->assertStringContainsString( 'No', $output );
+	}
+
+	// =========================================================================
+	// column_primary_domain()
+	// =========================================================================
+
+	/**
+	 * Test column_primary_domain returns 'Yes' for primary domain.
+	 */
+	public function test_column_primary_domain_returns_yes_for_primary(): void {
+
+		$item = $this->getMockBuilder( \stdClass::class )
+			->addMethods( [ 'is_primary_domain' ] )
+			->getMock();
+		$item->method( 'is_primary_domain' )->willReturn( true );
+
+		$output = $this->table->column_primary_domain( $item );
+
+		$this->assertStringContainsString( 'Yes', $output );
+	}
+
+	/**
+	 * Test column_primary_domain returns 'No' for non-primary domain.
+	 */
+	public function test_column_primary_domain_returns_no_for_non_primary(): void {
+
+		$item = $this->getMockBuilder( \stdClass::class )
+			->addMethods( [ 'is_primary_domain' ] )
+			->getMock();
+		$item->method( 'is_primary_domain' )->willReturn( false );
+
+		$output = $this->table->column_primary_domain( $item );
+
+		$this->assertStringContainsString( 'No', $output );
+	}
+
+	// =========================================================================
+	// column_secure()
+	// =========================================================================
+
+	/**
+	 * Test column_secure returns 'Yes' for secure domain.
+	 */
+	public function test_column_secure_returns_yes_for_secure(): void {
+
+		$item = $this->getMockBuilder( \stdClass::class )
+			->addMethods( [ 'is_secure' ] )
+			->getMock();
+		$item->method( 'is_secure' )->willReturn( true );
+
+		$output = $this->table->column_secure( $item );
+
+		$this->assertStringContainsString( 'Yes', $output );
+	}
+
+	/**
+	 * Test column_secure returns 'No' for non-secure domain.
+	 */
+	public function test_column_secure_returns_no_for_non_secure(): void {
+
+		$item = $this->getMockBuilder( \stdClass::class )
+			->addMethods( [ 'is_secure' ] )
+			->getMock();
+		$item->method( 'is_secure' )->willReturn( false );
+
+		$output = $this->table->column_secure( $item );
+
+		$this->assertStringContainsString( 'No', $output );
+	}
+
+	// =========================================================================
+	// column_stage()
+	// =========================================================================
+
+	/**
+	 * Test column_stage returns span with label and class.
+	 */
+	public function test_column_stage_returns_span_with_label(): void {
+
+		$item = $this->getMockBuilder( \stdClass::class )
+			->addMethods( [ 'get_stage_label', 'get_stage_class' ] )
+			->getMock();
+		$item->method( 'get_stage_label' )->willReturn( 'Verified' );
+		$item->method( 'get_stage_class' )->willReturn( 'wu-bg-green-200' );
+
+		$output = $this->table->column_stage( $item );
+
+		$this->assertStringContainsString( 'Verified', $output );
+		$this->assertStringContainsString( 'wu-bg-green-200', $output );
+		$this->assertStringContainsString( '<span', $output );
+	}
+}

--- a/tests/WP_Ultimo/List_Tables/Email_List_Table_Test.php
+++ b/tests/WP_Ultimo/List_Tables/Email_List_Table_Test.php
@@ -1,0 +1,293 @@
+<?php
+/**
+ * Tests for Email_List_Table class.
+ *
+ * @package WP_Ultimo\Tests
+ */
+
+namespace WP_Ultimo\List_Tables;
+
+use WP_UnitTestCase;
+
+/**
+ * Test class for Email_List_Table.
+ *
+ * @group list-tables
+ */
+class Email_List_Table_Test extends WP_UnitTestCase {
+
+	/**
+	 * @var Email_List_Table
+	 */
+	private Email_List_Table $table;
+
+	/**
+	 * Set up test fixtures.
+	 */
+	public function set_up(): void {
+
+		parent::set_up();
+
+		$this->table = new Email_List_Table();
+	}
+
+	/**
+	 * Tear down after each test.
+	 */
+	public function tear_down(): void {
+
+		unset( $_REQUEST['s'], $_REQUEST['target'] );
+
+		parent::tear_down();
+	}
+
+	// =========================================================================
+	// Constructor & Labels
+	// =========================================================================
+
+	/**
+	 * Test constructor sets singular label.
+	 */
+	public function test_constructor_sets_singular_label(): void {
+
+		$this->assertStringContainsString( 'Email', $this->table->get_label( 'singular' ) );
+	}
+
+	/**
+	 * Test constructor sets plural label.
+	 */
+	public function test_constructor_sets_plural_label(): void {
+
+		$this->assertStringContainsString( 'Emails', $this->table->get_label( 'plural' ) );
+	}
+
+	// =========================================================================
+	// get_columns()
+	// =========================================================================
+
+	/**
+	 * Test get_columns returns expected keys.
+	 */
+	public function test_get_columns_returns_expected_keys(): void {
+
+		$columns = $this->table->get_columns();
+
+		$this->assertIsArray( $columns );
+		$this->assertArrayHasKey( 'cb', $columns );
+		$this->assertArrayHasKey( 'title', $columns );
+		$this->assertArrayHasKey( 'slug', $columns );
+		$this->assertArrayHasKey( 'event', $columns );
+		$this->assertArrayHasKey( 'schedule', $columns );
+		$this->assertArrayHasKey( 'id', $columns );
+	}
+
+	/**
+	 * Test get_columns returns 6 columns.
+	 */
+	public function test_get_columns_returns_six_columns(): void {
+
+		$columns = $this->table->get_columns();
+
+		$this->assertCount( 6, $columns );
+	}
+
+	// =========================================================================
+	// get_sortable_columns()
+	// =========================================================================
+
+	/**
+	 * Test get_sortable_columns returns array.
+	 */
+	public function test_get_sortable_columns_returns_array(): void {
+
+		$columns = $this->table->get_sortable_columns();
+
+		$this->assertIsArray( $columns );
+	}
+
+	// =========================================================================
+	// get_filters()
+	// =========================================================================
+
+	/**
+	 * Test get_filters returns correct structure.
+	 */
+	public function test_get_filters_returns_correct_structure(): void {
+
+		$filters = $this->table->get_filters();
+
+		$this->assertIsArray( $filters );
+		$this->assertArrayHasKey( 'filters', $filters );
+		$this->assertArrayHasKey( 'date_filters', $filters );
+	}
+
+	/**
+	 * Test get_filters has type filter.
+	 */
+	public function test_get_filters_has_type_filter(): void {
+
+		$filters = $this->table->get_filters();
+
+		$this->assertArrayHasKey( 'type', $filters['filters'] );
+	}
+
+	/**
+	 * Test get_filters has date_created date filter.
+	 */
+	public function test_get_filters_has_date_created_date_filter(): void {
+
+		$filters = $this->table->get_filters();
+
+		$this->assertArrayHasKey( 'date_created', $filters['date_filters'] );
+	}
+
+	// =========================================================================
+	// get_views()
+	// =========================================================================
+
+	/**
+	 * Test get_views returns all, admin, customer keys.
+	 */
+	public function test_get_views_returns_expected_keys(): void {
+
+		$views = $this->table->get_views();
+
+		$this->assertArrayHasKey( 'all', $views );
+		$this->assertArrayHasKey( 'admin', $views );
+		$this->assertArrayHasKey( 'customer', $views );
+	}
+
+	/**
+	 * Test get_views entries have required keys.
+	 */
+	public function test_get_views_entries_have_required_keys(): void {
+
+		$views = $this->table->get_views();
+
+		foreach ( $views as $key => $view ) {
+			$this->assertArrayHasKey( 'field', $view, "Missing 'field' in {$key}" );
+			$this->assertArrayHasKey( 'url', $view, "Missing 'url' in {$key}" );
+			$this->assertArrayHasKey( 'label', $view, "Missing 'label' in {$key}" );
+			$this->assertArrayHasKey( 'count', $view, "Missing 'count' in {$key}" );
+		}
+	}
+
+	// =========================================================================
+	// column_event()
+	// =========================================================================
+
+	/**
+	 * Test column_event returns event slug in span.
+	 */
+	public function test_column_event_returns_event_in_span(): void {
+
+		$item = $this->getMockBuilder( \stdClass::class )
+			->addMethods( [ 'get_event' ] )
+			->getMock();
+		$item->method( 'get_event' )->willReturn( 'membership_created' );
+
+		$output = $this->table->column_event( $item );
+
+		$this->assertStringContainsString( 'membership_created', $output );
+		$this->assertStringContainsString( '<span', $output );
+		$this->assertStringContainsString( 'wu-font-mono', $output );
+	}
+
+	// =========================================================================
+	// column_slug()
+	// =========================================================================
+
+	/**
+	 * Test column_slug returns slug in span.
+	 */
+	public function test_column_slug_returns_slug_in_span(): void {
+
+		$item = $this->getMockBuilder( \stdClass::class )
+			->addMethods( [ 'get_slug' ] )
+			->getMock();
+		$item->method( 'get_slug' )->willReturn( 'welcome-email' );
+
+		$output = $this->table->column_slug( $item );
+
+		$this->assertStringContainsString( 'welcome-email', $output );
+		$this->assertStringContainsString( '<span', $output );
+	}
+
+	// =========================================================================
+	// column_schedule()
+	// =========================================================================
+
+	/**
+	 * Test column_schedule returns immediate text when no schedule.
+	 */
+	public function test_column_schedule_returns_immediate_when_no_schedule(): void {
+
+		$item = $this->getMockBuilder( \stdClass::class )
+			->addMethods( [ 'has_schedule', 'get_schedule_type', 'get_send_hours', 'get_send_days' ] )
+			->getMock();
+		$item->method( 'has_schedule' )->willReturn( false );
+
+		$output = $this->table->column_schedule( $item );
+
+		$this->assertStringContainsString( 'immediately', $output );
+	}
+
+	/**
+	 * Test column_schedule returns hours text for hours schedule type.
+	 */
+	public function test_column_schedule_returns_hours_text_for_hours_type(): void {
+
+		$item = $this->getMockBuilder( \stdClass::class )
+			->addMethods( [ 'has_schedule', 'get_schedule_type', 'get_send_hours', 'get_send_days' ] )
+			->getMock();
+		$item->method( 'has_schedule' )->willReturn( true );
+		$item->method( 'get_schedule_type' )->willReturn( 'hours' );
+		$item->method( 'get_send_hours' )->willReturn( '2:30' );
+
+		$output = $this->table->column_schedule( $item );
+
+		$this->assertStringContainsString( 'hour', $output );
+	}
+
+	/**
+	 * Test column_schedule returns days text for days schedule type.
+	 */
+	public function test_column_schedule_returns_days_text_for_days_type(): void {
+
+		$item = $this->getMockBuilder( \stdClass::class )
+			->addMethods( [ 'has_schedule', 'get_schedule_type', 'get_send_hours', 'get_send_days' ] )
+			->getMock();
+		$item->method( 'has_schedule' )->willReturn( true );
+		$item->method( 'get_schedule_type' )->willReturn( 'days' );
+		$item->method( 'get_send_days' )->willReturn( 3 );
+
+		$output = $this->table->column_schedule( $item );
+
+		$this->assertStringContainsString( 'day', $output );
+		$this->assertStringContainsString( '3', $output );
+	}
+
+	// =========================================================================
+	// get_items()
+	// =========================================================================
+
+	/**
+	 * Test get_items returns array.
+	 */
+	public function test_get_items_returns_array(): void {
+
+		$result = $this->table->get_items( 5, 1, false );
+
+		$this->assertIsArray( $result );
+	}
+
+	/**
+	 * Test get_items with count=true returns numeric.
+	 */
+	public function test_get_items_count_returns_numeric(): void {
+
+		$result = $this->table->get_items( 5, 1, true );
+
+		$this->assertIsNumeric( $result );
+	}
+}

--- a/tests/WP_Ultimo/List_Tables/Event_List_Table_Test.php
+++ b/tests/WP_Ultimo/List_Tables/Event_List_Table_Test.php
@@ -1,0 +1,259 @@
+<?php
+/**
+ * Tests for Event_List_Table class.
+ *
+ * @package WP_Ultimo\Tests
+ */
+
+namespace WP_Ultimo\List_Tables;
+
+use WP_UnitTestCase;
+
+/**
+ * Test class for Event_List_Table.
+ *
+ * @group list-tables
+ */
+class Event_List_Table_Test extends WP_UnitTestCase {
+
+	/**
+	 * @var Event_List_Table
+	 */
+	private Event_List_Table $table;
+
+	/**
+	 * Set up test fixtures.
+	 */
+	public function set_up(): void {
+
+		parent::set_up();
+
+		$this->table = new Event_List_Table();
+	}
+
+	// =========================================================================
+	// Constructor & Labels
+	// =========================================================================
+
+	/**
+	 * Test constructor sets singular label.
+	 */
+	public function test_constructor_sets_singular_label(): void {
+
+		$this->assertStringContainsString( 'Event', $this->table->get_label( 'singular' ) );
+	}
+
+	/**
+	 * Test constructor sets plural label.
+	 */
+	public function test_constructor_sets_plural_label(): void {
+
+		$this->assertStringContainsString( 'Events', $this->table->get_label( 'plural' ) );
+	}
+
+	// =========================================================================
+	// get_columns()
+	// =========================================================================
+
+	/**
+	 * Test get_columns returns expected keys.
+	 */
+	public function test_get_columns_returns_expected_keys(): void {
+
+		$columns = $this->table->get_columns();
+
+		$this->assertIsArray( $columns );
+		$this->assertArrayHasKey( 'cb', $columns );
+		$this->assertArrayHasKey( 'initiator', $columns );
+		$this->assertArrayHasKey( 'message', $columns );
+		$this->assertArrayHasKey( 'slug', $columns );
+		$this->assertArrayHasKey( 'object_type', $columns );
+		$this->assertArrayHasKey( 'date_created', $columns );
+		$this->assertArrayHasKey( 'id', $columns );
+	}
+
+	/**
+	 * Test get_columns applies filter.
+	 */
+	public function test_get_columns_applies_filter(): void {
+
+		add_filter(
+			'wu_events_list_table_get_columns',
+			function ( $columns ) {
+				$columns['custom_col'] = 'Custom';
+				return $columns;
+			}
+		);
+
+		$columns = $this->table->get_columns();
+
+		$this->assertArrayHasKey( 'custom_col', $columns );
+
+		remove_all_filters( 'wu_events_list_table_get_columns' );
+	}
+
+	// =========================================================================
+	// get_sortable_columns()
+	// =========================================================================
+
+	/**
+	 * Test get_sortable_columns returns array.
+	 */
+	public function test_get_sortable_columns_returns_array(): void {
+
+		$columns = $this->table->get_sortable_columns();
+
+		$this->assertIsArray( $columns );
+	}
+
+	// =========================================================================
+	// get_filters()
+	// =========================================================================
+
+	/**
+	 * Test get_filters returns correct structure.
+	 */
+	public function test_get_filters_returns_correct_structure(): void {
+
+		$filters = $this->table->get_filters();
+
+		$this->assertIsArray( $filters );
+		$this->assertArrayHasKey( 'filters', $filters );
+		$this->assertArrayHasKey( 'date_filters', $filters );
+	}
+
+	/**
+	 * Test get_filters has severity filter.
+	 */
+	public function test_get_filters_has_severity_filter(): void {
+
+		$filters = $this->table->get_filters();
+
+		$this->assertArrayHasKey( 'severity', $filters['filters'] );
+	}
+
+	/**
+	 * Test get_filters has date_created date filter.
+	 */
+	public function test_get_filters_has_date_created_date_filter(): void {
+
+		$filters = $this->table->get_filters();
+
+		$this->assertArrayHasKey( 'date_created', $filters['date_filters'] );
+	}
+
+	// =========================================================================
+	// column_object_type()
+	// =========================================================================
+
+	/**
+	 * Test column_object_type returns object type in span.
+	 */
+	public function test_column_object_type_returns_type_in_span(): void {
+
+		$item = $this->getMockBuilder( \stdClass::class )
+			->addMethods( [ 'get_object_type' ] )
+			->getMock();
+		$item->method( 'get_object_type' )->willReturn( 'membership' );
+
+		$output = $this->table->column_object_type( $item );
+
+		$this->assertStringContainsString( 'membership', $output );
+		$this->assertStringContainsString( '<span', $output );
+		$this->assertStringContainsString( 'wu-font-mono', $output );
+	}
+
+	// =========================================================================
+	// column_slug()
+	// =========================================================================
+
+	/**
+	 * Test column_slug returns slug in span.
+	 */
+	public function test_column_slug_returns_slug_in_span(): void {
+
+		$item = $this->getMockBuilder( \stdClass::class )
+			->addMethods( [ 'get_slug' ] )
+			->getMock();
+		$item->method( 'get_slug' )->willReturn( 'membership.created' );
+
+		$output = $this->table->column_slug( $item );
+
+		$this->assertStringContainsString( 'membership.created', $output );
+		$this->assertStringContainsString( '<span', $output );
+	}
+
+	// =========================================================================
+	// column_initiator() — system initiator
+	// =========================================================================
+
+	/**
+	 * Test column_initiator returns HTML for system initiator.
+	 */
+	public function test_column_initiator_returns_html_for_system_initiator(): void {
+
+		$item = $this->getMockBuilder( \stdClass::class )
+			->addMethods( [
+				'get_initiator',
+				'get_severity_label',
+				'get_severity_class',
+				'get_author_id',
+				'get_author_display_name',
+				'get_author_email_address',
+			] )
+			->getMock();
+		$item->method( 'get_initiator' )->willReturn( 'system' );
+		$item->method( 'get_severity_label' )->willReturn( 'Info' );
+		$item->method( 'get_severity_class' )->willReturn( 'wu-bg-blue-200' );
+
+		$output = $this->table->column_initiator( $item );
+
+		$this->assertIsString( $output );
+		$this->assertStringContainsString( 'System', $output );
+	}
+
+	/**
+	 * Test column_initiator returns HTML for unknown initiator.
+	 */
+	public function test_column_initiator_returns_not_found_for_unknown_initiator(): void {
+
+		$item = $this->getMockBuilder( \stdClass::class )
+			->addMethods( [
+				'get_initiator',
+				'get_severity_label',
+				'get_severity_class',
+				'get_author_id',
+				'get_author_display_name',
+				'get_author_email_address',
+			] )
+			->getMock();
+		$item->method( 'get_initiator' )->willReturn( 'unknown_type' );
+		$item->method( 'get_severity_label' )->willReturn( 'Info' );
+		$item->method( 'get_severity_class' )->willReturn( '' );
+
+		$output = $this->table->column_initiator( $item );
+
+		$this->assertStringContainsString( 'No initiator found', $output );
+	}
+
+	// =========================================================================
+	// column_message()
+	// =========================================================================
+
+	/**
+	 * Test column_message returns trimmed message.
+	 */
+	public function test_column_message_returns_trimmed_message(): void {
+
+		$item = $this->getMockBuilder( \stdClass::class )
+			->addMethods( [ 'get_id', 'get_message' ] )
+			->getMock();
+		$item->method( 'get_id' )->willReturn( 1 );
+		$item->method( 'get_message' )->willReturn( 'A membership was created for the customer.' );
+
+		$output = $this->table->column_message( $item );
+
+		$this->assertIsString( $output );
+		$this->assertStringContainsString( 'membership', $output );
+	}
+}

--- a/tests/WP_Ultimo/List_Tables/Membership_List_Table_Test.php
+++ b/tests/WP_Ultimo/List_Tables/Membership_List_Table_Test.php
@@ -1,0 +1,312 @@
+<?php
+/**
+ * Tests for Membership_List_Table class.
+ *
+ * @package WP_Ultimo\Tests
+ */
+
+namespace WP_Ultimo\List_Tables;
+
+use WP_UnitTestCase;
+
+/**
+ * Test class for Membership_List_Table.
+ *
+ * @group list-tables
+ */
+class Membership_List_Table_Test extends WP_UnitTestCase {
+
+	/**
+	 * @var Membership_List_Table
+	 */
+	private Membership_List_Table $table;
+
+	/**
+	 * Set up test fixtures.
+	 */
+	public function set_up(): void {
+
+		parent::set_up();
+
+		$this->table = new Membership_List_Table();
+	}
+
+	/**
+	 * Tear down after each test.
+	 */
+	public function tear_down(): void {
+
+		unset( $_REQUEST['customer_id'] );
+		remove_all_filters( 'wu_memberships_list_table_columns' );
+
+		parent::tear_down();
+	}
+
+	// =========================================================================
+	// Constructor & Labels
+	// =========================================================================
+
+	/**
+	 * Test constructor sets singular label.
+	 */
+	public function test_constructor_sets_singular_label(): void {
+
+		$this->assertStringContainsString( 'Membership', $this->table->get_label( 'singular' ) );
+	}
+
+	/**
+	 * Test constructor sets plural label.
+	 */
+	public function test_constructor_sets_plural_label(): void {
+
+		$this->assertStringContainsString( 'Memberships', $this->table->get_label( 'plural' ) );
+	}
+
+	// =========================================================================
+	// get_columns()
+	// =========================================================================
+
+	/**
+	 * Test get_columns returns expected keys.
+	 */
+	public function test_get_columns_returns_expected_keys(): void {
+
+		$columns = $this->table->get_columns();
+
+		$this->assertIsArray( $columns );
+		$this->assertArrayHasKey( 'cb', $columns );
+		$this->assertArrayHasKey( 'hash', $columns );
+		$this->assertArrayHasKey( 'status', $columns );
+		$this->assertArrayHasKey( 'customer', $columns );
+		$this->assertArrayHasKey( 'product', $columns );
+		$this->assertArrayHasKey( 'amount', $columns );
+		$this->assertArrayHasKey( 'date_created', $columns );
+		$this->assertArrayHasKey( 'date_expiration', $columns );
+		$this->assertArrayHasKey( 'id', $columns );
+	}
+
+	/**
+	 * Test get_columns applies filter.
+	 */
+	public function test_get_columns_applies_filter(): void {
+
+		add_filter(
+			'wu_memberships_list_table_columns',
+			function ( $columns ) {
+				$columns['extra_col'] = 'Extra';
+				return $columns;
+			}
+		);
+
+		$columns = $this->table->get_columns();
+
+		$this->assertArrayHasKey( 'extra_col', $columns );
+
+		remove_all_filters( 'wu_memberships_list_table_columns' );
+	}
+
+	// =========================================================================
+	// get_sortable_columns()
+	// =========================================================================
+
+	/**
+	 * Test get_sortable_columns returns array.
+	 */
+	public function test_get_sortable_columns_returns_array(): void {
+
+		$columns = $this->table->get_sortable_columns();
+
+		$this->assertIsArray( $columns );
+	}
+
+	// =========================================================================
+	// get_filters()
+	// =========================================================================
+
+	/**
+	 * Test get_filters returns correct structure.
+	 */
+	public function test_get_filters_returns_correct_structure(): void {
+
+		$filters = $this->table->get_filters();
+
+		$this->assertIsArray( $filters );
+		$this->assertArrayHasKey( 'filters', $filters );
+		$this->assertArrayHasKey( 'date_filters', $filters );
+	}
+
+	/**
+	 * Test get_filters has status filter.
+	 */
+	public function test_get_filters_has_status_filter(): void {
+
+		$filters = $this->table->get_filters();
+
+		$this->assertArrayHasKey( 'status', $filters['filters'] );
+	}
+
+	/**
+	 * Test get_filters has date_created, date_expiration, date_renewed date filters.
+	 */
+	public function test_get_filters_has_date_filters(): void {
+
+		$filters = $this->table->get_filters();
+
+		$this->assertArrayHasKey( 'date_created', $filters['date_filters'] );
+		$this->assertArrayHasKey( 'date_expiration', $filters['date_filters'] );
+		$this->assertArrayHasKey( 'date_renewed', $filters['date_filters'] );
+	}
+
+	// =========================================================================
+	// get_views()
+	// =========================================================================
+
+	/**
+	 * Test get_views returns expected status keys.
+	 */
+	public function test_get_views_returns_expected_keys(): void {
+
+		$views = $this->table->get_views();
+
+		$this->assertArrayHasKey( 'all', $views );
+		$this->assertArrayHasKey( 'active', $views );
+		$this->assertArrayHasKey( 'trialing', $views );
+		$this->assertArrayHasKey( 'pending', $views );
+		$this->assertArrayHasKey( 'on-hold', $views );
+		$this->assertArrayHasKey( 'expired', $views );
+		$this->assertArrayHasKey( 'cancelled', $views );
+	}
+
+	// =========================================================================
+	// get_extra_query_fields()
+	// =========================================================================
+
+	/**
+	 * Test get_extra_query_fields includes customer_id.
+	 */
+	public function test_get_extra_query_fields_includes_customer_id(): void {
+
+		$_REQUEST['customer_id'] = '3';
+
+		$fields = $this->table->get_extra_query_fields();
+
+		$this->assertIsArray( $fields );
+		$this->assertArrayHasKey( 'customer_id', $fields );
+
+		unset( $_REQUEST['customer_id'] );
+	}
+
+	// =========================================================================
+	// column_status()
+	// =========================================================================
+
+	/**
+	 * Test column_status returns span with label and class.
+	 */
+	public function test_column_status_returns_span_with_label(): void {
+
+		$item = $this->getMockBuilder( \stdClass::class )
+			->addMethods( [ 'get_status_label', 'get_status_class' ] )
+			->getMock();
+		$item->method( 'get_status_label' )->willReturn( 'Active' );
+		$item->method( 'get_status_class' )->willReturn( 'wu-bg-green-500' );
+
+		$output = $this->table->column_status( $item );
+
+		$this->assertStringContainsString( 'Active', $output );
+		$this->assertStringContainsString( 'wu-bg-green-500', $output );
+		$this->assertStringContainsString( '<span', $output );
+	}
+
+	// =========================================================================
+	// column_amount()
+	// =========================================================================
+
+	/**
+	 * Test column_amount returns 'Free' for zero amount.
+	 */
+	public function test_column_amount_returns_free_for_zero_amount(): void {
+
+		$item = $this->getMockBuilder( \stdClass::class )
+			->addMethods( [ 'get_amount', 'get_initial_amount', 'is_recurring' ] )
+			->getMock();
+		$item->method( 'get_amount' )->willReturn( 0 );
+		$item->method( 'get_initial_amount' )->willReturn( 0 );
+
+		$output = $this->table->column_amount( $item );
+
+		$this->assertStringContainsString( 'Free', $output );
+	}
+
+	/**
+	 * Test column_amount returns 'one time payment' for non-recurring.
+	 */
+	public function test_column_amount_returns_one_time_for_non_recurring(): void {
+
+		$item = $this->getMockBuilder( \stdClass::class )
+			->addMethods( [
+				'get_amount',
+				'get_initial_amount',
+				'is_recurring',
+				'get_currency',
+			] )
+			->getMock();
+		$item->method( 'get_amount' )->willReturn( 0 );
+		$item->method( 'get_initial_amount' )->willReturn( 50 );
+		$item->method( 'is_recurring' )->willReturn( false );
+		$item->method( 'get_currency' )->willReturn( 'USD' );
+
+		$output = $this->table->column_amount( $item );
+
+		$this->assertStringContainsString( 'one time payment', $output );
+	}
+
+	// =========================================================================
+	// column_date_expiration()
+	// =========================================================================
+
+	/**
+	 * Test column_date_expiration returns 'Lifetime' for empty date.
+	 */
+	public function test_column_date_expiration_returns_lifetime_for_empty_date(): void {
+
+		$item = $this->getMockBuilder( \stdClass::class )
+			->addMethods( [ 'get_date_expiration' ] )
+			->getMock();
+		$item->method( 'get_date_expiration' )->willReturn( '' );
+
+		$output = $this->table->column_date_expiration( $item );
+
+		$this->assertStringContainsString( 'Lifetime', $output );
+	}
+
+	/**
+	 * Test column_date_expiration returns 'Lifetime' for zero date.
+	 */
+	public function test_column_date_expiration_returns_lifetime_for_zero_date(): void {
+
+		$item = $this->getMockBuilder( \stdClass::class )
+			->addMethods( [ 'get_date_expiration' ] )
+			->getMock();
+		$item->method( 'get_date_expiration' )->willReturn( '0000-00-00 00:00:00' );
+
+		$output = $this->table->column_date_expiration( $item );
+
+		$this->assertStringContainsString( 'Lifetime', $output );
+	}
+
+	/**
+	 * Test column_date_expiration returns datetime HTML for valid date.
+	 */
+	public function test_column_date_expiration_returns_datetime_for_valid_date(): void {
+
+		$item = $this->getMockBuilder( \stdClass::class )
+			->addMethods( [ 'get_date_expiration' ] )
+			->getMock();
+		$item->method( 'get_date_expiration' )->willReturn( '2099-12-31 00:00:00' );
+
+		$output = $this->table->column_date_expiration( $item );
+
+		$this->assertStringContainsString( '<span', $output );
+	}
+}

--- a/tests/WP_Ultimo/List_Tables/Payment_List_Table_Test.php
+++ b/tests/WP_Ultimo/List_Tables/Payment_List_Table_Test.php
@@ -1,0 +1,285 @@
+<?php
+/**
+ * Tests for Payment_List_Table class.
+ *
+ * @package WP_Ultimo\Tests
+ */
+
+namespace WP_Ultimo\List_Tables;
+
+use WP_UnitTestCase;
+use WP_Ultimo\Database\Payments\Payment_Status;
+
+/**
+ * Test class for Payment_List_Table.
+ *
+ * @group list-tables
+ */
+class Payment_List_Table_Test extends WP_UnitTestCase {
+
+	/**
+	 * @var Payment_List_Table
+	 */
+	private Payment_List_Table $table;
+
+	/**
+	 * Set up test fixtures.
+	 */
+	public function set_up(): void {
+
+		parent::set_up();
+
+		$this->table = new Payment_List_Table();
+	}
+
+	/**
+	 * Tear down after each test.
+	 */
+	public function tear_down(): void {
+
+		unset( $_REQUEST['membership_id'], $_REQUEST['customer_id'] );
+		remove_all_filters( 'wu_payments_list_table_columns' );
+
+		parent::tear_down();
+	}
+
+	// =========================================================================
+	// Constructor & Labels
+	// =========================================================================
+
+	/**
+	 * Test constructor sets singular label.
+	 */
+	public function test_constructor_sets_singular_label(): void {
+
+		$this->assertStringContainsString( 'Payment', $this->table->get_label( 'singular' ) );
+	}
+
+	/**
+	 * Test constructor sets plural label.
+	 */
+	public function test_constructor_sets_plural_label(): void {
+
+		$this->assertStringContainsString( 'Payments', $this->table->get_label( 'plural' ) );
+	}
+
+	// =========================================================================
+	// get_columns()
+	// =========================================================================
+
+	/**
+	 * Test get_columns returns expected keys.
+	 */
+	public function test_get_columns_returns_expected_keys(): void {
+
+		$columns = $this->table->get_columns();
+
+		$this->assertIsArray( $columns );
+		$this->assertArrayHasKey( 'cb', $columns );
+		$this->assertArrayHasKey( 'hash', $columns );
+		$this->assertArrayHasKey( 'status', $columns );
+		$this->assertArrayHasKey( 'customer', $columns );
+		$this->assertArrayHasKey( 'membership', $columns );
+		$this->assertArrayHasKey( 'total', $columns );
+		$this->assertArrayHasKey( 'date_created', $columns );
+		$this->assertArrayHasKey( 'id', $columns );
+	}
+
+	/**
+	 * Test get_columns applies filter.
+	 */
+	public function test_get_columns_applies_filter(): void {
+
+		add_filter(
+			'wu_payments_list_table_columns',
+			function ( $columns ) {
+				$columns['extra_col'] = 'Extra';
+				return $columns;
+			}
+		);
+
+		$columns = $this->table->get_columns();
+
+		$this->assertArrayHasKey( 'extra_col', $columns );
+
+		remove_all_filters( 'wu_payments_list_table_columns' );
+	}
+
+	// =========================================================================
+	// get_sortable_columns()
+	// =========================================================================
+
+	/**
+	 * Test get_sortable_columns returns array.
+	 */
+	public function test_get_sortable_columns_returns_array(): void {
+
+		$columns = $this->table->get_sortable_columns();
+
+		$this->assertIsArray( $columns );
+	}
+
+	// =========================================================================
+	// get_filters()
+	// =========================================================================
+
+	/**
+	 * Test get_filters returns correct structure.
+	 */
+	public function test_get_filters_returns_correct_structure(): void {
+
+		$filters = $this->table->get_filters();
+
+		$this->assertIsArray( $filters );
+		$this->assertArrayHasKey( 'filters', $filters );
+		$this->assertArrayHasKey( 'date_filters', $filters );
+	}
+
+	/**
+	 * Test get_filters has status and gateway filters.
+	 */
+	public function test_get_filters_has_status_and_gateway(): void {
+
+		$filters = $this->table->get_filters();
+
+		$this->assertArrayHasKey( 'status', $filters['filters'] );
+		$this->assertArrayHasKey( 'gateway', $filters['filters'] );
+	}
+
+	/**
+	 * Test get_filters has date_created date filter.
+	 */
+	public function test_get_filters_has_date_created_date_filter(): void {
+
+		$filters = $this->table->get_filters();
+
+		$this->assertArrayHasKey( 'date_created', $filters['date_filters'] );
+	}
+
+	// =========================================================================
+	// get_views()
+	// =========================================================================
+
+	/**
+	 * Test get_views returns expected status keys.
+	 */
+	public function test_get_views_returns_expected_keys(): void {
+
+		$views = $this->table->get_views();
+
+		$this->assertArrayHasKey( 'all', $views );
+		$this->assertArrayHasKey( Payment_Status::COMPLETED, $views );
+		$this->assertArrayHasKey( Payment_Status::PENDING, $views );
+		$this->assertArrayHasKey( Payment_Status::REFUND, $views );
+		$this->assertArrayHasKey( Payment_Status::FAILED, $views );
+	}
+
+	// =========================================================================
+	// get_extra_query_fields()
+	// =========================================================================
+
+	/**
+	 * Test get_extra_query_fields includes membership_id and customer_id.
+	 */
+	public function test_get_extra_query_fields_includes_membership_and_customer_id(): void {
+
+		$fields = $this->table->get_extra_query_fields();
+
+		$this->assertIsArray( $fields );
+		$this->assertArrayHasKey( 'membership_id', $fields );
+		$this->assertArrayHasKey( 'customer_id', $fields );
+	}
+
+	/**
+	 * Test get_extra_query_fields includes parent_id__in filter.
+	 */
+	public function test_get_extra_query_fields_includes_parent_id_in(): void {
+
+		$fields = $this->table->get_extra_query_fields();
+
+		$this->assertArrayHasKey( 'parent_id__in', $fields );
+	}
+
+	// =========================================================================
+	// column_status()
+	// =========================================================================
+
+	/**
+	 * Test column_status returns span with label and class.
+	 */
+	public function test_column_status_returns_span_with_label(): void {
+
+		$item = $this->getMockBuilder( \stdClass::class )
+			->addMethods( [ 'get_status_label', 'get_status_class' ] )
+			->getMock();
+		$item->method( 'get_status_label' )->willReturn( 'Completed' );
+		$item->method( 'get_status_class' )->willReturn( 'wu-bg-green-500' );
+
+		$output = $this->table->column_status( $item );
+
+		$this->assertStringContainsString( 'Completed', $output );
+		$this->assertStringContainsString( 'wu-bg-green-500', $output );
+		$this->assertStringContainsString( '<span', $output );
+	}
+
+	// =========================================================================
+	// column_total()
+	// =========================================================================
+
+	/**
+	 * Test column_total returns formatted currency with gateway.
+	 */
+	public function test_column_total_returns_currency_with_gateway(): void {
+
+		$item = $this->getMockBuilder( \stdClass::class )
+			->addMethods( [ 'get_total', 'get_gateway' ] )
+			->getMock();
+		$item->method( 'get_total' )->willReturn( 99.99 );
+		$item->method( 'get_gateway' )->willReturn( 'stripe' );
+
+		$output = $this->table->column_total( $item );
+
+		$this->assertIsString( $output );
+		$this->assertStringContainsString( 'Stripe', $output );
+	}
+
+	// =========================================================================
+	// column_product()
+	// =========================================================================
+
+	/**
+	 * Test column_product returns 'No product found' when no product.
+	 */
+	public function test_column_product_returns_no_product_when_null(): void {
+
+		$item = $this->getMockBuilder( \stdClass::class )
+			->addMethods( [ 'get_product' ] )
+			->getMock();
+		$item->method( 'get_product' )->willReturn( null );
+
+		$output = $this->table->column_product( $item );
+
+		$this->assertStringContainsString( 'No product found', $output );
+	}
+
+	/**
+	 * Test column_product returns product name when product exists.
+	 */
+	public function test_column_product_returns_product_name_when_exists(): void {
+
+		$product = $this->getMockBuilder( \stdClass::class )
+			->addMethods( [ 'get_id', 'get_name' ] )
+			->getMock();
+		$product->method( 'get_id' )->willReturn( 1 );
+		$product->method( 'get_name' )->willReturn( 'Pro Plan' );
+
+		$item = $this->getMockBuilder( \stdClass::class )
+			->addMethods( [ 'get_product' ] )
+			->getMock();
+		$item->method( 'get_product' )->willReturn( $product );
+
+		$output = $this->table->column_product( $item );
+
+		$this->assertStringContainsString( 'Pro Plan', $output );
+	}
+}

--- a/tests/WP_Ultimo/List_Tables/Product_List_Table_Test.php
+++ b/tests/WP_Ultimo/List_Tables/Product_List_Table_Test.php
@@ -1,0 +1,278 @@
+<?php
+/**
+ * Tests for Product_List_Table class.
+ *
+ * @package WP_Ultimo\Tests
+ */
+
+namespace WP_Ultimo\List_Tables;
+
+use WP_UnitTestCase;
+
+/**
+ * Test class for Product_List_Table.
+ *
+ * @group list-tables
+ */
+class Product_List_Table_Test extends WP_UnitTestCase {
+
+	/**
+	 * @var Product_List_Table
+	 */
+	private Product_List_Table $table;
+
+	/**
+	 * Set up test fixtures.
+	 */
+	public function set_up(): void {
+
+		parent::set_up();
+
+		$this->table = new Product_List_Table();
+	}
+
+	// =========================================================================
+	// Constructor & Labels
+	// =========================================================================
+
+	/**
+	 * Test constructor sets singular label.
+	 */
+	public function test_constructor_sets_singular_label(): void {
+
+		$this->assertStringContainsString( 'Product', $this->table->get_label( 'singular' ) );
+	}
+
+	/**
+	 * Test constructor sets plural label.
+	 */
+	public function test_constructor_sets_plural_label(): void {
+
+		$this->assertStringContainsString( 'Products', $this->table->get_label( 'plural' ) );
+	}
+
+	// =========================================================================
+	// get_columns()
+	// =========================================================================
+
+	/**
+	 * Test get_columns returns expected keys.
+	 */
+	public function test_get_columns_returns_expected_keys(): void {
+
+		$columns = $this->table->get_columns();
+
+		$this->assertIsArray( $columns );
+		$this->assertArrayHasKey( 'cb', $columns );
+		$this->assertArrayHasKey( 'featured_image_id', $columns );
+		$this->assertArrayHasKey( 'name', $columns );
+		$this->assertArrayHasKey( 'type', $columns );
+		$this->assertArrayHasKey( 'slug', $columns );
+		$this->assertArrayHasKey( 'amount', $columns );
+		$this->assertArrayHasKey( 'setup_fee', $columns );
+		$this->assertArrayHasKey( 'id', $columns );
+	}
+
+	/**
+	 * Test get_columns returns 8 columns.
+	 */
+	public function test_get_columns_returns_eight_columns(): void {
+
+		$columns = $this->table->get_columns();
+
+		$this->assertCount( 8, $columns );
+	}
+
+	// =========================================================================
+	// get_sortable_columns()
+	// =========================================================================
+
+	/**
+	 * Test get_sortable_columns returns array.
+	 */
+	public function test_get_sortable_columns_returns_array(): void {
+
+		$columns = $this->table->get_sortable_columns();
+
+		$this->assertIsArray( $columns );
+	}
+
+	// =========================================================================
+	// get_filters()
+	// =========================================================================
+
+	/**
+	 * Test get_filters returns correct structure.
+	 */
+	public function test_get_filters_returns_correct_structure(): void {
+
+		$filters = $this->table->get_filters();
+
+		$this->assertIsArray( $filters );
+		$this->assertArrayHasKey( 'filters', $filters );
+	}
+
+	// =========================================================================
+	// get_views()
+	// =========================================================================
+
+	/**
+	 * Test get_views returns all, plan, package, service keys.
+	 */
+	public function test_get_views_returns_expected_keys(): void {
+
+		$views = $this->table->get_views();
+
+		$this->assertArrayHasKey( 'all', $views );
+		$this->assertArrayHasKey( 'plan', $views );
+		$this->assertArrayHasKey( 'package', $views );
+		$this->assertArrayHasKey( 'service', $views );
+	}
+
+	/**
+	 * Test get_views entries have required keys.
+	 */
+	public function test_get_views_entries_have_required_keys(): void {
+
+		$views = $this->table->get_views();
+
+		foreach ( $views as $key => $view ) {
+			$this->assertArrayHasKey( 'field', $view, "Missing 'field' in {$key}" );
+			$this->assertArrayHasKey( 'url', $view, "Missing 'url' in {$key}" );
+			$this->assertArrayHasKey( 'label', $view, "Missing 'label' in {$key}" );
+			$this->assertArrayHasKey( 'count', $view, "Missing 'count' in {$key}" );
+		}
+	}
+
+	// =========================================================================
+	// column_type()
+	// =========================================================================
+
+	/**
+	 * Test column_type returns span with label and class.
+	 */
+	public function test_column_type_returns_span_with_label(): void {
+
+		$item = $this->getMockBuilder( \stdClass::class )
+			->addMethods( [ 'get_type_label', 'get_type_class' ] )
+			->getMock();
+		$item->method( 'get_type_label' )->willReturn( 'Plan' );
+		$item->method( 'get_type_class' )->willReturn( 'wu-bg-blue-200' );
+
+		$output = $this->table->column_type( $item );
+
+		$this->assertStringContainsString( 'Plan', $output );
+		$this->assertStringContainsString( 'wu-bg-blue-200', $output );
+		$this->assertStringContainsString( '<span', $output );
+	}
+
+	// =========================================================================
+	// column_slug()
+	// =========================================================================
+
+	/**
+	 * Test column_slug returns slug in span.
+	 */
+	public function test_column_slug_returns_slug_in_span(): void {
+
+		$item = $this->getMockBuilder( \stdClass::class )
+			->addMethods( [ 'get_slug' ] )
+			->getMock();
+		$item->method( 'get_slug' )->willReturn( 'pro-plan' );
+
+		$output = $this->table->column_slug( $item );
+
+		$this->assertStringContainsString( 'pro-plan', $output );
+		$this->assertStringContainsString( '<span', $output );
+		$this->assertStringContainsString( 'wu-font-mono', $output );
+	}
+
+	// =========================================================================
+	// column_amount()
+	// =========================================================================
+
+	/**
+	 * Test column_amount returns 'Free' for zero amount.
+	 */
+	public function test_column_amount_returns_free_for_zero_amount(): void {
+
+		$item = $this->getMockBuilder( \stdClass::class )
+			->addMethods( [ 'get_pricing_type', 'get_amount', 'is_recurring' ] )
+			->getMock();
+		$item->method( 'get_pricing_type' )->willReturn( 'paid' );
+		$item->method( 'get_amount' )->willReturn( 0 );
+
+		$output = $this->table->column_amount( $item );
+
+		$this->assertStringContainsString( 'Free', $output );
+	}
+
+	/**
+	 * Test column_amount returns 'None' for contact_us pricing type.
+	 */
+	public function test_column_amount_returns_none_for_contact_us(): void {
+
+		$item = $this->getMockBuilder( \stdClass::class )
+			->addMethods( [ 'get_pricing_type', 'get_amount', 'is_recurring' ] )
+			->getMock();
+		$item->method( 'get_pricing_type' )->willReturn( 'contact_us' );
+
+		$output = $this->table->column_amount( $item );
+
+		$this->assertStringContainsString( 'None', $output );
+		$this->assertStringContainsString( 'contact', $output );
+	}
+
+	/**
+	 * Test column_amount returns 'one time payment' for non-recurring.
+	 */
+	public function test_column_amount_returns_one_time_for_non_recurring(): void {
+
+		$item = $this->getMockBuilder( \stdClass::class )
+			->addMethods( [ 'get_pricing_type', 'get_amount', 'is_recurring', 'get_currency' ] )
+			->getMock();
+		$item->method( 'get_pricing_type' )->willReturn( 'paid' );
+		$item->method( 'get_amount' )->willReturn( 50 );
+		$item->method( 'is_recurring' )->willReturn( false );
+		$item->method( 'get_currency' )->willReturn( 'USD' );
+
+		$output = $this->table->column_amount( $item );
+
+		$this->assertStringContainsString( 'one time payment', $output );
+	}
+
+	// =========================================================================
+	// column_setup_fee()
+	// =========================================================================
+
+	/**
+	 * Test column_setup_fee returns 'No Setup Fee' when no setup fee.
+	 */
+	public function test_column_setup_fee_returns_no_setup_fee(): void {
+
+		$item = $this->getMockBuilder( \stdClass::class )
+			->addMethods( [ 'get_pricing_type', 'has_setup_fee' ] )
+			->getMock();
+		$item->method( 'get_pricing_type' )->willReturn( 'paid' );
+		$item->method( 'has_setup_fee' )->willReturn( false );
+
+		$output = $this->table->column_setup_fee( $item );
+
+		$this->assertStringContainsString( 'No Setup Fee', $output );
+	}
+
+	/**
+	 * Test column_setup_fee returns 'None' for contact_us pricing type.
+	 */
+	public function test_column_setup_fee_returns_none_for_contact_us(): void {
+
+		$item = $this->getMockBuilder( \stdClass::class )
+			->addMethods( [ 'get_pricing_type', 'has_setup_fee' ] )
+			->getMock();
+		$item->method( 'get_pricing_type' )->willReturn( 'contact_us' );
+
+		$output = $this->table->column_setup_fee( $item );
+
+		$this->assertStringContainsString( 'None', $output );
+	}
+}

--- a/tests/WP_Ultimo/List_Tables/Site_List_Table_Test.php
+++ b/tests/WP_Ultimo/List_Tables/Site_List_Table_Test.php
@@ -1,0 +1,318 @@
+<?php
+/**
+ * Tests for Site_List_Table class.
+ *
+ * @package WP_Ultimo\Tests
+ */
+
+namespace WP_Ultimo\List_Tables;
+
+use WP_UnitTestCase;
+
+/**
+ * Test class for Site_List_Table.
+ *
+ * @group list-tables
+ */
+class Site_List_Table_Test extends WP_UnitTestCase {
+
+	/**
+	 * @var Site_List_Table
+	 */
+	private Site_List_Table $table;
+
+	/**
+	 * Set up test fixtures.
+	 */
+	public function set_up(): void {
+
+		parent::set_up();
+
+		$this->table = new Site_List_Table();
+	}
+
+	/**
+	 * Tear down after each test.
+	 */
+	public function tear_down(): void {
+
+		unset( $_REQUEST['type'] );
+		remove_all_filters( 'wu_site_list_get_bulk_actions' );
+
+		parent::tear_down();
+	}
+
+	// =========================================================================
+	// Constructor & Labels
+	// =========================================================================
+
+	/**
+	 * Test constructor sets singular label.
+	 */
+	public function test_constructor_sets_singular_label(): void {
+
+		$this->assertStringContainsString( 'Site', $this->table->get_label( 'singular' ) );
+	}
+
+	/**
+	 * Test constructor sets plural label.
+	 */
+	public function test_constructor_sets_plural_label(): void {
+
+		$this->assertStringContainsString( 'Sites', $this->table->get_label( 'plural' ) );
+	}
+
+	/**
+	 * Test constructor sets grid and list modes.
+	 */
+	public function test_constructor_sets_grid_and_list_modes(): void {
+
+		$this->assertArrayHasKey( 'grid', $this->table->modes );
+		$this->assertArrayHasKey( 'list', $this->table->modes );
+	}
+
+	// =========================================================================
+	// get_columns()
+	// =========================================================================
+
+	/**
+	 * Test get_columns returns expected keys.
+	 */
+	public function test_get_columns_returns_expected_keys(): void {
+
+		$columns = $this->table->get_columns();
+
+		$this->assertIsArray( $columns );
+		$this->assertArrayHasKey( 'cb', $columns );
+		$this->assertArrayHasKey( 'featured_image_id', $columns );
+		$this->assertArrayHasKey( 'path', $columns );
+		$this->assertArrayHasKey( 'type', $columns );
+		$this->assertArrayHasKey( 'customer', $columns );
+		$this->assertArrayHasKey( 'membership', $columns );
+		$this->assertArrayHasKey( 'domains', $columns );
+		$this->assertArrayHasKey( 'blog_id', $columns );
+	}
+
+	/**
+	 * Test get_columns returns 8 columns.
+	 */
+	public function test_get_columns_returns_eight_columns(): void {
+
+		$columns = $this->table->get_columns();
+
+		$this->assertCount( 8, $columns );
+	}
+
+	// =========================================================================
+	// get_sortable_columns()
+	// =========================================================================
+
+	/**
+	 * Test get_sortable_columns returns array.
+	 */
+	public function test_get_sortable_columns_returns_array(): void {
+
+		$columns = $this->table->get_sortable_columns();
+
+		$this->assertIsArray( $columns );
+	}
+
+	// =========================================================================
+	// get_filters()
+	// =========================================================================
+
+	/**
+	 * Test get_filters returns correct structure.
+	 */
+	public function test_get_filters_returns_correct_structure(): void {
+
+		$filters = $this->table->get_filters();
+
+		$this->assertIsArray( $filters );
+		$this->assertArrayHasKey( 'filters', $filters );
+		$this->assertArrayHasKey( 'date_filters', $filters );
+	}
+
+	/**
+	 * Test get_filters has vip filter.
+	 */
+	public function test_get_filters_has_vip_filter(): void {
+
+		$filters = $this->table->get_filters();
+
+		$this->assertArrayHasKey( 'vip', $filters['filters'] );
+	}
+
+	// =========================================================================
+	// get_views()
+	// =========================================================================
+
+	/**
+	 * Test get_views returns expected type keys.
+	 */
+	public function test_get_views_returns_expected_keys(): void {
+
+		$views = $this->table->get_views();
+
+		$this->assertArrayHasKey( 'all', $views );
+		$this->assertArrayHasKey( 'customer_owned', $views );
+		$this->assertArrayHasKey( 'site_template', $views );
+		$this->assertArrayHasKey( 'pending', $views );
+		$this->assertArrayHasKey( 'demo', $views );
+	}
+
+	// =========================================================================
+	// get_bulk_actions()
+	// =========================================================================
+
+	/**
+	 * Test get_bulk_actions returns screenshot and delete actions.
+	 */
+	public function test_get_bulk_actions_returns_screenshot_and_delete(): void {
+
+		$actions = $this->table->get_bulk_actions();
+
+		$this->assertIsArray( $actions );
+		$this->assertArrayHasKey( 'screenshot', $actions );
+	}
+
+	/**
+	 * Test get_bulk_actions applies filter.
+	 */
+	public function test_get_bulk_actions_applies_filter(): void {
+
+		add_filter(
+			'wu_site_list_get_bulk_actions',
+			function ( $actions ) {
+				$actions['custom_action'] = 'Custom';
+				return $actions;
+			}
+		);
+
+		$actions = $this->table->get_bulk_actions();
+
+		$this->assertArrayHasKey( 'custom_action', $actions );
+
+		remove_all_filters( 'wu_site_list_get_bulk_actions' );
+	}
+
+	// =========================================================================
+	// column_cb()
+	// =========================================================================
+
+	/**
+	 * Test column_cb returns checkbox with blog_id for non-pending site.
+	 */
+	public function test_column_cb_returns_checkbox_with_blog_id(): void {
+
+		$item = $this->getMockBuilder( \stdClass::class )
+			->addMethods( [ 'get_type', 'get_id', 'get_membership_id' ] )
+			->getMock();
+		$item->method( 'get_type' )->willReturn( 'customer_owned' );
+		$item->method( 'get_id' )->willReturn( 3 );
+
+		$output = $this->table->column_cb( $item );
+
+		$this->assertStringContainsString( 'type="checkbox"', $output );
+		$this->assertStringContainsString( '3', $output );
+	}
+
+	/**
+	 * Test column_cb returns checkbox with membership_id for pending site.
+	 */
+	public function test_column_cb_returns_membership_id_for_pending_site(): void {
+
+		$item = $this->getMockBuilder( \stdClass::class )
+			->addMethods( [ 'get_type', 'get_id', 'get_membership_id' ] )
+			->getMock();
+		$item->method( 'get_type' )->willReturn( 'pending' );
+		$item->method( 'get_id' )->willReturn( 3 );
+		$item->method( 'get_membership_id' )->willReturn( 7 );
+
+		$output = $this->table->column_cb( $item );
+
+		$this->assertStringContainsString( 'type="checkbox"', $output );
+		$this->assertStringContainsString( '7', $output );
+	}
+
+	// =========================================================================
+	// column_type()
+	// =========================================================================
+
+	/**
+	 * Test column_type returns span with label and class.
+	 */
+	public function test_column_type_returns_span_with_label(): void {
+
+		$item = $this->getMockBuilder( \stdClass::class )
+			->addMethods( [ 'get_type_label', 'get_type_class' ] )
+			->getMock();
+		$item->method( 'get_type_label' )->willReturn( 'Customer Owned' );
+		$item->method( 'get_type_class' )->willReturn( 'wu-bg-blue-200' );
+
+		$output = $this->table->column_type( $item );
+
+		$this->assertStringContainsString( 'Customer Owned', $output );
+		$this->assertStringContainsString( 'wu-bg-blue-200', $output );
+		$this->assertStringContainsString( '<span', $output );
+	}
+
+	// =========================================================================
+	// column_blog_id()
+	// =========================================================================
+
+	/**
+	 * Test column_blog_id returns '--' for pending site.
+	 */
+	public function test_column_blog_id_returns_dash_for_pending(): void {
+
+		$item = $this->getMockBuilder( \stdClass::class )
+			->addMethods( [ 'get_type', 'get_blog_id' ] )
+			->getMock();
+		$item->method( 'get_type' )->willReturn( \WP_Ultimo\Database\Sites\Site_Type::PENDING );
+
+		$output = $this->table->column_blog_id( $item );
+
+		$this->assertEquals( '--', $output );
+	}
+
+	/**
+	 * Test column_blog_id returns blog_id for non-pending site.
+	 */
+	public function test_column_blog_id_returns_blog_id_for_non_pending(): void {
+
+		$item = $this->getMockBuilder( \stdClass::class )
+			->addMethods( [ 'get_type', 'get_blog_id' ] )
+			->getMock();
+		$item->method( 'get_type' )->willReturn( 'customer_owned' );
+		$item->method( 'get_blog_id' )->willReturn( 5 );
+
+		$output = $this->table->column_blog_id( $item );
+
+		$this->assertEquals( 5, $output );
+	}
+
+	// =========================================================================
+	// get_items()
+	// =========================================================================
+
+	/**
+	 * Test get_items returns array.
+	 */
+	public function test_get_items_returns_array(): void {
+
+		$result = $this->table->get_items( 5, 1, false );
+
+		$this->assertIsArray( $result );
+	}
+
+	/**
+	 * Test get_items with count=true returns numeric.
+	 */
+	public function test_get_items_count_returns_numeric(): void {
+
+		$result = $this->table->get_items( 5, 1, true );
+
+		$this->assertIsNumeric( $result );
+	}
+}

--- a/tests/WP_Ultimo/List_Tables/Webhook_List_Table_Test.php
+++ b/tests/WP_Ultimo/List_Tables/Webhook_List_Table_Test.php
@@ -1,0 +1,250 @@
+<?php
+/**
+ * Tests for Webhook_List_Table class.
+ *
+ * @package WP_Ultimo\Tests
+ */
+
+namespace WP_Ultimo\List_Tables;
+
+use WP_UnitTestCase;
+
+/**
+ * Test class for Webhook_List_Table.
+ *
+ * @group list-tables
+ */
+class Webhook_List_Table_Test extends WP_UnitTestCase {
+
+	/**
+	 * @var Webhook_List_Table
+	 */
+	private Webhook_List_Table $table;
+
+	/**
+	 * Set up test fixtures.
+	 */
+	public function set_up(): void {
+
+		parent::set_up();
+
+		$this->table = new Webhook_List_Table();
+	}
+
+	// =========================================================================
+	// Constructor & Labels
+	// =========================================================================
+
+	/**
+	 * Test constructor sets singular label.
+	 */
+	public function test_constructor_sets_singular_label(): void {
+
+		$this->assertStringContainsString( 'Webhook', $this->table->get_label( 'singular' ) );
+	}
+
+	/**
+	 * Test constructor sets plural label.
+	 */
+	public function test_constructor_sets_plural_label(): void {
+
+		$this->assertStringContainsString( 'Webhooks', $this->table->get_label( 'plural' ) );
+	}
+
+	// =========================================================================
+	// get_columns()
+	// =========================================================================
+
+	/**
+	 * Test get_columns returns expected keys.
+	 */
+	public function test_get_columns_returns_expected_keys(): void {
+
+		$columns = $this->table->get_columns();
+
+		$this->assertIsArray( $columns );
+		$this->assertArrayHasKey( 'cb', $columns );
+		$this->assertArrayHasKey( 'name', $columns );
+		$this->assertArrayHasKey( 'webhook_url', $columns );
+		$this->assertArrayHasKey( 'event', $columns );
+		$this->assertArrayHasKey( 'event_count', $columns );
+		$this->assertArrayHasKey( 'integration', $columns );
+		$this->assertArrayHasKey( 'active', $columns );
+		$this->assertArrayHasKey( 'id', $columns );
+	}
+
+	/**
+	 * Test get_columns returns 8 columns.
+	 */
+	public function test_get_columns_returns_eight_columns(): void {
+
+		$columns = $this->table->get_columns();
+
+		$this->assertCount( 8, $columns );
+	}
+
+	// =========================================================================
+	// get_sortable_columns()
+	// =========================================================================
+
+	/**
+	 * Test get_sortable_columns returns array.
+	 */
+	public function test_get_sortable_columns_returns_array(): void {
+
+		$columns = $this->table->get_sortable_columns();
+
+		$this->assertIsArray( $columns );
+	}
+
+	// =========================================================================
+	// column_default()
+	// =========================================================================
+
+	/**
+	 * Test column_default returns value from getter.
+	 */
+	public function test_column_default_returns_value_from_getter(): void {
+
+		$item = $this->getMockBuilder( \stdClass::class )
+			->addMethods( [ 'get_name' ] )
+			->getMock();
+		$item->method( 'get_name' )->willReturn( 'My Webhook' );
+
+		$output = $this->table->column_default( $item, 'name' );
+
+		$this->assertEquals( 'My Webhook', $output );
+	}
+
+	// =========================================================================
+	// column_webhook_url()
+	// =========================================================================
+
+	/**
+	 * Test column_webhook_url returns truncated URL in span.
+	 */
+	public function test_column_webhook_url_returns_truncated_url_in_span(): void {
+
+		$item = $this->getMockBuilder( \stdClass::class )
+			->addMethods( [ 'get_webhook_url' ] )
+			->getMock();
+		$item->method( 'get_webhook_url' )->willReturn( 'https://example.com/webhook/endpoint' );
+
+		$output = $this->table->column_webhook_url( $item );
+
+		$this->assertStringContainsString( 'example.com', $output );
+		$this->assertStringContainsString( '<span', $output );
+		$this->assertStringContainsString( 'wu-font-mono', $output );
+	}
+
+	/**
+	 * Test column_webhook_url truncates long URLs.
+	 */
+	public function test_column_webhook_url_truncates_long_urls(): void {
+
+		$long_url = 'https://example.com/webhook/endpoint/with/a/very/long/path/that/exceeds/fifty/characters/limit';
+
+		$item = $this->getMockBuilder( \stdClass::class )
+			->addMethods( [ 'get_webhook_url' ] )
+			->getMock();
+		$item->method( 'get_webhook_url' )->willReturn( $long_url );
+
+		$output = $this->table->column_webhook_url( $item );
+
+		$this->assertStringContainsString( '...', $output );
+	}
+
+	// =========================================================================
+	// column_event()
+	// =========================================================================
+
+	/**
+	 * Test column_event returns event slug in span.
+	 */
+	public function test_column_event_returns_event_in_span(): void {
+
+		$item = $this->getMockBuilder( \stdClass::class )
+			->addMethods( [ 'get_event' ] )
+			->getMock();
+		$item->method( 'get_event' )->willReturn( 'membership.created' );
+
+		$output = $this->table->column_event( $item );
+
+		$this->assertStringContainsString( 'membership.created', $output );
+		$this->assertStringContainsString( '<span', $output );
+		$this->assertStringContainsString( 'wu-font-mono', $output );
+	}
+
+	// =========================================================================
+	// column_active()
+	// =========================================================================
+
+	/**
+	 * Test column_active returns 'Yes' for active webhook.
+	 */
+	public function test_column_active_returns_yes_for_active(): void {
+
+		$item = $this->getMockBuilder( \stdClass::class )
+			->addMethods( [ 'is_active' ] )
+			->getMock();
+		$item->method( 'is_active' )->willReturn( true );
+
+		$output = $this->table->column_active( $item );
+
+		$this->assertStringContainsString( 'Yes', $output );
+	}
+
+	/**
+	 * Test column_active returns 'No' for inactive webhook.
+	 */
+	public function test_column_active_returns_no_for_inactive(): void {
+
+		$item = $this->getMockBuilder( \stdClass::class )
+			->addMethods( [ 'is_active' ] )
+			->getMock();
+		$item->method( 'is_active' )->willReturn( false );
+
+		$output = $this->table->column_active( $item );
+
+		$this->assertStringContainsString( 'No', $output );
+	}
+
+	// =========================================================================
+	// column_integration()
+	// =========================================================================
+
+	/**
+	 * Test column_integration returns ucwords formatted integration name.
+	 */
+	public function test_column_integration_returns_formatted_name(): void {
+
+		$item = $this->getMockBuilder( \stdClass::class )
+			->addMethods( [ 'get_integration' ] )
+			->getMock();
+		$item->method( 'get_integration' )->willReturn( 'zapier_integration' );
+
+		$output = $this->table->column_integration( $item );
+
+		$this->assertStringContainsString( 'Zapier', $output );
+		$this->assertStringContainsString( 'Integration', $output );
+	}
+
+	// =========================================================================
+	// column_count()
+	// =========================================================================
+
+	/**
+	 * Test column_count returns count value.
+	 */
+	public function test_column_count_returns_count_value(): void {
+
+		$item = $this->getMockBuilder( \stdClass::class )
+			->addMethods( [ 'get_count' ] )
+			->getMock();
+		$item->method( 'get_count' )->willReturn( 42 );
+
+		$output = $this->table->column_count( $item );
+
+		$this->assertStringContainsString( '42', $output );
+	}
+}


### PR DESCRIPTION
## Summary

- Adds unit tests for all 15 list table classes that had 0% coverage (issue #677)
- 295 tests, 642 assertions, all passing locally
- Tests cover: constructor/labels, `get_columns()`, `get_sortable_columns()`, `get_filters()`, `get_views()`, `column_default()`, and all class-specific column methods

## Files Changed

| File | What/Why |
|------|----------|
| `tests/WP_Ultimo/List_Tables/Broadcast_List_Table_Test.php` | column_cb (disabled for email type), column_type (all 4 notice CSS classes), filters/views |
| `tests/WP_Ultimo/List_Tables/Checkout_Form_List_Table_Test.php` | column_slug, column_steps, column_shortcode, column_name |
| `tests/WP_Ultimo/List_Tables/Customer_List_Table_Test.php` | get_extra_query_fields (vip/online filters), column_customer_status (VIP tag), column_last_login |
| `tests/WP_Ultimo/List_Tables/Customers_Membership_List_Table_Test.php` | Inheritance from Membership_List_Table, responsive-only columns |
| `tests/WP_Ultimo/List_Tables/Customers_Payment_List_Table_Test.php` | Inheritance from Payment_List_Table, responsive-only columns |
| `tests/WP_Ultimo/List_Tables/Customers_Site_List_Table_Test.php` | Constructor forces list mode, get_items override for pending sites |
| `tests/WP_Ultimo/List_Tables/Discount_Code_List_Table_Test.php` | column_value (percentage/flat/zero), column_setup_fee_value, column_uses (limits), column_coupon_code (uppercase) |
| `tests/WP_Ultimo/List_Tables/Domain_List_Table_Test.php` | column_active/primary_domain/secure/stage, get_extra_query_fields (blog_id) |
| `tests/WP_Ultimo/List_Tables/Email_List_Table_Test.php` | column_event/slug/schedule (immediate/hours/days), get_items |
| `tests/WP_Ultimo/List_Tables/Event_List_Table_Test.php` | column_object_type/slug/initiator (system/unknown), column_message, filter hook |
| `tests/WP_Ultimo/List_Tables/Membership_List_Table_Test.php` | column_status/amount (free/one-time)/date_expiration (lifetime/valid), filter hook |
| `tests/WP_Ultimo/List_Tables/Payment_List_Table_Test.php` | column_status/total/product (null/exists), get_extra_query_fields, filter hook |
| `tests/WP_Ultimo/List_Tables/Product_List_Table_Test.php` | column_type/slug/amount (free/contact_us/one-time)/setup_fee, get_views |
| `tests/WP_Ultimo/List_Tables/Site_List_Table_Test.php` | column_cb (pending uses membership_id), column_type/blog_id (pending=--), get_bulk_actions, filter hook |
| `tests/WP_Ultimo/List_Tables/Webhook_List_Table_Test.php` | column_webhook_url (truncation at 50 chars), column_event/active/integration (ucwords)/count |

## Runtime Testing

- **Level:** unit-tested
- **Risk:** Low (test files only, no production code changes)
- **Smoke check:** `WP_TESTS_DIR=/tmp/wordpress-tests-lib vendor/bin/phpunit --group list-tables --no-coverage` → `OK (295 tests, 642 assertions)`

## Notes

- `wu_responsive_table_row()` is a template helper unavailable in unit test environment; `Customers_Membership_List_Table_Test` and `Customers_Payment_List_Table_Test` test method existence and column registration instead of calling the method directly
- DB errors in test output (`wptests_users doesn't exist`) are from teardown cleanup on the shared test DB — these are pre-existing and do not affect test results

Closes #677

actionable_findings_total=0
fixed_in_pr=0
deferred_tasks_created=0
coverage=unit-tested