### PR TITLE
t804: fix YAML indentation in addon-integration-test.yml e2e artifact upload steps

### DIFF
--- a/.github/workflows/addon-integration-test.yml
+++ b/.github/workflows/addon-integration-test.yml
@@ -252,16 +252,16 @@ jobs:
         if: always()
         continue-on-error: true
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
-         with:
-           name: cypress-screenshots-${{ inputs.addon-slug }}
-           path: |
-             core/tests/e2e/cypress/screenshots
-             addon/tests/e2e/cypress/screenshots
+        with:
+          name: cypress-screenshots-${{ inputs.addon-slug }}
+          path: |
+            core/tests/e2e/cypress/screenshots
+            addon/tests/e2e/cypress/screenshots
 
-       - name: Upload Cypress videos
-         if: always()
-         continue-on-error: true
-         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
+      - name: Upload Cypress videos
+        if: always()
+        continue-on-error: true
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
         with:
           name: cypress-videos-${{ inputs.addon-slug }}
           path: |


### PR DESCRIPTION
## Summary

Fixes persistent workflow failures on every push caused by YAML indentation errors in the `e2e` job's artifact upload steps.

## Root Cause

Two steps at the end of the `e2e` job had incorrect indentation:

1. **"Upload Cypress screenshots"** — `with:` had 9 spaces instead of 8 (extra leading space). The `name:` and `path:` inside `with:` were also shifted by one.
2. **"Upload Cypress videos"** — the `- name:` bullet was at 7 spaces instead of 6, and all step properties (`if:`, `continue-on-error:`, `uses:`) were at 9 spaces instead of 8. The `with:` then inconsistently dropped back to 8 spaces.

GitHub evaluates `workflow_call` reusable workflows against push events to determine check suite status. When the YAML cannot be parsed, every push gets flagged as a workflow failure — even though the workflow is never actually invoked via push.

## Changes

- EDIT: `.github/workflows/addon-integration-test.yml` lines 251–269 — normalised indentation on both artifact upload steps to match all other steps in the job (6-space bullet, 8-space properties, 10-space `with:` content).

## Verification

- `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/addon-integration-test.yml')); print('YAML valid')"` — passes
- After merge: `gh run list --repo Ultimate-Multisite/ultimate-multisite --limit 10 --json conclusion,workflowName` should show no `failure` for `addon-integration-test.yml` on push events

Resolves #804

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Fixed GitHub Actions workflow configuration for improved reliability in CI/CD artifact handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->