### PR TITLE
chore: add 5 production bug reports to TODO (GH#902-906)

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -120,3 +120,11 @@ Overall coverage: **35%** (20,720 / 59,212 statements). 90 files at 0% coverage.
 - [x] GH#808 test: add autoload-order regression tests for mpdf PSR HTTP message shim ref:GH#808 pr:#818 completed:2026-04-13
 - [x] GH#813 fix: guard false return from get_available_site_templates() in switch_template() — TypeError on PHP 8.0+ ref:GH#813 pr:#819 completed:2026-04-13
 - [x] GH#814 test(reactivation): add unit tests verifying all PR #751 review findings were addressed ref:GH#814 pr:#817 completed:2026-04-13
+
+## Production Bugs (2026-04-22)
+
+- [ ] t529 fix(membership): orphan pending_site after membership cancellation — watchdog cancels membership but pending_site meta stays, customer retries checkout and gets no site #bug #auto-dispatch ~4h ref:GH#902
+- [ ] t528 fix(checkout): duplicate WP users created on checkout retry — wp_insert_user called without get_user_by email check #bug #auto-dispatch ~2h ref:GH#903
+- [ ] t530 fix(checkout): reclaim orphan pending_site on WC order completion — no code picks up transferable pending_site when payment succeeds #bug #auto-dispatch ~4h ref:GH#904
+- [ ] t526 fix(i18n): JS checkout validator missing i18n strings — field_required etc. hardcoded English in checkout.min.js #bug #auto-dispatch ~2h ref:GH#905
+- [ ] t527 fix(ux): default minimum_password_strength too strict — super_strong rejects reasonable passwords, default to strong #enhancement #auto-dispatch ~1h ref:GH#906


### PR DESCRIPTION
## Summary

Adds TODO entries for 5 production bugs discovered on 2026-04-22, with linked GitHub issues:

- **t529** (GH#902): Orphan `pending_site` after membership cancellation — watchdog cancels but pending_site meta stays, blocking site provisioning on retry
- **t528** (GH#903): Duplicate `wp_users` on checkout retry — `wp_insert_user()` called without `get_user_by('email')` check
- **t530** (GH#904): No reclaim of orphan `pending_site` on WC order completion — customer pays, gets nothing
- **t526** (GH#905): JS checkout validator missing i18n strings — hardcoded English fallbacks for `field_required` etc.
- **t527** (GH#906): Default `minimum_password_strength` too strict (`super_strong` / zxcvbn 4)

All 5 issues have worker-ready bodies with file references and acceptance criteria. Tagged `#auto-dispatch` for autonomous implementation.

Ref #902, Ref #903, Ref #904, Ref #905, Ref #906

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.8.94 plugin for [OpenCode](https://opencode.ai) v1.3.17 with claude-opus-4-6 spent 4m and 7,404 tokens on this as a headless worker.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal documentation with a new section to track production bugs identified in the live environment
  * Fixed file formatting by adding missing newline at end of file

<!-- end of auto-generated comment: release notes by coderabbit.ai -->