### PR TITLE
fix: always regenerate encrypted OAuth secrets in release build

### DIFF
--- a/encrypt-secrets.php
+++ b/encrypt-secrets.php
@@ -23,12 +23,18 @@ function encryptValue($plaintext, $key) {
 
 $target_file = 'inc/stuff.php';
 
-if (!file_exists($target_file) || filemtime($filename) > filemtime($target_file)) {
-	file_put_contents($target_file, "<?php\nreturn ".var_export([
-		encryptValue($client_id, $key),
-		encryptValue($client_secret, $key),
-	], true).';');
-	echo "Updated $target_file\n";
-} else {
-	echo "$target_file is up to date\n";
-}
+// Always regenerate the ciphertext when credentials are supplied.
+//
+// The AES key is derived from the sha256 of inc/class-addon-repository.php
+// (see Addon_Repository::decrypt_value). Any change to that file — including
+// a whitespace/coding-standards fix — changes the key and makes previously
+// committed ciphertext undecryptable. An mtime-based "up to date" shortcut
+// was used here previously, but in CI (actions/checkout normalises mtimes)
+// it always reported "up to date" and shipped stale ciphertext, producing
+// `{"error":"invalid_client","error_description":"No client id supplied"}`
+// on every customer's OAuth flow. Regenerate unconditionally.
+file_put_contents($target_file, "<?php\nreturn ".var_export([
+	encryptValue($client_id, $key),
+	encryptValue($client_secret, $key),
+], true).';');
+echo "Updated $target_file\n";


### PR DESCRIPTION
## Summary

- Fixes `{\"error\":\"invalid_client\",\"error_description\":\"No client id supplied\"}` that every customer on the current release hits when clicking **Connect to UltimateMultisite.com** on the Addons page.
- Root cause: `inc/stuff.php` was shipped encrypted with an AES key derived from an older snapshot of `inc/class-addon-repository.php`. Any change to that file changes the sha256 used as the key, so `openssl_decrypt()` returns `false` and the OAuth request is sent with empty `client_id` / `client_secret`.
- The release workflow was *supposed* to regenerate `inc/stuff.php` on every build (via `npm run prearchive` → `php encrypt-secrets.php`), but an mtime shortcut (`filemtime(class-addon-repository.php) > filemtime(stuff.php)`) always evaluated false in CI — `actions/checkout` gives every file the same mtime — so the stale ciphertext was shipped unchanged.

## Change

`encrypt-secrets.php`: remove the mtime guard. Regenerate `inc/stuff.php` unconditionally whenever `MU_CLIENT_ID` and `MU_CLIENT_SECRET` are supplied. Added an explanatory comment so the optimisation doesn't get reintroduced.

## Reproduction (before)

```bash
php -r '
\$key = hash_file(\"sha256\", \"inc/class-addon-repository.php\");
\$stuff = include \"inc/stuff.php\";
foreach (\$stuff as \$i => \$data) {
    \$data = base64_decode(\$data);
    \$iv_len = openssl_cipher_iv_length(\"aes-256-cbc\");
    \$iv = substr(\$data, 0, \$iv_len);
    \$ct = substr(\$data, \$iv_len);
    echo \"slot \$i: \" . var_export(openssl_decrypt(\$ct, \"aes-256-cbc\", \$key, 0, \$iv), true) . \"\\n\";
}
'
# slot 0: false
# slot 1: false
```

## Verification

- Round-trip encrypt/decrypt succeeds with the new script against the current class file.
- Simulated the CI equal-mtime scenario: previously printed \"up to date\" and skipped; now regenerates correctly.

## Release plan

After merge, run the release workflow. With the env secrets `MU_CLIENT_ID` / `MU_CLIENT_SECRET` present, `npm run prearchive` will now regenerate `inc/stuff.php` with the current class file's hash, and the shipped zip will authenticate correctly against ultimatemultisite.com.