### PR TITLE
fix(command-palette): add missing wp-data dep and fix wp-icons handle

### DIFF
--- a/inc/ui/class-command-palette-manager.php
+++ b/inc/ui/class-command-palette-manager.php
@@ -137,7 +137,7 @@ class Command_Palette_Manager {
 		wp_enqueue_script(
 			'wu-command-palette',
 			wu_get_asset('command-palette.js', 'js'),
-			['wp-commands', 'wp-element', 'wp-i18n', 'wp-api-fetch', 'wp-components', 'wp-icons'],
+			['wp-commands', 'wp-data', 'wp-element', 'wp-i18n', 'wp-api-fetch', 'wp-components', 'wp-primitives'],
 			wu_get_version(),
 			true
 		);


### PR DESCRIPTION
## Summary

- **Add `wp-data`** to the `wu-command-palette` script dependency array — the JS uses `wp.data.dispatch()` to register commands/loaders but `wp-data` was not declared, causing silent failures when `wp-data` loaded after the script
- **Replace `wp-icons` with `wp-primitives`** — `wp-icons` is not a registered WordPress script handle; the correct handle for `@wordpress/icons` is `wp-primitives`

## What changed

`inc/ui/class-command-palette-manager.php:140` — dependency array in `wp_enqueue_script()`:

```diff
- ['wp-commands', 'wp-element', 'wp-i18n', 'wp-api-fetch', 'wp-components', 'wp-icons']
+ ['wp-commands', 'wp-data', 'wp-element', 'wp-i18n', 'wp-api-fetch', 'wp-components', 'wp-primitives']
```

## Testing

1. Navigate to any network admin page on WP 6.4+
2. Open the command palette (Ctrl/Cmd+K)
3. Verify Ultimate Multisite commands appear (Dashboard, Settings, entity search)
4. Search for an entity — results should load without console errors

---
[aidevops.sh](https://aidevops.sh) v3.5.528 plugin for [OpenCode](https://opencode.ai) v1.3.4 with claude-opus-4-6 spent 42m and 8,879 tokens on this with the user in an interactive session.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal script dependencies for improved code organization and compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->