### PR TITLE
t840: make wu_duplicate_site action test fail on WP_Error

### DIFF
--- a/tests/WP_Ultimo/Helpers/Site_Duplicator_Test.php
+++ b/tests/WP_Ultimo/Helpers/Site_Duplicator_Test.php
@@ -603,15 +603,17 @@ class Site_Duplicator_Test extends WP_UnitTestCase {
 
 		$result = Site_Duplicator::duplicate_site($this->template_site_id, 'Action Test Site', $args);
 
-		if ( ! is_wp_error($result)) {
-			$this->assertIsArray($captured);
-			$this->assertArrayHasKey('from_site_id', $captured);
-			$this->assertArrayHasKey('site_id', $captured);
-			$this->assertEquals($this->template_site_id, $captured['from_site_id']);
-			$this->assertEquals($result, $captured['site_id']);
-
-			wpmu_delete_blog($result, true);
+		if (is_wp_error($result)) {
+			$this->fail('Site duplication failed: ' . $result->get_error_message());
 		}
+
+		$this->assertIsArray($captured);
+		$this->assertArrayHasKey('from_site_id', $captured);
+		$this->assertArrayHasKey('site_id', $captured);
+		$this->assertEquals($this->template_site_id, $captured['from_site_id']);
+		$this->assertEquals($result, $captured['site_id']);
+
+		wpmu_delete_blog($result, true);
 	}
 
 	/**


### PR DESCRIPTION
## Summary

Tightens the assertion path in `test_wu_duplicate_site_action_includes_from_site_id` so the test fails immediately when `Site_Duplicator::duplicate_site()` returns a `WP_Error`, rather than silently skipping all assertions and producing a false positive.

**Before:** if duplication failed, the `if ( ! is_wp_error($result))` block was skipped entirely — the test passed with zero assertions.

**After:** if duplication fails, `$this->fail()` is called with the error message, making the failure visible and ensuring the remaining assertions always run on success.

## Changes

- `tests/WP_Ultimo/Helpers/Site_Duplicator_Test.php`: Replace silent-skip pattern with fail-fast `$this->fail()` check; unconditionally run payload assertions.

## Runtime Testing

**Risk level:** Low — test file only, no production code changed.
**Verification:** `self-assessed` — the logic change is structurally equivalent; the only behaviour difference is that a previously-hidden failure path now surfaces.

Resolves #840

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.8.24 plugin for [OpenCode](https://opencode.ai) v1.4.3 with claude-sonnet-4-6 spent 2m and 5,190 tokens on this as a headless worker.