### PR TITLE
fix: default role in Login & Registration settings shows administrator by default

### DIFF
--- a/inc/class-settings.php
+++ b/inc/class-settings.php
@@ -176,7 +176,7 @@ class Settings implements \WP_Ultimo\Interfaces\Singleton {
 			foreach ($section['fields'] ?? [] as $field_slug => $field_atts) {
 				if (is_callable($field_atts['value'])) {
 					$value = $field_atts['value']();
-					if (isset($all_settings[ $field_slug ]) && $value !== $all_settings[ $field_slug ]) {
+					if ( ! isset($all_settings[ $field_slug ]) || $value !== $all_settings[ $field_slug ]) {
 						$all_settings[ $field_slug ] = $value;
 					}
 				}
@@ -934,7 +934,7 @@ class Settings implements \WP_Ultimo\Interfaces\Singleton {
 				'desc'    => __('Set the role to be applied to the user during the signup process.', 'ultimate-multisite'),
 				'type'    => 'select',
 				'default' => 'administrator',
-				'options' => 'wu_get_roles_as_options',
+				'options' => fn() => wu_get_roles_as_options(),
 			]
 		);
 
@@ -957,7 +957,7 @@ class Settings implements \WP_Ultimo\Interfaces\Singleton {
 				'desc'    => __('Select the role Ultimate Multisite should use when adding the user to the main site of your network. Be careful.', 'ultimate-multisite'),
 				'type'    => 'select',
 				'default' => 'subscriber',
-				'options' => 'wu_get_roles_as_options',
+				'options' => fn() => wu_get_roles_as_options(),
 				'require' => [
 					'add_users_to_main_site' => 1,
 				],

--- a/tests/WP_Ultimo/Settings_Test.php
+++ b/tests/WP_Ultimo/Settings_Test.php
@@ -414,4 +414,87 @@ class Settings_Test extends WP_UnitTestCase {
 		$section = $this->settings->get_section('login-and-registration');
 		$this->assertArrayHasKey('minimum_password_strength', $section['fields']);
 	}
+
+	// ------------------------------------------------------------------
+	// default_role options — GH#865
+	// ------------------------------------------------------------------
+
+	/**
+	 * The default_role select must not include "Use Ultimate Multisite default"
+	 * (key 'default'). That option appears only when wu_get_roles_as_options()
+	 * is called with $add_default_option = true — which happened because the
+	 * string 'wu_get_roles_as_options' was passed as the options callback and
+	 * Field::__get() forwarded $this (truthy) as the first argument.
+	 */
+	public function test_default_role_options_do_not_include_wu_default_option() {
+		$section = $this->settings->get_section('login-and-registration');
+		$this->assertArrayHasKey('default_role', $section['fields']);
+
+		$options_callback = $section['fields']['default_role']['options'];
+		$this->assertIsCallable($options_callback);
+
+		$options = $options_callback();
+		$this->assertArrayNotHasKey('default', $options);
+	}
+
+	public function test_main_site_default_role_options_do_not_include_wu_default_option() {
+		$section = $this->settings->get_section('login-and-registration');
+		$this->assertArrayHasKey('main_site_default_role', $section['fields']);
+
+		$options_callback = $section['fields']['main_site_default_role']['options'];
+		$this->assertIsCallable($options_callback);
+
+		$options = $options_callback();
+		$this->assertArrayNotHasKey('default', $options);
+	}
+
+	public function test_default_role_options_include_administrator() {
+		$section          = $this->settings->get_section('login-and-registration');
+		$options_callback = $section['fields']['default_role']['options'];
+
+		$options = $options_callback();
+		$this->assertArrayHasKey('administrator', $options);
+	}
+
+	// ------------------------------------------------------------------
+	// get_all_with_defaults includes settings not yet saved to DB — GH#865
+	// ------------------------------------------------------------------
+
+	/**
+	 * When the DB has no saved settings (fresh install), get_all_with_defaults()
+	 * must still include registered fields with their computed defaults so the
+	 * Vue data-state on the settings page initialises correctly.
+	 */
+	public function test_get_all_with_defaults_includes_default_role_when_db_is_empty() {
+		// Simulate a fresh install with no saved settings.
+		wu_save_option(Settings::KEY, []);
+
+		$ref = new \ReflectionProperty(Settings::class, 'settings');
+		if (PHP_VERSION_ID < 80100) {
+			$ref->setAccessible(true);
+		}
+		$ref->setValue($this->settings, null);
+
+		$all = $this->settings->get_all_with_defaults();
+
+		$this->assertArrayHasKey('default_role', $all);
+		$this->assertEquals('administrator', $all['default_role']);
+	}
+
+	public function test_get_all_with_defaults_preserves_saved_values() {
+		// When a value IS saved in the DB it must be preserved.
+		$this->settings->save_setting('default_role', 'editor');
+
+		// Reset internal cache so get_all re-reads from option.
+		$ref = new \ReflectionProperty(Settings::class, 'settings');
+		if (PHP_VERSION_ID < 80100) {
+			$ref->setAccessible(true);
+		}
+		$ref->setValue($this->settings, null);
+
+		$all = $this->settings->get_all_with_defaults();
+
+		$this->assertArrayHasKey('default_role', $all);
+		$this->assertEquals('editor', $all['default_role']);
+	}
 }


### PR DESCRIPTION
## Problem

On a fresh install (no settings saved to DB), the **Default Role** select in the Login & Registration settings page showed **"Use Ultimate Multisite default"** as the visible selection instead of **"Administrator"**.

Two bugs combined to cause this:

### Bug 1 — Unwanted "Ultimate Multisite default" option injected

`Field::__get()` calls `wu_get_roles_as_options` via `call_user_func($attr, $this)`, forwarding the `Field` object as the first argument. Since an object is truthy, `wu_get_roles_as_options($field_object)` resolved `$add_default_option = true`, injecting the placeholder "Use Ultimate Multisite default" option (key `'default'`).

**Fix:** replace the bare string reference with an explicit closure:
```php
// Before
'options' => 'wu_get_roles_as_options',

// After
'options' => fn() => wu_get_roles_as_options(),
```
Applied to both `default_role` and `main_site_default_role` fields.

### Bug 2 — Vue data-state missing `default_role` on fresh install

`get_all_with_defaults()` guarded its update loop with `isset($all_settings[$field_slug])`. When the DB has no saved settings the key is absent, so the Vue `data-state` JSON never received the `default_role` entry. Vue's v-model had no value to bind and fell back to the first rendered option (the injected placeholder from Bug 1).

**Fix:** drop the `isset()` guard so registered fields are always included in the state with their computed default value:
```php
// Before
if (isset($all_settings[$field_slug]) && $value !== $all_settings[$field_slug]) {

// After
if (!isset($all_settings[$field_slug]) || $value !== $all_settings[$field_slug]) {
```

## Files changed

- `EDIT: inc/class-settings.php` — closures for both role select `options`, updated `get_all_with_defaults` condition
- `EDIT: tests/WP_Ultimo/Settings_Test.php` — 5 new assertions covering both regressions

## Verification

```bash
WP_TESTS_DIR=/tmp/wordpress-tests-lib vendor/bin/phpunit --filter Settings_Test
# OK (47 tests, 63 assertions)
```

Resolves #865