### PR TITLE
GH#710: fix(paypal-rest): use $title param in get_checkout_label_html and assert it in test

### DIFF
--- a/inc/gateways/class-paypal-rest-gateway.php
+++ b/inc/gateways/class-paypal-rest-gateway.php
@@ -259,7 +259,7 @@ class PayPal_REST_Gateway extends Base_PayPal_Gateway {
 
 		return sprintf(
 			'<span style="display:flex;align-items:center;flex:1;min-width:0"><span>%s</span><img src="%s" alt="PayPal" height="20" style="margin-left:auto;max-height:20px;display:block" loading="lazy"></span>',
-			esc_html__('PayPal', 'ultimate-multisite'),
+			esc_html($title),
 			esc_url('https://www.paypalobjects.com/webstatic/mktg/Logo/pp-logo-100px.png')
 		);
 	}

--- a/tests/WP_Ultimo/Gateways/PayPal_REST_Gateway_Test.php
+++ b/tests/WP_Ultimo/Gateways/PayPal_REST_Gateway_Test.php
@@ -746,13 +746,14 @@ class PayPal_REST_Gateway_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Test checkout label HTML includes the title text.
+	 * Test checkout label HTML includes the custom title text and PayPal logo alt text.
 	 */
 	public function test_get_checkout_label_html_includes_title(): void {
 
 		$html = $this->gateway->get_checkout_label_html('Custom Title');
 
-		$this->assertStringContainsString('PayPal', $html); // Always shows PayPal
+		$this->assertStringContainsString('Custom Title', $html);
+		$this->assertStringContainsString('PayPal', $html);
 	}
 
 	// -------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- `get_checkout_label_html()` was ignoring its `$title` argument and always rendering the hardcoded `'PayPal'` string via `esc_html__()`. Changed to `esc_html($title)` so the caller-supplied label is rendered in the checkout option span.
- `test_get_checkout_label_html_includes_title` now asserts both `'Custom Title'` (the passed argument) and `'PayPal'` (the logo alt text), fixing the intent/expectation mismatch flagged by CodeRabbit in PR #636.

## Files changed (2)

- `inc/gateways/class-paypal-rest-gateway.php` — use `$title` in sprintf instead of hardcoded i18n string
- `tests/WP_Ultimo/Gateways/PayPal_REST_Gateway_Test.php` — add `assertStringContainsString('Custom Title', $html)` assertion

## Risk

Low — test-only assertion change plus a one-line fix in a rendering helper. No business logic altered.

Closes #710

---
[aidevops.sh](https://aidevops.sh) v3.5.466 plugin for [OpenCode](https://opencode.ai) v1.3.0 with claude-sonnet-4-6 spent 2m and 5,266 tokens on this as a headless worker.