### PR TITLE
fix: skip PayPal button branding when checkout does not require payment

### DIFF
--- a/assets/js/gateways/paypal-rest.js
+++ b/assets/js/gateways/paypal-rest.js
@@ -100,33 +100,78 @@
 	}
 
 	/**
+	 * Check whether the current order actually requires payment.
+	 *
+	 * When the cart total is zero (free plan, 100 % discount, etc.)
+	 * the checkout hides the payment-method selector and the server
+	 * will route the signup through the free gateway — so the submit
+	 * button should NOT carry PayPal branding.
+	 *
+	 * @return {boolean} True when the order needs payment collection.
+	 */
+	function orderRequiresPayment() {
+		const checkout = window.wu_checkout_form;
+
+		if ( ! checkout || ! checkout.order ) {
+			// Order not loaded yet — assume payment is needed so branding
+			// can be applied once the order confirms it.
+			return true;
+		}
+
+		return !! checkout.order.should_collect_payment;
+	}
+
+	/**
 	 * Re-apply icon after Vue re-renders the button (e.g. spinner swap).
 	 * The CSS survives re-renders; only the icon DOM node needs re-injection.
 	 */
 	( function watchForRerender() {
-		let isPayPalActive = false;
+		let isPayPalSelected = false;
 
 		const observer = new MutationObserver( function () {
-			if ( isPayPalActive ) {
+			if ( isPayPalSelected && orderRequiresPayment() ) {
 				setButtonIcons( true );
 			}
 		} );
+
+		/**
+		 * Recalculate whether branding should be shown.
+		 *
+		 * Branding is active only when PayPal is the selected gateway
+		 * AND the order actually requires payment collection.
+		 */
+		function refreshBranding() {
+			const shouldBrand = isPayPalSelected && orderRequiresPayment();
+			applyBranding( shouldBrand );
+
+			const form = document.getElementById( 'wu_form' );
+			if ( form ) {
+				if ( shouldBrand ) {
+					observer.observe( form, { childList: true, subtree: true } );
+				} else {
+					observer.disconnect();
+				}
+			}
+		}
 
 		wp.hooks.addAction(
 			'wu_on_change_gateway',
 			'wp-ultimo/paypal-rest',
 			function ( newGateway ) {
-				isPayPalActive = ( newGateway === GATEWAY_ID );
-				applyBranding( isPayPalActive );
+				isPayPalSelected = ( newGateway === GATEWAY_ID );
+				refreshBranding();
+			}
+		);
 
-				const form = document.getElementById( 'wu_form' );
-				if ( form ) {
-					if ( isPayPalActive ) {
-						observer.observe( form, { childList: true, subtree: true } );
-					} else {
-						observer.disconnect();
-					}
-				}
+		/*
+		 * When the order updates (product change, coupon applied, etc.)
+		 * the should_collect_payment flag may flip — re-evaluate branding.
+		 */
+		wp.hooks.addAction(
+			'wu_on_form_updated',
+			'wp-ultimo/paypal-rest',
+			function () {
+				refreshBranding();
 			}
 		);
 	}() );


### PR DESCRIPTION
## Summary

- PayPal branding (yellow background, PayPal icon) was applied to the checkout submit button even when a free plan was selected or a 100% discount made the cart total zero
- The branding script only checked whether the gateway data property was `paypal-rest`, not whether payment was actually required
- Now checks `order.should_collect_payment` before applying branding, and re-evaluates whenever the form updates (product change, coupon applied, plan switch, etc.)

## Changes

**`assets/js/gateways/paypal-rest.js`**:
- Added `orderRequiresPayment()` — reads the same `should_collect_payment` flag that the payment methods template uses to show/hide the gateway selector
- Branding now requires both conditions: PayPal selected AND payment needed
- Added `wu_on_form_updated` hook listener to re-evaluate branding when the order changes (e.g. switching from paid to free plan)

## Testing

- Select a free plan on checkout → submit button should show default styling, not PayPal branding
- Select a paid plan with PayPal → submit button should show PayPal branding
- Switch from paid to free plan → branding should be removed
- Apply a 100% discount code → branding should be removed
- Remove the discount code → branding should reappear if PayPal is still selected

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed PayPal branding display logic to only show when PayPal is selected as the payment gateway and the order requires payment. PayPal branding now updates dynamically when order conditions change, such as coupon or product modifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->