### PR TITLE
chore: remove stale @todo comments from model and limit classes

### DIFF
--- a/inc/functions/reflection.php
+++ b/inc/functions/reflection.php
@@ -24,9 +24,6 @@ function wu_reflection_parse_object_arguments($class_name) {
 	$base_schema = wu_reflection_parse_arguments_from_setters($class_name, true);
 
 	if (wu_are_code_comments_available() === false) {
-		/*
-		 * @todo add a logger.
-		 */
 		return $base_schema;
 	}
 

--- a/inc/limits/class-customer-user-role-limits.php
+++ b/inc/limits/class-customer-user-role-limits.php
@@ -2,7 +2,6 @@
 /**
  * Handles limitations to the customer user role.
  *
- * @todo We need to move posts on downgrade.
  * @package WP_Ultimo
  * @subpackage Limits
  * @since 2.0.10

--- a/inc/limits/class-disk-space-limits.php
+++ b/inc/limits/class-disk-space-limits.php
@@ -2,7 +2,6 @@
 /**
  * Handles limitations to disk space
  *
- * @todo We need to move posts on downgrade.
  * @package WP_Ultimo
  * @subpackage Limits
  * @since 2.0.0

--- a/inc/limits/class-post-type-limits.php
+++ b/inc/limits/class-post-type-limits.php
@@ -2,7 +2,6 @@
 /**
  * Handles limitations to post types, uploads and more.
  *
- * @todo We need to move posts on downgrade.
  * @package WP_Ultimo
  * @subpackage Limits
  * @since 2.0.0

--- a/inc/limits/class-site-template-limits.php
+++ b/inc/limits/class-site-template-limits.php
@@ -2,7 +2,6 @@
 /**
  * Handles limitations to disk space
  *
- * @todo We need to move posts on downgrade.
  * @package WP_Ultimo
  * @subpackage Limits
  * @since 2.0.0

--- a/inc/models/class-membership.php
+++ b/inc/models/class-membership.php
@@ -416,7 +416,6 @@ class Membership extends Base_Model implements Limitable, Billable, Notable {
 	/**
 	 * Gets the customer object associated with this membership.
 	 *
-	 * @todo Implement this.
 	 * @since 2.0.0
 	 * @return \WP_Ultimo\Models\Customer;
 	 */

--- a/inc/models/class-payment.php
+++ b/inc/models/class-payment.php
@@ -256,7 +256,6 @@ class Payment extends Base_Model implements Notable {
 	/**
 	 * Gets the customer object associated with this payment.
 	 *
-	 * @todo Implement this.
 	 * @since 2.0.0
 	 * @return \WP_Ultimo\Models\Customer;
 	 */
@@ -291,7 +290,6 @@ class Payment extends Base_Model implements Notable {
 	/**
 	 * Gets the membership object associated with this payment.
 	 *
-	 * @todo Implement this.
 	 * @since 2.0.0
 	 * @return \WP_Ultimo\Models\Membership|false
 	 */


### PR DESCRIPTION
## Summary

- Remove `@todo Implement this.` from `Membership::get_customer()`, `Payment::get_customer()`, and `Payment::get_membership()` — all three methods are fully implemented.
- Remove `@todo We need to move posts on downgrade.` from file headers of four limit classes. Tracked as a real feature gap in #692.
- Remove vague `@todo add a logger.` inline comment from `inc/functions/reflection.php` — no action taken in years.

## Todos kept (accurate/legitimate)

| Location | Todo | Reason kept |
|---|---|---|
| `Payment::recalculate_totals()` | needs refactoring | legitimate future refactor |
| `Site::set_description()` | not yet persistent | accurate — only sets in-memory |
| `class-theme-limits.php:146` | Send patch to WordPress core | upstream contribution reminder |
| `class-dashboard-taxes-tab.php:163` | extract calculations | legitimate refactor note |

## Runtime Testing

- **Risk level:** Low — comment-only changes, no logic modified
- **Level:** self-assessed
- **Smoke check:** `git diff` confirms only `@todo` lines removed, no code changed

## Actionable Findings

- `actionable_findings_total=1`
- `fixed_in_pr=0`
- `deferred_tasks_created=1` — GH#692 tracks the move-posts-on-downgrade feature
- `coverage=100%`

Closes #691


---
[aidevops.sh](https://aidevops.sh) v3.5.108 plugin for [OpenCode](https://opencode.ai) v1.3.0 with claude-sonnet-4-6 spent 3m and 8,511 tokens on this.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed internal documentation comments and cleanup notes from codebase. No functional changes or user-facing features were affected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->