### PR TITLE
t858: fix Cypress E2E setup tests failing on all branches

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -92,6 +92,24 @@ jobs:
           echo "Final check:"
           curl -s http://localhost:8889 || echo "WordPress not responding"
 
+      - name: Network-activate plugin in tests environment
+        run: |
+          echo "=== Network-activating Ultimate Multisite plugin ==="
+          PLUGIN_SLUG=$(basename "$PWD")
+          echo "Plugin slug: $PLUGIN_SLUG"
+
+          # Network-activate so wu_save_setting() and other functions
+          # are fully bootstrapped for all wp eval / eval-file calls.
+          npx wp-env run tests-cli wp plugin activate "$PLUGIN_SLUG" --network || \
+            npx wp-env run tests-cli wp plugin activate ultimate-multisite --network || \
+            echo "⚠️  Could not network-activate by directory name, listing plugins..."
+
+          echo "Plugin list after activation attempt:"
+          npx wp-env run tests-cli wp plugin list --status=active --format=table
+
+          echo "Verifying wu_save_setting() is available:"
+          npx wp-env run tests-cli wp eval "var_dump(function_exists('wu_save_setting'));" || true
+
       - name: Comprehensive WordPress Debug
         run: |
           echo "=== WordPress Environment Debug ==="
@@ -144,6 +162,14 @@ jobs:
             --config-file cypress.config.test.js \
             --spec "tests/e2e/cypress/integration/000-setup.spec.js" \
             --browser ${{ matrix.browser }}
+
+      - name: Dump container logs on setup failure
+        if: failure() && steps.setup-test.outcome == 'failure'
+        run: |
+          echo "=== Container logs (last 100 lines) ==="
+          docker logs $(docker ps -q --filter "name=tests-wordpress") 2>&1 | tail -100 || echo "Could not get container logs"
+          echo "=== PHP error log ==="
+          npx wp-env run tests-cli cat /var/www/html/wp-content/debug.log 2>&1 | tail -100 || echo "No debug.log found"
 
       - name: Run Checkout Tests (After Setup)
         id: checkout-tests

--- a/tests/e2e/cypress/fixtures/setup-disable-custom-login.php
+++ b/tests/e2e/cypress/fixtures/setup-disable-custom-login.php
@@ -1,0 +1,18 @@
+<?php
+/**
+ * Disable the custom login page redirect for e2e testing.
+ *
+ * If a previous wizard run enabled the custom login page, /wp-login.php
+ * redirects to /login/ and loginByForm breaks. This runs with
+ * failOnNonZeroExit: false because the plugin may not yet be
+ * network-activated when the before() hook executes.
+ *
+ * Using a fixture file instead of inline wp eval to avoid shell-quoting
+ * issues through the npx -> wp-env -> docker exec -> wp eval chain.
+ */
+if ( function_exists( 'wu_save_setting' ) ) {
+	wu_save_setting( 'enable_custom_login_page', 0 );
+	echo 'disabled';
+} else {
+	echo 'skipped:wu_save_setting not available';
+}

--- a/tests/e2e/cypress/fixtures/setup-email-settings.php
+++ b/tests/e2e/cypress/fixtures/setup-email-settings.php
@@ -1,0 +1,13 @@
+<?php
+/**
+ * Disable email verification and enable sync site publish for e2e testing.
+ *
+ * Using a fixture file instead of inline wp eval to avoid shell-quoting
+ * issues through the npx -> wp-env -> docker exec -> wp eval chain.
+ */
+wu_save_setting( 'enable_email_verification', 'never' );
+wu_save_setting( 'force_publish_sites_sync', true );
+
+$email_verification = wu_get_setting( 'enable_email_verification', 'always' );
+
+echo 'email_verification:' . esc_html( $email_verification );

--- a/tests/e2e/cypress/fixtures/setup-gateway.php
+++ b/tests/e2e/cypress/fixtures/setup-gateway.php
@@ -1,0 +1,17 @@
+<?php
+/**
+ * Enable the manual gateway in Ultimate Multisite for e2e testing.
+ *
+ * Using a fixture file instead of inline wp eval to avoid shell-quoting
+ * issues through the npx -> wp-env -> docker exec -> wp eval chain.
+ */
+wu_save_setting( 'active_gateways', array( 'manual' ) );
+
+$active = wu_get_setting( 'active_gateways', array() );
+
+if ( in_array( 'manual', (array) $active, true ) ) {
+	echo 'gateway:manual';
+} else {
+	echo 'error:manual gateway not found in active_gateways';
+	exit( 1 );
+}

--- a/tests/e2e/cypress/fixtures/setup-password-strength.php
+++ b/tests/e2e/cypress/fixtures/setup-password-strength.php
@@ -1,0 +1,12 @@
+<?php
+/**
+ * Set password strength to 'strong' for e2e testing.
+ *
+ * Using a fixture file instead of inline wp eval to avoid shell-quoting
+ * issues through the npx -> wp-env -> docker exec -> wp eval chain.
+ */
+wu_save_setting( 'password_strength', 'strong' );
+
+$strength = wu_get_setting( 'password_strength', 'none' );
+
+echo 'password_strength:' . esc_html( $strength );

--- a/tests/e2e/cypress/integration/000-setup.spec.js
+++ b/tests/e2e/cypress/integration/000-setup.spec.js
@@ -2,8 +2,10 @@ describe("Ultimate Multisite Setup", () => {
 	before(() => {
 		// Disable custom login page if a previous wizard run enabled it,
 		// otherwise /wp-login.php redirects to /login/ and loginByForm breaks.
-		cy.wpCli(
-			'eval "if (function_exists(\'wu_save_setting\')) { wu_save_setting(\'enable_custom_login_page\', 0); }"',
+		// Uses failOnNonZeroExit: false because the plugin may not yet be
+		// network-activated at this point.
+		cy.wpCliFile(
+			"tests/e2e/cypress/fixtures/setup-disable-custom-login.php",
 			{ failOnNonZeroExit: false }
 		);
 
@@ -40,34 +42,32 @@ describe("Ultimate Multisite Setup", () => {
 	});
 
 	it("Should enable the manual gateway in Ultimate Multisite", () => {
-		cy.wpCli(
-			"eval \"wu_save_setting('active_gateways', ['manual']);\""
-		);
-
-		cy.wpCli(
-			"eval \"echo json_encode(wu_get_setting('active_gateways', []));\""
+		// Uses a fixture file to avoid shell-quoting issues through the
+		// npx -> wp-env -> docker exec -> wp eval chain.
+		cy.wpCliFile(
+			"tests/e2e/cypress/fixtures/setup-gateway.php"
 		).then((result) => {
-			expect(result.stdout).to.contain("manual");
+			expect(result.stdout).to.contain("gateway:manual");
 		});
 	});
 
 	it("Should disable email verification and enable sync site publish", () => {
-		cy.wpCli(
-			"eval \"wu_save_setting('enable_email_verification', 'never'); wu_save_setting('force_publish_sites_sync', true);\""
-		);
-
-		cy.wpCli(
-			"eval \"echo wu_get_setting('enable_email_verification', 'always');\""
+		// Uses a fixture file to avoid shell-quoting issues through the
+		// npx -> wp-env -> docker exec -> wp eval chain.
+		cy.wpCliFile(
+			"tests/e2e/cypress/fixtures/setup-email-settings.php"
 		).then((result) => {
-			expect(result.stdout).to.contain("never");
+			expect(result.stdout).to.contain("email_verification:never");
 		});
 	});
 
 	it("Should reset password strength to default", () => {
-		cy.wpCli(
-			"eval \"wu_save_setting('password_strength', 'strong'); echo wu_get_setting('password_strength', 'none');\""
+		// Uses a fixture file to avoid shell-quoting issues through the
+		// npx -> wp-env -> docker exec -> wp eval chain.
+		cy.wpCliFile(
+			"tests/e2e/cypress/fixtures/setup-password-strength.php"
 		).then((result) => {
-			expect(result.stdout).to.contain("strong");
+			expect(result.stdout).to.contain("password_strength:strong");
 		});
 	});
 });

--- a/tests/e2e/cypress/support/commands/index.js
+++ b/tests/e2e/cypress/support/commands/index.js
@@ -3,7 +3,9 @@ import "./wizard";
 import "./domain-mapping";
 
 Cypress.Commands.add("wpCli", (command, options = {}) => {
-  cy.exec(`npx wp-env run tests-cli wp ${command}`, {
+  // Redirect stderr to stdout so Cypress captures PHP errors from the container
+  // (wp-env only surfaces stderr as a Node TLS warning by default, hiding real errors).
+  cy.exec(`npx wp-env run tests-cli wp ${command} 2>&1`, {
     ...options,
     timeout: options.timeout || 60000,
   });
@@ -16,7 +18,8 @@ Cypress.Commands.add("wpCli", (command, options = {}) => {
 Cypress.Commands.add("wpCliFile", (filePath, options = {}) => {
   const containerPath = `/var/www/html/wp-content/plugins/ultimate-multisite/${filePath}`;
 
-  cy.exec(`npx wp-env run tests-cli wp eval-file ${containerPath}`, {
+  // Redirect stderr to stdout so Cypress captures PHP errors from the container.
+  cy.exec(`npx wp-env run tests-cli wp eval-file ${containerPath} 2>&1`, {
     ...options,
     timeout: options.timeout || 60000,
   });


### PR DESCRIPTION
## Summary

Fixes the consistent failure of 4/6 tests in `000-setup.spec.js` across all branches.

**Root causes fixed:**

1. **Plugin not network-activated** — `wp-env` installs but does not network-activate the plugin, so `wu_save_setting()` and related functions are unavailable for `wp eval`/`eval-file` calls. Fixed by adding an explicit network-activation step in the CI workflow before Cypress runs.

2. **Shell quoting corruption** — inline `wp eval "wu_save_setting('active_gateways', ['manual']);"` calls are mangled through the `npx → wp-env → docker exec → wp eval` chain. Fixed by extracting all three inline calls to dedicated fixture PHP files.

3. **Swallowed stderr** — `cy.exec()` only surfaced a Node TLS warning, hiding the actual PHP errors from the container. Fixed by appending `2>&1` in `wpCli`/`wpCliFile` commands so container stderr is merged into stdout and visible in Cypress output.

## Files changed

- `.github/workflows/e2e.yml` — adds "Network-activate plugin" step; adds "Dump container logs on setup failure" step for diagnostics
- `tests/e2e/cypress/integration/000-setup.spec.js` — replaces all inline `cy.wpCli("eval ...")` calls with `cy.wpCliFile()` pointing to fixture files
- `tests/e2e/cypress/support/commands/index.js` — adds `2>&1` to merge container stderr into stdout
- `tests/e2e/cypress/fixtures/setup-gateway.php` — new: enables manual gateway, asserts output
- `tests/e2e/cypress/fixtures/setup-email-settings.php` — new: disables email verification, enables force-publish sync
- `tests/e2e/cypress/fixtures/setup-password-strength.php` — new: sets password strength to `strong`
- `tests/e2e/cypress/fixtures/setup-disable-custom-login.php` — new: disables custom login redirect (before-hook, tolerates missing function)

## Verification

The CI E2E workflow (`e2e.yml`) is the verification gate. The network activation step will confirm `wu_save_setting()` is available via `var_dump(function_exists('wu_save_setting'))` output before Cypress runs. Container log dumping on failure provides actionable debug output if any test still fails.

Resolves #858