### PR TITLE
t523e: Log PayPal-Debug-Id response header from API calls

### DIFF
--- a/inc/gateways/class-paypal-rest-gateway.php
+++ b/inc/gateways/class-paypal-rest-gateway.php
@@ -723,13 +723,14 @@ class PayPal_REST_Gateway extends Base_PayPal_Gateway {
 
 		if ($code >= 400) {
 			$error_msg = $body['message'] ?? ($body['error_description'] ?? __('API request failed', 'ultimate-multisite'));
-			$this->log(sprintf('API Error (%d): %s', $code, wp_json_encode($body)), LogLevel::ERROR);
+			$this->log(sprintf('API Error (%d): %s [Debug-Id: %s]', $code, wp_json_encode($body), $debug_id ?: 'n/a'), LogLevel::ERROR);
 			return new \WP_Error(
 				'wu_paypal_api_error',
 				$error_msg,
 				[
-					'status'   => $code,
-					'response' => $body,
+					'status'    => $code,
+					'response'  => $body,
+					'debug_id'  => $debug_id,
 				]
 			);
 		}


### PR DESCRIPTION
## Summary

Captures the `PayPal-Debug-Id` response header from every PayPal REST API call and logs it to the PayPal log channel. PayPal support requires this header value when investigating API issues.

## Changes

- **`inc/gateways/class-paypal-rest-gateway.php`** — In `api_request()`:
  - Extract `PayPal-Debug-Id` via `wp_remote_retrieve_header()` after every successful HTTP response
  - Log it at `info` level: `PayPal-Debug-Id: <value>`
  - Include it in error log messages: `API Error (400): ... [Debug-Id: <value>]`
  - Expose it in the `WP_Error` data array under `debug_id` key for callers

## Acceptance Criteria

- [x] `PayPal-Debug-Id` extracted from every API response via `wp_remote_retrieve_header()`
- [x] Debug ID logged alongside existing API response logging

## Runtime Testing

**Risk level:** Low — logging-only change, no business logic altered.
**Verification:** `self-assessed` — the change adds a `wp_remote_retrieve_header()` call (standard WP function) and two `$this->log()` calls. No conditional logic, no data mutation, no side effects beyond logging.

## Files Changed

- `inc/gateways/class-paypal-rest-gateway.php` (+10, -3)

Closes #731
Part of #725

---
[aidevops.sh](https://aidevops.sh) v3.5.556 plugin for [OpenCode](https://opencode.ai) v1.3.0 with claude-sonnet-4-6 spent 10m on this as a headless worker.