### PR TITLE
GH#928: docs(agents): expand webfetch and bash-prerequisite guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -212,14 +212,26 @@ The `docs/` directory exists but is not described in the Project Structure secti
 
 ### No External URL Fetching
 
-Do **not** use webfetch for WordPress documentation, PHP manual pages, Stripe/PayPal API docs, or any developer documentation URLs — these requests consistently fail.
+Do **not** use webfetch for WordPress documentation, PHP manual pages, Stripe/PayPal API docs,
+BerlinDB documentation, npm package docs, or any other developer documentation URLs — these
+requests consistently fail.
 
-Use the codebase itself instead:
+Do **not** use webfetch for GitHub URLs (issues, PRs, raw content, commits). Use the `gh` CLI
+instead:
+
+```bash
+gh issue view 123 --repo Ultimate-Multisite/ultimate-multisite
+gh pr view 456 --repo Ultimate-Multisite/ultimate-multisite
+gh api repos/Ultimate-Multisite/ultimate-multisite/contents/path/to/file
+```
+
+Use the codebase itself for API/hook research:
 
 - WordPress functions and hooks → `rg 'function_name'` across `inc/`
 - Existing gateway patterns → read `inc/gateways/` directly
 - REST API shape → read `inc/apis/` trait files
 - Hook reference → `rg 'do_action\|apply_filters'` across `inc/`
+- BerlinDB schema → read `inc/database/` directly
 
 ### Read Before Edit (Mandatory)
 
@@ -238,3 +250,13 @@ ls ../wordpress/wp-config.php 2>/dev/null || echo "WordPress dev env not found �
 ```bash
 ls vendor/autoload.php 2>/dev/null || composer install
 ```
+
+`npm run lint:js`, `npm run lint:css`, and `npm run check` require `npm install`. Check before running JS/CSS lint or the combined quality check:
+
+```bash
+ls node_modules/.bin/eslint 2>/dev/null || npm install
+```
+
+Coverage reports (`--coverage-*` flags) require the xdebug PHP extension (`php -d zend_extension=xdebug`). If xdebug is not installed, omit the coverage flags — tests still run without them.
+
+For file discovery, use `git ls-files '<pattern>'` rather than `find` or glob patterns — only tracked files exist reliably, and gitignored paths (vendor, node_modules, *.xml without .dist) will cause `No such file` errors if accessed directly.


### PR DESCRIPTION
## Summary

Follows up on PR #920 (GH#919) which added the Agent Guidance section. That fix successfully eliminated `read:file_not_found` and `edit:not_read_first` errors (counts unchanged in subsequent scan). Two patterns persisted with new occurrences:

- **`webfetch:other` (+3 new, 34→37):** Agents were still attempting to fetch GitHub issue/PR URLs and additional doc sites not covered by the original guidance.
- **`bash:other` (+2 new, 20→22):** Missing npm install prerequisite check, no xdebug caveat for coverage commands, and no guidance to prefer `git ls-files` over `find`/glob for file discovery.

## Changes

**`No External URL Fetching` section:**
- Expanded prohibited URL list: added BerlinDB docs, npm package docs
- Added explicit GitHub URL guidance with `gh` CLI examples (issues, PRs, raw content via gh api)
- Added BerlinDB schema research pointer (`inc/database/`)

**`WP-CLI and Bash Prerequisites` section:**
- Added npm install prerequisite check for `npm run lint:js/css/check`
- Added xdebug caveat — coverage flags require the extension; tests run fine without it
- Added file discovery guidance: `git ls-files '<pattern>'` over `find`/glob to avoid `No such file` on gitignored paths

## Verification

Documentation-only change. No code modified. Guidance addresses the specific error classes observed.

Resolves #928

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.10.3 plugin for [OpenCode](https://opencode.ai) v1.3.17 with claude-sonnet-4-6 spent 3m and 10,171 tokens on this as a headless worker.
