### PR TITLE
fix: unset current_screen global when restoring null screen state in tests (#841)

### DIFF
--- a/tests/WP_Ultimo/Dashboard_Widgets_Test.php
+++ b/tests/WP_Ultimo/Dashboard_Widgets_Test.php
@@ -162,8 +162,10 @@ class Dashboard_Widgets_Test extends \WP_UnitTestCase {
 				$wp_scripts->queue = $original_queue;
 				$wp_scripts->done  = $original_done;
 			}
-			if ($original_screen_id) {
+			if (null !== $original_screen_id) {
 				set_current_screen($original_screen_id);
+			} else {
+				unset($GLOBALS['current_screen']);
 			}
 			$pagenow = $original;
 		}
@@ -209,8 +211,10 @@ class Dashboard_Widgets_Test extends \WP_UnitTestCase {
 				$wp_scripts->queue = $original_queue;
 				$wp_scripts->done  = $original_done;
 			}
-			if ($original_screen_id) {
+			if (null !== $original_screen_id) {
 				set_current_screen($original_screen_id);
+			} else {
+				unset($GLOBALS['current_screen']);
 			}
 			$pagenow = $original;
 		}


### PR DESCRIPTION
## Summary

Fixes screen state leakage in `Dashboard_Widgets_Test` — both `finally` blocks were silently skipping screen restoration when `$original_screen_id` was null, allowing the forced `dashboard-network` / `dashboard` screen states to leak into subsequent tests.

## Changes

**File**: `tests/WP_Ultimo/Dashboard_Widgets_Test.php`

Both `finally` blocks in `test_enqueue_scripts_enqueues_activity_stream_on_index` and `test_enqueue_scripts_skips_activity_stream_on_per_site_dashboard` updated:

- Changed `if ($original_screen_id)` → `if (null !== $original_screen_id)` (strict null check avoids falsy string '' or 0 bypassing restoration)
- Added `else { unset($GLOBALS['current_screen']); }` to explicitly clear the global when there was no original screen

This follows the WordPress core test practice recommended in [wordpress-develop PR #1380](https://github.com/WordPress/wordpress-develop/pull/1380) and `abstract-testcase.php`.

## Verification

The fix matches the pattern prescribed in the CodeRabbit review finding on PR #821. Both test methods now properly restore the global screen state regardless of whether a screen was active before the test ran.

Resolves #841