### PR TITLE
feat: add atomic increment_item() to BerlinDB Query class

### DIFF
--- a/inc/database/engine/class-query.php
+++ b/inc/database/engine/class-query.php
@@ -116,4 +116,139 @@ class Query extends \BerlinDB\Database\Query {
 			? array_values($filter)
 			: array();
 	}
+
+	/**
+	 * Atomically increment numeric columns on an existing item.
+	 *
+	 * Uses SQL `SET column = column + value` to avoid read-modify-write race
+	 * conditions when multiple processes update the same row concurrently.
+	 *
+	 * Non-numeric columns can be set (replaced) at the same time via $sets.
+	 *
+	 * Unlike update_item(), this method does NOT fire transition hooks, does
+	 * NOT process meta, and does NOT diff against the current row — by design,
+	 * it never reads the row before writing.
+	 *
+	 * @since 2.4.9
+	 *
+	 * @param int   $item_id          The item ID to update.
+	 * @param array $increments       Column => numeric value pairs to atomically add.
+	 *                                Example: ['cost_value' => 0.005, 'input_tokens' => 150].
+	 * @param array $sets             Column => value pairs to set (replace, not increment).
+	 *                                Example: ['provider_id' => 'anthropic', 'model_id' => 'claude-sonnet-4'].
+	 * @param bool  $invalidate_cache Whether to invalidate the object cache after the update.
+	 *                                Set to false for high-frequency increments where eventual
+	 *                                consistency is acceptable (e.g. usage counters read by
+	 *                                dashboards). The cache will self-heal on TTL expiry.
+	 *                                Default true.
+	 * @return int|false Number of rows affected, or false on failure.
+	 */
+	public function increment_item( $item_id = 0, $increments = [], $sets = [], $invalidate_cache = true ) {
+
+		// Bail if nothing to do.
+		if ( empty( $increments ) && empty( $sets ) ) {
+			return false;
+		}
+
+		// Bail if no item ID.
+		$item_id = absint( $item_id );
+		if ( empty( $item_id ) ) {
+			return false;
+		}
+
+		$db = $this->get_db();
+
+		// Bail if no database interface.
+		if ( empty( $db ) ) {
+			return false;
+		}
+
+		// Resolve the fully-qualified table name (same as private get_table_name()).
+		$table = $db->{$this->table_name};
+		if ( empty( $table ) ) {
+			return false;
+		}
+
+		// Get valid column names for this table.
+		$valid_columns = array_flip( $this->get_columns( [], 'and', 'name' ) );
+
+		// Get the primary column name.
+		$primary_columns = $this->get_columns( [ 'primary' => true ], 'and', 'name' );
+		$primary         = ! empty( $primary_columns ) ? reset( $primary_columns ) : 'id';
+
+		// Build SET clause fragments and prepare values.
+		$set_clauses = [];
+		$values      = [];
+
+		// Process increments: column = column + %f/%d.
+		foreach ( $increments as $column => $amount ) {
+
+			// Skip non-existent or primary columns.
+			if ( ! isset( $valid_columns[ $column ] ) || $column === $primary ) {
+				continue;
+			}
+
+			// Determine placeholder based on type.
+			if ( is_float( $amount ) ) {
+				$set_clauses[] = "`{$column}` = `{$column}` + %f";
+			} else {
+				$set_clauses[] = "`{$column}` = `{$column}` + %d";
+			}
+
+			$values[] = $amount;
+		}
+
+		// Process sets: column = %s/%f/%d.
+		foreach ( $sets as $column => $value ) {
+
+			// Skip non-existent or primary columns.
+			if ( ! isset( $valid_columns[ $column ] ) || $column === $primary ) {
+				continue;
+			}
+
+			if ( is_float( $value ) ) {
+				$set_clauses[] = "`{$column}` = %f";
+			} elseif ( is_int( $value ) ) {
+				$set_clauses[] = "`{$column}` = %d";
+			} else {
+				$set_clauses[] = "`{$column}` = %s";
+			}
+
+			$values[] = $value;
+		}
+
+		// Bail if no valid clauses.
+		if ( empty( $set_clauses ) ) {
+			return false;
+		}
+
+		// Add the WHERE value.
+		$values[] = $item_id;
+
+		// Build and execute the query.
+		$sql = sprintf(
+			"UPDATE `%s` SET %s WHERE `%s` = %%d",
+			$table,
+			implode( ', ', $set_clauses ),
+			$primary
+		);
+
+		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- Dynamic column names validated against schema above.
+		$result = $db->query( $db->prepare( $sql, $values ) );
+
+		// Bail on failure.
+		if ( ! $this->is_success( $result ) ) {
+			return false;
+		}
+
+		// Optionally invalidate object cache for this item.
+		if ( $invalidate_cache ) {
+			wp_cache_delete( $item_id, $this->cache_group );
+
+			// Bump last_changed so list queries re-fetch.
+			wp_cache_set( 'last_changed', microtime(), $this->cache_group );
+		}
+
+		return $result;
+	}
 }


### PR DESCRIPTION
Adds increment_item() for atomic SQL-level increments to avoid read-modify-write race conditions. Supports mixed increment/set operations, schema column validation, Network_Prefix-aware table resolution, and optional cache invalidation. Consumer: metered-plans PR 10.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features

* Enhanced item update operations with atomic database transactions for improved data consistency
* Improved cache management for updated items with automatic invalidation support

<!-- end of auto-generated comment: release notes by coderabbit.ai -->