### PR TITLE
t892: fix period-switch per-day rate comparison and downgrade null-guard test

### DIFF
--- a/inc/checkout/class-cart.php
+++ b/inc/checkout/class-cart.php
@@ -1319,6 +1319,14 @@ class Cart implements \JsonSerializable {
 		$old_price_per_day = $days_in_old_cycle > 0 ? $membership->get_amount() / $days_in_old_cycle : $membership->get_amount();
 		$new_price_per_day = $days_in_new_cycle > 0 ? $this->get_recurring_total() / $days_in_new_cycle : $this->get_recurring_total();
 
+		/*
+		 * Preserve the true per-day rates before search_for_same_period_plans()
+		 * may normalise them. The shorter-period override must compare the raw
+		 * membership vs. cart rates, not the normalised plan-variation rates.
+		 */
+		$orig_old_price_per_day = $old_price_per_day;
+		$orig_new_price_per_day = $new_price_per_day;
+
 		$is_same_product = $membership->get_plan_id() === $this->plan_id;
 
 		/**
@@ -1357,11 +1365,14 @@ class Cart implements \JsonSerializable {
 		 * fits this profile is treated as a scheduled downgrade regardless of
 		 * whether the nominal per-period amounts suggest an "upgrade".
 		 *
+		 * We use the original rates ($orig_*) captured before search_for_same_period_plans()
+		 * may have normalised them, so we compare the actual membership vs. cart rates.
+		 *
 		 * @since 2.6.2
 		 */
 		$is_period_switch_to_shorter = ! $membership->is_free()
 			&& $days_in_old_cycle > $days_in_new_cycle
-			&& $old_price_per_day < $new_price_per_day;
+			&& $orig_old_price_per_day < $orig_new_price_per_day;
 
 		/*
 		 * If is the same product and the customer will start to pay less,

--- a/tests/WP_Ultimo/Checkout/Cart_Test.php
+++ b/tests/WP_Ultimo/Checkout/Cart_Test.php
@@ -3034,11 +3034,11 @@ class Cart_Test extends WP_UnitTestCase {
 	 * null and cart_type happens to be 'downgrade' (defensive null guard).
 	 */
 	public function test_get_billing_next_charge_date_null_membership_guard() {
-		// Build a cart with cart_type=downgrade but no membership_id.
-		// The cart will default to type 'new' internally (no membership), but
-		// we can force the scenario by temporarily mocking; instead just verify
-		// that the guard at get_billing_next_charge_date does not throw on a
-		// null membership (regression test for the explicit null check added).
+		// Build a cart with no membership_id, then force cart_type to 'downgrade'
+		// via Reflection so the null-membership guard in get_billing_next_charge_date()
+		// is actually exercised. Before the guard was added this would fatal with
+		// "Call to member function is_active() on null" when cart_type was 'downgrade'
+		// and $this->membership was null.
 		$plan = $this->create_plan(['amount' => 30.00]);
 
 		$cart = new Cart([
@@ -3047,9 +3047,12 @@ class Cart_Test extends WP_UnitTestCase {
 			'duration_unit' => 'month',
 		]);
 
-		// Call get_billing_next_charge_date() on a cart that has no membership.
-		// Before the fix this would fatal with "Call to member function is_active() on null"
-		// if cart_type was forced to 'downgrade'. With the null guard it must not throw.
+		// Force the cart into the downgrade branch while membership stays null.
+		$ref = new \ReflectionProperty(Cart::class, 'cart_type');
+		$ref->setAccessible(true);
+		$ref->setValue($cart, 'downgrade');
+
+		// Must return an int without throwing despite membership being null.
 		$this->assertIsInt($cart->get_billing_next_charge_date());
 
 		$plan->delete();


### PR DESCRIPTION
## Summary

Addresses the two review findings from CodeRabbit on PR #889, filed as quality-debt issue #892.

### Fix 1: Use original per-day rates for period-switch detection ()

 may overwrite  /  with normalised plan-variation rates. The  check was then comparing those normalised rates instead of the true membership-vs-cart rates, which could mis-classify the transition direction.

**Fix:** capture  and  immediately after the initial computation (before the `search_for_same_period_plans()` block), then use those originals in the period-switch condition. The normalised rates continue to be used in the same-product / different-product downgrade comparisons as before.

### Fix 2: Force downgrade branch in null-membership guard test ()

`test_get_billing_next_charge_date_null_membership_guard` created a cart with no membership but never forced `cart_type` to `'downgrade'`, so the guard (the null check inside the downgrade branch of `get_billing_next_charge_date()`) was never actually exercised — the test trivially passed on the product-loop fallback path.

**Fix:** use `ReflectionProperty` to set `cart_type = 'downgrade'` after Cart construction, before calling `get_billing_next_charge_date()`. This ensures the null guard is hit, matching the failure mode the guard was added to prevent.

## Files modified

- **EDIT:** `inc/checkout/class-cart.php` — add `$orig_old_price_per_day` / `$orig_new_price_per_day` captures before normalization; use them in `$is_period_switch_to_shorter`
- **EDIT:** `tests/WP_Ultimo/Checkout/Cart_Test.php` — add ReflectionProperty call to force downgrade branch in null-guard test

## Verification

- PHPCS config has pre-existing sniff-reference errors (unrelated to this change); code follows the existing style conventions (tabs, same-line braces, snake_case).
- The test change now exercises the actual code path the test was written to guard.

Resolves #892

---

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.8.65 plugin for [OpenCode](https://opencode.ai) v1.4.6 with claude-sonnet-4-6 spent 3m and 11,463 tokens on this as a headless worker.