### PR TITLE
GH#935: fix email verification gate — hold site publish until customer verifies email

### DIFF
--- a/inc/checkout/class-checkout-pages.php
+++ b/inc/checkout/class-checkout-pages.php
@@ -490,7 +490,7 @@ class Checkout_Pages {
 	 */
 	public function add_verify_email_notice($payment, $membership, $customer): void {
 
-		if ($payment->get_total() === 0.0 && $customer->get_email_verification() === 'pending') {
+		if ($customer->get_email_verification() === 'pending') {
 			printf(
 				'<div class="wu-p-4 wu-bg-yellow-200 wu-mb-2 wu-text-yellow-700 wu-rounded">
                     %s

--- a/inc/managers/class-customer-manager.php
+++ b/inc/managers/class-customer-manager.php
@@ -305,6 +305,13 @@ class Customer_Manager extends Base_Manager {
 				$membership->save();
 			} elseif ($membership->get_status() === Membership_Status::TRIALING) {
 				$membership->publish_pending_site_async();
+			} elseif ($membership->get_status() === Membership_Status::ACTIVE) {
+				/*
+				 * Membership was activated (e.g. by the payment gateway) before
+				 * the customer completed email verification. Now that the email is
+				 * verified, publish the pending site that was held back.
+				 */
+				$membership->publish_pending_site_async();
 			}
 
 			$payments = $membership->get_payments();

--- a/inc/managers/class-membership-manager.php
+++ b/inc/managers/class-membership-manager.php
@@ -335,6 +335,18 @@ class Membership_Manager extends Base_Manager {
 		 */
 		$membership = wu_get_membership($membership_id);
 
+		/*
+		 * If the customer has not yet verified their email, hold off on
+		 * publishing the pending site. The site will be published later
+		 * when the customer completes email verification (handled in
+		 * Customer_Manager::handle_email_verification()).
+		 */
+		$customer = $membership->get_customer();
+
+		if ($customer && $customer->get_email_verification() === 'pending') {
+			return;
+		}
+
 		$membership->publish_pending_site_async();
 	}
 

--- a/tests/WP_Ultimo/Managers/Membership_Manager_Test.php
+++ b/tests/WP_Ultimo/Managers/Membership_Manager_Test.php
@@ -686,6 +686,106 @@ class Membership_Manager_Test extends \WP_UnitTestCase {
 	}
 
 	// ========================================================================
+	// email verification gate — GH#935
+	// ========================================================================
+
+	/**
+	 * When enable_email_verification=always and the customer has not yet verified
+	 * their email, transitioning from pending → active must NOT publish the pending
+	 * site. The site is held until the customer completes email verification.
+	 */
+	public function test_transition_status_skips_publish_when_customer_email_pending(): void {
+
+		// Make publishing synchronous so we can detect it via a hook.
+		wu_save_setting('force_publish_sites_sync', true);
+
+		// Create a customer whose email is still pending verification.
+		$this->customer->set_email_verification('pending');
+		$this->customer->save();
+
+		$membership = $this->create_membership(['status' => Membership_Status::PENDING]);
+
+		$membership->create_pending_site(
+			[
+				'title' => 'Email Pending Site',
+				'path'  => '/emailpending/',
+			]
+		);
+
+		// Track whether wu_before_pending_site_published fires.
+		$published = false;
+		add_action(
+			'wu_before_pending_site_published',
+			function () use (&$published) {
+				$published = true;
+			}
+		);
+
+		$manager = $this->get_manager_instance();
+
+		$manager->transition_membership_status(
+			Membership_Status::PENDING,
+			Membership_Status::ACTIVE,
+			$membership->get_id()
+		);
+
+		$this->assertFalse(
+			$published,
+			'Site must not be published while customer email is pending verification (GH#935).'
+		);
+
+		// Restore setting.
+		wu_save_setting('force_publish_sites_sync', false);
+	}
+
+	/**
+	 * When the customer has already verified their email (email_verification=none),
+	 * transitioning from pending → active must publish the pending site normally.
+	 */
+	public function test_transition_status_publishes_when_customer_email_not_pending(): void {
+
+		// Make publishing synchronous so we can detect it via a hook.
+		wu_save_setting('force_publish_sites_sync', true);
+
+		// Customer email is verified (default: none).
+		$this->customer->set_email_verification('none');
+		$this->customer->save();
+
+		$membership = $this->create_membership(['status' => Membership_Status::PENDING]);
+
+		$membership->create_pending_site(
+			[
+				'title' => 'Email Verified Site',
+				'path'  => '/emailverified/',
+			]
+		);
+
+		$published = false;
+		add_action(
+			'wu_before_pending_site_published',
+			function () use (&$published) {
+				$published = true;
+			}
+		);
+
+		$manager = $this->get_manager_instance();
+
+		$manager->transition_membership_status(
+			Membership_Status::PENDING,
+			Membership_Status::ACTIVE,
+			$membership->get_id()
+		);
+
+		$this->assertTrue(
+			$published,
+			'Site must be published when customer email is not pending verification.'
+		);
+
+		// Restore setting.
+		wu_save_setting('force_publish_sites_sync', false);
+	}
+
+	// ========================================================================
 	// handle_pending_site_on_cancellation()
 	// ========================================================================
 


### PR DESCRIPTION
## Summary

When `enable_email_verification=always`, the payment gateway (e.g. Stripe) can activate a membership via webhook before the customer has verified their email. The `wu_transition_membership_status` hook was unconditionally publishing the pending site on activation, completely bypassing the email-verification gate.

## Root cause

`Membership_Manager::transition_membership_status()` called `publish_pending_site_async()` without checking the customer's `email_verification` status.

## Changes

### `inc/managers/class-membership-manager.php`
Return early from `transition_membership_status()` when the customer's `email_verification === 'pending'`. The site is deferred until email verification completes.

### `inc/managers/class-customer-manager.php`
Add an `ACTIVE` branch to the post-verification publish block in `maybe_verify_email_address()`. Previously, the code only handled `PENDING` and `TRIALING` memberships. With this fix, if the gateway already activated the membership before email was verified, the pending site is published once the customer clicks their verification link.

### `inc/checkout/class-checkout-pages.php`
Remove the `$payment->get_total() === 0.0` guard from `add_verify_email_notice()`. With `always`, paid customers also need to see the "verify your email" banner on the thank-you page.

### `tests/WP_Ultimo/Managers/Membership_Manager_Test.php`
Two regression tests covering the email-gate behaviour.

## Verification

```bash
vendor/bin/phpunit --filter test_transition_status_skips_publish_when_customer_email_pending
vendor/bin/phpunit --filter test_transition_status_publishes_when_customer_email_not_pending
```

Resolves #935

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.11.0 plugin for [OpenCode](https://opencode.ai) v1.3.17 with claude-sonnet-4-6 spent 10m and 23,862 tokens on this as a headless worker.
