### PR TITLE
fix: relax over-strict validation_rules() so abilities accept minimal input

### DIFF
--- a/inc/functions/product.php
+++ b/inc/functions/product.php
@@ -116,25 +116,29 @@ function wu_get_product_by($column, $value) {
  */
 function wu_create_product($product_data) {
 
+	// Note: empty-string sentinels (instead of `false`) for fields that
+	// have model-level `default:` rules. rakit's validator treats `false`
+	// as a non-empty value (`!is_null(false)` is true), so model defaults
+	// would never fire if we used `false` here.
 	$product_data = wp_parse_args(
 		$product_data,
 		[
-			'name'                => false,
-			'description'         => false,
-			'currency'            => false,
-			'pricing_type'        => false,
-			'setup_fee'           => false,
+			'name'                => '',
+			'description'         => '',
+			'currency'            => '',
+			'pricing_type'        => '',
+			'setup_fee'           => '',
 			'parent_id'           => 0,
-			'slug'                => false,
-			'recurring'           => false,
+			'slug'                => '',
+			'recurring'           => '',
 			'trial_duration'      => 0,
 			'trial_duration_unit' => 'day',
 			'duration'            => 1,
 			'duration_unit'       => 'day',
-			'amount'              => false,
-			'billing_cycles'      => false,
-			'active'              => false,
-			'type'                => false,
+			'amount'              => '',
+			'billing_cycles'      => '',
+			'active'              => '',
+			'type'                => '',
 			'featured_image_id'   => 0,
 			'list_order'          => 0,
 			'date_created'        => wu_get_current_time('mysql', true),

--- a/inc/functions/site.php
+++ b/inc/functions/site.php
@@ -228,10 +228,29 @@ function wu_create_site($site_data) {
 
 	$current_site = get_current_site();
 
+	$network_domain = $current_site->domain;
+
+	// Mode-aware domain/path normalisation. When the caller passes a path
+	// but no explicit domain (or only the network root domain) on a
+	// subdomain multisite install, the path is meaningless — WordPress
+	// won't route to it. Convert the supplied path into a subdomain
+	// prefix instead so the site is reachable. Callers that pass an
+	// explicit non-root domain are respected as-is so subdomain/subdir
+	// mixing still works.
+	$path_supplied   = isset($site_data['path']) && '' !== $site_data['path'] && '/' !== $site_data['path'];
+	$domain_supplied = isset($site_data['domain']) && '' !== $site_data['domain'] && $site_data['domain'] !== $network_domain;
+
+	if (is_multisite() && is_subdomain_install() && $path_supplied && ! $domain_supplied) {
+		$slug                 = trim((string) $site_data['path'], '/');
+		$bare_network_domain  = preg_replace('/^www\./i', '', (string) $network_domain);
+		$site_data['domain']  = "{$slug}.{$bare_network_domain}";
+		$site_data['path']    = '/';
+	}
+
 	$site_data = wp_parse_args(
 		$site_data,
 		[
-			'domain'                => $current_site->domain,
+			'domain'                => $network_domain,
 			'path'                  => '/',
 			'title'                 => false,
 			'type'                  => false,

--- a/inc/models/class-broadcast.php
+++ b/inc/models/class-broadcast.php
@@ -129,7 +129,8 @@ class Broadcast extends Post_Base_Model {
 			'name'        => 'default:title',
 			'title'       => 'required|min:2',
 			'content'     => 'required|min:3',
-			'type'        => 'required|in:broadcast_email,broadcast_notice|default:broadcast_notice',
+			// Has a default — `required` is redundant.
+			'type'        => 'in:broadcast_email,broadcast_notice|default:broadcast_notice',
 		];
 	}
 

--- a/inc/models/class-customer.php
+++ b/inc/models/class-customer.php
@@ -176,8 +176,11 @@ class Customer extends Base_Model implements Billable, Notable {
 
 		return [
 			'user_id'            => "required|integer|unique:\WP_Ultimo\Models\Customer,user_id,{$id}",
-			'email_verification' => 'required|in:none,pending,verified',
-			'type'               => 'required|in:customer',
+			// Defaults to "none" so callers don't have to choose a verification
+			// state on creation — they can update it later if needed.
+			'email_verification' => 'in:none,pending,verified|default:none',
+			// Currently the only valid value, so default it.
+			'type'               => 'in:customer|default:customer',
 			'last_login'         => 'default:',
 			'has_trialed'        => 'boolean|default:0',
 			'vip'                => 'boolean|default:0',

--- a/inc/models/class-domain.php
+++ b/inc/models/class-domain.php
@@ -128,7 +128,8 @@ class Domain extends Base_Model {
 		return [
 			'blog_id'        => 'required|integer',
 			'domain'         => "required|domain|unique:\WP_Ultimo\Models\Domain,domain,{$id}",
-			'stage'          => 'required|in:checking-dns,checking-ssl-cert,done-without-ssl,done,failed,ssl-failed|default:checking-dns',
+			// Has a default — `required` is redundant.
+			'stage'          => 'in:checking-dns,checking-ssl-cert,done-without-ssl,done,failed,ssl-failed|default:checking-dns',
 			'active'         => 'default:1',
 			'secure'         => 'default:0',
 			'primary_domain' => 'default:0',

--- a/inc/models/class-payment.php
+++ b/inc/models/class-payment.php
@@ -244,7 +244,9 @@ class Payment extends Base_Model implements Notable {
 			'tax_total'                   => 'numeric',
 			'discount_code'               => 'alpha_dash',
 			'total'                       => 'required|numeric',
-			'status'                      => "required|in:{$payment_types}",
+			// Defaults to "pending" so callers can record a payment without
+			// having to choose a status up front; gateways update it later.
+			'status'                      => "in:{$payment_types}|default:pending",
 			'gateway'                     => 'default:',
 			'gateway_payment_id'          => 'default:',
 			'discount_total'              => 'integer',

--- a/inc/models/class-product.php
+++ b/inc/models/class-product.php
@@ -417,8 +417,11 @@ class Product extends Base_Model implements Limitable {
 
 		return [
 			'featured_image_id'     => 'integer',
-			'currency'              => "required|default:{$currency}",
-			'pricing_type'          => 'required|in:free,paid,contact_us,pay_what_you_want',
+			// Has a default — `required` is redundant.
+			'currency'              => "default:{$currency}",
+			// Defaults to "free" so a caller can create a basic product
+			// without having to choose a pricing model up front.
+			'pricing_type'          => 'in:free,paid,contact_us,pay_what_you_want|default:free',
 			'trial_duration'        => 'integer',
 			'trial_duration_unit'   => 'in:day,week,month,year|default:month',
 			'parent_id'             => 'integer',
@@ -430,7 +433,8 @@ class Product extends Base_Model implements Limitable {
 			'billing_cycles'        => 'integer|default:0',
 			'active'                => 'default:1',
 			'price_variations'      => "price_variations:{$duration},{$duration_unit}",
-			'type'                  => "required|default:plan|in:{$allowed_types}",
+			// Has a default — `required` is redundant.
+			'type'                  => "default:plan|in:{$allowed_types}",
 			'slug'                  => "required|unique:\WP_Ultimo\Models\Product,slug,{$id}|min:2",
 			'taxable'               => 'boolean|default:0',
 			'tax_category'          => 'default:',

--- a/inc/models/class-site.php
+++ b/inc/models/class-site.php
@@ -331,10 +331,15 @@ class Site extends Base_Model implements Limitable, Notable {
 		return [
 			'categories'        => 'default:',
 			'featured_image_id' => 'integer|default:',
-			'site_id'           => 'required|integer',
+			// site_id is the network id; defaults to 1 (the main network) in
+			// the model, so it's optional for a regular WordPress subsite.
+			'site_id'           => 'integer|default:1',
 			'title'             => 'required',
 			'name'              => 'required',
-			'description'       => 'required|min:2',
+			// description is optional metadata. A regular WordPress subsite
+			// doesn't have one at the network level — it lives in
+			// blogdescription per blog and can be set later.
+			'description'       => 'default:',
 			'domain'            => 'domain',
 			'path'              => 'required|default:',
 			'registered'        => "default:{$date}",
@@ -346,8 +351,12 @@ class Site extends Base_Model implements Limitable, Notable {
 			'deleted'           => 'boolean|default:0',
 			'is_publishing'     => 'boolean|default:0',
 			'land_id'           => 'integer|default:',
-			'customer_id'       => 'required|integer|exists:\WP_Ultimo\Models\Customer,id',
-			'membership_id'     => 'required|integer|exists:\WP_Ultimo\Models\Membership,id',
+			// customer_id and membership_id are WaaS-specific. A vanilla
+			// WordPress subsite (type=default) does not need a paying
+			// customer or a membership. Keep the foreign-key existence
+			// check so customer-owned sites still validate when supplied.
+			'customer_id'       => 'integer|default:|exists:\WP_Ultimo\Models\Customer,id',
+			'membership_id'     => 'integer|default:|exists:\WP_Ultimo\Models\Membership,id',
 			'template_id'       => 'integer|default:',
 			'type'              => "required|in:{$site_types}",
 			'signup_options'    => 'default:',
@@ -631,7 +640,7 @@ class Site extends Base_Model implements Limitable, Notable {
 	 * Set domain name used by this site..
 	 *
 	 * @since 2.0.0
-	 * @param string $domain The site domain. You don't need to put http or https in front of your domain in this field. e.g: example.com.
+	 * @param string $domain Full hostname for the site, no protocol. On a subdomain multisite install supply the full subdomain you want (e.g. "blog.example.com"). On a subdirectory install leave empty to inherit the network root domain. wu_create_site() will auto-derive this from `path` on subdomain installs when you only supply a slug.
 	 * @return void
 	 */
 	public function set_domain($domain): void {
@@ -653,7 +662,7 @@ class Site extends Base_Model implements Limitable, Notable {
 	 * Set path of the site. Used when in sub-directory mode..
 	 *
 	 * @since 2.0.0
-	 * @param string $path Path of the site. Used when in sub-directory mode.
+	 * @param string $path URL path for the site. On a subdirectory multisite install this is the URL prefix (e.g. "/blog/"). On a subdomain install supply just the slug (e.g. "blog") and wu_create_site() will convert it into the full subdomain "blog.<network-domain>" automatically.
 	 * @return void
 	 */
 	public function set_path($path): void {

--- a/inc/models/class-webhook.php
+++ b/inc/models/class-webhook.php
@@ -120,7 +120,10 @@ class Webhook extends Base_Model {
 			'event_count'      => 'default:0',
 			'active'           => 'default:1',
 			'hidden'           => 'default:0',
-			'integration'      => 'required|min:2',
+			// Defaults to "manual" so a caller can register a webhook
+			// without specifying which integration owns it. Plugins that
+			// register webhooks set their own integration tag.
+			'integration'      => 'min:2|default:manual',
 			'date_last_failed' => 'default:',
 		];
 	}


### PR DESCRIPTION
## Summary

The MCP `*-create-item` abilities (registered via `trait-mcp-abilities.php`) read each model's `validation_rules()` to build their JSON Schema and mark fields as `required`. Several models flagged fields that are either WaaS-specific extras (`customer_id`, `membership_id` on a default WP subsite), the only valid value (`type` on customer), or already had sensible model-level defaults that made `required` redundant.

Result: AI callers (and any other programmatic caller of `wu_create_*`) had to supply ~6 fields to create a vanilla WP subsite when only 4 are genuinely needed, and similar for the other entities. Weak LLMs would either guess wrong values or fall back to db-query / run-php hacks.

This PR removes **11 spurious `required` flags across 7 models**, adds explicit `default:` rules where one was missing, fixes a related bug in `wu_create_product` that prevented model-level defaults from firing, and fixes a subdomain-mode routing bug in `wu_create_site`.

Companion PR in [Ultimate-Multisite/gratis-ai-agent#807](https://github.com/Ultimate-Multisite/gratis-ai-agent/pull/807) adds the auto-discovery layer that surfaces these abilities to the agent in the first place — together they make it possible for an LLM agent to create a Multisite Ultimate subsite from a one-line prompt.

## Why

When an LLM agent sees the create-item schema for these models, every `required` field forces it to either guess a value or call a fetcher ability first. For the genuine fields (`title`, `customer_id` on a payment) that's fine — for spurious ones it's pure friction. The same applies to humans writing scripts against `wu_create_*`.

The site model in particular: a vanilla WordPress subsite (`type: default`) doesn't need a customer or membership — those are WaaS-specific concepts. Forcing them required the agent to walk a four-call workflow (list customers → list products → create membership → create site) just to reach a regular blog. With this PR a single `site-create-item` call with `{title, name, path, type}` suffices.

## Per-model changes

### Site (`inc/models/class-site.php`)

| Field | Was | Now |
|---|---|---|
| `site_id` | `required\|integer` | `integer\|default:1` |
| `description` | `required\|min:2` | `default:` |
| `customer_id` | `required\|integer\|exists:...` | `integer\|default:\|exists:...` |
| `membership_id` | `required\|integer\|exists:...` | `integer\|default:\|exists:...` |

`title`, `name`, `path`, `type` remain required (genuine WordPress minimum). The `exists:` foreign-key check still fires when a value is supplied so customer-owned sites still validate correctly.

### Subdomain mode (`inc/functions/site.php`)

`wu_create_site()` now detects subdomain multisite installs and auto-converts a supplied `path` slug into the correct subdomain (`{slug}.{network-domain}`) when no explicit `domain` was given. The existing `wu_get_site_domain_and_path()` helper does this conversion but `wu_create_site()` never used it — programmatic callers passing `path: "blog"` on a subdomain install ended up with an unroutable site row at `<network>/blog`. Subdomain/subdirectory mixing still works because callers that pass an explicit non-root `domain` are respected as-is.

`set_domain()` and `set_path()` doc comments rewritten to make the mode-aware behaviour explicit so any tool that surfaces field descriptions to an LLM (or any human reader) gets the right guidance.

### Customer (`inc/models/class-customer.php`)

| Field | Was | Now |
|---|---|---|
| `email_verification` | `required\|in:none,pending,verified` | `in:...\|default:none` |
| `type` | `required\|in:customer` | `in:customer\|default:customer` |

`type` only ever accepts one value, so requiring callers to specify it is pure friction.

### Product (`inc/models/class-product.php` + `inc/functions/product.php`)

| Field | Was | Now |
|---|---|---|
| `currency` | `required\|default:{site_currency}` | `default:{site_currency}` |
| `pricing_type` | `required\|in:free,paid,...` | `in:...\|default:free` |
| `type` | `required\|default:plan\|in:...` | `default:plan\|in:...` |

**Bonus fix in `wu_create_product()`:** the helper pre-filled missing fields with `false` sentinels via `wp_parse_args`. rakit's validator treats `false` as non-empty (`Required::check(false)` returns `!is_null(false) === true`), so the model-level `default:` rules never fired and `in:` then rejected `false`. Replaced the `false` sentinels with empty strings (`''`) for the relevant fields so rakit recognises them as empty and the defaults take effect.

### Payment / Domain / Webhook / Broadcast

| Model | Field | Change |
|---|---|---|
| payment | `status` | drop `required`, add `default:pending` (helper still overrides with COMPLETED, behaviour unchanged for existing helper callers) |
| domain | `stage` | drop redundant `required` (already had `default:checking-dns`) |
| webhook | `integration` | drop `required`, add `default:manual` |
| broadcast | `type` | drop redundant `required` (already had `default:broadcast_notice`) |

## What's NOT changed

- **Membership** `customer_id`, `plan_id` — genuine FKs, kept required.
- **Discount code** `name`, `code`, `value` — all genuinely essential.
- **Event** — system-internal model; manual creation is rare and the defaults would need extra care. Skipped to avoid surprising the event ingest pipeline.
- **Payment** `customer_id`, `subtotal`, `total` — genuine FK + the payment amount; kept required.
- **Domain** `blog_id`, `domain` — must point to a site, must be unique; kept required.
- **Webhook** `name`, `webhook_url`, `event` — all essential.
- **Broadcast** `title`, `content` — all essential.
- **Product** `slug` — kept required because it's used as a unique URL key. Could be auto-derived from `name` later but that's a separate change.

## Verification

After this change, every `multisite-ultimate/*-create-item` ability accepts a minimal payload:

```
customer:      ["user_id"]
product:       ["slug"]                       (was: slug, currency, pricing_type, type)
payment:       ["customer_id","subtotal","total"]
domain:        ["domain","blog_id"]
webhook:       ["name","webhook_url","event"]
broadcast:     ["title","content"]
membership:    ["customer_id","plan_id"]      (unchanged, both genuine FKs)
discount-code: ["name","code","value"]        (unchanged, all essential)
site:          ["title","name","path","type"] (was: site_id, description,
                                              customer_id, membership_id, ...)
```

Smoke tests via `wp_get_ability(...)->execute(...)` confirmed each entity creates successfully with only the minimal payload, and the defaults populate the omitted fields with the documented values.

End-to-end test against an LLM agent with the same prompt that previously failed ("Create a new subsite all about space and astronomy") now succeeds in 2 iterations on the model side, calling `multisite-ultimate/site-create-item` directly with only `title, name, path, type` and producing a routable subsite at the correct subdomain.

## Test plan

- [ ] PHPUnit suite passes
- [ ] PHPStan clean (verified locally during commit)
- [ ] Manual: `wp_get_ability('multisite-ultimate/site-create-item')->execute(['title'=>'X','name'=>'x','path'=>'x','type'=>'default'])` succeeds on a subdomain install and produces a routable site at `x.<network>`
- [ ] Manual: `wp_get_ability('multisite-ultimate/site-create-item')->execute(['title'=>'X','name'=>'x','path'=>'/x/','type'=>'default'])` succeeds on a subdirectory install and produces a routable site at `<network>/x/`
- [ ] Manual: existing form-based creation flow in the network admin still works (none of these helpers are called with `false` sentinels by the form layer; HTML forms post empty strings)
- [ ] Manual: customer/product/payment/domain/webhook/broadcast minimal-payload create via `wp eval` round-trip

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed validation behavior across multiple models (Product, Site, Customer, Domain, Payment, Broadcast, Webhook) to properly apply default values when fields are omitted, reducing required inputs during creation and updates.

* **Improvements**
  * Enhanced site creation logic to better normalize domain and path handling, with improved support for multisite subdomain configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->