### PR TITLE
t806: test: harden Dashboard_Widgets_Test global cleanup with try/finally

### DIFF
--- a/tests/WP_Ultimo/Dashboard_Widgets_Test.php
+++ b/tests/WP_Ultimo/Dashboard_Widgets_Test.php
@@ -124,39 +124,49 @@ class Dashboard_Widgets_Test extends \WP_UnitTestCase {
 
 		global $pagenow, $wp_scripts;
 
-		$original       = $pagenow;
-		$original_queue = isset($wp_scripts) ? $wp_scripts->queue : [];
-		$pagenow        = 'index.php';
+		$original           = $pagenow;
+		$original_queue     = isset($wp_scripts) ? $wp_scripts->queue : [];
+		$original_done      = isset($wp_scripts) ? $wp_scripts->done : [];
+		$original_screen    = function_exists('get_current_screen') ? get_current_screen() : null;
+		$original_screen_id = $original_screen ? $original_screen->id : null;
+		$pagenow            = 'index.php';
 
-		if (isset($wp_scripts)) {
-			$wp_scripts->queue = [];
-			$wp_scripts->done  = [];
+		try {
+			if (isset($wp_scripts)) {
+				$wp_scripts->queue = [];
+				$wp_scripts->done  = [];
+			}
+
+			// Simulate the network admin so is_network_admin() returns true.
+			set_current_screen('dashboard-network');
+
+			// Ensure wu-functions is registered so the dependency chain resolves.
+			\WP_Ultimo\Scripts::get_instance()->register_default_scripts();
+
+			$instance = $this->get_instance();
+			$instance->enqueue_scripts();
+
+			$this->assertTrue(
+				wp_script_is('wu-activity-stream', 'enqueued'),
+				'wu-activity-stream should be enqueued on the network admin index.php'
+			);
+
+			// Verify wu-functions and moment are declared dependencies.
+			$script = $wp_scripts->registered['wu-activity-stream'] ?? null;
+			$this->assertNotNull($script, 'wu-activity-stream should be registered');
+			$this->assertContains('wu-functions', $script->deps);
+			$this->assertContains('moment', $script->deps);
+
+		} finally {
+			if (isset($wp_scripts)) {
+				$wp_scripts->queue = $original_queue;
+				$wp_scripts->done  = $original_done;
+			}
+			if ($original_screen_id) {
+				set_current_screen($original_screen_id);
+			}
+			$pagenow = $original;
 		}
-
-		// Simulate the network admin so is_network_admin() returns true.
-		set_current_screen('dashboard-network');
-
-		// Ensure wu-functions is registered so the dependency chain resolves.
-		\WP_Ultimo\Scripts::get_instance()->register_default_scripts();
-
-		$instance = $this->get_instance();
-		$instance->enqueue_scripts();
-
-		$this->assertTrue(
-			wp_script_is('wu-activity-stream', 'enqueued'),
-			'wu-activity-stream should be enqueued on the network admin index.php'
-		);
-
-		// Verify wu-functions and moment are declared dependencies.
-		$script = $wp_scripts->registered['wu-activity-stream'] ?? null;
-		$this->assertNotNull($script, 'wu-activity-stream should be registered');
-		$this->assertContains('wu-functions', $script->deps);
-		$this->assertContains('moment', $script->deps);
-
-		if (isset($wp_scripts)) {
-			$wp_scripts->queue = $original_queue;
-		}
-		$pagenow = $original;
 	}
 
 	/**
@@ -170,30 +180,40 @@ class Dashboard_Widgets_Test extends \WP_UnitTestCase {
 
 		global $pagenow, $wp_scripts;
 
-		$original       = $pagenow;
-		$original_queue = isset($wp_scripts) ? $wp_scripts->queue : [];
-		$pagenow        = 'index.php';
+		$original           = $pagenow;
+		$original_queue     = isset($wp_scripts) ? $wp_scripts->queue : [];
+		$original_done      = isset($wp_scripts) ? $wp_scripts->done : [];
+		$original_screen    = function_exists('get_current_screen') ? get_current_screen() : null;
+		$original_screen_id = $original_screen ? $original_screen->id : null;
+		$pagenow            = 'index.php';
 
-		if (isset($wp_scripts)) {
-			$wp_scripts->queue = [];
-			$wp_scripts->done  = [];
+		try {
+			if (isset($wp_scripts)) {
+				$wp_scripts->queue = [];
+				$wp_scripts->done  = [];
+			}
+
+			// Simulate the per-site dashboard (not network admin).
+			set_current_screen('dashboard');
+
+			$instance = $this->get_instance();
+			$instance->enqueue_scripts();
+
+			$this->assertFalse(
+				wp_script_is('wu-activity-stream', 'enqueued'),
+				'wu-activity-stream should NOT be enqueued on the per-site dashboard'
+			);
+
+		} finally {
+			if (isset($wp_scripts)) {
+				$wp_scripts->queue = $original_queue;
+				$wp_scripts->done  = $original_done;
+			}
+			if ($original_screen_id) {
+				set_current_screen($original_screen_id);
+			}
+			$pagenow = $original;
 		}
-
-		// Simulate the per-site dashboard (not network admin).
-		set_current_screen('dashboard');
-
-		$instance = $this->get_instance();
-		$instance->enqueue_scripts();
-
-		$this->assertFalse(
-			wp_script_is('wu-activity-stream', 'enqueued'),
-			'wu-activity-stream should NOT be enqueued on the per-site dashboard'
-		);
-
-		if (isset($wp_scripts)) {
-			$wp_scripts->queue = $original_queue;
-		}
-		$pagenow = $original;
 	}
 
 	/**


### PR DESCRIPTION
## Summary

Addresses the unaddressed CodeRabbit review feedback from PR #801 (issue #806).

**Problem:** Two dashboard widget tests mutate `$wp_scripts->done`, `$pagenow`, and screen context but only restore `$wp_scripts->queue` and `$pagenow` — and only in the happy path. If an assertion throws, subsequent tests can inherit mutated globals/screen state causing hard-to-diagnose flicker failures.

**Fix:** For both `test_enqueue_scripts_enqueues_activity_stream_on_index` and `test_enqueue_scripts_skips_activity_stream_on_per_site_dashboard`:
- Capture `$original_done` and `$original_screen_id` before mutating state
- Wrap test body in `try/finally` so cleanup runs even when assertions throw
- Restore `$wp_scripts->queue`, `$wp_scripts->done`, screen context, and `$pagenow` in `finally`

## Files changed

- EDIT: `tests/WP_Ultimo/Dashboard_Widgets_Test.php` — lines 123–170 and 179–217

## Verification

Tests still pass with the same assertions; cleanup is now guaranteed on failure paths.

Resolves #806

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test reliability by improving global state preservation and cleanup procedures in dashboard widget tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->