### PR TITLE
Change 'checked' to 'selected' for select list options

### DIFF
--- a/views/checkout/fields/field-select.php
+++ b/views/checkout/fields/field-select.php
@@ -42,7 +42,7 @@ defined('ABSPATH') || exit;
 
 	<?php if ($field->placeholder) : ?>
 
-	<option <?php checked(! $field->value); ?> class="wu-opacity-75"><?php echo esc_html($field->placeholder); ?></option>
+	<option <?php selected(! $field->value); ?> class="wu-opacity-75"><?php echo esc_html($field->placeholder); ?></option>
 
 	<?php endif; ?>
 
@@ -50,7 +50,7 @@ defined('ABSPATH') || exit;
 
 		<option
 		value="<?php echo esc_attr($key); ?>"
-		<?php checked($key, $field->value); ?>
+		<?php selected($key, $field->value); ?>
 		>
 		<?php echo esc_html($label); ?>
 	</option>


### PR DESCRIPTION
Pre-selected values don't show correctly in the checkout forms, currently printing out "checked" instead of "selected".

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed select dropdown fields in checkout to properly display selected options during form submission.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->