### PR TITLE
fix: remove return type declarations from Base_Gateway abstract methods

### DIFF
--- a/inc/gateways/class-base-gateway.php
+++ b/inc/gateways/class-base-gateway.php
@@ -165,7 +165,7 @@ abstract class Base_Gateway {
 	 * @param \WP_Ultimo\Checkout\Cart $order The order.
 	 * @return void
 	 */
-	public function set_order($order): void {
+	public function set_order($order) {
 
 		if (null === $order) {
 			return;
@@ -608,7 +608,7 @@ abstract class Base_Gateway {
 	 * @param string $gateway_payment_id The gateway payment id.
 	 * @return string
 	 */
-	public function get_payment_url_on_gateway($gateway_payment_id): string {
+	public function get_payment_url_on_gateway($gateway_payment_id) {
 		unset($gateway_payment_id);
 		return '';
 	}
@@ -623,7 +623,7 @@ abstract class Base_Gateway {
 	 * @param string $gateway_subscription_id The gateway subscription id.
 	 * @return string
 	 */
-	public function get_subscription_url_on_gateway($gateway_subscription_id): string {
+	public function get_subscription_url_on_gateway($gateway_subscription_id) {
 		unset($gateway_subscription_id);
 		return '';
 	}
@@ -638,7 +638,7 @@ abstract class Base_Gateway {
 	 * @param string $gateway_customer_id The gateway customer id.
 	 * @return string
 	 */
-	public function get_customer_url_on_gateway($gateway_customer_id): string {
+	public function get_customer_url_on_gateway($gateway_customer_id) {
 		unset($gateway_customer_id);
 		return '';
 	}
@@ -853,7 +853,7 @@ abstract class Base_Gateway {
 	 * @param \WP_Ultimo\Models\Payment $payment The payment.
 	 * @return void
 	 */
-	public function set_payment($payment): void {
+	public function set_payment($payment) {
 
 		$this->payment = $payment;
 	}
@@ -865,7 +865,7 @@ abstract class Base_Gateway {
 	 * @param \WP_Ultimo\Models\Membership $membership The membership.
 	 * @return void
 	 */
-	public function set_membership($membership): void {
+	public function set_membership($membership) {
 
 		$this->membership = $membership;
 	}
@@ -877,7 +877,7 @@ abstract class Base_Gateway {
 	 * @param \WP_Ultimo\Models\Customer $customer The customer.
 	 * @return void
 	 */
-	public function set_customer($customer): void {
+	public function set_customer($customer) {
 
 		$this->customer = $customer;
 	}
@@ -891,7 +891,7 @@ abstract class Base_Gateway {
 	 * @param \WP_Ultimo\Models\Membership $membership The membership object.
 	 * @return void
 	 */
-	public function trigger_payment_processed($payment, $membership = null): void {
+	public function trigger_payment_processed($payment, $membership = null) {
 
 		if (null === $membership) {
 			$membership = $payment->get_membership();


### PR DESCRIPTION
## Summary

- Removes return type declarations from abstract methods in `Base_Gateway` that external gateway plugins may override without matching return types
- PHP fatals when a subclass overrides a method without the return type declared in the parent — removing types from the abstract base restores compatibility
- Concrete implementations (`Base_Stripe_Gateway`, `Base_PayPal_Gateway`) retain their return type declarations

## Files Changed

- `inc/gateways/class-base-gateway.php` — remove `: void` and `: string` from 8 abstract method signatures

## Methods Affected

- `set_order()`
- `get_payment_url_on_gateway()`
- `get_subscription_url_on_gateway()`
- `get_customer_url_on_gateway()`
- `set_payment()`
- `set_membership()`
- `set_customer()`
- `trigger_payment_processed()`


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.6.235 plugin for [OpenCode](https://opencode.ai) v1.3.16 with claude-sonnet-4-6 spent 7m and 19,647 tokens on this as a headless worker.