### PR TITLE
fix: add type and data-ajax-nonce to button kses allowlist

### DIFF
--- a/inc/functions/helper.php
+++ b/inc/functions/helper.php
@@ -491,9 +491,11 @@ function wu_kses_allowed_html(): array {
 		'value'    => true,
 	];
 	$allowed_html['button']   = [
-		'disabled' => true,
-		'name'     => true,
-		'value'    => true,
+		'type'            => true,
+		'disabled'        => true,
+		'name'            => true,
+		'value'           => true,
+		'data-ajax-nonce' => true,
 	];
 	$allowed_html['dynamic']  = [
 		':template' => true,


### PR DESCRIPTION
## Summary

- Adds `type` and `data-ajax-nonce` to the `<button>` allowlist in `wu_kses_allowed_html()`, fixing the setup wizard Network Activate button

## Root Cause

The setup wizard requirements table HTML passes through `wp_kses()` **twice** — once in `field-note.php` (line 33) and again in `default.php` (line 20). The `<button>` element's kses allowlist only permitted `disabled`, `name`, and `value`.

This stripped two critical attributes from the Network Activate button:

| Attribute | Effect of stripping |
|---|---|
| `type="button"` | Button defaults to `type="submit"`, submitting the wizard form instead of firing the AJAX handler |
| `data-ajax-nonce="..."` | JS reads `undefined`, sends no nonce → server responds `{"success":false,"data":[{"code":"bad-nonce",...}]}` |

PR #875 correctly moved the JS to an external file and switched to `_ajax_nonce` / `data-ajax-nonce`, but the button attributes were still stripped by `wp_kses()` before reaching the browser.

## Fix

One-line change to `inc/functions/helper.php` — adds `type` and `data-ajax-nonce` to the button's kses allowlist. Both are standard HTML attributes that pose no XSS risk.

## Verification

Tested on http://wordpress.local:8080 setup wizard:
- Button renders with `type="button"` and `data-ajax-nonce="<valid>"` in DOM
- AJAX request sends `_ajax_nonce=<value>` in POST body
- Server responds `{"success":true}`
- Page reloads with plugin network-activated

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated button element attribute handling to properly support additional functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->