### PR TITLE
GH#932: docs(agents): add non-existent file table, bash:other guidance, and strengthen read/webfetch rules

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -210,7 +210,29 @@ composer install && npm install
 
 The `docs/` directory exists but is not described in the Project Structure section above — it contains developer documentation markdown files. The `todo/` directory contains task briefs.
 
+The following paths are commonly attempted but **do not exist** in this repo — attempting to
+read them will produce `read:file_not_found`:
+
+| Path attempted | Reality |
+|---|---|
+| `wp-config.php` | Lives at `../wordpress/wp-config.php` (outside this repo) |
+| `wp-load.php`, `wp-settings.php` | WordPress core lives in `../wordpress/` |
+| `wp-admin/**`, `wp-includes/**` | WordPress core — not in this repo |
+| `CHANGELOG.md` | Does not exist; see git log for change history |
+| `.phpcs.xml` | Gitignored override; use `.phpcs.xml.dist` |
+| `phpunit.xml` | Gitignored override; use `phpunit.xml.dist` |
+| `phpstan.neon` | Gitignored override; use `phpstan.neon.dist` |
+| `vendor/**` | Gitignored; run `composer install` first |
+| `node_modules/**` | Gitignored; run `npm install` first |
+
+Always verify a file is tracked before reading it with `git ls-files '<path>'`. An empty result means the file does not exist in the repo.
+
 ### No External URL Fetching
+
+**NEVER construct or guess a URL for webfetch.** Only fetch URLs explicitly present in user
+messages or tool output. Constructed URLs (e.g. building a GitHub raw URL from a file path,
+guessing a docs URL from a package name) account for the majority of `webfetch:other` failures
+in this codebase.
 
 Do **not** use webfetch for WordPress documentation, PHP manual pages, Stripe/PayPal API docs,
 BerlinDB documentation, npm package docs, or any other developer documentation URLs — these
@@ -235,7 +257,9 @@ Use the codebase itself for API/hook research:
 
 ### Read Before Edit (Mandatory)
 
-The Edit tool **requires** a prior Read call on the same file in the current session. If you attempt to edit without reading first, the tool will fail. Always read the complete target file before editing — even for small changes.
+The Edit tool **requires** a prior Read call on the same file in the **current conversation session**. A prior read from a previous conversation does not count — if the session restarts or the context is cleared, re-read every file before editing it. If you attempt to edit without reading first, the tool will fail. Always read the complete target file before editing — even for small changes.
+
+When working on multiple files in the same session: read each file immediately before editing it, not at the start of the session. Reading file A, then file B, then editing file A will fail if A's content changed between your read and your edit.
 
 ### WP-CLI and Bash Prerequisites
 
@@ -260,3 +284,27 @@ ls node_modules/.bin/eslint 2>/dev/null || npm install
 Coverage reports (`--coverage-*` flags) require the xdebug PHP extension (`php -d zend_extension=xdebug`). If xdebug is not installed, omit the coverage flags — tests still run without them.
 
 For file discovery, use `git ls-files '<pattern>'` rather than `find` or glob patterns — only tracked files exist reliably, and gitignored paths (vendor, node_modules, *.xml without .dist) will cause `No such file` errors if accessed directly.
+
+### Common bash:other Failures
+
+Most `bash:other` errors in this codebase fall into one of these categories:
+
+**Tool not installed** — run the prerequisite checks above before any lint, test, or analysis command.
+
+**`wp` command not found or fails** — `wp` requires WP-CLI in PATH and the dev WordPress install
+at `../wordpress`. If `../wordpress/wp-config.php` is absent, all WP-CLI commands fail. Check:
+
+```bash
+command -v wp || echo "wp-cli not in PATH"
+ls ../wordpress/wp-config.php 2>/dev/null || echo "WordPress dev env missing"
+```
+
+**Wrong working directory** — all build/lint/test commands must be run from the repo root
+(`ultimate-multisite/`). Commands like `vendor/bin/phpunit` resolve paths relative to CWD.
+
+**PHP binary not found** — commands like `php -d zend_extension=xdebug` require PHP in PATH.
+If `php` is not available, omit the `php -d ...` prefix and call `vendor/bin/phpunit` directly.
+
+**Syntax error in one-liner** — when constructing a PHP or bash one-liner, test with `bash -n`
+(syntax check) or `php -l` before running. A typo in a bash heredoc or PHP string will cause
+`bash:other`.


### PR DESCRIPTION
## Summary

Follows up on PR #929 (GH#928) which expanded webfetch and bash-prerequisite guidance. All 4 error patterns from the contributor-insight scanner persisted with new occurrences since that fix:

- **`webfetch:other` (+1, 37→38):** Agents still constructing/guessing URLs despite existing guidance. Added an explicit `NEVER construct or guess a URL` rule at the top of the section.
- **`read:file_not_found` (+1, 32→33):** Agents still attempting to read non-existent paths. Added a reference table of common paths that do NOT exist in this repo (WordPress core files, `CHANGELOG.md`, non-`.dist` config files, `vendor/**`, `node_modules/**`) with correct alternatives.
- **`edit:not_read_first` (+1, 24→25):** Agents editing without reading. Clarified that the Read requirement is scoped to the **current conversation session** — reads from a prior session don't count, and each file must be re-read immediately before edit.
- **`bash:other` (+2, 22→24):** Added a new `### Common bash:other Failures` subsection covering: tool not installed, `wp` command missing/WP-CLI not in PATH, wrong working directory, PHP binary not found, and syntax errors in one-liners.

## Changes

`AGENTS.md` — Agent Guidance section only:

- Added `NEVER construct or guess a URL for webfetch` rule to `No External URL Fetching`
- Added table of non-existent file paths with correct alternatives to `File Discovery` section
- Strengthened `Read Before Edit` with session-scope clarification and multi-file read ordering note
- Added new `### Common bash:other Failures` subsection

Resolves #932
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.11.0 plugin for [OpenCode](https://opencode.ai) v1.3.17 with claude-sonnet-4-6 spent 5m and 16,378 tokens on this as a headless worker.
