### PR TITLE
t531: fix set_demo_behavior fatal TypeError on PHP 8 when null passed via deprecated compat layer

### DIFF
--- a/inc/models/class-product.php
+++ b/inc/models/class-product.php
@@ -1361,10 +1361,14 @@ class Product extends Base_Model implements Limitable {
 	 *
 	 * @since 2.5.0
 	 *
-	 * @param string $behavior Either 'delete_after_time' or 'keep_until_live'.
+	 * @param string|null $behavior Either 'delete_after_time' or 'keep_until_live'. Null is ignored (default applied at read time).
 	 * @return void
 	 */
-	public function set_demo_behavior(string $behavior): void {
+	public function set_demo_behavior($behavior) {
+
+		if (null === $behavior) {
+			return;
+		}
 
 		$this->meta[ self::META_DEMO_BEHAVIOR ] = $behavior;
 


### PR DESCRIPTION
## What

Remove the non-nullable `string` type hint from `Product::set_demo_behavior()` and add a null guard, preventing a `TypeError` fatal on PHP 8.0+ when `null` is passed through the generic `Base_Model::attributes()` setter dispatch.

## Why

Customers on PHP 8.x hit a fatal error loading any admin page that calls `wu_get_plan()` through the deprecated `WU_Plan` compat layer. The call chain:

```
wu_get_plan() → WU_Plan::__construct() → Base_Model::attributes()
  → call_user_func(['set_demo_behavior'], null)
  → TypeError: Argument #1 must be of type string, null given
```

Three compounding causes:
1. `set_demo_behavior(string $behavior)` — non-nullable type hint on a public model setter, violating our coding standard (AGENTS.md: "NEVER add PHP return type declarations to public methods on model classes")
2. PHP 8.0 removed implicit `null → ""` coercion for typed parameters that PHP 7.4 allowed silently
3. `Base_Model::attributes()` passes raw DB/compat-layer values to setters without null filtering

## How

`inc/models/class-product.php:1367`

- Drop `string` parameter type and `: void` return type (per coding standard — use `@param`/`@return` PHPDoc instead)
- Add `if (null === $behavior) { return; }` guard — null from legacy data is silently ignored; `get_demo_behavior()` already falls back to `'delete_after_time'` when the property is unset

## Verification

The fatal is reproducible by constructing a `Product` via `attributes(['demo_behavior' => null])`. After this fix, null is a no-op and `get_demo_behavior()` returns the default `'delete_after_time'`.

Reported environment: PHP 8.5.5, WordPress 6.9.4, Ultimate Multisite 2.6.3.


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.8.94 plugin for [OpenCode](https://opencode.ai) v1.3.17 with claude-sonnet-4-6 spent 4m and 6,734 tokens on this with the user in an interactive session.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved product demo behavior handling to support flexible input values, allowing the system to gracefully manage edge cases and enhance overall stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->