### PR TITLE
fix: show success banner immediately on multisite wizard complete page

### DIFF
--- a/inc/admin-pages/class-multisite-setup-admin-page.php
+++ b/inc/admin-pages/class-multisite-setup-admin-page.php
@@ -147,6 +147,7 @@ class Multisite_Setup_Admin_Page extends Wizard_Admin_Page {
 				'description'  => __('Setting up your WordPress Multisite network...', 'multisite-ultimate'),
 				'next_label'   => Core_Installer::get_instance()->all_done() ? __('Begin Ultimate Multisite Setup &rarr;', 'ultimate-multisite') : __('Install', 'ultimate-multisite'),
 				'disable_next' => true,
+				'handler'      => [$this, 'handle_install_complete'],
 				'back'         => false,
 				'fields'       => [
 					'terms' => [
@@ -304,6 +305,27 @@ class Multisite_Setup_Admin_Page extends Wizard_Admin_Page {
 		);
 
 		wp_safe_redirect($this->get_next_section_link());
+		exit;
+	}
+
+	/**
+	 * Handles the install step form submission.
+	 *
+	 * The JS auto-submits the form after all AJAX installation steps succeed.
+	 * This handler redirects to the complete step with result=success so
+	 * that section_complete() can show the success banner immediately,
+	 * even when is_multisite() returns false because OPcache is serving
+	 * a stale wp-config.php that doesn't yet have the MULTISITE constant.
+	 *
+	 * @since 2.6.1
+	 * @return void
+	 */
+	public function handle_install_complete(): void {
+
+		$next_url = add_query_arg('result', 'success', $this->get_next_section_link());
+
+		wp_safe_redirect($next_url);
+
 		exit;
 	}
 


### PR DESCRIPTION
## Summary

After the multisite setup wizard completes all 4 installation steps successfully, the "Complete" page showed **manual wp-config.php instructions** instead of the green success banner on the first load. Users had to refresh the page to see the success message. This was confusing — a fully successful automated install looked like a failure.

### Root cause

`section_complete()` checks `is_multisite()` to decide whether to show the success banner or manual instructions. But `is_multisite()` returns `false` on the first page load after `MULTISITE=true` is written to `wp-config.php`, because the PHP process that renders the complete page loaded `wp-config.php` before the constant existed (same OPcache timing issue described in #837).

The code already had a fallback: `'success' === $result` checks for a `result=success` query parameter. But the install step had no form handler, so it used `default_handler()` which redirects to the next step without passing `result=success`.

### Fix

Add `handle_install_complete()` as the form handler for the install step. When the JS auto-submits the form after all AJAX steps succeed, this handler redirects to `?step=complete&result=success`. The existing `section_complete()` check picks up the parameter and shows the green banner immediately.

**Before**: Install succeeds → redirect to `?step=complete` → `is_multisite()` returns false → manual instructions shown
**After**: Install succeeds → redirect to `?step=complete&result=success` → `'success' === $result` is true → green banner shown

## Files changed

- **EDIT: `inc/admin-pages/class-multisite-setup-admin-page.php`** — added `handler` key to the `install` step definition, added `handle_install_complete()` method (+22 lines)

## Verification

Browser-tested on a fresh WordPress 6.7.2 single-site install:
1. Activated plugin on single site
2. Ran full multisite setup wizard (all 4 steps green)
3. Complete page immediately showed green "Success!" banner
4. URL contained `result=success` query parameter
5. No manual instructions shown

```
PHPStan: [OK] No errors
```

Related: #837, PR #874

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved install wizard completion: Users now see a success notification and are redirected to the next setup step after completing the installation, ensuring a seamless transition through the multisite configuration process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->