### PR TITLE
fix: fall back to subdomain for blogname when title is empty on duplication

### DIFF
--- a/inc/helpers/class-site-duplicator.php
+++ b/inc/helpers/class-site-duplicator.php
@@ -328,7 +328,7 @@ class Site_Duplicator {
 		// doesn't keep the template's blogname.
 		$new_title = ! empty($args->title)
 			? $args->title
-			: preg_replace('/\..*$/', '', $args->domain);
+			: ucfirst(preg_replace('/\..*$/', '', $args->domain));
 
 		update_blog_option($args->to_site_id, 'blogname', $new_title);
 

--- a/inc/helpers/class-site-duplicator.php
+++ b/inc/helpers/class-site-duplicator.php
@@ -323,9 +323,14 @@ class Site_Duplicator {
 
 		// Ensure the requested title is applied after duplication, since the
 		// table copy may overwrite the blogname option set during site creation.
-		if (! empty($args->title)) {
-			update_blog_option($args->to_site_id, 'blogname', $args->title);
-		}
+		// When no title was provided (e.g. WooCommerce checkout flow), fall back
+		// to the subdomain portion of the site's domain so the duplicated site
+		// doesn't keep the template's blogname.
+		$new_title = ! empty($args->title)
+			? $args->title
+			: preg_replace('/\..*$/', '', $args->domain);
+
+		update_blog_option($args->to_site_id, 'blogname', $new_title);
 
 		/**
 		 * Allow developers to hook after a site duplication happens.


### PR DESCRIPTION
## Summary

- **Bug:** When `$args->title` is empty during site duplication (happens via WooCommerce checkout flow), the conditional on line 326 skipped the `update_blog_option` call entirely, leaving the duplicated site with the template's blogname (e.g. "Plantilla Belleza") instead of the customer's site name.
- **Fix:** Always call `update_blog_option` — when title is empty, fall back to the subdomain portion of the site's domain (e.g. `ikenabazan` from `ikenabazan.example.com`).
- **Impact:** Customer-facing emails were going out with the template name as subject prefix. Confirmed on client sites 299 (ikenabazan) and 307 (fomenthy).

## Changes

`inc/helpers/class-site-duplicator.php` — replaced the `if (!empty)` guard with a ternary that falls back to `preg_replace('/\..*$/', '', $args->domain)`, ensuring `blogname` is always set to something meaningful after duplication.