### PR TITLE
fix(dashboard): resolve wu_moment ReferenceError on network dashboard activity stream

### DIFF
--- a/inc/class-dashboard-widgets.php
+++ b/inc/class-dashboard-widgets.php
@@ -85,6 +85,17 @@ class Dashboard_Widgets implements \WP_Ultimo\Interfaces\Singleton {
 		 * we must enqueue wu-functions explicitly here.
 		 */
 		wp_enqueue_script('wu-functions');
+
+		/*
+		 * Enqueue the activity-stream script here — during admin_enqueue_scripts —
+		 * so WordPress resolves the full dependency chain (wu-functions, moment, etc.)
+		 * before the script runs. Previously this was enqueued inside the view
+		 * template during widget rendering, which fires after admin_enqueue_scripts
+		 * and caused wu_moment to be undefined.
+		 */
+		wp_enqueue_script('wu-activity-stream', wu_get_asset('activity-stream.js', 'js'), ['wu-vue', 'wu-functions', 'moment'], wu_get_version(), true);
+
+		wp_add_inline_script('wu-activity-stream', 'var wu_activity_stream_nonce = "' . esc_js(wp_create_nonce('wu_activity_stream')) . '";', 'before');
 	}
 
 	/**

--- a/inc/class-scripts.php
+++ b/inc/class-scripts.php
@@ -190,7 +190,7 @@ class Scripts {
 		/*
 		 * Adds General Functions
 		 */
-		$this->register_script('wu-functions', wu_get_asset('functions.js', 'js'), ['jquery-core', 'wu-tiptip', 'wu-flatpicker', 'wu-block-ui', 'wu-accounting', 'clipboard', 'wp-hooks']);
+		$this->register_script('wu-functions', wu_get_asset('functions.js', 'js'), ['jquery-core', 'moment', 'wu-tiptip', 'wu-flatpicker', 'wu-block-ui', 'wu-accounting', 'clipboard', 'wp-hooks']);
 
 		wp_localize_script(
 			'wu-functions',

--- a/tests/WP_Ultimo/Dashboard_Widgets_Test.php
+++ b/tests/WP_Ultimo/Dashboard_Widgets_Test.php
@@ -114,6 +114,45 @@ class Dashboard_Widgets_Test extends \WP_UnitTestCase {
 	}
 
 	/**
+	 * Test enqueue_scripts enqueues activity-stream with correct deps on index.php.
+	 */
+	public function test_enqueue_scripts_enqueues_activity_stream_on_index(): void {
+
+		global $pagenow, $wp_scripts;
+
+		$original       = $pagenow;
+		$original_queue = isset($wp_scripts) ? $wp_scripts->queue : [];
+		$pagenow        = 'index.php';
+
+		if (isset($wp_scripts)) {
+			$wp_scripts->queue = [];
+			$wp_scripts->done  = [];
+		}
+
+		// Ensure wu-functions is registered so the dependency chain resolves.
+		\WP_Ultimo\Scripts::get_instance()->register_default_scripts();
+
+		$instance = $this->get_instance();
+		$instance->enqueue_scripts();
+
+		$this->assertTrue(
+			wp_script_is('wu-activity-stream', 'enqueued'),
+			'wu-activity-stream should be enqueued on index.php'
+		);
+
+		// Verify wu-functions and moment are declared dependencies.
+		$script = $wp_scripts->registered['wu-activity-stream'] ?? null;
+		$this->assertNotNull($script, 'wu-activity-stream should be registered');
+		$this->assertContains('wu-functions', $script->deps);
+		$this->assertContains('moment', $script->deps);
+
+		if (isset($wp_scripts)) {
+			$wp_scripts->queue = $original_queue;
+		}
+		$pagenow = $original;
+	}
+
+	/**
 	 * Test get_registered_dashboard_widgets returns array.
 	 *
 	 * Note: The method uses ob_start/ob_clean internally which

--- a/views/dashboard-widgets/activity-stream.php
+++ b/views/dashboard-widgets/activity-stream.php
@@ -120,7 +120,6 @@ defined('ABSPATH') || exit;
 </div>
 
 <?php
-// wu-functions must be a dependency so window.wu_moment is defined before activity-stream.js runs.
-wp_enqueue_script('wu-activity-stream', wu_get_asset('activity-stream.js', 'js'), ['wu-vue', 'wu-functions'], wu_get_version(), true);
-wp_add_inline_script('wu-activity-stream', 'var wu_activity_stream_nonce = "' . esc_js(wp_create_nonce('wu_activity_stream')) . '";', 'before');
+// Script enqueued in Dashboard_Widgets::enqueue_scripts() during admin_enqueue_scripts
+// so WordPress resolves the full dependency chain before the script runs.
 ?>


### PR DESCRIPTION
## Summary

- Move `wu-activity-stream` script enqueue from the view template (`activity-stream.php`) to `Dashboard_Widgets::enqueue_scripts()` so it runs during `admin_enqueue_scripts` where WordPress properly resolves the dependency chain
- Add `moment` as a declared dependency of `wu-functions` since `functions.js` uses `moment.tz`/`moment.utc` in `wu_moment()`
- Add unit test verifying `wu-activity-stream` is enqueued with correct dependencies on `index.php`

## Problem

The Activity Stream widget on the network admin dashboard was permanently stuck on "Loading..." with:

```
Uncaught ReferenceError: wu_moment is not defined
    at HTMLDocument.<anonymous> (activity-stream.js:4:10)
```

`activity-stream.js` was enqueued inside the view template during widget rendering (meta_box output phase), which fires **after** `admin_enqueue_scripts`. WordPress cannot properly resolve the dependency chain for scripts enqueued that late, so `wu-functions` (which defines `window.wu_moment`) was not guaranteed to load before `activity-stream.js` executed.

## Fix

Moved the `wp_enqueue_script('wu-activity-stream', ...)` call from `views/dashboard-widgets/activity-stream.php` into `Dashboard_Widgets::enqueue_scripts()`, which hooks on `admin_enqueue_scripts`. This ensures WordPress resolves the full dependency chain (`moment` -> `wu-functions` -> `wu-activity-stream`) before any script executes.

Also added `moment` as an explicit dependency of `wu-functions` since `functions.js` line 626-634 defines `wu_moment()` which calls `moment.tz()` / `moment.utc()`.

## Verification

- Browser-tested on the network dashboard: Activity Stream widget now loads and displays events correctly
- `wu_moment is not defined` error is gone
- All 12 Dashboard_Widgets_Test tests pass (including new test)
- PHPStan clean

---
[aidevops.sh](https://aidevops.sh) v3.5.463 plugin for [OpenCode](https://opencode.ai) v1.3.4 with claude-opus-4-6 spent 39m and 15,589 tokens on this as a headless worker.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized activity stream script loading to resolve dependencies and timing issues during dashboard initialization.

* **Tests**
  * Added test coverage for activity stream script enqueuing on the dashboard index page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->