### PR TITLE
fix: remove return type declarations from base classes to restore addon compatibility

### DIFF
--- a/inc/checkout/signup-fields/class-base-signup-field.php
+++ b/inc/checkout/signup-fields/class-base-signup-field.php
@@ -244,7 +244,7 @@ abstract class Base_Signup_Field {
 	 * @param array $attributes Array containing settings for the field.
 	 * @return void
 	 */
-	public function set_attributes($attributes): void {
+	public function set_attributes($attributes) {
 
 		$this->attributes = $attributes;
 	}

--- a/inc/gateways/class-base-gateway.php
+++ b/inc/gateways/class-base-gateway.php
@@ -209,7 +209,7 @@ abstract class Base_Gateway {
 	 * @param \WP_Ultimo\Models\Membership $membership The membership.
 	 * @return array{brand: string, last4: string}|null Payment method info, or null.
 	 */
-	public function get_payment_method_display($membership): ?array {
+	public function get_payment_method_display($membership) {
 		unset($membership);
 		return null;
 	}
@@ -568,7 +568,7 @@ abstract class Base_Gateway {
 	 * @since 2.0.0
 	 * @return bool
 	 */
-	public function supports_payment_polling(): bool {
+	public function supports_payment_polling() {
 
 		return false;
 	}
@@ -589,7 +589,7 @@ abstract class Base_Gateway {
 	 * @param int $payment_id The local payment ID to verify.
 	 * @return array{success: bool, status: string, message: string}
 	 */
-	public function verify_and_complete_payment(int $payment_id): array {
+	public function verify_and_complete_payment($payment_id) {
 
 		return [
 			'success' => false,
@@ -816,7 +816,7 @@ abstract class Base_Gateway {
 	 * @param string $message The error message.
 	 * @return void
 	 */
-	public function redirect_with_error(string $message): void {
+	public function redirect_with_error($message) {
 
 		$url = remove_query_arg(['wu-confirm', 'payment', 'token', 'PayerID', 'ba_token', 'subscription_id', 'status'], $this->return_url ?: wu_get_current_url());
 

--- a/inc/gateways/class-base-gateway.php
+++ b/inc/gateways/class-base-gateway.php
@@ -165,7 +165,7 @@ abstract class Base_Gateway {
 	 * @param \WP_Ultimo\Checkout\Cart $order The order.
 	 * @return void
 	 */
-	public function set_order($order): void {
+	public function set_order($order) {
 
 		if (null === $order) {
 			return;
@@ -608,7 +608,7 @@ abstract class Base_Gateway {
 	 * @param string $gateway_payment_id The gateway payment id.
 	 * @return string
 	 */
-	public function get_payment_url_on_gateway($gateway_payment_id): string {
+	public function get_payment_url_on_gateway($gateway_payment_id) {
 		unset($gateway_payment_id);
 		return '';
 	}
@@ -623,7 +623,7 @@ abstract class Base_Gateway {
 	 * @param string $gateway_subscription_id The gateway subscription id.
 	 * @return string
 	 */
-	public function get_subscription_url_on_gateway($gateway_subscription_id): string {
+	public function get_subscription_url_on_gateway($gateway_subscription_id) {
 		unset($gateway_subscription_id);
 		return '';
 	}
@@ -638,7 +638,7 @@ abstract class Base_Gateway {
 	 * @param string $gateway_customer_id The gateway customer id.
 	 * @return string
 	 */
-	public function get_customer_url_on_gateway($gateway_customer_id): string {
+	public function get_customer_url_on_gateway($gateway_customer_id) {
 		unset($gateway_customer_id);
 		return '';
 	}
@@ -853,7 +853,7 @@ abstract class Base_Gateway {
 	 * @param \WP_Ultimo\Models\Payment $payment The payment.
 	 * @return void
 	 */
-	public function set_payment($payment): void {
+	public function set_payment($payment) {
 
 		$this->payment = $payment;
 	}
@@ -865,7 +865,7 @@ abstract class Base_Gateway {
 	 * @param \WP_Ultimo\Models\Membership $membership The membership.
 	 * @return void
 	 */
-	public function set_membership($membership): void {
+	public function set_membership($membership) {
 
 		$this->membership = $membership;
 	}
@@ -877,7 +877,7 @@ abstract class Base_Gateway {
 	 * @param \WP_Ultimo\Models\Customer $customer The customer.
 	 * @return void
 	 */
-	public function set_customer($customer): void {
+	public function set_customer($customer) {
 
 		$this->customer = $customer;
 	}
@@ -891,7 +891,7 @@ abstract class Base_Gateway {
 	 * @param \WP_Ultimo\Models\Membership $membership The membership object.
 	 * @return void
 	 */
-	public function trigger_payment_processed($payment, $membership = null): void {
+	public function trigger_payment_processed($payment, $membership = null) {
 
 		if (null === $membership) {
 			$membership = $payment->get_membership();

--- a/inc/gateways/class-base-paypal-gateway.php
+++ b/inc/gateways/class-base-paypal-gateway.php
@@ -127,7 +127,7 @@ abstract class Base_PayPal_Gateway extends Base_Gateway {
 	 * @param string $gateway_payment_id The gateway payment id.
 	 * @return string
 	 */
-	public function get_payment_url_on_gateway($gateway_payment_id): string {
+	public function get_payment_url_on_gateway($gateway_payment_id) {
 
 		if (empty($gateway_payment_id)) {
 			return '';
@@ -152,7 +152,7 @@ abstract class Base_PayPal_Gateway extends Base_Gateway {
 	 * @param string $gateway_subscription_id The gateway subscription id.
 	 * @return string
 	 */
-	public function get_subscription_url_on_gateway($gateway_subscription_id): string {
+	public function get_subscription_url_on_gateway($gateway_subscription_id) {
 
 		if (empty($gateway_subscription_id)) {
 			return '';

--- a/inc/gateways/class-base-stripe-gateway.php
+++ b/inc/gateways/class-base-stripe-gateway.php
@@ -828,7 +828,7 @@ class Base_Stripe_Gateway extends Base_Gateway {
 	 * @param \WP_Ultimo\Models\Membership $membership The membership.
 	 * @return array{brand: string, last4: string}|null Payment method info, or null.
 	 */
-	public function get_payment_method_display($membership): ?array {
+	public function get_payment_method_display($membership) {
 
 		try {
 			$sub_id = $membership->get_gateway_subscription_id();
@@ -3832,7 +3832,7 @@ class Base_Stripe_Gateway extends Base_Gateway {
 	 * @param string $gateway_payment_id The gateway payment id.
 	 * @return string.
 	 */
-	public function get_payment_url_on_gateway($gateway_payment_id): string {
+	public function get_payment_url_on_gateway($gateway_payment_id) {
 
 		$route = $this->test_mode ? '/test' : '/';
 
@@ -3855,7 +3855,7 @@ class Base_Stripe_Gateway extends Base_Gateway {
 	 * @param string $gateway_subscription_id The gateway subscription id.
 	 * @return string.
 	 */
-	public function get_subscription_url_on_gateway($gateway_subscription_id): string {
+	public function get_subscription_url_on_gateway($gateway_subscription_id) {
 
 		$route = $this->test_mode ? '/test' : '/';
 
@@ -3872,7 +3872,7 @@ class Base_Stripe_Gateway extends Base_Gateway {
 	 * @param string $gateway_customer_id The gateway customer id.
 	 * @return string.
 	 */
-	public function get_customer_url_on_gateway($gateway_customer_id): string {
+	public function get_customer_url_on_gateway($gateway_customer_id) {
 
 		$route = $this->test_mode ? '/test' : '/';
 
@@ -3883,7 +3883,7 @@ class Base_Stripe_Gateway extends Base_Gateway {
 	 * @inheritdoc
 	 * @since 2.0.0
 	 */
-	public function supports_payment_polling(): bool {
+	public function supports_payment_polling() {
 
 		return true;
 	}
@@ -3899,7 +3899,7 @@ class Base_Stripe_Gateway extends Base_Gateway {
 	 * @param int $payment_id The local payment ID to verify.
 	 * @return array{success: bool, message: string, status?: string}
 	 */
-	public function verify_and_complete_payment(int $payment_id): array {
+	public function verify_and_complete_payment($payment_id) {
 
 		$payment = wu_get_payment($payment_id);
 

--- a/inc/gateways/class-paypal-gateway.php
+++ b/inc/gateways/class-paypal-gateway.php
@@ -1715,7 +1715,7 @@ class PayPal_Gateway extends Base_PayPal_Gateway {
 	 * @param string $gateway_payment_id The gateway payment id.
 	 * @return string
 	 */
-	public function get_payment_url_on_gateway($gateway_payment_id): string {
+	public function get_payment_url_on_gateway($gateway_payment_id) {
 
 		return '';
 	}

--- a/inc/gateways/class-paypal-rest-gateway.php
+++ b/inc/gateways/class-paypal-rest-gateway.php
@@ -2090,7 +2090,7 @@ class PayPal_REST_Gateway extends Base_PayPal_Gateway {
 	 * @inheritdoc
 	 * @since 2.0.0
 	 */
-	public function supports_payment_polling(): bool {
+	public function supports_payment_polling() {
 
 		return true;
 	}
@@ -2107,7 +2107,7 @@ class PayPal_REST_Gateway extends Base_PayPal_Gateway {
 	 * @param int $payment_id The local payment ID to verify.
 	 * @return array{success: bool, message: string, status?: string}
 	 */
-	public function verify_and_complete_payment(int $payment_id): array {
+	public function verify_and_complete_payment($payment_id) {
 
 		$payment = wu_get_payment($payment_id);
 

--- a/inc/integrations/class-base-capability-module.php
+++ b/inc/integrations/class-base-capability-module.php
@@ -45,7 +45,7 @@ abstract class Base_Capability_Module implements Capability_Module {
 	 * @param string $feature The feature identifier to check.
 	 * @return bool
 	 */
-	public function supports(string $feature): bool {
+	public function supports($feature) {
 
 		return in_array($feature, $this->supported_features, true);
 	}
@@ -58,7 +58,7 @@ abstract class Base_Capability_Module implements Capability_Module {
 	 * @param Integration $integration The parent integration instance.
 	 * @return void
 	 */
-	public function set_integration(Integration $integration): void {
+	public function set_integration(Integration $integration) {
 
 		$this->integration = $integration;
 	}
@@ -66,7 +66,7 @@ abstract class Base_Capability_Module implements Capability_Module {
 	/**
 	 * {@inheritdoc}
 	 */
-	public function get_integration(): Integration {
+	public function get_integration() {
 
 		return $this->integration;
 	}
@@ -74,7 +74,7 @@ abstract class Base_Capability_Module implements Capability_Module {
 	/**
 	 * {@inheritdoc}
 	 */
-	public function get_supported_features(): array {
+	public function get_supported_features() {
 
 		return $this->supported_features;
 	}
@@ -82,12 +82,12 @@ abstract class Base_Capability_Module implements Capability_Module {
 	/**
 	 * {@inheritdoc}
 	 */
-	public function register_hooks(): void {}
+	public function register_hooks() {}
 
 	/**
 	 * {@inheritdoc}
 	 */
-	public function get_fields(): array {
+	public function get_fields() {
 
 		return [];
 	}
@@ -95,7 +95,7 @@ abstract class Base_Capability_Module implements Capability_Module {
 	/**
 	 * {@inheritdoc}
 	 */
-	public function get_explainer_lines(): array {
+	public function get_explainer_lines() {
 
 		return [
 			'will'     => [],

--- a/inc/integrations/host-providers/class-base-host-provider.php
+++ b/inc/integrations/host-providers/class-base-host-provider.php
@@ -78,7 +78,7 @@ abstract class Base_Host_Provider implements DNS_Provider_Interface {
 	 * @since 2.0.0
 	 * @return void
 	 */
-	public function init(): void {
+	public function init() {
 
 		if ($this->detect() && ! $this->is_enabled()) {
 			/*
@@ -197,7 +197,7 @@ abstract class Base_Host_Provider implements DNS_Provider_Interface {
 	 * @since 2.0.0
 	 * @return void
 	 */
-	public function add_to_integration_list(): void {
+	public function add_to_integration_list() {
 
 		$slug = $this->get_id();
 
@@ -237,7 +237,7 @@ abstract class Base_Host_Provider implements DNS_Provider_Interface {
 	 * @since 2.0.0
 	 * @return void
 	 */
-	public function alert_provider_detected(): void {
+	public function alert_provider_detected() {
 
 		if (WP_Ultimo()->is_loaded() === false) {
 			return;
@@ -270,7 +270,7 @@ abstract class Base_Host_Provider implements DNS_Provider_Interface {
 	 * @since 2.0.0
 	 * @return void
 	 */
-	public function alert_provider_not_setup(): void {
+	public function alert_provider_not_setup() {
 
 		if (WP_Ultimo()->is_loaded() === false) {
 			return;
@@ -349,7 +349,7 @@ abstract class Base_Host_Provider implements DNS_Provider_Interface {
 	 * @since 2.0.0
 	 * @return void
 	 */
-	public function register_hooks(): void {
+	public function register_hooks() {
 		/*
 		 * Hooks the event that is triggered when a new domain is added.
 		 */
@@ -494,7 +494,7 @@ abstract class Base_Host_Provider implements DNS_Provider_Interface {
 	 * @param array $constant_values Key => Value of the necessary constants.
 	 * @return void
 	 */
-	public function setup_constants($constant_values): void {
+	public function setup_constants($constant_values) {
 		/*
 		 * Important: This step is crucial, as it makes sure we clean up undesired constants.
 		 * Removing this can allow insertion of arbitrary constants onto the wp-config.pp file
@@ -631,7 +631,7 @@ abstract class Base_Host_Provider implements DNS_Provider_Interface {
 	 * @since 2.0.0
 	 * @return void
 	 */
-	public function test_connection(): void {
+	public function test_connection() {
 
 		wp_send_json_success([]);
 	}
@@ -664,7 +664,7 @@ abstract class Base_Host_Provider implements DNS_Provider_Interface {
 	 * @since 2.3.0
 	 * @return bool
 	 */
-	public function supports_dns_management(): bool {
+	public function supports_dns_management() {
 
 		return $this->supports('dns-management');
 	}
@@ -752,7 +752,7 @@ abstract class Base_Host_Provider implements DNS_Provider_Interface {
 	 *
 	 * @return array Array of supported record types.
 	 */
-	public function get_supported_record_types(): array {
+	public function get_supported_record_types() {
 
 		return ['A', 'AAAA', 'CNAME', 'MX', 'TXT'];
 	}
@@ -768,7 +768,7 @@ abstract class Base_Host_Provider implements DNS_Provider_Interface {
 	 * @param string $domain The domain name.
 	 * @return string|null Zone identifier or null if not found.
 	 */
-	public function get_zone_id(string $domain): ?string {
+	public function get_zone_id($domain) {
 
 		return null;
 	}
@@ -782,7 +782,7 @@ abstract class Base_Host_Provider implements DNS_Provider_Interface {
 	 *
 	 * @return bool
 	 */
-	public function is_dns_enabled(): bool {
+	public function is_dns_enabled() {
 
 		if (! $this->supports_dns_management()) {
 			return false;
@@ -801,7 +801,7 @@ abstract class Base_Host_Provider implements DNS_Provider_Interface {
 	 *
 	 * @return bool
 	 */
-	public function enable_dns(): bool {
+	public function enable_dns() {
 
 		if (! $this->supports_dns_management()) {
 			return false;
@@ -820,7 +820,7 @@ abstract class Base_Host_Provider implements DNS_Provider_Interface {
 	 *
 	 * @return bool
 	 */
-	public function disable_dns(): bool {
+	public function disable_dns() {
 
 		$dns_enabled                    = get_network_option(null, 'wu_dns_integrations_enabled', []);
 		$dns_enabled[ $this->get_id() ] = false;

--- a/inc/integrations/host-providers/class-cloudflare-host-provider.php
+++ b/inc/integrations/host-providers/class-cloudflare-host-provider.php
@@ -180,7 +180,7 @@ class Cloudflare_Host_Provider extends Base_Host_Provider {
 	 * @since 2.0.0
 	 * @return void
 	 */
-	public function test_connection(): void {
+	public function test_connection() {
 
 		$results = $this->cloudflare_api_call('client/v4/user/tokens/verify');
 
@@ -197,7 +197,7 @@ class Cloudflare_Host_Provider extends Base_Host_Provider {
 	 * @since 2.0.7
 	 * @return void
 	 */
-	public function additional_hooks(): void {
+	public function additional_hooks() {
 
 		add_filter('wu_domain_dns_get_record', [$this, 'add_cloudflare_dns_entries'], 10, 2);
 	}
@@ -232,7 +232,7 @@ class Cloudflare_Host_Provider extends Base_Host_Provider {
 	 * @param int    $site_id ID of the site that is receiving that mapping.
 	 * @return void
 	 */
-	public function on_add_subdomain($subdomain, $site_id): void {
+	public function on_add_subdomain($subdomain, $site_id) {
 
 		global $current_site;
 
@@ -309,7 +309,7 @@ class Cloudflare_Host_Provider extends Base_Host_Provider {
 	 * @param int    $site_id ID of the site that is receiving that mapping.
 	 * @return void
 	 */
-	public function on_remove_subdomain($subdomain, $site_id): void {
+	public function on_remove_subdomain($subdomain, $site_id) {
 
 		global $current_site;
 
@@ -706,7 +706,7 @@ class Cloudflare_Host_Provider extends Base_Host_Provider {
 	 * @param string $domain The domain name.
 	 * @return string|null Zone ID or null if not found.
 	 */
-	public function get_zone_id(string $domain): ?string {
+	public function get_zone_id($domain) {
 
 		// Try configured zone first
 		$default_zone = defined('WU_CLOUDFLARE_ZONE_ID') && WU_CLOUDFLARE_ZONE_ID ? WU_CLOUDFLARE_ZONE_ID : null;
@@ -789,7 +789,7 @@ class Cloudflare_Host_Provider extends Base_Host_Provider {
 	 * @since 2.0.0
 	 * @return void
 	 */
-	public function get_instructions(): void {
+	public function get_instructions() {
 
 		wu_get_template('wizards/host-integrations/cloudflare-instructions');
 	}

--- a/inc/integrations/host-providers/class-cpanel-host-provider.php
+++ b/inc/integrations/host-providers/class-cpanel-host-provider.php
@@ -145,7 +145,7 @@ class CPanel_Host_Provider extends Base_Host_Provider {
 	 * @param int    $site_id ID of the site that is receiving that mapping.
 	 * @return void
 	 */
-	public function on_add_domain($domain, $site_id): void {
+	public function on_add_domain($domain, $site_id) {
 
 		// Root Directory
 		$root_dir = defined('WU_CPANEL_ROOT_DIR') && WU_CPANEL_ROOT_DIR ? WU_CPANEL_ROOT_DIR : '/public_html';
@@ -172,7 +172,7 @@ class CPanel_Host_Provider extends Base_Host_Provider {
 	 * @param int    $site_id ID of the site that is receiving that mapping.
 	 * @return void
 	 */
-	public function on_remove_domain($domain, $site_id): void {
+	public function on_remove_domain($domain, $site_id) {
 
 		// Send Request
 		$results = $this->load_api()->api2(
@@ -197,7 +197,7 @@ class CPanel_Host_Provider extends Base_Host_Provider {
 	 * @param int    $site_id ID of the site that is receiving that mapping.
 	 * @return void
 	 */
-	public function on_add_subdomain($subdomain, $site_id): void {
+	public function on_add_subdomain($subdomain, $site_id) {
 
 		// Root Directory
 		$root_dir = defined('WU_CPANEL_ROOT_DIR') && WU_CPANEL_ROOT_DIR ? WU_CPANEL_ROOT_DIR : '/public_html';
@@ -657,7 +657,7 @@ class CPanel_Host_Provider extends Base_Host_Provider {
 	 * @since 2.0.0
 	 * @return void
 	 */
-	public function test_connection(): void {
+	public function test_connection() {
 
 		$results = $this->load_api()->api2('Cron', 'fetchcron', []);
 

--- a/inc/integrations/host-providers/class-hestia-host-provider.php
+++ b/inc/integrations/host-providers/class-hestia-host-provider.php
@@ -141,7 +141,7 @@ class Hestia_Host_Provider extends Base_Host_Provider {
 	 * @param string $domain  Domain name to add.
 	 * @param int    $site_id Site ID.
 	 */
-	public function on_add_domain($domain, $site_id): void {
+	public function on_add_domain($domain, $site_id) {
 
 		$account     = defined('WU_HESTIA_ACCOUNT') ? WU_HESTIA_ACCOUNT : '';
 		$base_domain = defined('WU_HESTIA_WEB_DOMAIN') ? WU_HESTIA_WEB_DOMAIN : '';
@@ -168,7 +168,7 @@ class Hestia_Host_Provider extends Base_Host_Provider {
 	 * @param string $domain  Domain name to remove.
 	 * @param int    $site_id Site ID.
 	 */
-	public function on_remove_domain($domain, $site_id): void {
+	public function on_remove_domain($domain, $site_id) {
 
 		$account     = defined('WU_HESTIA_ACCOUNT') ? WU_HESTIA_ACCOUNT : '';
 		$base_domain = defined('WU_HESTIA_WEB_DOMAIN') ? WU_HESTIA_WEB_DOMAIN : '';
@@ -208,7 +208,7 @@ class Hestia_Host_Provider extends Base_Host_Provider {
 	/**
 	 * Test connection by listing web domains for the configured account.
 	 */
-	public function test_connection(): void {
+	public function test_connection() {
 
 		$account = defined('WU_HESTIA_ACCOUNT') ? WU_HESTIA_ACCOUNT : '';
 
@@ -246,7 +246,7 @@ class Hestia_Host_Provider extends Base_Host_Provider {
 	 * @param string $action_label Log label.
 	 * @return void
 	 */
-	protected function call_and_log($cmd, $args, $action_label): void {
+	protected function call_and_log($cmd, $args, $action_label) {
 
 		$result = $this->send_hestia_request($cmd, $args);
 

--- a/inc/integrations/host-providers/interface-dns-provider.php
+++ b/inc/integrations/host-providers/interface-dns-provider.php
@@ -31,7 +31,7 @@ interface DNS_Provider_Interface {
 	 *
 	 * @return bool True if DNS management is supported.
 	 */
-	public function supports_dns_management(): bool;
+	public function supports_dns_management();
 
 	/**
 	 * Check if DNS management is enabled for this provider.
@@ -40,7 +40,7 @@ interface DNS_Provider_Interface {
 	 *
 	 * @return bool True if DNS management is enabled.
 	 */
-	public function is_dns_enabled(): bool;
+	public function is_dns_enabled();
 
 	/**
 	 * Enable DNS management for this provider.
@@ -49,7 +49,7 @@ interface DNS_Provider_Interface {
 	 *
 	 * @return bool True on success.
 	 */
-	public function enable_dns(): bool;
+	public function enable_dns();
 
 	/**
 	 * Disable DNS management for this provider.
@@ -58,7 +58,7 @@ interface DNS_Provider_Interface {
 	 *
 	 * @return bool True on success.
 	 */
-	public function disable_dns(): bool;
+	public function disable_dns();
 
 	/**
 	 * Get DNS records for a domain.
@@ -111,5 +111,5 @@ interface DNS_Provider_Interface {
 	 *
 	 * @return array Array of supported record types (e.g., ['A', 'AAAA', 'CNAME', 'MX', 'TXT']).
 	 */
-	public function get_supported_record_types(): array;
+	public function get_supported_record_types();
 }

--- a/inc/integrations/interface-capability-module.php
+++ b/inc/integrations/interface-capability-module.php
@@ -30,7 +30,7 @@ interface Capability_Module {
 	 * @since 2.5.0
 	 * @return string E.g. 'domain-mapping', 'domain-selling', 'multi-tenancy'.
 	 */
-	public function get_capability_id(): string;
+	public function get_capability_id();
 
 	/**
 	 * Returns the display title for this capability.
@@ -38,7 +38,7 @@ interface Capability_Module {
 	 * @since 2.5.0
 	 * @return string
 	 */
-	public function get_title(): string;
+	public function get_title();
 
 	/**
 	 * Returns the list of supported features.
@@ -46,7 +46,7 @@ interface Capability_Module {
 	 * @since 2.5.0
 	 * @return array E.g. ['autossl'], ['remote_sites'].
 	 */
-	public function get_supported_features(): array;
+	public function get_supported_features();
 
 	/**
 	 * Checks if a specific feature is supported.
@@ -56,7 +56,7 @@ interface Capability_Module {
 	 * @param string $feature Feature identifier to check.
 	 * @return bool
 	 */
-	public function supports(string $feature): bool;
+	public function supports($feature);
 
 	/**
 	 * Registers WordPress hooks for this capability.
@@ -64,7 +64,7 @@ interface Capability_Module {
 	 * @since 2.5.0
 	 * @return void
 	 */
-	public function register_hooks(): void;
+	public function register_hooks();
 
 	/**
 	 * Returns additional wizard fields beyond shared integration credentials.
@@ -72,7 +72,7 @@ interface Capability_Module {
 	 * @since 2.5.0
 	 * @return array
 	 */
-	public function get_fields(): array;
+	public function get_fields();
 
 	/**
 	 * Returns explainer lines for the wizard activation screen.
@@ -80,7 +80,7 @@ interface Capability_Module {
 	 * @since 2.5.0
 	 * @return array{will: array, will_not: array}
 	 */
-	public function get_explainer_lines(): array;
+	public function get_explainer_lines();
 
 	/**
 	 * Sets the parent integration reference.
@@ -90,7 +90,7 @@ interface Capability_Module {
 	 * @param Integration $integration The parent integration.
 	 * @return void
 	 */
-	public function set_integration(Integration $integration): void;
+	public function set_integration(Integration $integration);
 
 	/**
 	 * Gets the parent integration reference.
@@ -98,7 +98,7 @@ interface Capability_Module {
 	 * @since 2.5.0
 	 * @return Integration
 	 */
-	public function get_integration(): Integration;
+	public function get_integration();
 
 	/**
 	 * Tests the connection for this capability.

--- a/inc/models/class-base-model.php
+++ b/inc/models/class-base-model.php
@@ -166,7 +166,7 @@ abstract class Base_Model implements \JsonSerializable {
 	 *
 	 * @param mixed $slug The slug.
 	 */
-	public function set_slug($slug): void {
+	public function set_slug($slug) {
 
 		$this->slug = $slug;
 	}
@@ -952,7 +952,7 @@ abstract class Base_Model implements \JsonSerializable {
 	 * @param string $date_created Model creation date.
 	 * @return void
 	 */
-	public function set_date_created($date_created): void {
+	public function set_date_created($date_created) {
 
 		$this->date_created = $date_created;
 	}
@@ -964,7 +964,7 @@ abstract class Base_Model implements \JsonSerializable {
 	 * @param string $date_modified Model last modification date.
 	 * @return void
 	 */
-	public function set_date_modified($date_modified): void {
+	public function set_date_modified($date_modified) {
 
 		$this->date_modified = $date_modified;
 	}
@@ -987,7 +987,7 @@ abstract class Base_Model implements \JsonSerializable {
 	 * @param int $migrated_from_id The ID of the original 1.X model that was used to generate this item on migration.
 	 * @return void
 	 */
-	public function set_migrated_from_id($migrated_from_id): void {
+	public function set_migrated_from_id($migrated_from_id) {
 
 		$this->migrated_from_id = absint($migrated_from_id);
 	}
@@ -1093,7 +1093,7 @@ abstract class Base_Model implements \JsonSerializable {
 	 * @since 2.0.0
 	 * @return void
 	 */
-	public function hydrate(): void {
+	public function hydrate() {
 
 		$attributes = get_object_vars($this);
 		$attributes = array_filter($attributes, fn ($value) => null === $value);
@@ -1127,7 +1127,7 @@ abstract class Base_Model implements \JsonSerializable {
 	 * @param boolean $skip_validation Set true to have field information validation bypassed when saving this event.
 	 * @return void
 	 */
-	public function set_skip_validation($skip_validation = false): void {
+	public function set_skip_validation($skip_validation = false) {
 
 		$this->skip_validation = $skip_validation;
 	}

--- a/inc/ui/class-account-summary-element.php
+++ b/inc/ui/class-account-summary-element.php
@@ -290,7 +290,7 @@ class Account_Summary_Element extends Base_Element {
 	 * @param string|null $content The content inside the shortcode.
 	 * @return void
 	 */
-	public function output($atts, $content = null): void {
+	public function output($atts, $content = null) {
 
 		$this->ensure_setup();
 

--- a/inc/ui/class-base-element.php
+++ b/inc/ui/class-base-element.php
@@ -207,7 +207,7 @@ abstract class Base_Element {
 	 * @param string|null $content The content inside the shortcode.
 	 * @return void
 	 */
-	abstract public function output($atts, $content = null): void;
+	abstract public function output($atts, $content = null);
 
 	// Boilerplate -----------------------------------
 
@@ -217,7 +217,7 @@ abstract class Base_Element {
 	 * @since 2.0.0
 	 * @return void
 	 */
-	public function init(): void {
+	public function init() {
 
 		add_action('plugins_loaded', [$this, 'register_form']);
 
@@ -258,7 +258,7 @@ abstract class Base_Element {
 	 * @param mixed $element The element instance to be registered.
 	 * @return void
 	 */
-	public static function register_public_element($element): void {
+	public static function register_public_element($element) {
 
 		static::$public_elements[] = $element;
 	}
@@ -387,7 +387,7 @@ abstract class Base_Element {
 	 * @since 2.0.0
 	 * @return void
 	 */
-	public function setup_for_admin(): void {
+	public function setup_for_admin() {
 
 		if (true === $this->loaded) {
 			return;
@@ -409,7 +409,7 @@ abstract class Base_Element {
 	 * @since 2.0.0
 	 * @return void
 	 */
-	public function maybe_setup(): void {
+	public function maybe_setup() {
 
 		global $post;
 
@@ -590,7 +590,7 @@ abstract class Base_Element {
 	 * @since 2.0.0
 	 * @return void
 	 */
-	public function enqueue_element_scripts(): void {
+	public function enqueue_element_scripts() {
 
 		global $post;
 
@@ -644,7 +644,7 @@ abstract class Base_Element {
 	 * @since 2.0.0
 	 * @return void
 	 */
-	public function register_shortcode(): void {
+	public function register_shortcode() {
 
 		if (wu_get_current_site()->get_type() === Site_Type::CUSTOMER_OWNED && is_admin() === false) {
 			return;
@@ -659,7 +659,7 @@ abstract class Base_Element {
 	 * @since 2.0.0
 	 * @return void
 	 */
-	public function register_form(): void {
+	public function register_form() {
 		/*
 		 * Add Generator Forms
 		 */
@@ -691,7 +691,7 @@ abstract class Base_Element {
 	 * @since 2.0.0
 	 * @return void
 	 */
-	public function render_generator_modal(): void {
+	public function render_generator_modal() {
 
 		$fields = $this->fields();
 
@@ -806,7 +806,7 @@ abstract class Base_Element {
 	 * @since 2.0.0
 	 * @return void
 	 */
-	public function render_customize_modal(): void {
+	public function render_customize_modal() {
 
 		$fields = [];
 
@@ -890,7 +890,7 @@ abstract class Base_Element {
 	 * @since 2.0.0
 	 * @return void
 	 */
-	public function handle_customize_modal(): void {
+	public function handle_customize_modal() {
 
 		$settings = [];
 
@@ -931,7 +931,7 @@ abstract class Base_Element {
 	 * @since 2.0.0
 	 * @return void
 	 */
-	public function register_default_scripts(): void {
+	public function register_default_scripts() {
 
 		wp_enqueue_style('wu-admin');
 	}
@@ -1012,7 +1012,7 @@ abstract class Base_Element {
 	 *
 	 * @return string
 	 */
-	public function get_content($atts): string {
+	public function get_content($atts) {
 		ob_start();
 		$this->display($atts);
 		return ob_get_clean();
@@ -1076,7 +1076,7 @@ abstract class Base_Element {
 	 * @param array  $atts Array containing the shortcode attributes.
 	 * @return void
 	 */
-	public function as_inline_content($screen_id, $hook = 'admin_notices', $atts = []): void {
+	public function as_inline_content($screen_id, $hook = 'admin_notices', $atts = []) {
 
 		if ( ! function_exists('get_current_screen')) {
 			_doing_it_wrong(__METHOD__, esc_html__('An element can not be loaded as inline content unless the get_current_screen() function is already available.', 'ultimate-multisite'), '2.0.0');
@@ -1143,7 +1143,7 @@ abstract class Base_Element {
 	 * @param array $settings The settings to save. Key => value array.
 	 * @return void
 	 */
-	public function save_widget_settings($settings): void {
+	public function save_widget_settings($settings) {
 
 		$key = wu_replace_dashes($this->id);
 
@@ -1173,7 +1173,7 @@ abstract class Base_Element {
 	 * @param array  $atts Array containing the shortcode attributes.
 	 * @return void
 	 */
-	public function as_metabox($screen_id, $position = 'normal', $atts = []): void {
+	public function as_metabox($screen_id, $position = 'normal', $atts = []) {
 
 		$this->setup();
 
@@ -1226,7 +1226,7 @@ abstract class Base_Element {
 	 * @since 2.0.0
 	 * @return void
 	 */
-	public function super_admin_notice(): void {
+	public function super_admin_notice() {
 
 		$should_display = $this->should_display_customize_controls();
 
@@ -1286,7 +1286,7 @@ abstract class Base_Element {
 	 * @param boolean $display Controls whether or not the widget and element should display.
 	 * @return void
 	 */
-	public function set_display($display): void {
+	public function set_display($display) {
 
 		$this->display = $display;
 	}

--- a/inc/ui/class-billing-info-element.php
+++ b/inc/ui/class-billing-info-element.php
@@ -82,7 +82,7 @@ class Billing_Info_Element extends Base_Element {
 	 * @since 2.0.0
 	 * @return void
 	 */
-	public function init(): void {
+	public function init() {
 
 		parent::init();
 
@@ -268,7 +268,7 @@ class Billing_Info_Element extends Base_Element {
 	 * @param string|null $content The content inside the shortcode.
 	 * @return string
 	 */
-	public function output($atts, $content = null): void {
+	public function output($atts, $content = null) {
 
 		$this->ensure_setup();
 

--- a/inc/ui/class-checkout-element.php
+++ b/inc/ui/class-checkout-element.php
@@ -696,7 +696,7 @@ class Checkout_Element extends Base_Element {
 	 * @param string|null $content The content inside the shortcode.
 	 * @return void
 	 */
-	public function output($atts, $content = null): void {
+	public function output($atts, $content = null) {
 
 		if (wu_is_update_page()) {
 			$atts = [

--- a/inc/ui/class-command-palette-manager.php
+++ b/inc/ui/class-command-palette-manager.php
@@ -37,7 +37,7 @@ class Command_Palette_Manager {
 	 * @since 2.1.0
 	 * @return void
 	 */
-	public function init(): void {
+	public function init() {
 
 		add_action('admin_enqueue_scripts', [$this, 'enqueue_scripts'], 100);
 

--- a/inc/ui/class-current-membership-element.php
+++ b/inc/ui/class-current-membership-element.php
@@ -66,7 +66,7 @@ class Current_Membership_Element extends Base_Element {
 	 * @since 2.0.0
 	 * @return void
 	 */
-	public function init(): void {
+	public function init() {
 
 		parent::init();
 
@@ -298,7 +298,7 @@ class Current_Membership_Element extends Base_Element {
 	 * @param string|null $content The content inside the shortcode.
 	 * @return void
 	 */
-	public function output($atts, $content = null): void {
+	public function output($atts, $content = null) {
 
 		$atts['membership'] = $this->membership;
 		$atts['plan']       = $this->plan;

--- a/inc/ui/class-current-site-element.php
+++ b/inc/ui/class-current-site-element.php
@@ -82,7 +82,7 @@ class Current_Site_Element extends Base_Element {
 	 * @since 2.0.0
 	 * @return void
 	 */
-	public function init(): void {
+	public function init() {
 
 		parent::init();
 
@@ -350,7 +350,7 @@ class Current_Site_Element extends Base_Element {
 	 * @param string|null $content The content inside the shortcode.
 	 * @return void
 	 */
-	public function output($atts, $content = null): void {
+	public function output($atts, $content = null) {
 
 		$this->ensure_setup();
 

--- a/inc/ui/class-domain-mapping-element.php
+++ b/inc/ui/class-domain-mapping-element.php
@@ -203,7 +203,7 @@ class Domain_Mapping_Element extends Base_Element {
 	 * @since 2.0.0
 	 * @return void
 	 */
-	public function init(): void {
+	public function init() {
 
 		parent::init();
 
@@ -1095,7 +1095,7 @@ class Domain_Mapping_Element extends Base_Element {
 	 * @param string|null $content The content inside the shortcode.
 	 * @return void
 	 */
-	public function output($atts, $content = null): void {
+	public function output($atts, $content = null) {
 
 		$current_site = $this->site;
 

--- a/inc/ui/class-invoices-element.php
+++ b/inc/ui/class-invoices-element.php
@@ -270,7 +270,7 @@ class Invoices_Element extends Base_Element {
 	 * @param string|null $content The content inside the shortcode.
 	 * @return void
 	 */
-	public function output($atts, $content = null): void {
+	public function output($atts, $content = null) {
 
 		$this->ensure_setup();
 

--- a/inc/ui/class-limits-element.php
+++ b/inc/ui/class-limits-element.php
@@ -236,7 +236,7 @@ class Limits_Element extends Base_Element {
 	 * @param string|null $content The content inside the shortcode.
 	 * @return void
 	 */
-	public function output($atts, $content = null): void {
+	public function output($atts, $content = null) {
 
 		$this->ensure_setup();
 

--- a/inc/ui/class-login-form-element.php
+++ b/inc/ui/class-login-form-element.php
@@ -60,7 +60,7 @@ class Login_Form_Element extends Base_Element {
 	 * @since 2.0.11
 	 * @return void
 	 */
-	public function init(): void {
+	public function init() {
 
 		// Handle login redirection
 		add_filter('login_redirect', [$this, 'handle_redirect'], -1, 3);
@@ -582,7 +582,7 @@ class Login_Form_Element extends Base_Element {
 	 * @param string|null $content The content inside the shortcode.
 	 * @return void
 	 */
-	public function output($atts, $content = null): void {
+	public function output($atts, $content = null) {
 
 		$view = 'dashboard-widgets/login-additional-forms';
 

--- a/inc/ui/class-magic-link-url-element.php
+++ b/inc/ui/class-magic-link-url-element.php
@@ -373,7 +373,7 @@ class Magic_Link_Url_Element extends Base_Element {
 	 * @param string|null          $content The content inside the shortcode.
 	 * @return void
 	 */
-	public function output($atts, $content = null): void {
+	public function output($atts, $content = null) {
 
 		$this->ensure_setup();
 

--- a/inc/ui/class-my-sites-element.php
+++ b/inc/ui/class-my-sites-element.php
@@ -321,7 +321,7 @@ class My_Sites_Element extends Base_Element {
 	 * @param string|null $content The content inside the shortcode.
 	 * @return void
 	 */
-	public function output($atts, $content = null): void {
+	public function output($atts, $content = null) {
 
 		$atts['customer'] = $this->customer;
 

--- a/inc/ui/class-payment-methods-element.php
+++ b/inc/ui/class-payment-methods-element.php
@@ -185,7 +185,7 @@ class Payment_Methods_Element extends Base_Element {
 	 * @param string|null $content The content inside the shortcode.
 	 * @return void
 	 */
-	public function output($atts, $content = null): void {
+	public function output($atts, $content = null) {
 
 		$gateway_id      = $this->membership ? $this->membership->get_gateway() : '';
 		$gateway         = $gateway_id ? wu_get_gateway($gateway_id) : null;

--- a/inc/ui/class-simple-text-element.php
+++ b/inc/ui/class-simple-text-element.php
@@ -215,7 +215,7 @@ class Simple_Text_Element extends Base_Element {
 	 * @param string|null $content The content inside the shortcode.
 	 * @return void
 	 */
-	public function output($atts, $content = null): void {
+	public function output($atts, $content = null) {
 
 		wu_get_template('dashboard-widgets/simple-text', $atts);
 	}

--- a/inc/ui/class-site-actions-element.php
+++ b/inc/ui/class-site-actions-element.php
@@ -303,7 +303,7 @@ class Site_Actions_Element extends Base_Element {
 	 * @since 2.0.21
 	 * @return void
 	 */
-	public function init(): void {
+	public function init() {
 
 		parent::init();
 
@@ -1554,7 +1554,7 @@ class Site_Actions_Element extends Base_Element {
 	 * @param string|null $content The content inside the shortcode.
 	 * @return void
 	 */
-	public function output($atts, $content = null): void {
+	public function output($atts, $content = null) {
 
 		$atts['actions'] = $this->get_actions($atts);
 

--- a/inc/ui/class-site-maintenance-element.php
+++ b/inc/ui/class-site-maintenance-element.php
@@ -52,7 +52,7 @@ class Site_Maintenance_Element extends Base_Element {
 	 * @since 2.0.0
 	 * @return void
 	 */
-	public function init(): void {
+	public function init() {
 
 		if (wu_get_setting('maintenance_mode')) {
 			parent::init();
@@ -266,7 +266,7 @@ class Site_Maintenance_Element extends Base_Element {
 	 * @param string|null $content The content inside the shortcode.
 	 * @return void
 	 */
-	public function output($atts, $content = null): void {
+	public function output($atts, $content = null) {
 
 		$fields = [
 			'maintenance_mode' => [

--- a/inc/ui/class-template-previewer.php
+++ b/inc/ui/class-template-previewer.php
@@ -42,7 +42,7 @@ class Template_Previewer {
 	 * @since 2.0.0
 	 * @return void
 	 */
-	public function init(): void {
+	public function init() {
 
 		add_action('plugins_loaded', [$this, 'hooks']);
 	}

--- a/inc/ui/class-template-switching-element.php
+++ b/inc/ui/class-template-switching-element.php
@@ -101,7 +101,7 @@ class Template_Switching_Element extends Base_Element {
 	 * @since 2.0.0
 	 * @return void
 	 */
-	public function init(): void {
+	public function init() {
 
 		add_action('wu_ajax_wu_switch_template', [$this, 'switch_template']);
 
@@ -324,7 +324,7 @@ class Template_Switching_Element extends Base_Element {
 	 * @param string|null $content The content inside the shortcode.
 	 * @return void
 	 */
-	public function output($atts, $content = null): void {
+	public function output($atts, $content = null) {
 
 		if ($this->site) {
 			$filter_template_limits = \WP_Ultimo\Limits\Site_Template_Limits::get_instance();

--- a/inc/ui/class-thank-you-element.php
+++ b/inc/ui/class-thank-you-element.php
@@ -366,7 +366,7 @@ class Thank_You_Element extends Base_Element {
 	 * @param string|null $content The content inside the shortcode.
 	 * @return void
 	 */
-	public function output($atts, $content = null): void {
+	public function output($atts, $content = null) {
 
 		$atts['payment'] = $this->payment;
 

--- a/inc/ui/class-toolbox.php
+++ b/inc/ui/class-toolbox.php
@@ -27,7 +27,7 @@ class Toolbox {
 	 * @since 2.0.0
 	 * @return void
 	 */
-	public function init(): void {
+	public function init() {
 
 		add_action('init', [$this, 'load_toolbox']);
 	}
@@ -85,7 +85,7 @@ class Toolbox {
 	 * @since 2.0.0
 	 * @return void
 	 */
-	public function output(): void {
+	public function output() {
 
 		$current_site = wu_get_current_site();
 

--- a/inc/ui/class-tours.php
+++ b/inc/ui/class-tours.php
@@ -35,7 +35,7 @@ class Tours {
 	 * @since 2.0.0
 	 * @return void
 	 */
-	public function init(): void {
+	public function init() {
 
 		add_action('wp_ajax_wu_mark_tour_as_finished', [$this, 'mark_as_finished']);
 


### PR DESCRIPTION
## Summary

Fixes a **fatal Compile Error** on PHP 8.x that breaks the WooCommerce addon v2.0.22 (and potentially other addons) when upgrading to UM v2.5.1. Sites go completely down on any page load.

## Root Cause

Two earlier commits added PHP return type declarations to public methods on base/abstract classes that external addons extend:

| Commit | What it did |
|--------|-------------|
| `b41dc2b2` "Use PHP 7.4 features" | Added `: void` to setters (`set_order`, `set_payment`, `set_membership`, `set_customer`, `trigger_payment_processed`) |
| `b8df0b85` "Add PayPal REST gateway" | Added `: string` to URL methods (`get_payment_url_on_gateway`, `get_subscription_url_on_gateway`, `get_customer_url_on_gateway`) |

PHP enforces that child class method signatures must be compatible with parent declarations. When a parent adds `: string`, any existing child class overriding that method **without** the return type causes:

```
Compile Error: Declaration of ChildClass::method($param)
must be compatible with ParentClass::method($param): string
```

This is a **fatal error** — no graceful degradation, site is completely down.

## What Changed

Removed return type declarations from all overridable public methods across 6 base/abstract classes and their bundled subclasses (36 files total):

- **`Base_Gateway`** (12 methods) — the confirmed breaking class
- **`Base_Element`** (17 methods) — `output(): void` is abstract, every UI element addon must implement it
- **`Base_Model`** (6 methods) — `set_slug()`, `hydrate()`, etc.
- **`Base_Host_Provider`** (11 methods) — extended by hosting integration addons
- **`Base_Capability_Module`** + `Capability_Module` interface (7 methods)
- **`Base_Signup_Field`** (1 method)

All bundled subclasses (Stripe, PayPal, PayPal REST, all UI elements, host providers) also had their return types removed for consistency.

**PHPDoc `@return` tags are preserved** — IDEs and PHPStan still get type information.

## Why Not Just Fix the Addon?

The addon fix is trivial (add `: string` to the override). But:
1. The core plugin should not break existing addons with a minor release
2. There are likely other addons and custom gateway implementations affected
3. The `Base_Element::output(): void` abstract method would break **every** custom UI element addon
4. Return types on extensible base classes are a semver-major change

## Testing

- PHPStan: zero new errors (15 pre-existing unrelated errors)
- Verified child classes with return types (provider implementations) still pass — PHP allows a child to be more specific than its parent

## Runtime Testing

- **Risk**: Critical (payment gateway, site-down fatal)
- **Level**: `self-assessed` — the fix is mechanical (removing type declarations), verified by PHPStan, and the failure mode is a PHP Compile Error that would be immediately visible

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated method signatures across gateway, integration, UI, and model classes to remove explicit return type and parameter type declarations while preserving existing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->