### PR TITLE
fix: skip activity-stream assets on non-network admin dashboard

### DIFF
--- a/inc/class-dashboard-widgets.php
+++ b/inc/class-dashboard-widgets.php
@@ -75,6 +75,16 @@ class Dashboard_Widgets implements \WP_Ultimo\Interfaces\Singleton {
 		}
 
 		/*
+		 * The activity-stream widget is only registered on the network dashboard
+		 * (wp_network_dashboard_setup). Skip enqueueing its assets on the regular
+		 * per-site dashboard to avoid the Vue "Cannot find element: #activity-stream-content"
+		 * console error.
+		 */
+		if ( ! is_network_admin()) {
+			return;
+		}
+
+		/*
 		 * The activity-stream widget view wraps its output in <div class="wu-styling">,
 		 * which requires framework.css (registered as 'wu-styling'). The network admin
 		 * dashboard is not a wp-ultimo page, so enqueue_default_admin_styles() skips it —


### PR DESCRIPTION
## Summary

- The `enqueue_scripts()` method in `Dashboard_Widgets` only checked `$pagenow === 'index.php'`, which matches both the per-site dashboard (`/wp-admin/index.php`) and the network dashboard (`/wp-admin/network/index.php`).
- The activity-stream Vue app (`#activity-stream-content`) is only rendered on the **network** dashboard via `wp_network_dashboard_setup`. Loading the script on the per-site dashboard caused a JS console error: `[Vue warn]: Cannot find element: #activity-stream-content`.
- Fix: add `is_network_admin()` guard in `enqueue_scripts()` to bail early when not on the network admin.

## Files Changed

- `inc/class-dashboard-widgets.php` — added `is_network_admin()` early-return guard

## Testing

- Visit `/wp-admin/index.php` (per-site dashboard): no Vue console error, activity-stream script not loaded.
- Visit `/wp-admin/network/index.php` (network dashboard): activity-stream widget loads and functions correctly.

## Runtime Testing

**Risk level:** Low — guard condition only, no logic change to the widget itself.
**Verification:** `self-assessed` — the fix is a single conditional that prevents script enqueue on the wrong screen.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Optimized dashboard widget asset loading to prevent unnecessary resources from being loaded on per-site admin dashboards, ensuring activity-stream widget resources display only in appropriate contexts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->