### PR TITLE
fix: template selection blocked when product uses default (allow all) mode

### DIFF
--- a/inc/limitations/class-limit-site-templates.php
+++ b/inc/limitations/class-limit-site-templates.php
@@ -205,6 +205,14 @@ class Limit_Site_Templates extends Limit {
 	 */
 	public function get_available_site_templates() {
 
+		/*
+		 * MODE_DEFAULT means "allow all templates" — no restriction.
+		 * Return false so callers that check is_array() treat this as unrestricted.
+		 */
+		if (self::MODE_DEFAULT === $this->mode) {
+			return false;
+		}
+
 		$limits = $this->get_limit();
 
 		if ( ! $limits) {
@@ -219,8 +227,7 @@ class Limit_Site_Templates extends Limit {
 			$site_settings = (object) $site_settings;
 
 			if (self::BEHAVIOR_AVAILABLE === $site_settings->behavior ||
-				self::BEHAVIOR_PRE_SELECTED === $site_settings->behavior ||
-				self::MODE_DEFAULT === $this->mode) {
+				self::BEHAVIOR_PRE_SELECTED === $site_settings->behavior) {
 				// Convert to integer to match type used in validation (absint)
 				$available[] = absint($site_id);
 			}

--- a/inc/limits/class-site-template-limits.php
+++ b/inc/limits/class-site-template-limits.php
@@ -220,6 +220,11 @@ class Site_Template_Limits {
 			} else {
 				$available_templates = $limits->site_templates->get_available_site_templates();
 
+				// false means no restriction (MODE_DEFAULT) — all templates are available.
+				if ( false === $available_templates ) {
+					return true;
+				}
+
 				return in_array( $template_id, $available_templates, true );
 			}
 		}


### PR DESCRIPTION
## Summary

- `get_available_site_templates()` returned `[]` (empty array) when a product's site template mode is `MODE_DEFAULT` ("Default - Allow All Site Templates")
- The validation rule in `class-site-template.php` checks `is_array($allowed_templates) && !in_array(...)` — an empty array passes `is_array()`, so every template was blocked with "The selected template is not available for this product"
- Fix: return `false` for `MODE_DEFAULT` to signal "no restriction", matching the existing `is_array()` gate used by the validator

## Changes

**`inc/limitations/class-limit-site-templates.php`**
- `get_available_site_templates()` returns `false` immediately when `mode === MODE_DEFAULT`
- Removed the dead `MODE_DEFAULT` branch inside the loop (unreachable after the early return)

**`inc/limits/class-site-template-limits.php`**
- `is_template_available()` guards against `false` from `get_available_site_templates()` before calling `in_array()`, preventing a PHP warning and correctly returning `true` for the default mode

## Reproduction

1. Create a product with **Site Template Selection Mode = Default - Allow All Site Templates**
2. Add a Template Selection field to a checkout form (set to "All templates")
3. Attempt to select any template during checkout
4. Before fix: "The selected template is not available for this product."
5. After fix: template selection proceeds normally

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved template availability filtering logic to correctly handle default mode settings
  * Refined template eligibility checks to ensure only properly configured templates are presented as available options

<!-- end of auto-generated comment: release notes by coderabbit.ai -->