### PR TITLE
GH#919: docs(agents): add Agent Guidance section to address recurring error patterns

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -181,3 +181,60 @@ wp plugin activate $(basename $PWD)   # activate this plugin
 wp plugin deactivate $(basename $PWD) # deactivate
 wp db reset --yes && cd ../wordpress && ./reset.sh  # full DB + WordPress reset (requires reset.sh in ../wordpress)
 ```
+
+## Agent Guidance
+
+Recurring error patterns observed in this codebase. Review before starting any session.
+
+### File Discovery — `.dist` Config Convention
+
+Config files are committed as `.dist` versions; un-suffixed copies are gitignored and may not exist locally:
+
+| Tracked (exists) | Local override (gitignored, may be absent) |
+|---|---|
+| `.phpcs.xml.dist` | `.phpcs.xml` |
+| `phpunit.xml.dist` | `phpunit.xml` |
+| `phpstan.neon.dist` | `phpstan.neon` |
+
+Always verify a file is tracked before reading it:
+
+```bash
+git ls-files 'phpunit.xml*'   # shows phpunit.xml.dist, not phpunit.xml
+```
+
+The `vendor/` and `node_modules/` directories are gitignored. If they are absent, run:
+
+```bash
+composer install && npm install
+```
+
+The `docs/` directory exists but is not described in the Project Structure section above — it contains developer documentation markdown files. The `todo/` directory contains task briefs.
+
+### No External URL Fetching
+
+Do **not** use webfetch for WordPress documentation, PHP manual pages, Stripe/PayPal API docs, or any developer documentation URLs — these requests consistently fail.
+
+Use the codebase itself instead:
+
+- WordPress functions and hooks → `rg 'function_name'` across `inc/`
+- Existing gateway patterns → read `inc/gateways/` directly
+- REST API shape → read `inc/apis/` trait files
+- Hook reference → `rg 'do_action\|apply_filters'` across `inc/`
+
+### Read Before Edit (Mandatory)
+
+The Edit tool **requires** a prior Read call on the same file in the current session. If you attempt to edit without reading first, the tool will fail. Always read the complete target file before editing — even for small changes.
+
+### WP-CLI and Bash Prerequisites
+
+`wp` commands require the dev WordPress install at `../wordpress`. Check it exists before running:
+
+```bash
+ls ../wordpress/wp-config.php 2>/dev/null || echo "WordPress dev env not found — run ./reset.sh in ../wordpress first"
+```
+
+`vendor/bin/phpunit`, `vendor/bin/phpcs`, and `vendor/bin/phpstan` require `composer install`. Check before running test or lint commands:
+
+```bash
+ls vendor/autoload.php 2>/dev/null || composer install
+```


### PR DESCRIPTION
## Summary

Addresses the 4 recurring tool failure patterns identified in GH#919 by adding an **Agent Guidance** section to `AGENTS.md`.

## Problem

Contributor-insight telemetry (GH#919) recorded across multiple models and sessions:
- `read:file_not_found` — 32x: agents tried to read `phpunit.xml`, `.phpcs.xml`, `phpstan.neon` which don't exist (only `.dist` versions are tracked)
- `webfetch:other` — 34x: agents tried fetching WordPress/PHP/Stripe/PayPal docs from URLs that consistently fail
- `edit:not_read_first` — 24x: agents attempted Edit without a prior Read call
- `bash:other` — 20x: commands like `vendor/bin/phpunit` failed because `vendor/` was not installed

## Fix

Added `## Agent Guidance` section to `AGENTS.md` covering:

1. **File Discovery — `.dist` Config Convention** — table mapping the tracked `.dist` files to their local overrides; reminds agents to use `git ls-files` before reading; notes that `vendor/` and `node_modules/` are gitignored
2. **No External URL Fetching** — explicit prohibition on webfetching WordPress/PHP/gateway docs with concrete codebase alternatives (`rg`, read from `inc/`)
3. **Read Before Edit (Mandatory)** — reinforces the framework rule in project context
4. **WP-CLI and Bash Prerequisites** — check commands to verify the WordPress dev env and Composer install before running commands

## Verification

- `git ls-files AGENTS.md` confirms the file is tracked
- Content reviewed for accuracy against actual project structure

Resolves #919

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.10.1 plugin for [OpenCode](https://opencode.ai) v1.3.17 with claude-sonnet-4-6 spent 4m and 12,863 tokens on this as a headless worker.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive agent playbook documentation with development workflow guidance and best practices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->