### PR TITLE
Fix select placeholder falsy comparison and add value attribute

### DIFF
--- a/views/checkout/fields/field-select.php
+++ b/views/checkout/fields/field-select.php
@@ -42,7 +42,7 @@ defined('ABSPATH') || exit;
 
 	<?php if ($field->placeholder) : ?>
 
-	<option <?php selected(! $field->value); ?> class="wu-opacity-75"><?php echo esc_html($field->placeholder); ?></option>
+	<option value="" <?php selected('', (string) $field->value); ?> class="wu-opacity-75"><?php echo esc_html($field->placeholder); ?></option>
 
 	<?php endif; ?>
 


### PR DESCRIPTION
## Summary

Follow-up to #843 (by @commercial-hippie) — addresses the additional finding from CodeRabbit's review.

**Two issues on the placeholder `<option>` in `field-select.php`:**

1. **Missing `value=""` attribute** — without it, the form submits the placeholder text as the value instead of an empty string
2. **Falsy comparison bug** — `selected(! $field->value)` treats any falsy value (`"0"`, `0`, `null`, `""`) as "no selection", so a legitimate option with value `"0"` would incorrectly show the placeholder as selected

### Change

```diff
-<option <?php selected(! $field->value); ?> class="wu-opacity-75">
+<option value="" <?php selected('', (string) $field->value); ?> class="wu-opacity-75">
```

Uses the proper two-argument `selected()` comparison with explicit string cast, so the placeholder is only selected when the field value is genuinely empty.