### PR TITLE
GH#812: fix: sanitize subdomain slug in wu_create_site

### DIFF
--- a/inc/functions/site.php
+++ b/inc/functions/site.php
@@ -250,7 +250,16 @@ function wu_create_site($site_data) {
 	$domain_supplied           = '' !== $normalized_input_domain && $normalized_input_domain !== $normalized_network_domain;
 
 	if (is_multisite() && is_subdomain_install() && $path_supplied && ! $domain_supplied) {
-		$slug                 = trim((string) $site_data['path'], '/');
+		$raw_slug             = trim((string) $site_data['path'], '/');
+		$slug                 = sanitize_title_with_dashes(wu_clean($raw_slug));
+
+		if ('' === $slug) {
+			return new \WP_Error(
+				'invalid_site_path',
+				__('Invalid site path for subdomain creation.', 'ultimate-multisite')
+			);
+		}
+
 		$bare_network_domain  = preg_replace('/^www\./i', '', (string) $network_domain);
 		$site_data['domain']  = "{$slug}.{$bare_network_domain}";
 		$site_data['path']    = '/';

--- a/tests/WP_Ultimo/Functions/Site_Functions_Extended_Test.php
+++ b/tests/WP_Ultimo/Functions/Site_Functions_Extended_Test.php
@@ -206,4 +206,57 @@ class Site_Functions_Extended_Test extends WP_UnitTestCase {
 		$this->assertIsString($result);
 		$this->assertNotEmpty($result);
 	}
+
+	/**
+	 * Test that the subdomain slug sanitization logic produces valid hostnames.
+	 *
+	 * This verifies the sanitize_title_with_dashes + wu_clean pipeline used
+	 * by wu_create_site when converting a path to a subdomain slug.
+	 */
+	public function test_subdomain_slug_sanitization_produces_valid_hostname(): void {
+
+		// Simulate the sanitization pipeline from wu_create_site.
+		$raw_slug = trim('/My Cool Site!/', '/');
+		$slug     = sanitize_title_with_dashes(wu_clean($raw_slug));
+
+		$this->assertNotEmpty($slug, 'A path with valid characters should produce a non-empty slug.');
+		$this->assertEquals('my-cool-site', $slug);
+		$this->assertMatchesRegularExpression(
+			'/^[a-z0-9]([a-z0-9-]*[a-z0-9])?$/',
+			$slug,
+			'Slug should be a valid DNS label (lowercase alphanumeric + hyphens).'
+		);
+	}
+
+	/**
+	 * Test that paths with only invalid characters sanitize to empty.
+	 *
+	 * This verifies the guard in wu_create_site that returns WP_Error when
+	 * the sanitized slug is empty, preventing malformed hostnames.
+	 */
+	public function test_subdomain_slug_sanitization_empty_for_invalid_path(): void {
+
+		// Paths with only special characters should sanitize to empty.
+		$raw_slug = trim('/!!!/', '/');
+		$slug     = sanitize_title_with_dashes(wu_clean($raw_slug));
+
+		$this->assertEmpty($slug, 'A path with only special characters should sanitize to empty.');
+	}
+
+	/**
+	 * Test that unicode paths sanitize to valid slugs.
+	 */
+	public function test_subdomain_slug_sanitization_handles_unicode(): void {
+
+		$raw_slug = trim('/Café Blog/', '/');
+		$slug     = sanitize_title_with_dashes(wu_clean($raw_slug));
+
+		$this->assertNotEmpty($slug, 'A path with unicode chars should produce a non-empty slug.');
+		// Should contain only valid hostname characters.
+		$this->assertMatchesRegularExpression(
+			'/^[a-z0-9%]([a-z0-9%-]*[a-z0-9%])?$/',
+			$slug,
+			'Slug should only contain valid hostname characters.'
+		);
+	}
 }


### PR DESCRIPTION
## Summary

Resolves #812

Addresses the remaining unresolved review bot feedback from PR #755: sanitize and validate the derived subdomain slug before building the `domain` in `wu_create_site()`.

**Context:** PR #755 was merged with 3 unaddressed CodeRabbit suggestions. Two of them (domain normalization and `site_id` default) were already implemented in prior work. This PR implements the third: subdomain slug sanitization.

## Changes

### `inc/functions/site.php`

- **Sanitize subdomain slug** (lines 253-261): The path-derived slug is now processed through `sanitize_title_with_dashes(wu_clean())` before being interpolated into a hostname. This prevents invalid characters, mixed case, and special characters from producing malformed domain names.
- **Empty slug guard**: If the sanitized slug is empty (e.g., path contained only special characters like `!!!`), the function returns a `WP_Error('invalid_site_path')` instead of creating a site with an invalid domain.

### `tests/WP_Ultimo/Functions/Site_Functions_Extended_Test.php`

- 3 new unit tests verifying the sanitization pipeline:
  - Valid path produces correct DNS-safe slug (`My Cool Site!` → `my-cool-site`)
  - Invalid-only path sanitizes to empty (guarded by WP_Error in production)
  - Unicode paths produce non-empty valid slugs

## Testing

```bash
WP_TESTS_DIR=/tmp/wordpress-tests-lib vendor/bin/phpunit --no-coverage \
  --filter "test_subdomain_slug_sanitization" \
  tests/WP_Ultimo/Functions/Site_Functions_Extended_Test.php
# OK (3 tests, 6 assertions)
```

All 21 tests in `Site_Functions_Extended_Test` pass. All 18 tests in `Site_Functions_Test` pass.