### PR TITLE
Rename Cloudflare for SaaS to Cloudflare Custom Hostnames in user-facing strings

### DIFF
--- a/inc/integrations/providers/cloudflare/class-cloudflare-domain-mapping.php
+++ b/inc/integrations/providers/cloudflare/class-cloudflare-domain-mapping.php
@@ -66,9 +66,9 @@ class Cloudflare_Domain_Mapping extends Base_Capability_Module implements Domain
 		$explainer_lines['will_not']['send_domain'] = __('Add domain mappings as new CloudFlare zones', 'ultimate-multisite');
 
 		if ($this->get_cloudflare()->get_credential('WU_CLOUDFLARE_SAAS_ZONE_ID')) {
-			$explainer_lines['will']['custom_hostnames'] = __('Register custom domains as Custom Hostnames in your Cloudflare for SaaS zone, enabling automatic SSL provisioning for mapped domains', 'ultimate-multisite');
+			$explainer_lines['will']['custom_hostnames'] = __('Register custom domains as Cloudflare Custom Hostnames, enabling automatic SSL provisioning for mapped domains', 'ultimate-multisite');
 		} else {
-			$explainer_lines['will_not']['custom_hostnames'] = __('Register custom domains as Cloudflare Custom Hostnames (requires SaaS Zone ID to be configured)', 'ultimate-multisite');
+			$explainer_lines['will_not']['custom_hostnames'] = __('Register custom domains as Cloudflare Custom Hostnames (requires Custom Hostnames Zone ID to be configured)', 'ultimate-multisite');
 		}
 
 		return $explainer_lines;

--- a/inc/integrations/providers/cloudflare/class-cloudflare-integration.php
+++ b/inc/integrations/providers/cloudflare/class-cloudflare-integration.php
@@ -100,9 +100,9 @@ class Cloudflare_Integration extends Integration {
 				],
 			],
 			'WU_CLOUDFLARE_SAAS_ZONE_ID' => [
-				'title'       => __('SaaS Zone ID (Custom Hostnames)', 'ultimate-multisite'),
+				'title'       => __('Custom Hostnames Zone ID', 'ultimate-multisite'),
 				'placeholder' => __('e.g. 644c7705723d62e31f700bb798219c75', 'ultimate-multisite'),
-				'desc'        => __('Optional. The Zone ID of your Cloudflare for SaaS zone. When set, custom domains added to subsites will be registered as Custom Hostnames in that zone, enabling automatic SSL via Cloudflare SaaS.', 'ultimate-multisite'),
+				'desc'        => __('Optional. The Zone ID of the Cloudflare zone with Custom Hostnames enabled. When set, custom domains added to subsites will be registered as Custom Hostnames in that zone, enabling automatic SSL provisioning for mapped domains.', 'ultimate-multisite'),
 			],
 		];
 	}

--- a/readme.txt
+++ b/readme.txt
@@ -292,7 +292,7 @@ Version [2.5.0] - Released on 2026-04-06
 - New: Resubscription flow for cancelled memberships.
 - New: Reactivation flow for cancelled memberships.
 - New: Client-side JavaScript validation on checkout forms.
-- New: Cloudflare for SaaS Custom Hostnames API integration.
+- New: Cloudflare Custom Hostnames integration for automatic SSL on mapped domains.
 - New: DNS record management for mapped domains.
 - New: Template Library behind WU_TEMPLATE_LIBRARY_ENABLED feature flag.
 - New: External Cron Service behind WU_EXTERNAL_CRON_ENABLED feature flag.

--- a/views/wizards/host-integrations/cloudflare-instructions.php
+++ b/views/wizards/host-integrations/cloudflare-instructions.php
@@ -54,12 +54,12 @@ defined('ABSPATH') || exit;
 <hr class="wu-my-6">
 
 <h3 class="wu-m-0 wu-py-4 wu-text-lg" id="cloudflare-saas-custom-hostnames">
-	<?php esc_html_e('Cloudflare for SaaS — Custom Hostnames (Optional)', 'ultimate-multisite'); ?>
+	<?php esc_html_e('Cloudflare Custom Hostnames — Automatic SSL for Mapped Domains (Optional)', 'ultimate-multisite'); ?>
 </h3>
 
 <p class="wu-text-sm wu-bg-green-100 wu-p-4 wu-text-green-700 wu-rounded">
 	<strong><?php esc_html_e('What is this?', 'ultimate-multisite'); ?></strong><br>
-	<?php esc_html_e('Cloudflare for SaaS lets you issue SSL certificates for custom domains mapped to your multisite — without requiring each customer to add your IP to their DNS. When a new domain is added to a subsite, Ultimate Multisite will automatically register it as a Custom Hostname in your SaaS zone so Cloudflare can provision the SSL certificate.', 'ultimate-multisite'); ?>
+	<?php esc_html_e('Cloudflare Custom Hostnames let you issue SSL certificates for custom domains mapped to your multisite — without requiring each customer to add your IP to their DNS. When a new domain is added to a subsite, Ultimate Multisite will automatically register it as a Custom Hostname in your Cloudflare zone so Cloudflare can provision the SSL certificate.', 'ultimate-multisite'); ?>
 </p>
 
 <p class="wu-text-sm">
@@ -67,11 +67,11 @@ defined('ABSPATH') || exit;
 </p>
 
 <ol class="wu-text-sm wu-list-decimal wu-pl-6 wu-space-y-2">
-	<li><?php esc_html_e('In your Cloudflare dashboard, open the zone you want to use as the SaaS provider zone (this is typically your main domain zone).', 'ultimate-multisite'); ?></li>
+	<li><?php esc_html_e('In your Cloudflare dashboard, open the zone you want to use for Custom Hostnames (this is typically your main domain zone).', 'ultimate-multisite'); ?></li>
 	<li><?php esc_html_e('Go to SSL/TLS → Custom Hostnames and enable Cloudflare for SaaS for that zone.', 'ultimate-multisite'); ?></li>
-	<li><?php esc_html_e('Copy the Zone ID of that SaaS zone from the Overview sidebar — this is your SaaS Zone ID.', 'ultimate-multisite'); ?></li>
-	<li><?php esc_html_e('Ensure your API token has the "SSL and Certificates: Edit" permission in addition to "DNS: Edit" for the SaaS zone.', 'ultimate-multisite'); ?></li>
-	<li><?php esc_html_e('Paste the SaaS Zone ID into the SaaS Zone ID (Custom Hostnames) field on the next step.', 'ultimate-multisite'); ?></li>
+	<li><?php esc_html_e('Copy the Zone ID of that zone from the Overview sidebar — this is your Custom Hostnames Zone ID.', 'ultimate-multisite'); ?></li>
+	<li><?php esc_html_e('Ensure your API token has the "SSL and Certificates: Edit" permission in addition to "DNS: Edit" for the Custom Hostnames zone.', 'ultimate-multisite'); ?></li>
+	<li><?php esc_html_e('Paste the Zone ID into the Custom Hostnames Zone ID field on the next step.', 'ultimate-multisite'); ?></li>
 </ol>
 
 <p class="wu-text-sm wu-bg-yellow-100 wu-p-4 wu-text-yellow-700 wu-rounded wu-mt-4">


### PR DESCRIPTION
## Summary

- Renames all user-facing references from "Cloudflare for SaaS" to "Cloudflare Custom Hostnames" across changelog, admin UI fields, explainer lines, and setup instructions.
- "Cloudflare for SaaS" is Cloudflare's product-tier branding, not a description of what the feature does for our users. The actual value is "automatic SSL for mapped domains via Custom Hostnames" — the new naming describes the capability, not the upsell label.

## Changes

| File | Change |
|---|---|
| `readme.txt` | Changelog entry rewritten to describe the feature |
| `class-cloudflare-integration.php` | Field title: "SaaS Zone ID (Custom Hostnames)" → "Custom Hostnames Zone ID"; description updated |
| `class-cloudflare-domain-mapping.php` | Explainer lines: removed "in your Cloudflare for SaaS zone" phrasing |
| `cloudflare-instructions.php` | Section heading, "What is this?" paragraph, and setup steps updated |

## Intentionally unchanged

- `WU_CLOUDFLARE_SAAS_ZONE_ID` constant — renaming would break existing deployments
- PHPDoc comments referencing "Cloudflare for SaaS Custom Hostnames API" — developer-facing, matches Cloudflare's API docs
- Instructions step 2: "enable Cloudflare for SaaS for that zone" — that's the literal button label in the Cloudflare dashboard

## Verification

- `vendor/bin/phpcs` on the 3 changed PHP files
- Visual review of all user-facing strings for consistency