### PR TITLE
t811: address CodeRabbit review feedback on AGENTS.md local dev section

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -170,7 +170,7 @@ The shared WordPress dev install for testing this plugin is at `../wordpress` (r
 
 - **URL**: http://wordpress.local:8080
 - **Admin**: http://wordpress.local:8080/wp-admin — `admin` / `admin`
-- **WordPress version**: 7.0-RC2
+- **WordPress version**: 7.0-RC2 (pre-release dev environment)
 - **This plugin**: symlinked into `../wordpress/wp-content/plugins/$(basename $PWD)`
 - **Reset to clean state**: `cd ../wordpress && ./reset.sh`
 
@@ -179,5 +179,5 @@ WP-CLI is configured via `wp-cli.yml` in this repo root — run `wp` commands di
 ```bash
 wp plugin activate $(basename $PWD)   # activate this plugin
 wp plugin deactivate $(basename $PWD) # deactivate
-wp db reset --yes && cd ../wordpress && ./reset.sh  # full reset
+wp db reset --yes && cd ../wordpress && ./reset.sh  # full DB + WordPress reset (requires reset.sh in ../wordpress)
 ```


### PR DESCRIPTION
## Summary

Addresses unaddressed CodeRabbit review feedback from PR #756 (tracked in #811).

**Changes to `AGENTS.md`:**

- **WordPress version line** (line 173): Added `(pre-release dev environment)` clarification to `7.0-RC2`. The version accurately reflects the actual local dev install; the parenthetical acknowledges the pre-release nature flagged by CodeRabbit's actionable comment.
- **reset.sh command comment** (line 182): Updated from `# full reset` to `# full DB + WordPress reset (requires reset.sh in ../wordpress)` — implements CodeRabbit's nitpick suggestion to document the script's purpose and its `../wordpress` dependency.

## Verification

Documentation-only change. No PHP/JS/CSS changes — no linting or test run required.

```bash
grep "WordPress version" AGENTS.md   # should show "(pre-release dev environment)"
grep "reset.sh" AGENTS.md           # should show "(requires reset.sh in ../wordpress)"
```

Resolves #811

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated local development instructions to clarify the pre-release version designation and full reset operation requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->