### PR TITLE
GH#915: fix: emit wu_inline_login_error hook in pre-submit catch block

### DIFF
--- a/assets/js/checkout.js
+++ b/assets/js/checkout.js
@@ -1229,6 +1229,25 @@
 
 						this.logging_in = false;
 						this.login_error = (err && err.message) ? err.message : (wu_checkout.i18n.login_failed || 'Login failed. Please try again.');
+
+						/**
+						 * Fires when an inline login attempt fails due to a rejected
+						 * wu_before_inline_login_submitted promise.
+						 *
+						 * Mirrors the failure hook emitted by the AJAX error path so that
+						 * addons (e.g. captcha widgets) can reset themselves regardless of
+						 * which failure path was taken.
+						 *
+						 * @param {Object} error      Object containing the error message and originalError.
+						 * @param {string} field_type The field type ('email' or 'username').
+						 */
+						hooks.doAction('wu_inline_login_error', {
+							data: {
+								message: this.login_error,
+							},
+							originalError: err,
+						}, field_type);
+
 						return false;
 
 					}


### PR DESCRIPTION
## What

Emit `wu_inline_login_error` action in the `catch` block that handles rejection of `wu_before_inline_login_submitted` promises.

## Why

When `Promise.all(hooks.applyFilters('wu_before_inline_login_submitted', [], field_type))` rejects (e.g. a captcha promise rejects), the catch block set `this.login_error` and returned `false` but never fired the `wu_inline_login_error` action. Addons that listen to that hook to reset captcha widgets or other UI state would silently no-op on this failure path, even though the AJAX error path already fires the hook correctly.

## How

After setting `this.login_error`, call:

```js
hooks.doAction('wu_inline_login_error', {
    data: {
        message: this.login_error,
    },
    originalError: err,
}, field_type);
```

This mirrors `assets/js/checkout.js:1293` (the AJAX error handler) while wrapping the error in a structured object so addon callbacks receive consistent data regardless of which failure path fired.

## Verification

1. Register a `wu_before_inline_login_submitted` filter that returns a rejected promise.
2. Trigger the inline login form.
3. Confirm `wu_inline_login_error` fires and any registered callback (e.g. captcha reset) runs.
4. Confirm `wu_inline_login_error` still fires on a normal AJAX login failure (regression check on the AJAX path).

Resolves #915
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.10.1 plugin for [OpenCode](https://opencode.ai) v1.3.17 with claude-sonnet-4-6 spent 2m and 6,791 tokens on this as a headless worker.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced error handling for inline login failures with improved error reporting and diagnostics, providing better visibility and troubleshooting capabilities when login submission issues occur during checkout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->