### PR TITLE
GH#697: test(integrations): add unit tests for 9 uncovered provider classes

### DIFF
--- a/tests/WP_Ultimo/Integrations/Providers/BunnyNet_Domain_Mapping_Test.php
+++ b/tests/WP_Ultimo/Integrations/Providers/BunnyNet_Domain_Mapping_Test.php
@@ -1,0 +1,149 @@
+<?php
+
+namespace WP_Ultimo\Integrations\Providers\BunnyNet;
+
+use WP_UnitTestCase;
+
+class BunnyNet_Domain_Mapping_Test extends WP_UnitTestCase {
+
+	private BunnyNet_Domain_Mapping $module;
+	private BunnyNet_Integration $integration;
+
+	public function setUp(): void {
+
+		parent::setUp();
+
+		$this->integration = $this->getMockBuilder(BunnyNet_Integration::class)
+			->onlyMethods(['send_bunnynet_request', 'get_credential'])
+			->getMock();
+
+		$this->module = new BunnyNet_Domain_Mapping();
+		$this->module->set_integration($this->integration);
+	}
+
+	public function test_get_capability_id(): void {
+
+		$this->assertSame('domain-mapping', $this->module->get_capability_id());
+	}
+
+	public function test_get_title(): void {
+
+		$this->assertNotEmpty($this->module->get_title());
+	}
+
+	public function test_get_explainer_lines_has_will_and_will_not_keys(): void {
+
+		$lines = $this->module->get_explainer_lines();
+
+		$this->assertArrayHasKey('will', $lines);
+		$this->assertArrayHasKey('will_not', $lines);
+	}
+
+	public function test_register_hooks_adds_actions(): void {
+
+		$this->module->register_hooks();
+
+		$this->assertIsInt(has_action('wu_add_domain', [$this->module, 'on_add_domain']));
+		$this->assertIsInt(has_action('wu_remove_domain', [$this->module, 'on_remove_domain']));
+		$this->assertIsInt(has_action('wu_add_subdomain', [$this->module, 'on_add_subdomain']));
+		$this->assertIsInt(has_action('wu_remove_subdomain', [$this->module, 'on_remove_subdomain']));
+	}
+
+	public function test_register_hooks_adds_dns_filter(): void {
+
+		$this->module->register_hooks();
+
+		$this->assertIsInt(has_filter('wu_domain_dns_get_record', [$this->module, 'add_bunnynet_dns_entries']));
+	}
+
+	public function test_on_add_domain_is_noop(): void {
+
+		// BunnyNet does not support automated custom domain mapping.
+		$this->integration->expects($this->never())
+			->method('send_bunnynet_request');
+
+		$this->module->on_add_domain('example.com', 1);
+	}
+
+	public function test_on_remove_domain_is_noop(): void {
+
+		// BunnyNet does not support automated custom domain mapping.
+		$this->integration->expects($this->never())
+			->method('send_bunnynet_request');
+
+		$this->module->on_remove_domain('example.com', 1);
+	}
+
+	public function test_on_add_subdomain_skips_when_no_zone_id(): void {
+
+		$this->integration->method('get_credential')
+			->with('WU_BUNNYNET_ZONE_ID')
+			->willReturn('');
+
+		$this->integration->expects($this->never())
+			->method('send_bunnynet_request');
+
+		$this->module->on_add_subdomain('sub.example.com', 1);
+	}
+
+	public function test_on_remove_subdomain_skips_when_no_zone_id(): void {
+
+		$this->integration->method('get_credential')
+			->with('WU_BUNNYNET_ZONE_ID')
+			->willReturn('');
+
+		$this->integration->expects($this->never())
+			->method('send_bunnynet_request');
+
+		$this->module->on_remove_subdomain('sub.example.com', 1);
+	}
+
+	public function test_add_bunnynet_dns_entries_returns_unchanged_when_no_zone_id(): void {
+
+		$this->integration->method('get_credential')
+			->with('WU_BUNNYNET_ZONE_ID')
+			->willReturn('');
+
+		$existing = [['type' => 'A', 'data' => '1.2.3.4']];
+
+		$result = $this->module->add_bunnynet_dns_entries($existing, 'example.com');
+
+		$this->assertSame($existing, $result);
+	}
+
+	public function test_add_bunnynet_dns_entries_returns_unchanged_on_api_error(): void {
+
+		$this->integration->method('get_credential')
+			->with('WU_BUNNYNET_ZONE_ID')
+			->willReturn('12345');
+
+		$this->integration->method('send_bunnynet_request')
+			->willReturn(new \WP_Error('fail', 'error'));
+
+		$existing = [['type' => 'A', 'data' => '1.2.3.4']];
+
+		$result = $this->module->add_bunnynet_dns_entries($existing, 'example.com');
+
+		$this->assertSame($existing, $result);
+	}
+
+	public function test_test_connection_delegates_to_integration(): void {
+
+		$this->integration->method('get_credential')
+			->willReturnCallback(function (string $key) {
+				if ('WU_BUNNYNET_ZONE_ID' === $key) {
+					return '12345';
+				}
+
+				return '';
+			});
+
+		$this->integration->expects($this->once())
+			->method('send_bunnynet_request')
+			->willReturn((object) ['Id' => 12345]);
+
+		$result = $this->module->test_connection();
+
+		$this->assertNotNull($result);
+	}
+}

--- a/tests/WP_Ultimo/Integrations/Providers/Cloudways_Domain_Mapping_Test.php
+++ b/tests/WP_Ultimo/Integrations/Providers/Cloudways_Domain_Mapping_Test.php
@@ -1,0 +1,117 @@
+<?php
+
+namespace WP_Ultimo\Integrations\Providers\Cloudways;
+
+use WP_UnitTestCase;
+
+class Cloudways_Domain_Mapping_Test extends WP_UnitTestCase {
+
+	private Cloudways_Domain_Mapping $module;
+	private Cloudways_Integration $integration;
+
+	public function setUp(): void {
+
+		parent::setUp();
+
+		$this->integration = $this->getMockBuilder(Cloudways_Integration::class)
+			->onlyMethods(['send_cloudways_request'])
+			->getMock();
+
+		$this->module = new Cloudways_Domain_Mapping();
+		$this->module->set_integration($this->integration);
+	}
+
+	public function test_get_capability_id(): void {
+
+		$this->assertSame('domain-mapping', $this->module->get_capability_id());
+	}
+
+	public function test_get_title(): void {
+
+		$this->assertNotEmpty($this->module->get_title());
+	}
+
+	public function test_supports_autossl(): void {
+
+		$this->assertTrue($this->module->supports('autossl'));
+	}
+
+	public function test_does_not_support_unknown_feature(): void {
+
+		$this->assertFalse($this->module->supports('nonexistent'));
+	}
+
+	public function test_get_explainer_lines_structure(): void {
+
+		$lines = $this->module->get_explainer_lines();
+
+		$this->assertArrayHasKey('will', $lines);
+		$this->assertNotEmpty($lines['will']);
+		$this->assertArrayHasKey('will_not', $lines);
+	}
+
+	public function test_register_hooks_adds_actions(): void {
+
+		$this->module->register_hooks();
+
+		$this->assertIsInt(has_action('wu_add_domain', [$this->module, 'on_add_domain']));
+		$this->assertIsInt(has_action('wu_remove_domain', [$this->module, 'on_remove_domain']));
+		$this->assertIsInt(has_action('wu_add_subdomain', [$this->module, 'on_add_subdomain']));
+		$this->assertIsInt(has_action('wu_remove_subdomain', [$this->module, 'on_remove_subdomain']));
+	}
+
+	public function test_register_hooks_adds_ssl_action(): void {
+
+		$this->module->register_hooks();
+
+		$this->assertIsInt(has_action('wu_domain_manager_dns_propagation_finished', [$this->module, 'request_ssl']));
+	}
+
+	public function test_on_add_domain_calls_aliases_api(): void {
+
+		$this->integration->expects($this->once())
+			->method('send_cloudways_request')
+			->with('/app/manage/aliases', $this->anything())
+			->willReturn((object) ['status' => true]);
+
+		$this->module->on_add_domain('example.com', 1);
+	}
+
+	public function test_on_remove_domain_calls_aliases_api(): void {
+
+		$this->integration->expects($this->once())
+			->method('send_cloudways_request')
+			->with('/app/manage/aliases', $this->anything())
+			->willReturn((object) ['status' => true]);
+
+		$this->module->on_remove_domain('example.com', 1);
+	}
+
+	public function test_on_add_subdomain_is_noop(): void {
+
+		$this->integration->expects($this->never())
+			->method('send_cloudways_request');
+
+		$this->module->on_add_subdomain('sub.example.com', 1);
+	}
+
+	public function test_on_remove_subdomain_is_noop(): void {
+
+		$this->integration->expects($this->never())
+			->method('send_cloudways_request');
+
+		$this->module->on_remove_subdomain('sub.example.com', 1);
+	}
+
+	public function test_test_connection_delegates_to_integration(): void {
+
+		$this->integration->expects($this->once())
+			->method('send_cloudways_request')
+			->with('/app/manage/fpm_setting', [], 'GET')
+			->willReturn((object) ['fpm_setting' => []]);
+
+		$result = $this->module->test_connection();
+
+		$this->assertNotNull($result);
+	}
+}

--- a/tests/WP_Ultimo/Integrations/Providers/Enhance_Domain_Mapping_Test.php
+++ b/tests/WP_Ultimo/Integrations/Providers/Enhance_Domain_Mapping_Test.php
@@ -1,0 +1,187 @@
+<?php
+
+namespace WP_Ultimo\Integrations\Providers\Enhance;
+
+use WP_UnitTestCase;
+
+class Enhance_Domain_Mapping_Test extends WP_UnitTestCase {
+
+	private Enhance_Domain_Mapping $module;
+	private Enhance_Integration $integration;
+
+	public function setUp(): void {
+
+		parent::setUp();
+
+		$this->integration = $this->getMockBuilder(Enhance_Integration::class)
+			->onlyMethods(['send_enhance_api_request', 'get_credential'])
+			->getMock();
+
+		$this->integration->method('get_credential')
+			->willReturnCallback(function (string $key) {
+				$map = [
+					'WU_ENHANCE_ORG_ID'     => 'org-uuid-1234',
+					'WU_ENHANCE_WEBSITE_ID' => 'site-uuid-5678',
+				];
+
+				return $map[ $key ] ?? '';
+			});
+
+		$this->module = new Enhance_Domain_Mapping();
+		$this->module->set_integration($this->integration);
+	}
+
+	public function test_get_capability_id(): void {
+
+		$this->assertSame('domain-mapping', $this->module->get_capability_id());
+	}
+
+	public function test_get_title(): void {
+
+		$this->assertNotEmpty($this->module->get_title());
+	}
+
+	public function test_supports_autossl(): void {
+
+		$this->assertTrue($this->module->supports('autossl'));
+	}
+
+	public function test_does_not_support_unknown_feature(): void {
+
+		$this->assertFalse($this->module->supports('nonexistent'));
+	}
+
+	public function test_get_explainer_lines_structure(): void {
+
+		$lines = $this->module->get_explainer_lines();
+
+		$this->assertArrayHasKey('will', $lines);
+		$this->assertNotEmpty($lines['will']);
+		$this->assertArrayHasKey('will_not', $lines);
+	}
+
+	public function test_register_hooks_adds_actions(): void {
+
+		$this->module->register_hooks();
+
+		$this->assertIsInt(has_action('wu_add_domain', [$this->module, 'on_add_domain']));
+		$this->assertIsInt(has_action('wu_remove_domain', [$this->module, 'on_remove_domain']));
+		$this->assertIsInt(has_action('wu_add_subdomain', [$this->module, 'on_add_subdomain']));
+		$this->assertIsInt(has_action('wu_remove_subdomain', [$this->module, 'on_remove_subdomain']));
+	}
+
+	public function test_on_add_domain_calls_api_with_correct_endpoint(): void {
+
+		$this->integration->expects($this->once())
+			->method('send_enhance_api_request')
+			->with(
+				'/orgs/org-uuid-1234/websites/site-uuid-5678/domains',
+				'POST',
+				['domain' => 'example.com']
+			)
+			->willReturn(['id' => 'domain-uuid-abc']);
+
+		$this->module->on_add_domain('example.com', 1);
+	}
+
+	public function test_on_add_domain_skips_when_no_org_id(): void {
+
+		$integration = $this->getMockBuilder(Enhance_Integration::class)
+			->onlyMethods(['send_enhance_api_request', 'get_credential'])
+			->getMock();
+
+		$integration->method('get_credential')->willReturn('');
+
+		$integration->expects($this->never())
+			->method('send_enhance_api_request');
+
+		$module = new Enhance_Domain_Mapping();
+		$module->set_integration($integration);
+		$module->on_add_domain('example.com', 1);
+	}
+
+	public function test_on_add_domain_skips_when_no_website_id(): void {
+
+		$integration = $this->getMockBuilder(Enhance_Integration::class)
+			->onlyMethods(['send_enhance_api_request', 'get_credential'])
+			->getMock();
+
+		$integration->method('get_credential')
+			->willReturnCallback(function (string $key) {
+				if ('WU_ENHANCE_ORG_ID' === $key) {
+					return 'org-uuid-1234';
+				}
+
+				return '';
+			});
+
+		$integration->expects($this->never())
+			->method('send_enhance_api_request');
+
+		$module = new Enhance_Domain_Mapping();
+		$module->set_integration($integration);
+		$module->on_add_domain('example.com', 1);
+	}
+
+	public function test_on_remove_domain_fetches_domain_list_first(): void {
+
+		$this->integration->expects($this->atLeast(1))
+			->method('send_enhance_api_request')
+			->willReturnCallback(function (string $endpoint, string $method = 'GET') {
+				if ('GET' === $method) {
+					return [
+						'items' => [
+							['id' => 'domain-uuid-abc', 'domain' => 'example.com'],
+						],
+					];
+				}
+
+				return ['success' => true];
+			});
+
+		$this->module->on_remove_domain('example.com', 1);
+	}
+
+	public function test_on_remove_domain_skips_when_domain_not_found(): void {
+
+		$this->integration->expects($this->once())
+			->method('send_enhance_api_request')
+			->willReturn(['items' => []]);
+
+		$this->module->on_remove_domain('notfound.com', 1);
+	}
+
+	public function test_on_add_subdomain_delegates_to_on_add_domain(): void {
+
+		$this->integration->expects($this->once())
+			->method('send_enhance_api_request')
+			->with(
+				'/orgs/org-uuid-1234/websites/site-uuid-5678/domains',
+				'POST',
+				['domain' => 'sub.example.com']
+			)
+			->willReturn(['id' => 'domain-uuid-xyz']);
+
+		$this->module->on_add_subdomain('sub.example.com', 1);
+	}
+
+	public function test_on_remove_subdomain_delegates_to_on_remove_domain(): void {
+
+		$this->integration->expects($this->atLeast(1))
+			->method('send_enhance_api_request')
+			->willReturn(['items' => []]);
+
+		$this->module->on_remove_subdomain('sub.example.com', 1);
+	}
+
+	public function test_test_connection_delegates_to_integration(): void {
+
+		$this->integration->expects($this->once())
+			->method('send_enhance_api_request')
+			->willReturn(['id' => 'site-uuid-5678']);
+
+		$result = $this->module->test_connection();
+
+		$this->assertNotNull($result);
+	}
+}

--- a/tests/WP_Ultimo/Integrations/Providers/LaravelForge_Domain_Mapping_Test.php
+++ b/tests/WP_Ultimo/Integrations/Providers/LaravelForge_Domain_Mapping_Test.php
@@ -1,0 +1,143 @@
+<?php
+
+namespace WP_Ultimo\Integrations\Providers\LaravelForge;
+
+use WP_UnitTestCase;
+
+class LaravelForge_Domain_Mapping_Test extends WP_UnitTestCase {
+
+	private LaravelForge_Domain_Mapping $module;
+	private LaravelForge_Integration $integration;
+
+	public function setUp(): void {
+
+		parent::setUp();
+
+		$this->integration = $this->getMockBuilder(LaravelForge_Integration::class)
+			->onlyMethods(['send_forge_request', 'parse_response', 'get_server_list', 'get_primary_server_id', 'get_primary_site_id', 'get_load_balancer_server_id', 'get_load_balancer_site_id', 'get_deploy_command', 'get_credential'])
+			->getMock();
+
+		$this->module = new LaravelForge_Domain_Mapping();
+		$this->module->set_integration($this->integration);
+	}
+
+	public function test_get_capability_id(): void {
+
+		$this->assertSame('domain-mapping', $this->module->get_capability_id());
+	}
+
+	public function test_get_title(): void {
+
+		$this->assertNotEmpty($this->module->get_title());
+	}
+
+	public function test_supports_autossl(): void {
+
+		$this->assertTrue($this->module->supports('autossl'));
+	}
+
+	public function test_does_not_support_unknown_feature(): void {
+
+		$this->assertFalse($this->module->supports('nonexistent'));
+	}
+
+	public function test_get_explainer_lines_structure(): void {
+
+		$this->integration->method('get_credential')->willReturn('');
+
+		$lines = $this->module->get_explainer_lines();
+
+		$this->assertArrayHasKey('will', $lines);
+		$this->assertNotEmpty($lines['will']);
+		$this->assertArrayHasKey('will_not', $lines);
+	}
+
+	public function test_register_hooks_adds_actions(): void {
+
+		$this->module->register_hooks();
+
+		$this->assertIsInt(has_action('wu_add_domain', [$this->module, 'on_add_domain']));
+		$this->assertIsInt(has_action('wu_remove_domain', [$this->module, 'on_remove_domain']));
+		$this->assertIsInt(has_action('wu_add_subdomain', [$this->module, 'on_add_subdomain']));
+		$this->assertIsInt(has_action('wu_remove_subdomain', [$this->module, 'on_remove_subdomain']));
+	}
+
+	public function test_on_add_domain_skips_when_no_servers(): void {
+
+		$this->integration->method('get_server_list')->willReturn([]);
+
+		$this->integration->expects($this->never())
+			->method('send_forge_request');
+
+		$this->module->on_add_domain('example.com', 1);
+	}
+
+	public function test_on_add_domain_creates_site_on_server(): void {
+
+		$this->integration->method('get_server_list')->willReturn([12345]);
+		$this->integration->method('get_load_balancer_server_id')->willReturn(0);
+		$this->integration->method('get_primary_server_id')->willReturn(12345);
+		$this->integration->method('get_primary_site_id')->willReturn(67890);
+		$this->integration->method('get_deploy_command')->willReturn('');
+
+		$fake_response = ['response' => ['code' => 201], 'body' => '{"site":{"id":99}}'];
+
+		$this->integration->expects($this->atLeast(1))
+			->method('send_forge_request')
+			->willReturn($fake_response);
+
+		$this->integration->method('parse_response')
+			->willReturn(['site' => ['id' => 99]]);
+
+		$this->module->on_add_domain('example.com', 1);
+	}
+
+	public function test_on_remove_domain_skips_when_site_not_found(): void {
+
+		$this->integration->method('get_server_list')->willReturn([12345]);
+
+		// GET /servers/12345/sites returns empty list — no DELETE should be called.
+		$this->integration->expects($this->once())
+			->method('send_forge_request')
+			->with($this->stringContains('/servers/12345/sites'), [], 'GET')
+			->willReturn(['response' => ['code' => 200], 'body' => '{"sites":[]}']);
+
+		$this->integration->method('parse_response')
+			->willReturn(['sites' => []]);
+
+		$this->module->on_remove_domain('notfound.com', 1);
+	}
+
+	public function test_on_add_subdomain_is_noop(): void {
+
+		$this->integration->expects($this->never())
+			->method('send_forge_request');
+
+		$this->module->on_add_subdomain('sub.example.com', 1);
+	}
+
+	public function test_on_remove_subdomain_is_noop(): void {
+
+		$this->integration->expects($this->never())
+			->method('send_forge_request');
+
+		$this->module->on_remove_subdomain('sub.example.com', 1);
+	}
+
+	public function test_test_connection_delegates_to_integration(): void {
+
+		$this->integration->method('get_primary_server_id')->willReturn(12345);
+
+		$this->integration->expects($this->once())
+			->method('send_forge_request')
+			->with('/servers/12345', [], 'GET')
+			->willReturn(['response' => ['code' => 200], 'body' => '{"server":{"id":12345}}']);
+
+		$this->integration->method('parse_response')
+			->willReturn(['server' => ['id' => 12345]]);
+
+		$result = $this->module->test_connection();
+
+		$this->assertNotNull($result);
+	}
+}

--- a/tests/WP_Ultimo/Integrations/Providers/Plesk_Domain_Mapping_Test.php
+++ b/tests/WP_Ultimo/Integrations/Providers/Plesk_Domain_Mapping_Test.php
@@ -1,0 +1,179 @@
+<?php
+
+namespace WP_Ultimo\Integrations\Providers\Plesk;
+
+use WP_UnitTestCase;
+
+class Plesk_Domain_Mapping_Test extends WP_UnitTestCase {
+
+	private Plesk_Domain_Mapping $module;
+	private Plesk_Integration $integration;
+
+	public function setUp(): void {
+
+		parent::setUp();
+
+		$this->integration = $this->getMockBuilder(Plesk_Integration::class)
+			->onlyMethods(['send_plesk_api_request', 'get_credential'])
+			->getMock();
+
+		$this->integration->method('get_credential')
+			->willReturnCallback(function (string $key) {
+				$map = [
+					'WU_PLESK_DOMAIN' => 'mysite.com',
+				];
+
+				return $map[ $key ] ?? '';
+			});
+
+		$this->module = new Plesk_Domain_Mapping();
+		$this->module->set_integration($this->integration);
+	}
+
+	public function test_get_capability_id(): void {
+
+		$this->assertSame('domain-mapping', $this->module->get_capability_id());
+	}
+
+	public function test_get_title(): void {
+
+		$this->assertNotEmpty($this->module->get_title());
+	}
+
+	public function test_supports_autossl(): void {
+
+		$this->assertTrue($this->module->supports('autossl'));
+	}
+
+	public function test_does_not_support_unknown_feature(): void {
+
+		$this->assertFalse($this->module->supports('nonexistent'));
+	}
+
+	public function test_get_explainer_lines_structure(): void {
+
+		$lines = $this->module->get_explainer_lines();
+
+		$this->assertArrayHasKey('will', $lines);
+		$this->assertNotEmpty($lines['will']);
+		$this->assertArrayHasKey('will_not', $lines);
+	}
+
+	public function test_register_hooks_adds_actions(): void {
+
+		$this->module->register_hooks();
+
+		$this->assertIsInt(has_action('wu_add_domain', [$this->module, 'on_add_domain']));
+		$this->assertIsInt(has_action('wu_remove_domain', [$this->module, 'on_remove_domain']));
+		$this->assertIsInt(has_action('wu_add_subdomain', [$this->module, 'on_add_subdomain']));
+		$this->assertIsInt(has_action('wu_remove_subdomain', [$this->module, 'on_remove_subdomain']));
+	}
+
+	public function test_on_add_domain_calls_site_alias_create(): void {
+
+		$this->integration->expects($this->atLeast(1))
+			->method('send_plesk_api_request')
+			->with(
+				'/api/v2/cli/site_alias/call',
+				'POST',
+				$this->callback(function (array $data) {
+					return isset($data['params']) && in_array('--create', $data['params'], true);
+				})
+			)
+			->willReturn(['success' => true]);
+
+		$this->module->on_add_domain('example.com', 1);
+	}
+
+	public function test_on_add_domain_skips_when_no_base_domain(): void {
+
+		$integration = $this->getMockBuilder(Plesk_Integration::class)
+			->onlyMethods(['send_plesk_api_request', 'get_credential'])
+			->getMock();
+
+		$integration->method('get_credential')->willReturn('');
+
+		$integration->expects($this->never())
+			->method('send_plesk_api_request');
+
+		$module = new Plesk_Domain_Mapping();
+		$module->set_integration($integration);
+		$module->on_add_domain('example.com', 1);
+	}
+
+	public function test_on_remove_domain_calls_site_alias_delete(): void {
+
+		$this->integration->expects($this->atLeast(1))
+			->method('send_plesk_api_request')
+			->with(
+				'/api/v2/cli/site_alias/call',
+				'POST',
+				$this->callback(function (array $data) {
+					return isset($data['params']) && in_array('--delete', $data['params'], true);
+				})
+			)
+			->willReturn(['success' => true]);
+
+		$this->module->on_remove_domain('example.com', 1);
+	}
+
+	public function test_on_add_subdomain_calls_subdomain_create(): void {
+
+		$this->integration->expects($this->once())
+			->method('send_plesk_api_request')
+			->with(
+				'/api/v2/cli/subdomain/call',
+				'POST',
+				$this->callback(function (array $data) {
+					return isset($data['params']) && in_array('--create', $data['params'], true);
+				})
+			)
+			->willReturn(['success' => true]);
+
+		$this->module->on_add_subdomain('sub.mysite.com', 1);
+	}
+
+	public function test_on_add_subdomain_skips_when_no_base_domain(): void {
+
+		$integration = $this->getMockBuilder(Plesk_Integration::class)
+			->onlyMethods(['send_plesk_api_request', 'get_credential'])
+			->getMock();
+
+		$integration->method('get_credential')->willReturn('');
+
+		$integration->expects($this->never())
+			->method('send_plesk_api_request');
+
+		$module = new Plesk_Domain_Mapping();
+		$module->set_integration($integration);
+		$module->on_add_subdomain('sub.example.com', 1);
+	}
+
+	public function test_on_remove_subdomain_calls_subdomain_delete(): void {
+
+		$this->integration->expects($this->once())
+			->method('send_plesk_api_request')
+			->with(
+				'/api/v2/cli/subdomain/call',
+				'POST',
+				$this->callback(function (array $data) {
+					return isset($data['params']) && in_array('--delete', $data['params'], true);
+				})
+			)
+			->willReturn(['success' => true]);
+
+		$this->module->on_remove_subdomain('sub.mysite.com', 1);
+	}
+
+	public function test_test_connection_delegates_to_integration(): void {
+
+		$this->integration->expects($this->once())
+			->method('send_plesk_api_request')
+			->with('/api/v2/server', 'GET')
+			->willReturn(['platform' => 'Linux']);
+
+		$result = $this->module->test_connection();
+
+		$this->assertNotNull($result);
+	}
+}

--- a/tests/WP_Ultimo/Integrations/Providers/Rocket_Domain_Mapping_Test.php
+++ b/tests/WP_Ultimo/Integrations/Providers/Rocket_Domain_Mapping_Test.php
@@ -1,0 +1,143 @@
+<?php
+
+namespace WP_Ultimo\Integrations\Providers\Rocket;
+
+use WP_UnitTestCase;
+
+class Rocket_Domain_Mapping_Test extends WP_UnitTestCase {
+
+	private Rocket_Domain_Mapping $module;
+	private Rocket_Integration $integration;
+
+	public function setUp(): void {
+
+		parent::setUp();
+
+		$this->integration = $this->getMockBuilder(Rocket_Integration::class)
+			->onlyMethods(['send_rocket_request'])
+			->getMock();
+
+		$this->module = new Rocket_Domain_Mapping();
+		$this->module->set_integration($this->integration);
+	}
+
+	public function test_get_capability_id(): void {
+
+		$this->assertSame('domain-mapping', $this->module->get_capability_id());
+	}
+
+	public function test_get_title(): void {
+
+		$this->assertNotEmpty($this->module->get_title());
+	}
+
+	public function test_supports_autossl(): void {
+
+		$this->assertTrue($this->module->supports('autossl'));
+	}
+
+	public function test_does_not_support_unknown_feature(): void {
+
+		$this->assertFalse($this->module->supports('nonexistent'));
+	}
+
+	public function test_get_explainer_lines_structure(): void {
+
+		$lines = $this->module->get_explainer_lines();
+
+		$this->assertArrayHasKey('will', $lines);
+		$this->assertNotEmpty($lines['will']);
+		$this->assertArrayHasKey('will_not', $lines);
+	}
+
+	public function test_register_hooks_adds_actions(): void {
+
+		$this->module->register_hooks();
+
+		$this->assertIsInt(has_action('wu_add_domain', [$this->module, 'on_add_domain']));
+		$this->assertIsInt(has_action('wu_remove_domain', [$this->module, 'on_remove_domain']));
+		$this->assertIsInt(has_action('wu_add_subdomain', [$this->module, 'on_add_subdomain']));
+		$this->assertIsInt(has_action('wu_remove_subdomain', [$this->module, 'on_remove_subdomain']));
+	}
+
+	public function test_on_add_domain_posts_to_domains_endpoint(): void {
+
+		$this->integration->expects($this->once())
+			->method('send_rocket_request')
+			->with(
+				'domains',
+				['domain' => 'example.com'],
+				'POST'
+			)
+			->willReturn(['response' => ['code' => 201], 'body' => '{"id":42}']);
+
+		$this->module->on_add_domain('example.com', 1);
+	}
+
+	public function test_on_add_domain_handles_wp_error(): void {
+
+		$this->integration->expects($this->once())
+			->method('send_rocket_request')
+			->willReturn(new \WP_Error('fail', 'API error'));
+
+		// Should not throw — just logs.
+		$this->module->on_add_domain('example.com', 1);
+	}
+
+	public function test_on_remove_domain_fetches_domain_list_first(): void {
+
+		$this->integration->expects($this->atLeast(1))
+			->method('send_rocket_request')
+			->willReturnCallback(function (string $endpoint, array $data, string $method) {
+				if ('GET' === $method) {
+					return [
+						'response' => ['code' => 200],
+						'body'     => '{"data":[{"id":42,"domain":"example.com"}]}',
+					];
+				}
+
+				return ['response' => ['code' => 204], 'body' => ''];
+			});
+
+		$this->module->on_remove_domain('example.com', 1);
+	}
+
+	public function test_on_remove_domain_skips_delete_when_domain_not_found(): void {
+
+		// First call (GET domains) returns empty list.
+		$this->integration->expects($this->once())
+			->method('send_rocket_request')
+			->with('domains', [], 'GET')
+			->willReturn(['response' => ['code' => 200], 'body' => '{"data":[]}']);
+
+		$this->module->on_remove_domain('notfound.com', 1);
+	}
+
+	public function test_on_add_subdomain_is_noop(): void {
+
+		$this->integration->expects($this->never())
+			->method('send_rocket_request');
+
+		$this->module->on_add_subdomain('sub.example.com', 1);
+	}
+
+	public function test_on_remove_subdomain_is_noop(): void {
+
+		$this->integration->expects($this->never())
+			->method('send_rocket_request');
+
+		$this->module->on_remove_subdomain('sub.example.com', 1);
+	}
+
+	public function test_test_connection_delegates_to_integration(): void {
+
+		$this->integration->expects($this->once())
+			->method('send_rocket_request')
+			->with('domains', [], 'GET')
+			->willReturn(['response' => ['code' => 200], 'body' => '{"data":[]}']);
+
+		$result = $this->module->test_connection();
+
+		$this->assertNotNull($result);
+	}
+}

--- a/tests/WP_Ultimo/Integrations/Providers/ServerPilot_Domain_Mapping_Test.php
+++ b/tests/WP_Ultimo/Integrations/Providers/ServerPilot_Domain_Mapping_Test.php
@@ -1,0 +1,194 @@
+<?php
+
+namespace WP_Ultimo\Integrations\Providers\ServerPilot;
+
+use WP_UnitTestCase;
+
+class ServerPilot_Domain_Mapping_Test extends WP_UnitTestCase {
+
+	private ServerPilot_Domain_Mapping $module;
+	private ServerPilot_Integration $integration;
+
+	public function setUp(): void {
+
+		parent::setUp();
+
+		$this->integration = $this->getMockBuilder(ServerPilot_Integration::class)
+			->onlyMethods(['send_server_pilot_api_request'])
+			->getMock();
+
+		$this->module = new ServerPilot_Domain_Mapping();
+		$this->module->set_integration($this->integration);
+	}
+
+	public function test_get_capability_id(): void {
+
+		$this->assertSame('domain-mapping', $this->module->get_capability_id());
+	}
+
+	public function test_get_title(): void {
+
+		$this->assertNotEmpty($this->module->get_title());
+	}
+
+	public function test_supports_autossl(): void {
+
+		$this->assertTrue($this->module->supports('autossl'));
+	}
+
+	public function test_does_not_support_unknown_feature(): void {
+
+		$this->assertFalse($this->module->supports('nonexistent'));
+	}
+
+	public function test_get_explainer_lines_structure(): void {
+
+		$lines = $this->module->get_explainer_lines();
+
+		$this->assertArrayHasKey('will', $lines);
+		$this->assertNotEmpty($lines['will']);
+		$this->assertArrayHasKey('will_not', $lines);
+	}
+
+	public function test_register_hooks_adds_actions(): void {
+
+		$this->module->register_hooks();
+
+		$this->assertIsInt(has_action('wu_add_domain', [$this->module, 'on_add_domain']));
+		$this->assertIsInt(has_action('wu_remove_domain', [$this->module, 'on_remove_domain']));
+		$this->assertIsInt(has_action('wu_add_subdomain', [$this->module, 'on_add_subdomain']));
+		$this->assertIsInt(has_action('wu_remove_subdomain', [$this->module, 'on_remove_subdomain']));
+	}
+
+	public function test_on_add_domain_fetches_current_domains_first(): void {
+
+		$domains_updated = false;
+
+		$this->integration->expects($this->atLeast(2))
+			->method('send_server_pilot_api_request')
+			->willReturnCallback(function (string $endpoint, array $data, string $method) use (&$domains_updated) {
+				if ('GET' === $method) {
+					return ['data' => ['domains' => ['existing.com']]];
+				}
+
+				// POST to update domains (endpoint '' with domains key) or SSL endpoint.
+				if (isset($data['domains'])) {
+					$this->assertContains('example.com', $data['domains']);
+					$domains_updated = true;
+				}
+
+				return ['data' => []];
+			});
+
+		$this->module->on_add_domain('example.com', 1);
+
+		$this->assertTrue($domains_updated, 'Domain list was never updated via API');
+	}
+
+	public function test_on_add_domain_skips_when_no_current_domains(): void {
+
+		$this->integration->expects($this->once())
+			->method('send_server_pilot_api_request')
+			->with('', [], 'GET')
+			->willReturn(['data' => []]);
+
+		$this->module->on_add_domain('example.com', 1);
+	}
+
+	public function test_on_remove_domain_removes_domain_from_list(): void {
+
+		$this->integration->expects($this->atLeast(1))
+			->method('send_server_pilot_api_request')
+			->willReturnCallback(function (string $endpoint, array $data, string $method) {
+				if ('GET' === $method) {
+					return ['data' => ['domains' => ['example.com', 'other.com']]];
+				}
+
+				// POST to update domains — example.com should be removed.
+				$this->assertNotContains('example.com', $data['domains']);
+				$this->assertContains('other.com', $data['domains']);
+
+				return ['data' => ['domains' => ['other.com']]];
+			});
+
+		$this->module->on_remove_domain('example.com', 1);
+	}
+
+	public function test_on_add_subdomain_adds_subdomain_to_list(): void {
+
+		$subdomain_added = false;
+
+		$this->integration->expects($this->atLeast(2))
+			->method('send_server_pilot_api_request')
+			->willReturnCallback(function (string $endpoint, array $data, string $method) use (&$subdomain_added) {
+				if ('GET' === $method) {
+					return ['data' => ['domains' => ['existing.com']]];
+				}
+
+				if (isset($data['domains'])) {
+					$this->assertContains('sub.example.com', $data['domains']);
+					$subdomain_added = true;
+				}
+
+				return ['data' => []];
+			});
+
+		$this->module->on_add_subdomain('sub.example.com', 1);
+
+		$this->assertTrue($subdomain_added, 'Subdomain was never added to domain list');
+	}
+
+	public function test_on_remove_subdomain_is_noop(): void {
+
+		$this->integration->expects($this->never())
+			->method('send_server_pilot_api_request');
+
+		$this->module->on_remove_subdomain('sub.example.com', 1);
+	}
+
+	public function test_get_server_pilot_domains_returns_domain_list(): void {
+
+		$this->integration->expects($this->once())
+			->method('send_server_pilot_api_request')
+			->with('', [], 'GET')
+			->willReturn(['data' => ['domains' => ['example.com', 'other.com']]]);
+
+		$domains = $this->module->get_server_pilot_domains();
+
+		$this->assertIsArray($domains);
+		$this->assertContains('example.com', $domains);
+	}
+
+	public function test_get_server_pilot_domains_returns_false_on_error(): void {
+
+		$this->integration->expects($this->once())
+			->method('send_server_pilot_api_request')
+			->willReturn(['error' => 'API error']);
+
+		$result = $this->module->get_server_pilot_domains();
+
+		$this->assertFalse($result);
+	}
+
+	public function test_turn_server_pilot_auto_ssl_on_calls_ssl_endpoint(): void {
+
+		$this->integration->expects($this->once())
+			->method('send_server_pilot_api_request')
+			->with('/ssl', ['auto' => true])
+			->willReturn(['data' => ['ssl' => ['auto' => true]]]);
+
+		$this->module->turn_server_pilot_auto_ssl_on();
+	}
+
+	public function test_test_connection_delegates_to_integration(): void {
+
+		$this->integration->expects($this->once())
+			->method('send_server_pilot_api_request')
+			->with('', [], 'GET')
+			->willReturn(['data' => ['id' => 'app123']]);
+
+		$result = $this->module->test_connection();
+
+		$this->assertNotNull($result);
+	}
+}

--- a/tests/WP_Ultimo/Integrations/Providers/WPEngine_Domain_Mapping_Test.php
+++ b/tests/WP_Ultimo/Integrations/Providers/WPEngine_Domain_Mapping_Test.php
@@ -1,0 +1,103 @@
+<?php
+
+namespace WP_Ultimo\Integrations\Providers\WPEngine;
+
+use WP_UnitTestCase;
+
+class WPEngine_Domain_Mapping_Test extends WP_UnitTestCase {
+
+	private WPEngine_Domain_Mapping $module;
+	private WPEngine_Integration $integration;
+
+	public function setUp(): void {
+
+		parent::setUp();
+
+		$this->integration = $this->getMockBuilder(WPEngine_Integration::class)
+			->onlyMethods(['load_dependencies'])
+			->getMock();
+
+		$this->module = new WPEngine_Domain_Mapping();
+		$this->module->set_integration($this->integration);
+	}
+
+	public function test_get_capability_id(): void {
+
+		$this->assertSame('domain-mapping', $this->module->get_capability_id());
+	}
+
+	public function test_get_title(): void {
+
+		$this->assertNotEmpty($this->module->get_title());
+	}
+
+	public function test_does_not_support_autossl(): void {
+
+		// WP Engine does not declare autossl support.
+		$this->assertFalse($this->module->supports('autossl'));
+	}
+
+	public function test_get_explainer_lines_structure(): void {
+
+		$lines = $this->module->get_explainer_lines();
+
+		$this->assertArrayHasKey('will', $lines);
+		$this->assertNotEmpty($lines['will']);
+		$this->assertArrayHasKey('will_not', $lines);
+	}
+
+	public function test_register_hooks_adds_actions(): void {
+
+		$this->module->register_hooks();
+
+		$this->assertIsInt(has_action('wu_add_domain', [$this->module, 'on_add_domain']));
+		$this->assertIsInt(has_action('wu_remove_domain', [$this->module, 'on_remove_domain']));
+		$this->assertIsInt(has_action('wu_add_subdomain', [$this->module, 'on_add_subdomain']));
+		$this->assertIsInt(has_action('wu_remove_subdomain', [$this->module, 'on_remove_subdomain']));
+	}
+
+	public function test_on_add_domain_loads_dependencies(): void {
+
+		$this->integration->expects($this->once())
+			->method('load_dependencies');
+
+		// WPE_API class is not available in test env — on_add_domain returns early.
+		$this->module->on_add_domain('example.com', 1);
+	}
+
+	public function test_on_remove_domain_loads_dependencies(): void {
+
+		$this->integration->expects($this->once())
+			->method('load_dependencies');
+
+		$this->module->on_remove_domain('example.com', 1);
+	}
+
+	public function test_on_add_subdomain_delegates_to_on_add_domain(): void {
+
+		// Both should call load_dependencies once each.
+		$this->integration->expects($this->once())
+			->method('load_dependencies');
+
+		$this->module->on_add_subdomain('sub.example.com', 1);
+	}
+
+	public function test_on_remove_subdomain_delegates_to_on_remove_domain(): void {
+
+		$this->integration->expects($this->once())
+			->method('load_dependencies');
+
+		$this->module->on_remove_subdomain('sub.example.com', 1);
+	}
+
+	public function test_test_connection_delegates_to_integration(): void {
+
+		$this->integration->expects($this->once())
+			->method('load_dependencies');
+
+		$result = $this->module->test_connection();
+
+		// WPE_API not available in test env — returns WP_Error.
+		$this->assertNotNull($result);
+	}
+}

--- a/tests/WP_Ultimo/Integrations/Providers/WPMUDEV_Domain_Mapping_Test.php
+++ b/tests/WP_Ultimo/Integrations/Providers/WPMUDEV_Domain_Mapping_Test.php
@@ -1,0 +1,134 @@
+<?php
+
+namespace WP_Ultimo\Integrations\Providers\WPMUDEV;
+
+use WP_UnitTestCase;
+use WP_Ultimo\Database\Domains\Domain_Stage;
+
+class WPMUDEV_Domain_Mapping_Test extends WP_UnitTestCase {
+
+	private WPMUDEV_Domain_Mapping $module;
+	private WPMUDEV_Integration $integration;
+
+	public function setUp(): void {
+
+		parent::setUp();
+
+		$this->integration = $this->getMockBuilder(WPMUDEV_Integration::class)
+			->onlyMethods(['get_credential'])
+			->getMock();
+
+		$this->integration->method('get_credential')
+			->willReturnCallback(function (string $key) {
+				$map = [
+					'WPMUDEV_HOSTING_SITE_ID' => '12345',
+				];
+
+				return $map[ $key ] ?? '';
+			});
+
+		$this->module = new WPMUDEV_Domain_Mapping();
+		$this->module->set_integration($this->integration);
+	}
+
+	public function test_get_capability_id(): void {
+
+		$this->assertSame('domain-mapping', $this->module->get_capability_id());
+	}
+
+	public function test_get_title(): void {
+
+		$this->assertNotEmpty($this->module->get_title());
+	}
+
+	public function test_supports_autossl(): void {
+
+		$this->assertTrue($this->module->supports('autossl'));
+	}
+
+	public function test_does_not_support_unknown_feature(): void {
+
+		$this->assertFalse($this->module->supports('nonexistent'));
+	}
+
+	public function test_get_explainer_lines_structure(): void {
+
+		$lines = $this->module->get_explainer_lines();
+
+		$this->assertArrayHasKey('will', $lines);
+		$this->assertNotEmpty($lines['will']);
+		$this->assertArrayHasKey('will_not', $lines);
+	}
+
+	public function test_register_hooks_adds_actions(): void {
+
+		$this->module->register_hooks();
+
+		$this->assertIsInt(has_action('wu_add_domain', [$this->module, 'on_add_domain']));
+		$this->assertIsInt(has_action('wu_remove_domain', [$this->module, 'on_remove_domain']));
+		$this->assertIsInt(has_action('wu_add_subdomain', [$this->module, 'on_add_subdomain']));
+		$this->assertIsInt(has_action('wu_remove_subdomain', [$this->module, 'on_remove_subdomain']));
+	}
+
+	public function test_register_hooks_adds_ssl_tries_filter(): void {
+
+		$this->module->register_hooks();
+
+		$this->assertIsInt(has_filter('wu_async_process_domain_stage_max_tries', [$this->module, 'ssl_tries']));
+	}
+
+	public function test_on_remove_domain_is_noop(): void {
+
+		// WPMU DEV API does not support domain removal yet.
+		// Verify no HTTP calls are made (no wp_remote_post mock needed).
+		$this->module->on_remove_domain('example.com', 1);
+
+		// If we get here without error, the noop is confirmed.
+		$this->assertTrue(true);
+	}
+
+	public function test_on_add_subdomain_is_noop(): void {
+
+		// WPMU DEV handles subdomains automatically.
+		$this->module->on_add_subdomain('sub.example.com', 1);
+
+		$this->assertTrue(true);
+	}
+
+	public function test_on_remove_subdomain_is_noop(): void {
+
+		// WPMU DEV handles subdomains automatically.
+		$this->module->on_remove_subdomain('sub.example.com', 1);
+
+		$this->assertTrue(true);
+	}
+
+	public function test_ssl_tries_increases_for_checking_ssl_cert_stage(): void {
+
+		$domain = $this->createMock(\WP_Ultimo\Models\Domain::class);
+		$domain->method('get_stage')->willReturn(Domain_Stage::CHECKING_SSL);
+
+		$result = $this->module->ssl_tries(5, $domain);
+
+		$this->assertSame(10, $result);
+	}
+
+	public function test_ssl_tries_unchanged_for_other_stages(): void {
+
+		$domain = $this->createMock(\WP_Ultimo\Models\Domain::class);
+		$domain->method('get_stage')->willReturn('checking-dns');
+
+		$result = $this->module->ssl_tries(5, $domain);
+
+		$this->assertSame(5, $result);
+	}
+
+	public function test_test_connection_delegates_to_integration(): void {
+
+		// test_connection calls wp_remote_get internally — we verify it returns a value.
+		// Since no real HTTP call is made in tests, it will return a WP_Error or true.
+		$result = $this->module->test_connection();
+
+		$this->assertNotNull($result);
+	}
+}


### PR DESCRIPTION
## Summary

- Adds `*_Domain_Mapping_Test.php` for all 9 previously uncovered integration providers: bunnynet, cloudways, enhance, laravel-forge, plesk, rocket, serverpilot, wpengine, wpmudev
- Each test class covers: capability ID, title, supported features, explainer lines structure, hook registration, API delegation, error handling, and noop behaviour
- All 114 tests in the new files pass; existing 130 provider tests unaffected

## Runtime Testing

- **Level**: `unit-tested`
- **Risk**: Low (test files only, no production code changes)
- **Smoke check**: `WP_TESTS_DIR=/tmp/wordpress-tests-lib vendor/bin/phpunit --no-coverage --filter "BunnyNet_Domain_Mapping_Test|Cloudways_Domain_Mapping_Test|Enhance_Domain_Mapping_Test|LaravelForge_Domain_Mapping_Test|Plesk_Domain_Mapping_Test|Rocket_Domain_Mapping_Test|ServerPilot_Domain_Mapping_Test|WPEngine_Domain_Mapping_Test|WPMUDEV_Domain_Mapping_Test"` → **OK (114 tests, 175 assertions)**

## Files Changed

| File | What/Why |
|------|----------|
| `tests/WP_Ultimo/Integrations/Providers/BunnyNet_Domain_Mapping_Test.php` | BunnyNet: noop domain ops, subdomain DNS, dns entries filter |
| `tests/WP_Ultimo/Integrations/Providers/Cloudways_Domain_Mapping_Test.php` | Cloudways: alias sync, SSL hook, noop subdomain ops |
| `tests/WP_Ultimo/Integrations/Providers/Enhance_Domain_Mapping_Test.php` | Enhance: add/remove domain via API, subdomain delegation |
| `tests/WP_Ultimo/Integrations/Providers/LaravelForge_Domain_Mapping_Test.php` | Forge: site creation, noop subdomain ops, remove by domain lookup |
| `tests/WP_Ultimo/Integrations/Providers/Plesk_Domain_Mapping_Test.php` | Plesk: CLI gateway alias/subdomain create+delete |
| `tests/WP_Ultimo/Integrations/Providers/Rocket_Domain_Mapping_Test.php` | Rocket: POST domain, GET+DELETE remove, noop subdomain ops |
| `tests/WP_Ultimo/Integrations/Providers/ServerPilot_Domain_Mapping_Test.php` | ServerPilot: domain list merge/filter, SSL auto-on |
| `tests/WP_Ultimo/Integrations/Providers/WPEngine_Domain_Mapping_Test.php` | WPEngine: load_dependencies delegation, WPE_API absent guard |
| `tests/WP_Ultimo/Integrations/Providers/WPMUDEV_Domain_Mapping_Test.php` | WPMUDEV: ssl_tries filter, noop remove/subdomain ops |

## Actionable Findings

- `actionable_findings_total=0`
- `fixed_in_pr=0`
- `deferred_tasks_created=0`
- `coverage=9 new test classes`

Closes #697

---
[aidevops.sh](https://aidevops.sh) v3.5.126 plugin for [OpenCode](https://opencode.ai) v1.3.0 with claude-sonnet-4-6 spent 12m and 26,525 tokens on this as a headless worker.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test coverage for domain mapping integrations across nine hosting providers: BunnyNet, Cloudways, Enhance, LaravelForge, Plesk, Rocket, ServerPilot, WPEngine, and WPMUDEV. Test suites validate provider metadata, feature support, domain operations, error handling, and integration connectivity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->