### PR TITLE
feat: add WordPress.org SVN deploy to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -116,3 +116,50 @@ jobs:
             - Compatible with WordPress 5.3+
             - Requires PHP 7.4.30+
             - Always backup your site before upgrading
+
+  deploy-to-wporg:
+    name: Deploy to WordPress.org
+    runs-on: ubuntu-latest
+    needs: build
+    # Only deploy stable releases to wp.org (skip pre-releases)
+    if: ${{ !contains(github.ref, '-alpha') && !contains(github.ref, '-beta') && !contains(github.ref, '-rc') && !contains(github.ref, '-dev') && !contains(github.ref, '-preview') }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@accd6127cb78bee3e8082180cb391013d204ef9f # v2
+        with:
+          php-version: '7.4'
+          extensions: mbstring, intl, curl
+          tools: composer, wp-cli
+
+      - name: Set up Node.js
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: '18'
+          cache: 'npm'
+
+      - name: Install PHP dependencies
+        run: composer install --no-dev --optimize-autoloader
+
+      - name: Install Node dependencies
+        run: npm ci
+
+      - name: Build plugin
+        run: npm run build
+        env:
+          MU_CLIENT_ID: ${{ secrets.MU_CLIENT_ID }}
+          MU_CLIENT_SECRET: ${{ secrets.MU_CLIENT_SECRET }}
+
+      - name: Deploy to WordPress.org SVN
+        uses: 10up/action-wordpress-plugin-deploy@stable
+        with:
+          generate-zip: false
+        env:
+          SVN_USERNAME: ${{ secrets.SVN_USERNAME }}
+          SVN_PASSWORD: ${{ secrets.SVN_PASSWORD }}
+          SLUG: ultimate-multisite


### PR DESCRIPTION
## Summary

- Adds a `deploy-to-wporg` job to the existing `release.yml` workflow
- Uses `10up/action-wordpress-plugin-deploy@stable` with the existing `.distignore`
- Runs after the build job, only on stable releases (pre-releases like alpha/beta/rc are skipped)
- Builds with `composer install --no-dev` and `npm run build` before deploying to SVN
- Slug: `ultimate-multisite`

## Required setup

Add these repo secrets before the next stable release:

- `SVN_USERNAME` — WordPress.org SVN username
- `SVN_PASSWORD` — WordPress.org SVN password (set at https://profiles.wordpress.org/me/profile/edit/group/3/?screen=svn-password)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced deployment automation to WordPress.org for stable releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->