### PR TITLE
t793: fix dual retry path in check_pending_site_created

### DIFF
--- a/inc/managers/class-membership-manager.php
+++ b/inc/managers/class-membership-manager.php
@@ -219,11 +219,13 @@ class Membership_Manager extends Base_Manager {
 			);
 
 			/*
-			 * Re-enqueue the async action so Action Scheduler retries
-			 * the site creation without waiting for the next cron tick.
+			 * Return 'stopped' so the frontend polling loop retries.
+			 * Do NOT also enqueue wu_async_publish_pending_site here —
+			 * that would create two competing retry sources (Action
+			 * Scheduler + frontend) and risk double site creation.
+			 * The existing AS scheduled action will pick up the reset
+			 * flag on its next run.
 			 */
-			wu_enqueue_async_action('wu_async_publish_pending_site', ['membership_id' => $membership->get_id()], 'membership');
-
 			wp_send_json(['publish_status' => 'stopped']);
 
 			exit;


### PR DESCRIPTION
## Summary

Removes the competing `wu_enqueue_async_action` call from `check_pending_site_created()` that was introduced in PR #792.

When a stale `is_publishing` flag is detected and reset, the previous code both:
1. Enqueued `wu_async_publish_pending_site` via Action Scheduler
2. Returned `publish_status => 'stopped'` to the frontend polling loop

This created two competing retry sources that could trigger double site creation for the same membership.

## Fix

Remove the `wu_enqueue_async_action` call. The frontend polling loop retries on `'stopped'` status, and the existing AS scheduled action will pick up the reset flag on its next run — a single retry path is sufficient.

## Files Changed

- EDIT: `inc/managers/class-membership-manager.php:221-225` — removed `wu_enqueue_async_action` call and updated comment

## Runtime Testing

**Risk level**: Medium (site creation flow)

The change removes a call that was added in PR #792. The stale-flag reset logic remains intact; only the redundant AS re-enqueue is removed. The frontend retry path (`publish_status => 'stopped'`) continues to work as before.

**Self-assessed**: The change is a removal of a single function call with no new logic introduced. The existing AS scheduled action (`wu_async_publish_pending_site`) remains registered and will fire on its normal schedule after the flag is reset.

Resolves #793

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.6.239 plugin for [OpenCode](https://opencode.ai) v1.3.16 with claude-sonnet-4-6 spent 2m and 3,669 tokens on this as a headless worker.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of stalled site creation attempts to prevent unnecessary duplicate retry actions, resulting in more efficient processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->