### PR TITLE
feat: add template selection field to single-step and multi-step checkout form templates

### DIFF
--- a/inc/models/class-checkout-form.php
+++ b/inc/models/class-checkout-form.php
@@ -609,6 +609,14 @@ class Checkout_Form extends Base_Model {
 						'display_url_preview' => true,
 					],
 					[
+						'step'                        => 'checkout',
+						'name'                        => __('Template Selection', 'ultimate-multisite'),
+						'type'                        => 'template_selection',
+						'id'                          => 'template_selection',
+						'template_selection_type'     => 'all',
+						'template_selection_template' => 'clean',
+					],
+					[
 						'step'                   => 'checkout',
 						'name'                   => __('Your Order', 'ultimate-multisite'),
 						'type'                   => 'order_summary',
@@ -820,6 +828,14 @@ class Checkout_Form extends Base_Model {
 						'tooltip'             => '',
 						'auto_generate'       => false,
 						'display_url_preview' => true,
+					],
+					[
+						'step'                        => 'checkout',
+						'name'                        => __('Template Selection', 'ultimate-multisite'),
+						'type'                        => 'template_selection',
+						'id'                          => 'template_selection',
+						'template_selection_type'     => 'all',
+						'template_selection_template' => 'clean',
 					],
 					[
 						'step' => 'site',

--- a/tests/WP_Ultimo/Models/Checkout_Form_Test.php
+++ b/tests/WP_Ultimo/Models/Checkout_Form_Test.php
@@ -3034,4 +3034,65 @@ class Checkout_Form_Test extends WP_UnitTestCase {
 		$this->assertContains('email', $field_types);
 		$this->assertContains('password', $field_types);
 	}
+
+	/**
+	 * Test single-step template includes a template_selection field showing all templates.
+	 */
+	public function test_single_step_template_contains_template_selection_field(): void {
+		$checkout_form = new Checkout_Form();
+
+		$checkout_form->use_template('single-step');
+		$settings = $checkout_form->get_settings();
+
+		$field_types = array_column($settings[0]['fields'], 'type');
+		$this->assertContains('template_selection', $field_types, 'Single-step template must include a template_selection field');
+
+		// Locate the field and verify it is configured to show all templates.
+		$template_field = null;
+		foreach ($settings[0]['fields'] as $field) {
+			if ('template_selection' === $field['type']) {
+				$template_field = $field;
+				break;
+			}
+		}
+
+		$this->assertNotNull($template_field, 'template_selection field must be present');
+		$this->assertEquals('all', $template_field['template_selection_type'], 'template_selection_type must be "all"');
+	}
+
+	/**
+	 * Test multi-step template includes a template_selection field in the site step showing all templates.
+	 */
+	public function test_multi_step_template_site_step_contains_template_selection_field(): void {
+		$checkout_form = new Checkout_Form();
+
+		$checkout_form->use_template('multi-step');
+		$settings = $checkout_form->get_settings();
+
+		// Find the 'site' step.
+		$site_step = null;
+		foreach ($settings as $step) {
+			if ('site' === $step['id']) {
+				$site_step = $step;
+				break;
+			}
+		}
+
+		$this->assertNotNull($site_step, 'Multi-step template must have a "site" step');
+
+		$field_types = array_column($site_step['fields'], 'type');
+		$this->assertContains('template_selection', $field_types, 'Multi-step "site" step must include a template_selection field');
+
+		// Locate the field and verify it is configured to show all templates.
+		$template_field = null;
+		foreach ($site_step['fields'] as $field) {
+			if ('template_selection' === $field['type']) {
+				$template_field = $field;
+				break;
+			}
+		}
+
+		$this->assertNotNull($template_field, 'template_selection field must be present in the site step');
+		$this->assertEquals('all', $template_field['template_selection_type'], 'template_selection_type must be "all"');
+	}
 }


### PR DESCRIPTION
## Summary

All three pre-configured checkout forms (single-step, multi-step, simple) now include a `template_selection` field configured to show all available site templates. This ensures the out-of-the-box experience results in template sites being applied when customers complete checkout.

- **single-step**: added `template_selection` field after `site_url`, before `order_summary`
- **multi-step**: added `template_selection` field in the 'site' step after `site_url`, before the next-step button
- **simple**: already had the field (no change required)

Both new fields use `template_selection_type => 'all'` and `template_selection_template => 'clean'` to match the existing simple template configuration and show all available templates.

## Files Modified

- `EDIT: inc/models/class-checkout-form.php` — added `template_selection` field array to `get_single_step_template()` and `get_multi_step_template()`
- `EDIT: tests/WP_Ultimo/Models/Checkout_Form_Test.php` — added two new tests asserting the field is present and configured correctly in both templates

## Testing

```bash
WP_TESTS_DIR=/tmp/wordpress-tests-lib vendor/bin/phpunit --filter "Checkout_Form_Test"
# OK (121 tests, 393 assertions)
```

Resolves #867