### PR TITLE
t741: fix(checkout): add form_has_auto_generate_password() and strip JS password rules

### DIFF
--- a/inc/checkout/class-checkout.php
+++ b/inc/checkout/class-checkout.php
@@ -2124,6 +2124,33 @@ class Checkout {
 	}
 
 	/**
+	 * Returns true when the current checkout form has a password field
+	 * configured with auto_generate_password enabled.
+	 *
+	 * Used to suppress client-side password validation rules when no
+	 * password input is rendered.
+	 *
+	 * @since 2.0.20
+	 * @return bool
+	 */
+	protected function form_has_auto_generate_password(): bool {
+
+		if ( ! $this->checkout_form) {
+			return false;
+		}
+
+		foreach ($this->checkout_form->get_settings() as $step) {
+			foreach (wu_get_isset($step, 'fields', []) as $field) {
+				if ('password' === wu_get_isset($field, 'type') && ! empty($field['auto_generate_password'])) {
+					return true;
+				}
+			}
+		}
+
+		return false;
+	}
+
+	/**
 	 * Converts the PHP validation rules into a JS-friendly structure.
 	 *
 	 * Each rule string (e.g. "required|min:4|email") is parsed into an array of
@@ -2140,39 +2167,15 @@ class Checkout {
 	 */
 	public function get_js_validation_rules(): array {
 
-		/*
-		 * When the checkout form has a password field with auto_generate_password
-		 * enabled, the hidden flag is submitted with the form but is not present
-		 * in the GET request at render time. We detect this from the form settings
-		 * so the JS validator knows to skip password rules without needing the
-		 * flag to be in the request.
-		 */
-		$form_auto_generates_password = false;
-
-		if ($this->checkout_form) {
-			$password_fields = $this->checkout_form->get_all_fields_by_type('password');
-
-			foreach ($password_fields as $field) {
-				if (! empty($field['auto_generate_password'])) {
-					$form_auto_generates_password = true;
-					break;
-				}
-			}
-		}
-
 		$raw_rules = $this->validation_rules();
 
 		/*
-		 * When the form auto-generates the password, clear the password rules
-		 * so the JS validator does not require a password field that is not
-		 * rendered. The server-side validation_rules() already handles this via
-		 * request_or_session(), but at render time the flag is not in the request
-		 * so we must detect it from the form settings instead.
+		 * When the checkout form uses auto-generated passwords, strip the
+		 * password-related rules from the JS ruleset so the client-side
+		 * validator does not block submission on a field that is never shown.
 		 */
-		if ($form_auto_generates_password) {
-			$raw_rules['password']       = '';
-			$raw_rules['password_conf']  = '';
-			$raw_rules['valid_password'] = '';
+		if ($this->form_has_auto_generate_password()) {
+			unset($raw_rules['password'], $raw_rules['password_conf'], $raw_rules['valid_password']);
 		}
 
 		/*


### PR DESCRIPTION
## Summary

- Adds `form_has_auto_generate_password(): bool` protected method to the `Checkout` class that iterates form settings to detect password fields with `auto_generate_password` enabled
- Uses this method in `get_js_validation_rules()` to `unset()` the `password`, `password_conf`, and `valid_password` rules when auto-generate is active
- Prevents the JS validator from blocking form submission on a password field that is never rendered

## Problem

After PR #737 (simple checkout form template) merged, checkout forms using auto-generated passwords had their JS validator require a password field that was never shown, blocking form submission.

## Acceptance Criteria

- [x] `form_has_auto_generate_password()` method exists in `Checkout` class
- [x] `get_js_validation_rules()` strips password rules when auto-generate is enabled
- [x] PHPStan level 0 passes

Closes #741

---
[aidevops.sh](https://aidevops.sh) v3.5.718 plugin for [OpenCode](https://opencode.ai) v1.3.0 with claude-sonnet-4-6 spent 2m and 5,470 tokens on this as a headless worker.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal checkout form logic for auto-generated password field handling and validation rules processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->