### PR TITLE
fix: auto-reset stale is_publishing flag to prevent infinite Creating spinner

### DIFF
--- a/inc/managers/class-membership-manager.php
+++ b/inc/managers/class-membership-manager.php
@@ -167,6 +167,11 @@ class Membership_Manager extends Base_Manager {
 	/**
 	 * Processes a delayed site publish action.
 	 *
+	 * Checks whether the pending site has been created. If is_publishing
+	 * has been true for longer than 5 minutes, we assume the creation
+	 * process was killed (PHP timeout, OOM, server restart) and reset
+	 * the flag so the Action Scheduler retry can pick it up.
+	 *
 	 * @since 2.0.11
 	 */
 	public function check_pending_site_created() {
@@ -186,6 +191,40 @@ class Membership_Manager extends Base_Manager {
 			 * We do not have a pending site, so we can assume the site was created.
 			 */
 			wp_send_json(['publish_status' => 'completed']);
+
+			exit;
+		}
+
+		/*
+		 * Detect stale publishing state. When the PHP process that was
+		 * creating the site gets killed mid-execution, is_publishing
+		 * stays true forever — the AS retry sees the flag and bails
+		 * out, creating an infinite loop. Reset the flag after 5 min
+		 * so the next AS run or cron kick can retry site creation.
+		 *
+		 * @since 2.5.3
+		 */
+		if ($pending_site->is_publishing_stale()) {
+			$pending_site->set_publishing(false);
+
+			$membership->update_pending_site($pending_site);
+
+			wu_log_add(
+				self::LOG_FILE_NAME,
+				sprintf(
+					// translators: %d: membership ID.
+					__('Reset stale is_publishing flag for membership %d. The site creation process appears to have been killed before completing.', 'ultimate-multisite'),
+					$membership->get_id()
+				)
+			);
+
+			/*
+			 * Re-enqueue the async action so Action Scheduler retries
+			 * the site creation without waiting for the next cron tick.
+			 */
+			wu_enqueue_async_action('wu_async_publish_pending_site', ['membership_id' => $membership->get_id()], 'membership');
+
+			wp_send_json(['publish_status' => 'stopped']);
 
 			exit;
 		}

--- a/inc/models/class-site.php
+++ b/inc/models/class-site.php
@@ -159,6 +159,18 @@ class Site extends Base_Model implements Limitable, Notable {
 	protected $is_publishing;
 
 	/**
+	 * Unix timestamp when is_publishing was set to true.
+	 *
+	 * Used to detect stale publishing state (e.g. process killed mid-creation).
+	 * Not persisted to the sites DB table — only lives in the serialized
+	 * pending_site metadata on memberships.
+	 *
+	 * @since 2.5.3
+	 * @var int
+	 */
+	protected $publishing_started_at = 0;
+
+	/**
 	 * Is this a active site?
 	 *
 	 * @since 2.0.0
@@ -753,13 +765,65 @@ class Site extends Base_Model implements Limitable, Notable {
 	/**
 	 * Set if the site is being published.
 	 *
+	 * When set to true, also records the current timestamp so that
+	 * stale publishing states can be detected and reset.
+	 *
 	 * @since 2.0.11
-	 * @param int $publishing Holds the ID of the customer that owns this site.
+	 * @param bool $publishing Whether the site is currently being published.
 	 * @return void
 	 */
 	public function set_publishing($publishing): void {
 
 		$this->is_publishing = $publishing;
+
+		if ($publishing) {
+			$this->publishing_started_at = time();
+		} else {
+			$this->publishing_started_at = 0;
+		}
+	}
+
+	/**
+	 * Get the Unix timestamp when publishing started.
+	 *
+	 * @since 2.5.3
+	 * @return int Unix timestamp, or 0 if not publishing.
+	 */
+	public function get_publishing_started_at() {
+
+		return (int) $this->publishing_started_at;
+	}
+
+	/**
+	 * Check if the publishing state is stale (stuck).
+	 *
+	 * A publishing state is considered stale if is_publishing has been
+	 * true for longer than the given timeout. This happens when the PHP
+	 * process is killed mid-creation (OOM, timeout, server restart)
+	 * after the flag is set but before the error handlers can reset it.
+	 *
+	 * @since 2.5.3
+	 * @param int $timeout_seconds Maximum allowed publishing duration in seconds. Default 300 (5 minutes).
+	 * @return bool True if publishing started more than $timeout_seconds ago.
+	 */
+	public function is_publishing_stale($timeout_seconds = 300) {
+
+		if ( ! $this->is_publishing()) {
+			return false;
+		}
+
+		$started = $this->get_publishing_started_at();
+
+		/*
+		 * If publishing_started_at is 0 or missing (pre-2.5.3 serialized
+		 * objects), treat the state as stale — there's no way to know
+		 * when it started, and the process that set it is clearly gone.
+		 */
+		if (empty($started)) {
+			return true;
+		}
+
+		return (time() - $started) > $timeout_seconds;
 	}
 
 	/**

--- a/tests/WP_Ultimo/Models/Site_Test.php
+++ b/tests/WP_Ultimo/Models/Site_Test.php
@@ -892,6 +892,89 @@ class Site_Test extends \WP_UnitTestCase {
 	}
 
 	/**
+	 * Test set_publishing(true) records publishing_started_at timestamp.
+	 */
+	public function test_set_publishing_records_timestamp(): void {
+		$before = time();
+		$this->site->set_publishing(true);
+		$after = time();
+
+		$started = $this->site->get_publishing_started_at();
+		$this->assertGreaterThanOrEqual($before, $started);
+		$this->assertLessThanOrEqual($after, $started);
+	}
+
+	/**
+	 * Test set_publishing(false) clears publishing_started_at.
+	 */
+	public function test_set_publishing_false_clears_timestamp(): void {
+		$this->site->set_publishing(true);
+		$this->assertGreaterThan(0, $this->site->get_publishing_started_at());
+
+		$this->site->set_publishing(false);
+		$this->assertEquals(0, $this->site->get_publishing_started_at());
+	}
+
+	/**
+	 * Test is_publishing_stale returns false when not publishing.
+	 */
+	public function test_is_publishing_stale_when_not_publishing(): void {
+		$this->site->set_publishing(false);
+		$this->assertFalse($this->site->is_publishing_stale());
+	}
+
+	/**
+	 * Test is_publishing_stale returns false when recently started.
+	 */
+	public function test_is_publishing_stale_when_recent(): void {
+		$this->site->set_publishing(true);
+		$this->assertFalse($this->site->is_publishing_stale(), 'Should not be stale immediately after starting.');
+	}
+
+	/**
+	 * Test is_publishing_stale returns true after timeout expires.
+	 */
+	public function test_is_publishing_stale_after_timeout(): void {
+		$this->site->set_publishing(true);
+
+		// Simulate time passing by setting publishing_started_at to 10 minutes ago.
+		$reflection = new \ReflectionProperty(Site::class, 'publishing_started_at');
+		$reflection->setAccessible(true);
+		$reflection->setValue($this->site, time() - 600);
+
+		$this->assertTrue($this->site->is_publishing_stale(), 'Should be stale after 10 minutes (default timeout 300s).');
+	}
+
+	/**
+	 * Test is_publishing_stale with custom timeout.
+	 */
+	public function test_is_publishing_stale_custom_timeout(): void {
+		$this->site->set_publishing(true);
+
+		$reflection = new \ReflectionProperty(Site::class, 'publishing_started_at');
+		$reflection->setAccessible(true);
+		$reflection->setValue($this->site, time() - 60);
+
+		$this->assertFalse($this->site->is_publishing_stale(120), 'Should not be stale with 120s timeout after 60s.');
+		$this->assertTrue($this->site->is_publishing_stale(30), 'Should be stale with 30s timeout after 60s.');
+	}
+
+	/**
+	 * Test is_publishing_stale returns true for pre-2.5.3 objects without timestamp.
+	 */
+	public function test_is_publishing_stale_legacy_object_without_timestamp(): void {
+		$this->site->set_publishing(true);
+
+		// Simulate a pre-2.5.3 serialized object that has is_publishing=true
+		// but no publishing_started_at value.
+		$reflection = new \ReflectionProperty(Site::class, 'publishing_started_at');
+		$reflection->setAccessible(true);
+		$reflection->setValue($this->site, 0);
+
+		$this->assertTrue($this->site->is_publishing_stale(), 'Pre-2.5.3 objects without timestamp should be treated as stale.');
+	}
+
+	/**
 	 * Test get_template returns false when template_id does not match a site.
 	 */
 	public function test_get_template_nonexistent(): void {


### PR DESCRIPTION
## Summary

Fixes the infinite "Creating" spinner on the thank-you page when the site creation process is killed mid-execution.

**Root cause:** `publish_pending_site()` sets `is_publishing=true` on the pending site object and saves it to membership meta. If the PHP process dies (OOM, timeout, server restart) after the flag is set but before the site creation completes or error handlers run, the flag stays `true` permanently. The AJAX poll handler (`wu_check_pending_site_created`) returns `running` forever, and the Action Scheduler retry bails out because it sees the flag and assumes another process is already handling it.

**Fix:**
- Add `publishing_started_at` timestamp to the Site model, automatically recorded when `set_publishing(true)` is called
- Add `is_publishing_stale($timeout)` method — returns true when publishing has been running longer than the timeout (default 5 minutes)
- `check_pending_site_created()` now detects stale state, resets the flag, re-enqueues the async action, and returns `stopped` so the JS can retry
- Pre-2.5.3 serialized pending site objects (which lack the timestamp field) are treated as stale when `is_publishing` is true, since the process that set it is clearly gone

**Files changed:**
- `inc/models/class-site.php` — new property, getter, and staleness check method
- `inc/managers/class-membership-manager.php` — staleness detection in AJAX handler
- `tests/WP_Ultimo/Models/Site_Test.php` — 7 new test cases for the staleness logic

**Testing instructions:**
1. Install the build from this branch
2. Go through a WooCommerce checkout flow that creates a site
3. Verify the thank-you page transitions from "Creating" to the completed state
4. To test the stuck state recovery: if a site is currently stuck in "Creating", this fix should auto-recover within 5 minutes of installing

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Implemented automatic detection and recovery for site publishing processes that become stalled or unresponsive
  * Publishing tasks now automatically resume when a stalled state is detected beyond the timeout threshold

* **Bug Fixes**
  * Resolved issues where sites could remain indefinitely stuck in an incomplete publishing state

* **Tests**
  * Added comprehensive unit tests validating publishing state detection, timeout handling, and automatic recovery mechanisms

<!-- end of auto-generated comment: release notes by coderabbit.ai -->