### PR TITLE
GH#738: fix: simple checkout form follow-up fixes

### DIFF
--- a/inc/admin-pages/class-checkout-form-list-admin-page.php
+++ b/inc/admin-pages/class-checkout-form-list-admin-page.php
@@ -139,6 +139,10 @@ class Checkout_Form_List_Admin_Page extends List_Admin_Page {
 						'title' => __('Multi-Step', 'ultimate-multisite'),
 						'icon'  => 'dashicons-before dashicons-excerpt-view',
 					],
+					'simple'      => [
+						'title' => __('Simple (Email Only)', 'ultimate-multisite'),
+						'icon'  => 'dashicons-before dashicons-email-alt',
+					],
 					'blank'       => [
 						'title' => __('Blank', 'ultimate-multisite'),
 						'icon'  => 'dashicons-before dashicons-admin-page',

--- a/inc/checkout/class-checkout.php
+++ b/inc/checkout/class-checkout.php
@@ -2140,7 +2140,40 @@ class Checkout {
 	 */
 	public function get_js_validation_rules(): array {
 
+		/*
+		 * When the checkout form has a password field with auto_generate_password
+		 * enabled, the hidden flag is submitted with the form but is not present
+		 * in the GET request at render time. We detect this from the form settings
+		 * so the JS validator knows to skip password rules without needing the
+		 * flag to be in the request.
+		 */
+		$form_auto_generates_password = false;
+
+		if ($this->checkout_form) {
+			$password_fields = $this->checkout_form->get_all_fields_by_type('password');
+
+			foreach ($password_fields as $field) {
+				if (! empty($field['auto_generate_password'])) {
+					$form_auto_generates_password = true;
+					break;
+				}
+			}
+		}
+
 		$raw_rules = $this->validation_rules();
+
+		/*
+		 * When the form auto-generates the password, clear the password rules
+		 * so the JS validator does not require a password field that is not
+		 * rendered. The server-side validation_rules() already handles this via
+		 * request_or_session(), but at render time the flag is not in the request
+		 * so we must detect it from the form settings instead.
+		 */
+		if ($form_auto_generates_password) {
+			$raw_rules['password']       = '';
+			$raw_rules['password_conf']  = '';
+			$raw_rules['valid_password'] = '';
+		}
 
 		/*
 		 * Rules that require a database lookup or complex server-side logic.

--- a/inc/class-wp-ultimo.php
+++ b/inc/class-wp-ultimo.php
@@ -116,6 +116,21 @@ final class WP_Ultimo {
 	 */
 	public function init(): void {
 
+		/*
+		 * Ensure wu_dmtable is registered on $wpdb early in the plugin load.
+		 * Domain_Mapping::startup() only runs during the sunrise/mu-plugins phase
+		 * (it returns early if muplugins_loaded has already fired). Without this,
+		 * any code that accesses $wpdb->wu_dmtable before Domain_Mapping::startup()
+		 * runs triggers a PHP notice about an undefined property, which causes
+		 * "headers already sent" errors that break admin redirects and AJAX.
+		 */
+		global $wpdb;
+
+		if (empty($wpdb->wu_dmtable)) {
+			$wpdb->wu_dmtable        = $wpdb->base_prefix . 'wu_domain_mappings';
+			$wpdb->ms_global_tables[] = 'wu_domain_mappings';
+		}
+
 		add_filter('extra_plugin_headers', [$this, 'register_addon_headers']);
 		add_action('admin_init', [$this, 'check_addon_compatibility']);
 

--- a/inc/models/class-domain.php
+++ b/inc/models/class-domain.php
@@ -694,6 +694,16 @@ class Domain extends Base_Model {
 
 		$placeholders_in = implode(',', $placeholders);
 
+		/*
+		 * Ensure wu_dmtable is set on $wpdb. In normal (non-sunrise) plugin load
+		 * paths Domain_Mapping::startup() may not have run yet, which causes a
+		 * PHP notice about an undefined property. Set it here as a fallback so
+		 * the query can proceed without warnings.
+		 */
+		if (empty($wpdb->wu_dmtable)) {
+			$wpdb->wu_dmtable = $wpdb->base_prefix . 'wu_domain_mappings';
+		}
+
 		// Prepare the query
 		$query = "SELECT * FROM {$wpdb->wu_dmtable} WHERE domain IN ($placeholders_in) ORDER BY primary_domain DESC, active DESC, secure DESC LIMIT 1";
 


### PR DESCRIPTION
## Summary

- Skip JS password validation rules when `auto_generate_password` is enabled on the checkout form — the server-side logic already handles this but at render time the flag is not in the request, so detect it from form settings instead.
- Register `wu_dmtable` on `$wpdb` early in `WP_Ultimo::init()` to prevent PHP notices about undefined property when domain mapping code runs before `Domain_Mapping::startup()`.
- Add the same `wu_dmtable` fallback in `Domain::get_by_domain()` for non-sunrise plugin load paths.
- Add `simple` template entry (Email Only icon) to the checkout form template list.

## Files Changed

- `inc/checkout/class-checkout.php` — JS validation fix for auto-generated passwords
- `inc/class-wp-ultimo.php` — early `wu_dmtable` registration
- `inc/models/class-domain.php` — `wu_dmtable` fallback in `get_by_domain()`
- `inc/admin-pages/class-checkout-form-list-admin-page.php` — add `simple` template entry

## Runtime Testing

Risk level: **Low** — these are follow-up fixes to PR #737 (already merged). Changes are: a JS validation guard (no new logic path, only skips rules when flag is set), two `` property guards (defensive fallbacks, no new queries), and a template list entry (UI-only addition). Self-assessed.

Closes #738


---
[aidevops.sh](https://aidevops.sh) v3.5.611 plugin for [OpenCode](https://opencode.ai) v1.3.0 with claude-sonnet-4-6 spent 2m on this as a headless worker.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "Simple (Email Only)" checkout form template option

* **Bug Fixes**
  * Fixed password validation handling when auto-generate password is configured in checkout forms
  * Improved domain mapping table initialization to prevent reference errors

<!-- end of auto-generated comment: release notes by coderabbit.ai -->