### PR TITLE
fix(release): fix SVN deploy — download artifact instead of rebuilding with --no-dev

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
-          node-version: '18'
+          node-version: '20'
           cache: 'npm'
 
       - name: Install PHP dependencies
@@ -89,6 +89,13 @@ jobs:
           mkdir -p build
           mv ultimate-multisite.zip build/ultimate-multisite-${{ env.VERSION }}.zip
 
+      - name: Upload build artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ultimate-multisite-zip
+          path: build/ultimate-multisite-${{ env.VERSION }}.zip
+          retention-days: 7
+
       - name: Create Release
         id: create_release
         uses: softprops/action-gh-release@de2c0eb89ae2a093876385947365aca7b0e5f844 # v1
@@ -130,30 +137,20 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Setup PHP
-        uses: shivammathur/setup-php@accd6127cb78bee3e8082180cb391013d204ef9f # v2
+      - name: Get the version
+        run: |
+          VERSION="${GITHUB_REF#refs/tags/v}"
+          echo "VERSION=$VERSION" >> $GITHUB_ENV
+
+      - name: Download build artifact
+        uses: actions/download-artifact@v4
         with:
-          php-version: '7.4'
-          extensions: mbstring, intl, curl
-          tools: composer, wp-cli
+          name: ultimate-multisite-zip
+          path: build/
 
-      - name: Set up Node.js
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
-        with:
-          node-version: '18'
-          cache: 'npm'
-
-      - name: Install PHP dependencies
-        run: composer install --no-dev --optimize-autoloader
-
-      - name: Install Node dependencies
-        run: npm ci
-
-      - name: Build plugin
-        run: npm run build
-        env:
-          MU_CLIENT_ID: ${{ secrets.MU_CLIENT_ID }}
-          MU_CLIENT_SECRET: ${{ secrets.MU_CLIENT_SECRET }}
+      - name: Unzip build artifact into workspace
+        run: |
+          unzip -o build/ultimate-multisite-${{ env.VERSION }}.zip -d .
 
       - name: Deploy to WordPress.org SVN
         uses: 10up/action-wordpress-plugin-deploy@stable


### PR DESCRIPTION
## Problem

The `deploy-to-wporg` job was failing on `npm run build` with:

```
Error: Command failed: vendor/wp-cli/wp-cli/bin/wp i18n make-pot ...
/bin/sh: 1: vendor/wp-cli/wp-cli/bin/wp: not found
```

**Root cause**: The job ran `composer install --no-dev`, which skips `wp-cli/wp-cli-bundle` (a dev dependency). Then `npm run build` triggers the `prebuild` script → `makepot` → calls `vendor/wp-cli/wp-cli/bin/wp` → not found → exit 1. The SVN deploy step never ran.

## Fix

- **Build job**: upload the built zip as a GitHub Actions artifact (`actions/upload-artifact@v4`, 7-day retention).
- **Deploy job**: download that artifact and unzip it into the workspace. No rebuild — no WP-CLI dependency, no `MU_CLIENT_ID`/`MU_CLIENT_SECRET` secrets needed.
- **Node.js**: bumped from 18 → 20 in the build job. Several packages (`commander`, `listr2`, `string-width`, `nano-spawn`, `qified`) already require `node>=20` and were emitting `EBADENGINE` warnings.

This matches the pattern used in `Ultimate-Multisite/ai-provider-for-any-compatible-endpoint` (`deploy.yml`).

## Verification

Merge and tag a patch release (e.g. `v2.5.1`) — the `deploy-to-wporg` job should complete the SVN deploy step successfully.

The v2.5.0 SVN deploy did not complete. After this merges, we should re-trigger it manually or tag a patch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated Node.js build runtime from version 18 to 20
  * Streamlined release pipeline to generate and reuse build artifacts across deployment stages
  * Implemented 7-day retention policy for build artifacts

<!-- end of auto-generated comment: release notes by coderabbit.ai -->