### PR TITLE
chore: add wp-cli.yml and local dev environment docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -157,3 +157,21 @@ Set up with: `npm run setup:hooks` or `bash bin/setup-hooks.sh`.
 ## JSON / YAML
 
 Indent with 2 spaces (not tabs). See `.editorconfig`.
+
+## Local Development Environment
+
+The shared WordPress dev install for testing this plugin is at `../wordpress` (relative to this repo root).
+
+- **URL**: http://wordpress.local:8080
+- **Admin**: http://wordpress.local:8080/wp-admin — `admin` / `admin`
+- **WordPress version**: 7.0-RC2
+- **This plugin**: symlinked into `../wordpress/wp-content/plugins/$(basename $PWD)`
+- **Reset to clean state**: `cd ../wordpress && ./reset.sh`
+
+WP-CLI is configured via `wp-cli.yml` in this repo root — run `wp` commands directly from here without specifying `--path`.
+
+```bash
+wp plugin activate $(basename $PWD)   # activate this plugin
+wp plugin deactivate $(basename $PWD) # deactivate
+wp db reset --yes && cd ../wordpress && ./reset.sh  # full reset
+```

--- a/wp-cli.yml
+++ b/wp-cli.yml
@@ -1,0 +1,2 @@
+path: ../wordpress
+url: http://wordpress.local:8080


### PR DESCRIPTION
Point wp-cli at shared WordPress 7.0-RC2 multisite dev install at ../wordpress (wordpress.local:8080). Documents reset workflow and WP-CLI usage in AGENTS.md.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Added comprehensive local development environment setup guide, including configuration details, reset procedures, and command-line tool examples.

* **Chores**
  * Added configuration file for command-line tool integration with development environment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->