### PR TITLE
GH#940: docs(agents): expand bash:other guidance for WP test suite, npm build, and PHP one-liners

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -308,3 +308,40 @@ If `php` is not available, omit the `php -d ...` prefix and call `vendor/bin/php
 **Syntax error in one-liner** — when constructing a PHP or bash one-liner, test with `bash -n`
 (syntax check) or `php -l` before running. A typo in a bash heredoc or PHP string will cause
 `bash:other`.
+
+**WordPress test suite not installed** — `vendor/bin/phpunit` requires a WordPress test
+environment. Without it, it fails with database connection errors or missing `bootstrap.php`
+messages. Install it once with:
+
+```bash
+bash bin/install-wp-tests.sh <db-name> <db-user> <db-pass> [db-host]
+# Example: bash bin/install-wp-tests.sh wordpress_test root root localhost
+```
+
+The test environment is installed to `/tmp/wordpress-tests-lib` and `/tmp/wordpress` by default.
+Check it exists before running the test suite:
+
+```bash
+ls /tmp/wordpress-tests-lib/includes/bootstrap.php 2>/dev/null || echo "WP test suite not installed — run bin/install-wp-tests.sh first"
+```
+
+**`npm run build` is a release command, not a dev command** — the `build` script runs
+minification, pot-file generation, and an encryption step (`encrypt-secrets.php`). Running it
+outside a release context will fail or produce unexpected output. For routine development
+quality checks, use:
+
+```bash
+npm run check    # lint (phpcs + eslint + stylelint) + phpstan + phpunit
+npm run lint     # lint only
+npm run stan     # phpstan only
+npm test         # phpunit only (equivalent to vendor/bin/phpunit)
+```
+
+**PHP functions unavailable in one-liners** — WordPress functions (`add_filter`, `apply_filters`,
+`get_option`, etc.) are not available in bare `php -r` one-liners. They require WordPress to be
+bootstrapped. Use WP-CLI for WordPress-context commands instead:
+
+```bash
+wp eval 'echo get_option("blogname");'   # correct — WP context available
+php -r 'echo get_option("blogname");'    # wrong — fatal: Call to undefined function
+```


### PR DESCRIPTION
## Summary

Follows up on PR #933 (GH#932) which added the bash:other section. Four new bash:other errors (+5) occurred since that fix — the most significant increase of the four tracked patterns:

- **`bash:other` (+5, 24→29):** Three new failure modes not covered by existing guidance:
  1. `vendor/bin/phpunit` fails when WordPress test environment is not installed — agents attempt to run tests without the bootstrap from `bin/install-wp-tests.sh`.
  2. `npm run build` is a release command (runs encryption, minification) not a dev-testing shortcut — agents confuse it with `npm run check`.
  3. Bare `php -r` one-liners calling WordPress functions (`add_filter`, `get_option`, etc.) fail because WP is not bootstrapped in that context.

- Other patterns unchanged or at ±1 (marginal): `webfetch:other` +1, `read:file_not_found` 0, `edit:not_read_first` +1.

## Changes

`AGENTS.md` — `### Common bash:other Failures` section only:

- Added **WordPress test suite not installed** entry: failure message, `bin/install-wp-tests.sh` invocation example, and a pre-check command for `/tmp/wordpress-tests-lib`.
- Added **`npm run build` is a release command** entry: explains it runs encryption/minification, and lists the correct dev alternatives (`npm run check`, `npm run lint`, `npm test`).
- Added **PHP functions unavailable in one-liners** entry: explains WP functions require WP bootstrap; shows `wp eval` as the correct alternative.

## Verification

Documentation-only change. No code modified. Guidance directly addresses the specific new bash:other failure classes observed.

Resolves #940


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.11.0 plugin for [OpenCode](https://opencode.ai) v1.3.17 with claude-sonnet-4-6 spent 5m and 12,836 tokens on this as a headless worker.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded troubleshooting guidance for common WordPress development setup issues.
  * Clarified test suite requirements and installation steps for running unit tests.
  * Documented proper commands for development quality checks versus release builds.
  * Added guidance on executing WordPress functions from the command line with correct bootstrapping.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->