### PR TITLE
GH#839: test: remove redundant unserialize() calls on get_post_meta() results (GH#839)

### DIFF
--- a/tests/WP_Ultimo/Helpers/Site_Duplicator_Postmeta_Test.php
+++ b/tests/WP_Ultimo/Helpers/Site_Duplicator_Postmeta_Test.php
@@ -955,7 +955,7 @@ class Site_Duplicator_Postmeta_Test extends WP_UnitTestCase {
 	private function verify_attachment_backfill() {
 		switch_to_blog($this->to_blog_id);
 		$this->assertEquals('2024/01/logo.png', get_post_meta($this->to_attachment_id, '_wp_attached_file', true));
-		$meta = unserialize(get_post_meta($this->to_attachment_id, '_wp_attachment_metadata', true));
+		$meta = get_post_meta($this->to_attachment_id, '_wp_attachment_metadata', true);
 		$this->assertIsArray($meta);
 		$this->assertEquals(200, $meta['width']);
 		$this->assertEquals('Site Logo', get_post_meta($this->to_attachment_id, '_wp_attachment_image_alt', true));
@@ -979,9 +979,7 @@ class Site_Duplicator_Postmeta_Test extends WP_UnitTestCase {
 			'header',
 			get_post_meta($this->from_elementor_post_id, '_elementor_template_type', true)
 		);
-		$settings = unserialize(
-			get_post_meta($this->from_elementor_post_id, '_elementor_page_settings', true)
-		);
+		$settings = get_post_meta($this->from_elementor_post_id, '_elementor_page_settings', true);
 		$this->assertIsArray($settings);
 		$this->assertEquals('header', $settings['template']);
 		restore_current_blog();


### PR DESCRIPTION
## Summary

Removed two remaining redundant unserialize() calls on get_post_meta() results in Site_Duplicator_Postmeta_Test.php. WordPress get_post_meta($id, $key, true) already applies maybe_unserialize() internally, so wrapping with unserialize() fails in PHP 8+ when the returned value is already an array. Commit dd3461d fixed one of three occurrences; this commit fixes the other two in verify_attachment_backfill() and verify_elementor_backfill().

## Files Changed

tests/WP_Ultimo/Helpers/Site_Duplicator_Postmeta_Test.php

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** self-assessed: test-only change, removes double-unserialize on already-unserialized values; no logic change to production code

Resolves #839


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.8.24 plugin for [OpenCode](https://opencode.ai) v1.4.3 with claude-sonnet-4-6 spent 1m and 2,895 tokens on this as a headless worker.