### PR TITLE
689: fix(security): replace wp_redirect with wp_safe_redirect in class-primary-domain.php

### DIFF
--- a/inc/domain-mapping/class-primary-domain.php
+++ b/inc/domain-mapping/class-primary-domain.php
@@ -32,6 +32,39 @@ class Primary_Domain {
 	public function init(): void {
 
 		add_action('wu_domain_mapping_load', [$this, 'add_hooks'], -20);
+
+		add_filter('allowed_redirect_hosts', [$this, 'allow_mapped_domain_redirect_hosts']);
+	}
+
+	/**
+	 * Adds mapped domain hosts to the list of allowed redirect hosts.
+	 *
+	 * wp_safe_redirect() validates the redirect target host against this list.
+	 * Without this filter, redirects to mapped domains (which differ from the
+	 * network's own host) would be blocked and fall back to wp_admin_url().
+	 *
+	 * @since 2.1.0
+	 * @param string[] $hosts Allowed redirect hosts.
+	 * @return string[]
+	 */
+	public function allow_mapped_domain_redirect_hosts(array $hosts): array {
+
+		if ( ! function_exists('wu_get_domains')) {
+			return $hosts;
+		}
+
+		$domains = wu_get_domains(
+			[
+				'blog_id' => get_current_blog_id(),
+				'active'  => 1,
+			]
+		);
+
+		foreach ($domains as $domain) {
+			$hosts[] = $domain->get_domain();
+		}
+
+		return $hosts;
 	}
 
 	/**
@@ -106,8 +139,7 @@ class Primary_Domain {
 			$new_url = Domain_Mapping::get_instance()->replace_url($url, $primary_domain);
 
 			if ($url !== $new_url ) {
-				// TODO: Use wp_safe_redirect
-				wp_redirect(set_url_scheme($new_url)); // phpcs:ignore WordPress.Security.SafeRedirect.wp_redirect_wp_redirect
+				wp_safe_redirect(set_url_scheme($new_url));
 
 				exit;
 			}
@@ -175,7 +207,7 @@ class Primary_Domain {
 			 * full URL including the query string, so separate query arg
 			 * processing is not needed.
 			 */
-			wp_redirect($redirect_url); // phpcs:ignore WordPress.Security.SafeRedirect.wp_redirect_wp_redirect
+			wp_safe_redirect($redirect_url);
 
 			exit;
 		}

--- a/tests/WP_Ultimo/Domain_Mapping/Primary_Domain_Test.php
+++ b/tests/WP_Ultimo/Domain_Mapping/Primary_Domain_Test.php
@@ -1,0 +1,124 @@
+<?php
+
+namespace WP_Ultimo\Domain_Mapping;
+
+/**
+ * Tests for the Primary_Domain class.
+ */
+class Primary_Domain_Test extends \WP_UnitTestCase {
+
+	/**
+	 * Test class exists.
+	 */
+	public function test_class_exists() {
+
+		$this->assertTrue(class_exists(Primary_Domain::class));
+	}
+
+	/**
+	 * Test singleton returns same instance.
+	 */
+	public function test_singleton() {
+
+		$instance1 = Primary_Domain::get_instance();
+		$instance2 = Primary_Domain::get_instance();
+
+		$this->assertSame($instance1, $instance2);
+	}
+
+	/**
+	 * Test allow_mapped_domain_redirect_hosts returns hosts array unchanged
+	 * when wu_get_domains is not available.
+	 */
+	public function test_allow_mapped_domain_redirect_hosts_no_function() {
+
+		$instance = Primary_Domain::get_instance();
+
+		// When wu_get_domains does not exist the method should return the
+		// original hosts array unmodified.
+		if (function_exists('wu_get_domains')) {
+			$this->markTestSkipped('wu_get_domains exists; skipping no-function path.');
+		}
+
+		$hosts  = ['example.com'];
+		$result = $instance->allow_mapped_domain_redirect_hosts($hosts);
+
+		$this->assertSame($hosts, $result);
+	}
+
+	/**
+	 * Test allow_mapped_domain_redirect_hosts adds mapped domains to hosts.
+	 */
+	public function test_allow_mapped_domain_redirect_hosts_adds_domains() {
+
+		if ( ! function_exists('wu_get_domains')) {
+			$this->markTestSkipped('wu_get_domains not available.');
+		}
+
+		$instance = Primary_Domain::get_instance();
+
+		// Capture the hosts list produced by the filter.
+		$result = $instance->allow_mapped_domain_redirect_hosts([]);
+
+		// Result must be an array (may be empty if no domains are mapped in
+		// the test environment, but must not be false/null).
+		$this->assertIsArray($result);
+	}
+
+	/**
+	 * Test that the allowed_redirect_hosts filter is registered.
+	 */
+	public function test_allowed_redirect_hosts_filter_registered() {
+
+		$instance = Primary_Domain::get_instance();
+
+		$priority = has_filter(
+			'allowed_redirect_hosts',
+			[$instance, 'allow_mapped_domain_redirect_hosts']
+		);
+
+		// has_filter returns the priority (int) when registered, false otherwise.
+		$this->assertNotFalse($priority);
+	}
+
+	/**
+	 * Test that wp_safe_redirect is used (no phpcs:ignore suppression present).
+	 *
+	 * This is a static analysis guard: if someone reverts to wp_redirect with a
+	 * phpcs:ignore, this test will catch it by inspecting the source file.
+	 */
+	public function test_no_wp_redirect_phpcs_ignore_in_source() {
+
+		$source = file_get_contents(
+			dirname(__DIR__, 3) . '/inc/domain-mapping/class-primary-domain.php'
+		);
+
+		$this->assertStringNotContainsString(
+			'wp_redirect(',
+			$source,
+			'class-primary-domain.php must not use wp_redirect(); use wp_safe_redirect() instead.'
+		);
+
+		$this->assertStringNotContainsString(
+			'phpcs:ignore WordPress.Security.SafeRedirect',
+			$source,
+			'class-primary-domain.php must not suppress SafeRedirect PHPCS sniff.'
+		);
+	}
+
+	/**
+	 * Test that wp_safe_redirect is present in the source.
+	 */
+	public function test_wp_safe_redirect_used_in_source() {
+
+		$source = file_get_contents(
+			dirname(__DIR__, 3) . '/inc/domain-mapping/class-primary-domain.php'
+		);
+
+		$this->assertStringContainsString(
+			'wp_safe_redirect(',
+			$source,
+			'class-primary-domain.php must use wp_safe_redirect().'
+		);
+	}
+}


### PR DESCRIPTION
## Summary

- Replace both `wp_redirect()` calls with `wp_safe_redirect()` in `class-primary-domain.php` (lines 109 and 178 in original)
- Remove both `// phpcs:ignore WordPress.Security.SafeRedirect.wp_redirect_wp_redirect` suppressions and the `// TODO: Use wp_safe_redirect` comment
- Add `allowed_redirect_hosts` filter in `init()` via new `allow_mapped_domain_redirect_hosts()` method — ensures mapped domain hosts are whitelisted so `wp_safe_redirect()` does not block valid domain-mapping redirects
- Add `Primary_Domain_Test` covering singleton, filter registration, `allow_mapped_domain_redirect_hosts()`, and source-level guards

## Changes

| File | What / Why |
|------|-----------|
| `inc/domain-mapping/class-primary-domain.php` | Replace `wp_redirect` → `wp_safe_redirect`, remove phpcs:ignore, add `allowed_redirect_hosts` filter |
| `tests/WP_Ultimo/Domain_Mapping/Primary_Domain_Test.php` | New test class covering the redirect security fix |

## Runtime Testing

- **Risk level:** Medium (redirect handler, no payment/auth/data-deletion path)
- **Level:** self-assessed — no dev environment available in this session
- **Rationale:** The change is a direct function swap (`wp_redirect` → `wp_safe_redirect`). The `allowed_redirect_hosts` filter ensures mapped domains are whitelisted, preserving existing redirect behaviour. Source-level tests guard against regression.

## Acceptance Criteria

- [x] `wp_redirect` replaced with `wp_safe_redirect` in both redirect paths
- [x] phpcs:ignore comments removed
- [x] `allowed_redirect_hosts` filter added to whitelist mapped domains
- [x] Unit tests added (`Primary_Domain_Test`)

Closes #689


---
[aidevops.sh](https://aidevops.sh) v3.5.108 plugin for [OpenCode](https://opencode.ai) v1.3.0 with claude-sonnet-4-6 spent 4m and 12,230 tokens on this.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced security for domain redirects by replacing unsafe redirect methods with secure alternatives and expanding the redirect allowlist to properly support currently active mapped domain hostnames.

* **Tests**
  * Added comprehensive test coverage to validate domain redirect security implementation, verify proper allowlist functionality, and ensure correct behavior for mapped domain redirects across various scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->