### PR TITLE
fix: prevent PWYW pricing type from being reset to free on save

### DIFF
--- a/inc/models/class-product.php
+++ b/inc/models/class-product.php
@@ -1097,10 +1097,17 @@ class Product extends Base_Model implements Limitable {
 	/**
 	 * Checks if this plan is free or not.
 	 *
+	 * Pay What You Want products are never considered free, even when the
+	 * suggested and minimum amounts are zero — the customer decides the price.
+	 *
 	 * @since 2.0.0
 	 * @return boolean
 	 */
 	public function is_free() {
+
+		if ($this->is_pay_what_you_want()) {
+			return false;
+		}
 
 		return empty($this->get_amount()) && empty($this->get_initial_amount());
 	}
@@ -1634,7 +1641,7 @@ class Product extends Base_Model implements Limitable {
 			$this->set_slug(sanitize_title($this->name));
 		}
 
-		if ($this->is_free() && $this->get_pricing_type() !== 'contact_us') {
+		if ($this->is_free() && 'paid' === $this->get_pricing_type()) {
 			$this->set_pricing_type('free');
 		}
 


### PR DESCRIPTION
## Summary

- **Bug**: Setting a product's pricing type to "Pay What You Want" silently reverted to "Free" on save when the suggested/minimum amounts were $0
- **Root cause**: `Product::is_free()` returned `true` for PWYW products with $0 amounts, triggering the `save()` guard that auto-normalizes free products
- **Fix**: PWYW products are never "free" by definition — the customer decides the price. `is_free()` now returns `false` for PWYW, and the `save()` guard is narrowed to only normalize the `paid` type

## Reproduction

1. Network Admin → Products → Add New
2. Set Pricing Type to "Pay What You Want"
3. Leave Minimum/Suggested Price at $0
4. Save → pricing type silently changed to "Free"

## Changes

- `inc/models/class-product.php`
  - `is_free()`: early return `false` for PWYW products
  - `save()`: guard condition narrowed from `!== 'contact_us'` to `=== 'paid'`

## Testing

- 183 existing Product_Test assertions pass
- Verified via WP-CLI: PWYW with $0 amounts, PWYW with non-zero amounts, paid $0→free normalization, contact_us preservation, existing product→PWYW conversion
- Verified in browser: new product with PWYW/$0 persists correctly through multiple saves

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed product pricing logic to correctly classify Pay What You Want products, preventing them from being incorrectly treated as free items.
  * Improved product pricing type validation to ensure consistent handling when saving product configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->