### PR TITLE
fix: use _ajax_nonce for network-activate AJAX handler (#836)

### DIFF
--- a/assets/js/network-activate.js
+++ b/assets/js/network-activate.js
@@ -1,0 +1,65 @@
+/**
+ * Network Activate button handler for the Setup Wizard requirements table.
+ *
+ * Fires an AJAX request to network-activate Ultimate Multisite, then
+ * reloads the page on success or shows an error message with a fallback
+ * help link on failure.
+ *
+ * @package WP_Ultimo
+ * @subpackage Assets
+ * @since 2.6.0
+ */
+
+/* global jQuery, ajaxurl, wu_network_activate */
+jQuery(function($) {
+
+	$(document).on('click', '.wu-network-activate-btn', function() {
+
+		var $btn      = $(this);
+		var $wrapper  = $btn.closest('div');
+		var nonce     = $btn.data('ajax-nonce');
+		var $spinner  = $wrapper.find('.wu-network-activate-spinner');
+		var $message  = $wrapper.find('.wu-network-activate-message');
+		var $fallback = $wrapper.find('.wu-network-activate-fallback');
+
+		$btn.prop('disabled', true);
+		$spinner.addClass('is-active');
+		$message.text('');
+
+		$.post(
+			ajaxurl,
+			{
+				action: 'wu_setup_network_activate',
+				_ajax_nonce: nonce,
+			},
+			function(response) {
+
+				if (response.success) {
+					window.location.reload();
+					return;
+				}
+
+				$spinner.removeClass('is-active');
+				$btn.hide();
+				$fallback.show();
+
+				var errorMsg = wu_network_activate.error_message;
+
+				if (response.data && response.data.message) {
+					errorMsg = response.data.message;
+				}
+
+				$message.text(errorMsg);
+			}
+		).fail(function() {
+
+			$spinner.removeClass('is-active');
+			$btn.hide();
+			$fallback.show();
+			$message.text(wu_network_activate.error_message);
+
+		});
+
+	});
+
+});

--- a/inc/admin-pages/class-setup-wizard-admin-page.php
+++ b/inc/admin-pages/class-setup-wizard-admin-page.php
@@ -161,10 +161,14 @@ class Setup_Wizard_Admin_Page extends Wizard_Admin_Page {
 	 */
 	public function ajax_network_activate(): void {
 
-		check_ajax_referer('wu_setup_network_activate', 'nonce');
-
 		if ( ! current_user_can('manage_network')) {
 			wp_send_json_error(new \WP_Error('not-allowed', __('Permission denied.', 'ultimate-multisite')));
+
+			exit;
+		}
+
+		if ( ! check_ajax_referer('wu_setup_network_activate', false, false)) {
+			wp_send_json_error(new \WP_Error('bad-nonce', __('Security check failed. Please reload the page and try again.', 'ultimate-multisite')));
 
 			exit;
 		}
@@ -973,6 +977,16 @@ class Setup_Wizard_Admin_Page extends Wizard_Admin_Page {
 		}
 
 		wp_enqueue_script('wu-setup-wizard-extra', wu_get_asset('setup-wizard-extra.js', 'js'), ['jquery', 'wu-fields', 'wu-functions', 'wubox'], wu_get_version(), true);
+
+		wp_enqueue_script('wu-network-activate', wu_get_asset('network-activate.js', 'js'), ['jquery'], wu_get_version(), true);
+
+		wp_localize_script(
+			'wu-network-activate',
+			'wu_network_activate',
+			[
+				'error_message' => __('Activation failed. Please activate the plugin manually.', 'ultimate-multisite'),
+			]
+		);
 
 		wp_enqueue_media();
 

--- a/tests/WP_Ultimo/Admin_Pages/Setup_Wizard_Admin_Page_Test.php
+++ b/tests/WP_Ultimo/Admin_Pages/Setup_Wizard_Admin_Page_Test.php
@@ -453,12 +453,12 @@ class Setup_Wizard_Admin_Page_Test extends WP_UnitTestCase {
 	}
 
 	// -------------------------------------------------------------------------
-	// ajax_network_activate() — permission guard
+	// ajax_network_activate() — permission guard (checked before nonce)
 	// -------------------------------------------------------------------------
 
 	public function test_ajax_network_activate_sends_json_error_without_permission(): void {
-		// Provide a valid nonce so the nonce check passes, isolating the permission check.
-		$_REQUEST['nonce'] = wp_create_nonce('wu_setup_network_activate');
+		// Capability check fires before nonce check, so no nonce needed to
+		// isolate this path — an unauthenticated user is rejected immediately.
 		wp_set_current_user(0);
 		$this->expectException(\WPAjaxDieStopException::class);
 		$this->page->ajax_network_activate();

--- a/views/wizards/setup/requirements_table.php
+++ b/views/wizards/setup/requirements_table.php
@@ -77,7 +77,7 @@ defined('ABSPATH') || exit;
 						<button
 							type="button"
 							class="button button-primary wu-network-activate-btn"
-							data-nonce="<?php echo esc_attr($req['network_activate_nonce']); ?>"
+							data-ajax-nonce="<?php echo esc_attr($req['network_activate_nonce']); ?>"
 						>
 							<?php esc_html_e('Network Activate', 'ultimate-multisite'); ?>
 						</button>
@@ -126,58 +126,3 @@ defined('ABSPATH') || exit;
 	<?php endif; ?>
 
 </div>
-
-<script type="text/javascript">
-jQuery(function($) {
-
-	$(document).on('click', '.wu-network-activate-btn', function() {
-
-		var $btn     = $(this);
-		var $wrapper = $btn.closest('div');
-		var nonce    = $btn.data('nonce');
-		var $spinner  = $wrapper.find('.wu-network-activate-spinner');
-		var $message  = $wrapper.find('.wu-network-activate-message');
-		var $fallback = $wrapper.find('.wu-network-activate-fallback');
-
-		$btn.prop('disabled', true);
-		$spinner.addClass('is-active');
-		$message.text('');
-
-		$.post(
-			ajaxurl,
-			{
-				action: 'wu_setup_network_activate',
-				nonce: nonce,
-			},
-			function(response) {
-
-				if (response.success) {
-					window.location.reload();
-					return;
-				}
-
-				$spinner.removeClass('is-active');
-				$btn.hide();
-				$fallback.show();
-
-				var errorMsg = <?php echo wp_json_encode(__('Activation failed. Please activate the plugin manually.', 'ultimate-multisite')); ?>;
-
-				if (response.data && response.data.message) {
-					errorMsg = response.data.message;
-				}
-
-				$message.text(errorMsg);
-			}
-		).fail(function() {
-
-			$spinner.removeClass('is-active');
-			$btn.hide();
-			$fallback.show();
-			$message.text(<?php echo wp_json_encode(__('Activation failed. Please activate the plugin manually.', 'ultimate-multisite')); ?>);
-
-		});
-
-	});
-
-});
-</script>


### PR DESCRIPTION
## Summary

Follow-up to #871. The Network Activate button now fires correctly (inline `<script>` moved to external file), but the AJAX request returned 403 because the nonce parameter name `nonce` was not matching WordPress's standard `_ajax_nonce` convention.

## Changes

- **JS** (`assets/js/network-activate.js`): send nonce as `_ajax_nonce` (WordPress standard), read from `data-ajax-nonce` attribute
- **PHP** (`inc/admin-pages/class-setup-wizard-admin-page.php`): 
  - Move `current_user_can()` check before nonce check — gives a meaningful "Permission denied" error instead of opaque 403
  - Use `check_ajax_referer('...', false, false)` — the `false` second arg makes WordPress check both `_ajax_nonce` and `_wpnonce` fallbacks; the `false` third arg prevents `wp_die(-1)` so we return a JSON error instead
- **View** (`views/wizards/setup/requirements_table.php`): `data-nonce` → `data-ajax-nonce`
- **Test**: updated to reflect reordered guards (capability before nonce)

## Testing

- `Setup_Wizard_Admin_Page_Test` passes (37 tests, exit 0)
- Manual: visit Setup Wizard → Pre-install Checks when plugin is not network-activated → click Network Activate

Resolves #836

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced security and error handling for network plugin activation. When nonce verification fails, users now receive clear instructions to reload the page and retry the activation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->