### PR TITLE
fix: add hidden user_id for logged-in checkout retry

### DIFF
--- a/views/checkout/form.php
+++ b/views/checkout/form.php
@@ -22,6 +22,16 @@ defined('ABSPATH') || exit;
 		 */
 		do_action('wu_checkout_errors', $checkout_form_name);
 
+		/*
+		 * When the user is already logged in, include user_id as a hidden
+		 * field so both client-side and server-side validation know that
+		 * email/username/password fields are not required.
+		 */
+		if (is_user_logged_in()) :
+		?>
+			<input type="hidden" name="user_id" value="<?php echo esc_attr(get_current_user_id()); ?>">
+		<?php endif;
+
 		/**
 		 * Instantiate the form for the order details.
 		 *


### PR DESCRIPTION
## Summary
- When a PayPal payment fails and redirects the buyer back to checkout, the user is already logged in (account created before PayPal redirect)
- The email/username/password fields are hidden for logged-in users, but the JS validator still enforced `required_without:user_id` because no `user_id` field existed in the form DOM
- Adds a hidden `user_id` input when the user is logged in so both client-side and server-side validation correctly skip account creation fields

## Test plan
- [ ] Register with PayPal, simulate a payment failure (or cancel on PayPal)
- [ ] Verify the checkout page shows the error message without email/username/password validation errors
- [ ] Verify the user can retry payment successfully
- [ ] Verify normal (logged-out) checkout still validates email/username/password

🤖 Generated with [Claude Code](https://claude.com/claude-code)