### PR TITLE
fix(sso): add GlotPress compatibility for cross-domain SSO

### DIFF
--- a/inc/sso/class-sso.php
+++ b/inc/sso/class-sso.php
@@ -273,6 +273,22 @@ class SSO {
 
 		add_action('login_head', [$this, 'enqueue_script']);
 
+		/*
+		 * GlotPress uses its own template system with gp_head()/gp_footer()
+		 * instead of wp_head()/wp_footer(). Without this hook the SSO script
+		 * never loads on GlotPress pages, breaking cross-domain login for
+		 * translation sites.
+		 *
+		 * Registration is deferred to plugins_loaded so we can check whether
+		 * GlotPress is actually active before adding the hook.
+		 */
+		add_action('plugins_loaded', function (): void {
+
+			if (defined('GP_VERSION')) {
+				add_action('gp_head', [$this, 'enqueue_script']);
+			}
+		});
+
 		/**
 		 * Allow plugin developers to add additional hooks, if needed.
 		 *


### PR DESCRIPTION
## Summary

- Hooks the SSO `enqueue_script` callback onto GlotPress's `gp_head` action so the SSO JavaScript loads on GlotPress pages
- Only registers the hook when GlotPress is active (`GP_VERSION` defined), deferred to `plugins_loaded` since SSO starts at sunrise

## Problem

GlotPress uses its own template system (`gp_head()`/`gp_footer()`) instead of WordPress's `wp_head()`/`wp_footer()`. The SSO script is registered on `wp_head`, so it never fires on GlotPress pages. This means cross-domain login is completely broken for translation sites (e.g. `translate.example.com`) — users log in on the main site but the session is never propagated to the GlotPress subsite.

## Root Cause

`class-sso.php` line 272 hooks `enqueue_script` to `wp_head` and `login_head`, but GlotPress never calls either of those actions. Its header template calls `gp_head()` which fires the `gp_head` action instead.

## Fix

Register `enqueue_script` on `gp_head` in addition to `wp_head` and `login_head`. The registration is deferred to `plugins_loaded` so we can check `defined('GP_VERSION')` — SSO `startup()` runs at sunrise before plugins are loaded.

When GlotPress is not installed, `GP_VERSION` is never defined and the hook is not registered. Even if it were registered unconditionally, it would be a no-op since `gp_head` would never fire.

## Testing

1. Install GlotPress on a multisite subsite with a different domain (e.g. `translate.example.com`)
2. Enable SSO in Ultimate Multisite settings
3. Log in on the main site
4. Navigate to the GlotPress site — SSO should propagate the session and show you as logged in
5. Without this fix, the GlotPress site always shows "Log in" regardless of main site auth state

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved SSO compatibility for GlotPress environments with optimized script initialization when GlotPress is detected and active.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->