### PR TITLE
fix: prevent duplicate WP users on checkout retry

### DIFF
--- a/inc/checkout/class-checkout.php
+++ b/inc/checkout/class-checkout.php
@@ -1096,8 +1096,23 @@ class Checkout {
 					'email'              => wp_get_current_user()->user_email,
 					'email_verification' => 'verified',
 				];
-			} elseif (isset($customer_data['email']) && get_user_by('email', $customer_data['email'])) {
-				return new \WP_Error('email_exists', __('The email address you entered is already in use.', 'ultimate-multisite'));
+			} elseif (isset($customer_data['email']) && ($existing_wp_user = get_user_by('email', $customer_data['email']))) {
+				/*
+				 * A WP user already exists with this email.
+				 *
+				 * Only block checkout when a customer record also exists for
+				 * that user — the email is genuinely in use. If no customer
+				 * exists yet, the previous checkout attempt created the WP
+				 * user but failed before saving the customer (partial /
+				 * orphaned state). Allow the retry to proceed by passing the
+				 * existing user's ID to wu_create_customer(), which will skip
+				 * WP user creation and link the new customer to it instead.
+				 */
+				if (wu_get_customer_by_user_id($existing_wp_user->ID)) {
+					return new \WP_Error('email_exists', __('The email address you entered is already in use.', 'ultimate-multisite'));
+				}
+
+				$customer_data['user_id'] = $existing_wp_user->ID;
 			}
 
 			/*

--- a/inc/functions/customer.php
+++ b/inc/functions/customer.php
@@ -142,6 +142,17 @@ function wu_create_customer($customer_data) {
 		]
 	);
 
+	/*
+	 * Sanitize the email early so the duplicate check and the
+	 * subsequent wpmu_create_user() / register_new_user() call both
+	 * operate on the same normalized value. Without this, subtle
+	 * format differences (e.g. trailing whitespace) can cause
+	 * get_user_by() to miss an existing user and create a duplicate.
+	 */
+	if ($customer_data['email']) {
+		$customer_data['email'] = sanitize_email($customer_data['email']);
+	}
+
 	$user = get_user_by('email', $customer_data['email']);
 
 	if ( ! $user) {

--- a/tests/WP_Ultimo/Functions/Customer_Functions_Test.php
+++ b/tests/WP_Ultimo/Functions/Customer_Functions_Test.php
@@ -248,4 +248,79 @@ class Customer_Functions_Test extends WP_UnitTestCase {
 
 		$this->assertEquals('', $result);
 	}
+
+	/**
+	 * Test wu_create_customer reuses existing WP user instead of creating a duplicate.
+	 *
+	 * Scenario: a previous checkout attempt created a WP user but failed before
+	 * saving the customer record (orphaned user). On retry, wu_create_customer()
+	 * must reuse the existing user rather than calling wpmu_create_user() again.
+	 */
+	public function test_create_customer_reuses_existing_wp_user_on_retry(): void {
+
+		$email   = 'retry-test-' . uniqid() . '@example.com';
+		$user_id = self::factory()->user->create(['user_email' => $email]);
+
+		// Confirm no customer exists for this user yet (simulates orphaned state).
+		$this->assertFalse(wu_get_customer_by_user_id($user_id));
+
+		// Now call wu_create_customer() with the same email.
+		$customer = wu_create_customer([
+			'email'           => $email,
+			'username'        => 'retryuser',
+			'password'        => 'Str0ngP@ss!',
+			'skip_validation' => true,
+		]);
+
+		$this->assertNotWPError($customer);
+		$this->assertInstanceOf(\WP_Ultimo\Models\Customer::class, $customer);
+
+		// The customer must be linked to the pre-existing WP user, not a new one.
+		$this->assertSame($user_id, $customer->get_user_id());
+
+		// Confirm only one WP user exists with this email.
+		$users_with_email = get_users(['search' => $email, 'search_columns' => ['user_email']]);
+		$this->assertCount(1, $users_with_email);
+	}
+
+	/**
+	 * Test wu_create_customer returns WP_Error when email belongs to a user
+	 * who already has a customer record (genuine email-in-use case).
+	 *
+	 * This is tested at the checkout layer (maybe_create_customer), but we also
+	 * verify wu_create_customer itself does not create a duplicate customer row.
+	 */
+	public function test_create_customer_prevents_duplicate_customer_for_same_user(): void {
+
+		$user_id = self::factory()->user->create();
+
+		// First customer creation for this user must succeed.
+		$first = wu_create_customer([
+			'user_id'         => $user_id,
+			'skip_validation' => true,
+		]);
+
+		$this->assertNotWPError($first);
+		$this->assertInstanceOf(\WP_Ultimo\Models\Customer::class, $first);
+
+		// A second call for the same user_id must not create a second customer row.
+		wu_create_customer([
+			'user_id'         => $user_id,
+			'skip_validation' => true,
+		]);
+
+		// wu_create_customer reuses the existing user; save() may return an error
+		// for the duplicate or the existing customer object — either is acceptable.
+		// What must NOT happen is a second customer row being saved.
+
+		// There should still be exactly one customer linked to this user.
+		$customers_for_user = array_filter(
+			wu_get_customers(),
+			function ($c) use ($user_id) {
+				return (int) $c->get_user_id() === (int) $user_id;
+			}
+		);
+
+		$this->assertCount(1, $customers_for_user);
+	}
 }


### PR DESCRIPTION
## Summary

On checkout retry, `maybe_create_customer()` returned an `email_exists` error for **any** WP user already holding the submitted email — including users whose previous checkout had failed after WP user creation but before the customer record was saved (orphaned WP user). This permanently blocked retry for those users.

## Root cause

`inc/checkout/class-checkout.php:1099` — the `elseif` guard checked only whether a WP user existed with the email, not whether a customer record also existed for that user. An orphaned WP user (partial first attempt) triggered the same error as a genuine email-in-use collision.

## Changes

### `inc/checkout/class-checkout.php`
- Narrow the `email_exists` block: only return the error when `wu_get_customer_by_user_id()` confirms a customer record already exists for the found WP user.
- When no customer record exists (orphaned state), set `$customer_data['user_id']` to the existing user's ID so `wu_create_customer()` skips `wpmu_create_user()` and links the new customer to the pre-existing WP user.

### `inc/functions/customer.php`
- Sanitize the email **before** the `get_user_by('email')` duplicate check (previously sanitization happened only inside the `if (!$user)` branch). Prevents format-based mismatches (e.g. trailing whitespace) from causing the check to miss an existing user.

### `tests/WP_Ultimo/Functions/Customer_Functions_Test.php`
- `test_create_customer_reuses_existing_wp_user_on_retry` — creates an orphaned WP user, calls `wu_create_customer()` with the same email, asserts: no `WP_Error`, correct `user_id`, and exactly one `wp_users` row for the email.
- `test_create_customer_prevents_duplicate_customer_for_same_user` — creates a customer, calls `wu_create_customer()` again for the same `user_id`, asserts exactly one customer row exists.

Resolves #903
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.8.94 plugin for [OpenCode](https://opencode.ai) v1.3.17 with claude-sonnet-4-6 spent 8m and 24,182 tokens on this as a headless worker.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced customer creation logic to better handle duplicate detection during checkout retries and account reuse scenarios.
  * Standardized email input handling for more reliable customer matching and duplicate prevention.

* **Tests**
  * Added test coverage for customer creation idempotency and duplicate-detection scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->