### PR TITLE
fix: remove extra padding-right on number inputs and fix flex group overflow (GH#829)

### DIFF
--- a/assets/css/admin.css
+++ b/assets/css/admin.css
@@ -1955,6 +1955,20 @@ body.wu-page-wp-ultimo-settings .selectize-control.single .selectize-input::afte
   max-height: calc(100vh - 480px);
 }
 
+/*
+ * Number inputs with browser-native spinner arrows (up/down buttons) should
+ * not carry the extra right padding that WP admin (forms.css) applies to all
+ * text-type inputs (padding: 0 12px). The spinner occupies the right edge of
+ * the element, and the extra 12px of right padding makes it visually crowd or
+ * obscure adjacent fields in flex-group layouts (e.g. duration + duration_unit
+ * on the product edit page). Removing right padding lets the spinner sit flush
+ * at the right border without stealing horizontal space from neighbouring
+ * elements. (GH#829)
+ */
+.wu-styling input[type="number"] {
+  padding-right: 0;
+}
+
 .flatpickr-calendar {
   background: transparent;
   opacity: 0;

--- a/inc/admin-pages/class-product-edit-admin-page.php
+++ b/inc/admin-pages/class-product-edit-admin-page.php
@@ -470,7 +470,7 @@ class Product_Edit_Admin_Page extends Edit_Admin_Page {
 								'type'            => 'number',
 								'value'           => $this->get_object()->get_duration(),
 								'placeholder'     => '',
-								'wrapper_classes' => 'wu-mx-2 wu-w-1/3',
+								'wrapper_classes' => 'wu-ml-2 wu-w-1/3',
 								'min'             => 0,
 								'html_attr'       => [
 									'v-model' => 'duration',
@@ -861,7 +861,7 @@ class Product_Edit_Admin_Page extends Edit_Admin_Page {
 							'type'            => 'select',
 							'title'           => __('Period', 'ultimate-multisite'),
 							'placeholder'     => '',
-							'wrapper_classes' => 'wu-w-1/3 wu-mx-2',
+							'wrapper_classes' => 'wu-w-1/3 wu-ml-2',
 							'html_attr'       => [
 								'v-model'     => 'price_variation.duration_unit',
 								'v-bind:name' => '"price_variations[" + index + "][duration_unit]"',


### PR DESCRIPTION
## Summary

Fixes the visual bug where the duration unit select (Day(s)/Month(s)/etc.) is hidden by the browser-native spinner arrows (up/down buttons) on the number input in the product edit page pricing configuration.

## Root Cause

Two compounding issues:

1. **Padding**: WP admin's `forms.css` applies `padding: 0 12px` to all text-type inputs including `input[type=number]`. The browser renders spinner arrows inside this right 12 px padding area, making the spinner appear to crowd or obscure adjacent elements in tight flex-group layouts.

2. **Layout overflow**: In the `amount_group` and `price_variations` group fields, the duration number input wrapper used `wu-mx-2` (8 px margins on **both** sides). This added 16 px of extra margin to a `1/3 + 2/3 = 100%` flex layout, causing the container to overflow and flex-shrink to squeeze the `duration_unit` select to near-zero width — directly behind the spinner.

## Changes

### `assets/css/admin.css`
Added `.wu-styling input[type="number"] { padding-right: 0; }` scoped to the admin area to remove the extra right padding. The spinner sits flush at the right border without stealing horizontal space from neighbouring elements.

### `inc/admin-pages/class-product-edit-admin-page.php`
- `amount_group` > `duration`: `wu-mx-2 wu-w-1/3` → `wu-ml-2 wu-w-1/3` (left margin only — eliminates 8 px right-side overflow, preserves visual gap between the money amount field and the duration number)
- `price_variations_duration_unit`: `wu-w-1/3 wu-mx-2` → `wu-w-1/3 wu-ml-2` (same fix for price variations group)

## Testing

Verify in the WP network admin → Products → Edit any recurring product:
1. The "Price" widget shows `[Amount] [Duration number] [Unit select]` — the unit select (Months/Years/etc.) should be fully visible and not obscured by the spinner arrows
2. The "Price Variations" section shows `[Duration] [Period select] [New Price]` — all three fields should be visible
3. Inspect `input[type="number"]` elements in the admin forms — they should have `padding-right: 0` applied via `.wu-styling input[type="number"]`

Resolves #829