### PR TITLE
t833: fix: preserve saved gateway and skip gateway pre-selection on free carts

### DIFF
--- a/inc/checkout/class-checkout.php
+++ b/inc/checkout/class-checkout.php
@@ -1963,12 +1963,23 @@ class Checkout {
 		/*
 		 * Get the default gateway.
 		 *
-		 * Only pre-select when there is exactly one active gateway so
-		 * the user is not surprised by branded buttons (e.g. PayPal)
-		 * before they have made a choice.
+		 * Restore a previously-chosen gateway from the session (multi-step
+		 * checkout), or auto-select only when there is exactly one active
+		 * gateway and the cart actually requires payment. This prevents
+		 * branded buttons (e.g. PayPal) from appearing before the user has
+		 * made a choice, and avoids pre-selecting a paid gateway on free carts.
 		 */
 		$active_gateways = array_keys(wu_get_active_gateway_as_options());
-		$default_gateway = count($active_gateways) === 1 ? current($active_gateways) : '';
+		$saved_gateway   = $this->request_or_session('gateway', '');
+		$default_gateway = '';
+
+		if ($this->should_collect_payment()) {
+			if ($saved_gateway && in_array($saved_gateway, $active_gateways, true)) {
+				$default_gateway = $saved_gateway;
+			} elseif (1 === count($active_gateways)) {
+				$default_gateway = current($active_gateways);
+			}
+		}
 
 		$d = wu_get_site_domain_and_path('replace');
 


### PR DESCRIPTION
## Summary

Addresses CodeRabbit review feedback from PR #830 on `inc/checkout/class-checkout.php`.

**Problem:** The code added in #830 used `count($active_gateways) === 1` as the only guard, which had two flaws:
1. On multi-step checkout redirects with multiple gateways active, any gateway the user had already selected was dropped from the session
2. On free carts with exactly one (paid) gateway configured, that gateway was pre-selected, reintroducing the branded-button issue #830 was meant to fix

**Fix:** Three-tier gateway selection logic:
1. Only attempt gateway pre-selection when `should_collect_payment()` is true (free carts get no gateway pre-selection)
2. If a gateway was already saved in the request/session, restore it (provided it is still an active gateway)
3. Fall back to auto-selecting only when exactly one gateway is configured

## Files Modified

- EDIT: `inc/checkout/class-checkout.php:1970-1971` — replaced two-line gateway selection with the three-tier logic described above

## Verification

- `php -l inc/checkout/class-checkout.php` — no syntax errors
- Logic verified: `request_or_session()` (line 3006) and `should_collect_payment()` (line 2303) both exist and have the expected signatures

Resolves #833