### PR TITLE
fix(tests): restore null screen state with unset in Dashboard_Widgets_Test finally blocks

### DIFF
--- a/tests/WP_Ultimo/Dashboard_Widgets_Test.php
+++ b/tests/WP_Ultimo/Dashboard_Widgets_Test.php
@@ -162,8 +162,10 @@ class Dashboard_Widgets_Test extends \WP_UnitTestCase {
 				$wp_scripts->queue = $original_queue;
 				$wp_scripts->done  = $original_done;
 			}
-			if ($original_screen_id) {
+			if (null !== $original_screen_id) {
 				set_current_screen($original_screen_id);
+			} else {
+				unset($GLOBALS['current_screen']);
 			}
 			$pagenow = $original;
 		}
@@ -209,8 +211,10 @@ class Dashboard_Widgets_Test extends \WP_UnitTestCase {
 				$wp_scripts->queue = $original_queue;
 				$wp_scripts->done  = $original_done;
 			}
-			if ($original_screen_id) {
+			if (null !== $original_screen_id) {
 				set_current_screen($original_screen_id);
+			} else {
+				unset($GLOBALS['current_screen']);
 			}
 			$pagenow = $original;
 		}


### PR DESCRIPTION
## Summary

Fixes leaking screen state in `Dashboard_Widgets_Test` when no screen existed before test execution.

Both `finally` blocks used `if ($original_screen_id)` as the guard before calling `set_current_screen()`. When `$original_screen_id` is `null` (no screen was active before the test), the guard evaluates as falsy and the forced `dashboard-network`/`dashboard` screen leaks into subsequent tests.

**Fix:** replace `if ($original_screen_id)` with `if (null !== $original_screen_id)` and add an `else` branch that calls `unset($GLOBALS['current_screen'])` — the WordPress-recommended way to restore a previously-null screen state (see `wordpress-develop/tests/phpunit/includes/abstract-testcase.php`).

Applies to both test methods:
- `test_enqueue_scripts_enqueues_activity_stream_on_index` (line 165-167)
- `test_enqueue_scripts_skips_activity_stream_on_per_site_dashboard` (line 212-214)

## Changes

- `tests/WP_Ultimo/Dashboard_Widgets_Test.php` — two `finally` blocks updated

## Verification

The fix matches the pattern used in WordPress core test infrastructure. The change prevents screen state leakage when tests run in isolation (no prior screen context).

Resolves #835