### PR TITLE
GH#883: handle WP_Error array payloads in network-activate error handler

### DIFF
--- a/assets/js/network-activate.js
+++ b/assets/js/network-activate.js
@@ -45,8 +45,12 @@ jQuery(function($) {
 
 				var errorMsg = wu_network_activate.error_message;
 
-				if (response.data && response.data.message) {
-					errorMsg = response.data.message;
+				if (response.data) {
+					if (Array.isArray(response.data) && response.data.length > 0 && response.data[ 0 ] && response.data[ 0 ].message) {
+						errorMsg = response.data[ 0 ].message;
+					} else if (response.data.message) {
+						errorMsg = response.data.message;
+					}
 				}
 
 				$message.text(errorMsg);


### PR DESCRIPTION
## Summary

Handle WP_Error serialized array payloads in the network-activate AJAX error handler.

When WordPress serializes a `WP_Error` to JSON via `wp_send_json_error()`, it can
produce `response.data` as either:
- A plain object with a `.message` property, or
- An array of error objects (each with a `.message` property)

The previous handler only covered the plain-object case. This fix adds detection for
the array case (`Array.isArray(response.data)`), safely extracts the message from
`response.data[0].message`, and falls back gracefully through:
1. Array WP_Error payload → `response.data[0].message`
2. Object WP_Error payload → `response.data.message`
3. Fallback → `wu_network_activate.error_message`

All missing element/field guards are in place to prevent runtime errors.

## Files Changed

- EDIT: `assets/js/network-activate.js:46-54` — updated error message extraction logic

## Runtime Testing

- **Risk level**: Low (JavaScript error-path only — no new functionality, no data mutation)
- **Verified**: ESLint clean (no new violations introduced); logic covers all three payload shapes

## Key Decisions

- Used `Array.isArray()` check (not `instanceof Array`) for cross-frame compatibility
- Guards `response.data.length > 0 && response.data[0] && response.data[0].message` prevent all runtime errors on sparse/malformed arrays
- Pre-existing lint warnings (`var`, alignment spaces, JSDoc tags) are untouched — they predate this PR

Resolves #883


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.8.56 plugin for [OpenCode](https://opencode.ai) v1.4.6 with claude-sonnet-4-6 spent 3m and 4,211 tokens on this as a headless worker.