### PR TITLE
t809: fix: address PR #781 review feedback — restore param types and fix return type issues

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -91,7 +91,7 @@ assets/                  # JS, CSS, images, fonts
   classes or interfaces** — external addons extend these classes and PHP will fatal if
   the child class doesn't declare the same return type. Use `@return` PHPDoc tags instead.
   This applies to all classes in `inc/gateways/`, `inc/ui/class-base-element.php`,
-  `inc/models/class-base-model.php`, `inc/integrations/`, and `inc/checkout/signup-fields/`.
+  `inc/models/class-base-model.php`, `inc/integrations/`, and `inc/checkout/`.
   Private and final methods may use PHP return types freely.
 - **PHPDoc**: Required on classes and public methods in `inc/`. Not required in `tests/`.
   Every file header: `@package WP_Ultimo`, `@subpackage`, `@since`.

--- a/inc/gateways/class-base-gateway.php
+++ b/inc/gateways/class-base-gateway.php
@@ -594,7 +594,7 @@ abstract class Base_Gateway {
 	 * @param int $payment_id The local payment ID to verify.
 	 * @return array{success: bool, status: string, message: string}
 	 */
-	public function verify_and_complete_payment($payment_id) {
+	public function verify_and_complete_payment(int $payment_id) {
 
 		unset($payment_id);
 
@@ -823,7 +823,7 @@ abstract class Base_Gateway {
 	 * @param string $message The error message.
 	 * @return void
 	 */
-	public function redirect_with_error($message) {
+	public function redirect_with_error(string $message) {
 
 		$url = remove_query_arg(['wu-confirm', 'payment', 'token', 'PayerID', 'ba_token', 'subscription_id', 'status'], $this->return_url ?: wu_get_current_url());
 

--- a/inc/integrations/host-providers/class-cloudflare-host-provider.php
+++ b/inc/integrations/host-providers/class-cloudflare-host-provider.php
@@ -144,7 +144,7 @@ class Cloudflare_Host_Provider extends Base_Host_Provider {
 	 *
 	 * @since 2.0.0
 	 */
-	public function detect(): bool {
+	public function detect() {
 		/**
 		 * As Cloudflare recently enabled wildcards for all customers, this integration is no longer required.
 		 * https://blog.cloudflare.com/wildcard-proxy-for-everyone/

--- a/inc/integrations/host-providers/class-cpanel-host-provider.php
+++ b/inc/integrations/host-providers/class-cpanel-host-provider.php
@@ -97,7 +97,7 @@ class CPanel_Host_Provider extends Base_Host_Provider {
 	 *
 	 * @since 2.0.0
 	 */
-	public function detect(): bool {
+	public function detect() {
 
 		return false;
 	}
@@ -262,7 +262,7 @@ class CPanel_Host_Provider extends Base_Host_Provider {
 	 * @since  1.6.2
 	 * @param null|int $site_id The site id.
 	 */
-	public function get_site_url($site_id = null): string {
+	public function get_site_url($site_id = null) {
 
 		return trim(preg_replace('#^https?://#', '', get_site_url($site_id)), '/');
 	}

--- a/inc/integrations/interface-capability-module.php
+++ b/inc/integrations/interface-capability-module.php
@@ -56,7 +56,7 @@ interface Capability_Module {
 	 * @param string $feature Feature identifier to check.
 	 * @return bool
 	 */
-	public function supports($feature);
+	public function supports(string $feature);
 
 	/**
 	 * Registers WordPress hooks for this capability.

--- a/inc/ui/class-billing-info-element.php
+++ b/inc/ui/class-billing-info-element.php
@@ -266,7 +266,7 @@ class Billing_Info_Element extends Base_Element {
 	 *
 	 * @param array       $atts Parameters of the block/shortcode.
 	 * @param string|null $content The content inside the shortcode.
-	 * @return string
+	 * @return void
 	 */
 	public function output($atts, $content = null) {
 


### PR DESCRIPTION
## Summary

Addresses unresolved CodeRabbit review feedback from PR #781 (merged with open findings).

### Critical fixes

**Restore removed parameter type declarations** (PHP contravariance violation):

PR #781 incorrectly removed parameter types from two `Base_Gateway` methods. When a parent method is untyped, child overrides cannot declare narrower types without a fatal `Declaration must be compatible` error. Existing addons with typed overrides would fatal on upgrade.

- `Base_Gateway::verify_and_complete_payment(int $payment_id)` — restored `int`
- `Base_Gateway::redirect_with_error(string $message)` — restored `string`

**Restore `string` parameter type on `Capability_Module::supports()`**:

Same contravariance issue: the interface `supports(string $feature)` had `string` removed. Implementations that already declare `supports(string $feature)` (including `class-integration.php`) would have fatalled.

- `Capability_Module::supports(string $feature)` — restored `string`

### Minor fixes (missed in PR #781)

Remaining return type declarations on extensible host provider classes:

- `CPanel_Host_Provider::detect()` — removed `: bool`
- `CPanel_Host_Provider::get_site_url()` — removed `: string`
- `Cloudflare_Host_Provider::detect()` — removed `: bool`

PHPDoc correction:

- `Billing_Info_Element::output()` — `@return` updated from `string` to `void` (method renders via side effects, uses bare `return;`)

### Documentation fix (AGENTS.md)

The "Type hints" rule narrowly referenced `inc/checkout/signup-fields/` but the actual guideline covers `inc/checkout/` broadly. Updated to match the intended scope.

## Runtime Testing

Risk: **Low** — PHP parameter/return type declarations only. No logic changes. All changes are backward-compatible with existing subclasses (bundled Stripe and PayPal gateways use untyped `$payment_id` which is valid widening when parent declares `int`).

Verified: `php -l` clean on all 5 modified files.

## Files Modified

- EDIT: `AGENTS.md:93-94` — expand scope reference
- EDIT: `inc/gateways/class-base-gateway.php:597,826` — restore param types
- EDIT: `inc/integrations/interface-capability-module.php:59` — restore string param
- EDIT: `inc/integrations/host-providers/class-cpanel-host-provider.php:100,265` — remove return types
- EDIT: `inc/integrations/host-providers/class-cloudflare-host-provider.php:147` — remove return type
- EDIT: `inc/ui/class-billing-info-element.php:269` — fix PHPDoc

Resolves #809

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.8.5 plugin for [OpenCode](https://opencode.ai) v1.3.16 with claude-sonnet-4-6 spent 6m and 21,124 tokens on this as a headless worker.