### PR TITLE
t813: fix TypeError in switch_template() when product uses default template mode

### DIFF
--- a/inc/limitations/class-limit-site-templates.php
+++ b/inc/limitations/class-limit-site-templates.php
@@ -201,7 +201,7 @@ class Limit_Site_Templates extends Limit {
 	 * Get available themes.
 	 *
 	 * @since 2.0.0
-	 * @return array
+	 * @return array|false Array of available template IDs, or false when MODE_DEFAULT (unrestricted).
 	 */
 	public function get_available_site_templates() {
 

--- a/inc/ui/class-template-switching-element.php
+++ b/inc/ui/class-template-switching-element.php
@@ -274,9 +274,10 @@ class Template_Switching_Element extends Base_Element {
 
 		$template_id = (int) wu_request('template_id', '');
 
-		$available_templates = array_map('intval', $this->site->get_limitations()->site_templates->get_available_site_templates());
+		// false means MODE_DEFAULT (no restriction) — all templates are allowed.
+		$available_templates = $this->site->get_limitations()->site_templates->get_available_site_templates();
 
-		if (! in_array($template_id, $available_templates, true)) {
+		if (false !== $available_templates && ! in_array($template_id, array_map('intval', $available_templates), true)) {
 			wp_send_json_error(new \WP_Error('not_authorized', __('You are not allowed to use this template.', 'ultimate-multisite')));
 		}
 


### PR DESCRIPTION
## Summary

- `get_available_site_templates()` can return `false` when a product's site template mode is `MODE_DEFAULT` (unrestricted), as fixed in PR #754
- `class-template-switching-element.php:277` passed this return value directly to `array_map('intval', ...)`, which throws a `TypeError` in PHP 8.0+ and silently produces an empty array in PHP 7.4 (causing every template switch to be blocked with "not_authorized")
- `get_available_site_templates()` PHPDoc still declared `@return array` despite the change to return `false|array`

## Changes

**`inc/limitations/class-limit-site-templates.php`**
- Updated PHPDoc `@return array` → `@return array|false` with description

**`inc/ui/class-template-switching-element.php`**
- Store the raw return value first; only call `array_map()` and `in_array()` when the result is not `false`
- When `false` (MODE_DEFAULT), skip the restriction check — all templates are allowed

## Verification

- PHPStan level 0: passes on both modified files
- No new PHPCS violations introduced (pre-existing violations in these files are unrelated)
- Logic: `false !== $available_templates && ! in_array(...)` mirrors the guard pattern already established in `class-site-template-limits.php:224` by PR #754

Resolves #813


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.8.6 plugin for [OpenCode](https://opencode.ai) v1.3.16 with claude-sonnet-4-6 spent 4m and 8,600 tokens on this as a headless worker.