### PR TITLE
GH#774: chore(ci): upgrade GitHub Actions to Node.js 24

### DIFF
--- a/.github/workflows/addon-integration-test.yml
+++ b/.github/workflows/addon-integration-test.yml
@@ -251,17 +251,17 @@ jobs:
       - name: Upload Cypress screenshots
         if: always()
         continue-on-error: true
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
-        with:
-          name: cypress-screenshots-${{ inputs.addon-slug }}
-          path: |
-            core/tests/e2e/cypress/screenshots
-            addon/tests/e2e/cypress/screenshots
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
+         with:
+           name: cypress-screenshots-${{ inputs.addon-slug }}
+           path: |
+             core/tests/e2e/cypress/screenshots
+             addon/tests/e2e/cypress/screenshots
 
-      - name: Upload Cypress videos
-        if: always()
-        continue-on-error: true
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+       - name: Upload Cypress videos
+         if: always()
+         continue-on-error: true
+         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
         with:
           name: cypress-videos-${{ inputs.addon-slug }}
           path: |

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -245,15 +245,15 @@ jobs:
       - name: Upload Cypress screenshots
         if: always()
         continue-on-error: true
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
-        with:
-          name: cypress-screenshots-${{ matrix.php }}-${{ matrix.browser }}
-          path: tests/e2e/cypress/screenshots
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
+         with:
+           name: cypress-screenshots-${{ matrix.php }}-${{ matrix.browser }}
+           path: tests/e2e/cypress/screenshots
 
-      - name: Upload Cypress videos
-        if: always()
-        continue-on-error: true
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+       - name: Upload Cypress videos
+         if: always()
+         continue-on-error: true
+         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
         with:
           name: cypress-videos-${{ matrix.php }}-${{ matrix.browser }}
           path: tests/e2e/cypress/videos

--- a/.github/workflows/pr-build-test.yml
+++ b/.github/workflows/pr-build-test.yml
@@ -64,7 +64,7 @@ jobs:
           echo "Prepared artifact: $PLUGIN_DIR as $ARCHIVE_NAME"
 
       - name: Upload build artifact
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
         with:
           name: ${{ steps.artifact.outputs.name }}
           path: ${{ steps.artifact.outputs.path }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -92,7 +92,7 @@ jobs:
           mv ultimate-multisite.zip build/ultimate-multisite-${{ env.VERSION }}.zip
 
       - name: Upload build artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
         with:
           name: ultimate-multisite-zip
           path: build/ultimate-multisite-${{ env.VERSION }}.zip
@@ -100,7 +100,9 @@ jobs:
 
       - name: Create Release
         id: create_release
-        uses: softprops/action-gh-release@de2c0eb89ae2a093876385947365aca7b0e5f844 # v1
+        uses: softprops/action-gh-release@153bb8e04406b158c6c84fc1615b65b24149a1fe # v2
+        env:
+          FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
         with:
           files: |
             build/ultimate-multisite-${{ env.VERSION }}.zip
@@ -145,7 +147,7 @@ jobs:
           echo "VERSION=$VERSION" >> $GITHUB_ENV
 
       - name: Download build artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: ultimate-multisite-zip
           path: build/

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -355,7 +355,7 @@ jobs:
 
       - name: Upload performance results
         if: always()
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
         with:
           name: performance-results-${{ github.run_number }}
           path: |


### PR DESCRIPTION
## Summary

Upgraded all GitHub Actions from Node.js 20 to Node.js 24 to avoid deprecation warnings and forced migration on June 2, 2026. Updated upload-artifact v4→v7, download-artifact v4→v8, action-gh-release v1→v2 with FORCE_JAVASCRIPT_ACTIONS_TO_NODE24 env var across 5 workflow files.

## Files Changed

.github/workflows/addon-integration-test.yml,.github/workflows/e2e.yml,.github/workflows/pr-build-test.yml,.github/workflows/release.yml,.github/workflows/tests.yml

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** self-assessed: CI-only changes with no runtime logic. Verification requires triggering a workflow run post-merge to confirm no Node.js 20 deprecation warnings.

Resolves #774


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.6.235 plugin for [OpenCode](https://opencode.ai) v1.3.16 with claude-sonnet-4-6 spent 2m and 6,461 tokens on this as a headless worker.