### PR TITLE
fix: resolve PHP 8.1+ TypeError that hides Save button on Domain Mapping settings (#823)

### DIFF
--- a/inc/managers/class-dns-record-manager.php
+++ b/inc/managers/class-dns-record-manager.php
@@ -634,11 +634,11 @@ class DNS_Record_Manager extends Base_Manager {
 				'desc'    => __('Select which DNS record types customers can manage.', 'ultimate-multisite'),
 				'type'    => 'multiselect',
 				'options' => [
-					'A'     => __('A (IPv4 Address)', 'ultimate-multisite'),
-					'AAAA'  => __('AAAA (IPv6 Address)', 'ultimate-multisite'),
-					'CNAME' => __('CNAME (Alias)', 'ultimate-multisite'),
-					'MX'    => __('MX (Mail Exchange)', 'ultimate-multisite'),
-					'TXT'   => __('TXT (Text Record)', 'ultimate-multisite'),
+					'A'     => ['title' => __('A (IPv4 Address)', 'ultimate-multisite')],
+					'AAAA'  => ['title' => __('AAAA (IPv6 Address)', 'ultimate-multisite')],
+					'CNAME' => ['title' => __('CNAME (Alias)', 'ultimate-multisite')],
+					'MX'    => ['title' => __('MX (Mail Exchange)', 'ultimate-multisite')],
+					'TXT'   => ['title' => __('TXT (Text Record)', 'ultimate-multisite')],
 				],
 				'default' => ['A', 'CNAME', 'TXT'],
 				'require' => [

--- a/views/admin-pages/fields/field-multiselect.php
+++ b/views/admin-pages/fields/field-multiselect.php
@@ -46,6 +46,12 @@ defined('ABSPATH') || exit;
 
 		<?php foreach ($field->options as $value => $option) : ?>
 
+		<?php
+		// Support both string options ('key' => 'Label') and array options ('key' => ['title' => 'Label', 'desc' => '...'])
+		$option_title = is_array($option) ? ($option['title'] ?? '') : (string) $option;
+		$option_desc  = is_array($option) ? ($option['desc'] ?? '') : '';
+		?>
+
 		<li class="item wu-box-border wu-m-0 wu-my-2">
 
 			<div class="wu-bg-gray-100 wu-p-3 wu-m-0 wu-border-gray-300 wu-border-solid wu-border wu-rounded wu-items-center wu-flex wu-justify-between">
@@ -54,15 +60,15 @@ defined('ABSPATH') || exit;
 
 				<span class="wu-my-1 wu-text-xs wu-font-bold wu-block">
 
-				<?php echo esc_html($option['title']); ?>
+				<?php echo esc_html($option_title); ?>
 
 				</span>
 
-				<?php if (isset($option['desc']) && ! empty($option['desc'])) : ?>
+				<?php if ( ! empty($option_desc)) : ?>
 
 				<span class="wu-my-1 wu-inline-block wu-text-xs">
 
-					<?php echo esc_html($option['desc']); ?>
+					<?php echo esc_html($option_desc); ?>
 
 				</span>
 


### PR DESCRIPTION
## Summary

Fixes the "Domain mapping no way to save" bug (GH#823).

**Root cause**: `DNS_Record_Manager::add_dns_settings()` registered `dns_record_types_allowed` as a multiselect field with options defined as plain strings (`'A' => 'A (IPv4 Address)'`). The `field-multiselect.php` template accessed `$option['title']` on each option. On PHP 8.1+, accessing a string value with a non-integer string key throws `TypeError: Cannot access offset of type string on string`, which interrupted form rendering before the Save Settings button could be output.

**Changes**:
- `inc/managers/class-dns-record-manager.php`: Convert `dns_record_types_allowed` options from plain strings to the `['title' => '...']` array format expected by the multiselect template.
- `views/admin-pages/fields/field-multiselect.php`: Harden the template to support both string and array option formats for backward compatibility with any existing multiselect fields that use plain strings.

## Testing

```bash
# Verify no TypeError during domain-mapping form rendering
wp --path=../wordpress --user=admin eval '
$sections = WP_Ultimo()->settings->get_sections();
$section = $sections["domain-mapping"];
$fields = array_filter($section["fields"] ?? [], fn($item) => current_user_can($item["capability"]));
uasort($fields, "wu_sort_by_order");
$fields["save"] = ["type" => "submit", "title" => "Save Settings"];
ob_start();
$form = new \WP_Ultimo\UI\Form("domain-mapping", $fields, ["views" => "admin-pages/fields", "html_attr" => ["data-state" => "{}"]]);
$form->render();
$html = ob_get_clean();
echo (strpos($html, "Save Settings") !== false ? "PASS: Save button present" : "FAIL: Save button missing") . "\n";
'
```

Visit Settings > Domain Mapping in network admin — the "Save Settings" button now renders correctly on PHP 8.1+.

Resolves #823

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated DNS record type options data structure for improved consistency.
  * Enhanced multiselect field rendering to support flexible option formats with backward compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->