### PR TITLE
fix: prevent free memberships from expiring by treating them as lifetime

### DIFF
--- a/inc/checkout/class-checkout.php
+++ b/inc/checkout/class-checkout.php
@@ -1312,8 +1312,18 @@ class Checkout {
 
 		/*
 		 * Important dates.
+		 *
+		 * For free, non-recurring products the billing start date is null,
+		 * meaning there is no next charge — the membership should be
+		 * treated as lifetime. Passing null into gmdate() silently uses
+		 * the current timestamp, which sets the expiration to *today*
+		 * and causes the membership to expire within hours/days.
 		 */
-		$membership_data['date_expiration'] = gmdate('Y-m-d 23:59:59', $this->order->get_billing_start_date());
+		$billing_start_date = $this->order->get_billing_start_date();
+
+		$membership_data['date_expiration'] = $billing_start_date
+			? gmdate('Y-m-d 23:59:59', $billing_start_date)
+			: null;
 
 		$membership = wu_create_membership($membership_data);
 

--- a/tests/WP_Ultimo/Checkout/Checkout_Test.php
+++ b/tests/WP_Ultimo/Checkout/Checkout_Test.php
@@ -3510,6 +3510,90 @@ class Checkout_Test extends WP_UnitTestCase {
 		$order_prop->setValue($checkout, null);
 	}
 
+	/**
+	 * Test maybe_create_membership sets null expiration for free products.
+	 *
+	 * Free, non-recurring products should produce a lifetime membership
+	 * (date_expiration = null). Before the fix, gmdate() was called with
+	 * null which resolved to "today 23:59:59", causing the membership to
+	 * expire at end-of-day.
+	 */
+	public function test_maybe_create_membership_free_product_has_null_expiration(): void {
+
+		$customer = self::$customer;
+
+		$free_plan = wu_create_product([
+			'name'          => 'Free Test Plan',
+			'slug'          => 'free-test-plan-' . wp_rand(1000, 9999),
+			'amount'        => 0,
+			'recurring'     => false,
+			'duration'      => 1,
+			'duration_unit' => 'month',
+			'type'          => 'plan',
+			'pricing_type'  => 'free',
+			'active'        => true,
+		]);
+
+		if (is_wp_error($free_plan)) {
+			$this->markTestSkipped('Product creation failed: ' . $free_plan->get_error_message());
+		}
+
+		$checkout   = Checkout::get_instance();
+		$reflection = new \ReflectionClass($checkout);
+		$method     = $reflection->getMethod('maybe_create_membership');
+
+		if (PHP_VERSION_ID < 80100) {
+			$method->setAccessible(true);
+		}
+
+		$cart = new Cart(['products' => [$free_plan->get_id()]]);
+
+		// Verify the cart recognises this as free
+		$this->assertTrue($cart->is_free(), 'Cart should be free for a zero-cost plan');
+		$this->assertNull($cart->get_billing_start_date(), 'Billing start date should be null for free plan');
+
+		$order_prop = $this->get_order_prop($reflection);
+		$order_prop->setValue($checkout, $cart);
+
+		$customer_prop = $reflection->getProperty('customer');
+		if (PHP_VERSION_ID < 80100) {
+			$customer_prop->setAccessible(true);
+		}
+		$customer_prop->setValue($checkout, $customer);
+
+		$gateway_prop = $reflection->getProperty('gateway_id');
+		if (PHP_VERSION_ID < 80100) {
+			$gateway_prop->setAccessible(true);
+		}
+		$gateway_prop->setValue($checkout, 'free');
+
+		$result = $method->invoke($checkout);
+
+		if (is_wp_error($result)) {
+			$this->markTestSkipped('Membership creation failed: ' . $result->get_error_message());
+		}
+
+		$this->assertInstanceOf(\WP_Ultimo\Models\Membership::class, $result);
+
+		// The critical assertion: free membership must NOT have an expiration date
+		$this->assertNull(
+			$result->get_date_expiration(),
+			'Free membership must have null date_expiration (lifetime). ' .
+			'Got: ' . var_export($result->get_date_expiration(), true)
+		);
+
+		// Consequently, the membership should be identified as lifetime
+		$this->assertTrue(
+			$result->is_lifetime(),
+			'Free membership must be recognised as lifetime'
+		);
+
+		// Cleanup
+		$result->delete();
+		$free_plan->delete();
+		$order_prop->setValue($checkout, null);
+	}
+
 	// -------------------------------------------------------------------------
 	// maybe_create_payment — create new payment path
 	// -------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- **Bug**: Free membership signups were expiring within hours/days instead of being treated as lifetime
- **Root cause**: `Checkout::maybe_create_membership()` passed `null` (from `Cart::get_billing_start_date()`) into `gmdate()`, which silently used the current timestamp — setting `date_expiration` to today at 23:59:59
- **Fix**: Check for null billing start date before calling `gmdate()`; when null (free product), set `date_expiration` to `null` so the membership is correctly identified as lifetime

## Details

### The bug trace

1. `Cart::get_billing_start_date()` correctly returns `null` for free, non-recurring products
2. `Checkout::maybe_create_membership()` ran `gmdate('Y-m-d 23:59:59', null)` — PHP treats `null` as current time
3. Membership created with `date_expiration = "today 23:59:59"`
4. `Membership::is_lifetime()` returns `false` (expiration is non-empty)
5. Cron `membership_expired_check()` picks it up after 3-day grace period → membership marked EXPIRED

### The fix

```php
$billing_start_date = $this->order->get_billing_start_date();

$membership_data['date_expiration'] = $billing_start_date
    ? gmdate('Y-m-d 23:59:59', $billing_start_date)
    : null;
```

When `date_expiration` is `null`:
- `Membership::is_lifetime()` → `true`
- Cron explicitly excludes `null` dates from the expired-check query (`date_expiration__not_in => [null, '0000-00-00 00:00:00']`)

### Files changed

- `inc/checkout/class-checkout.php` — fix in `maybe_create_membership()`
- `tests/WP_Ultimo/Checkout/Checkout_Test.php` — new test `test_maybe_create_membership_free_product_has_null_expiration`

### Testing

- New test verifies free membership gets `null` expiration and `is_lifetime() === true`
- 332 Cart/Checkout tests pass (0 failures, 1 pre-existing skip)
- 107 Membership tests pass (0 failures)

### Note on existing free memberships

Existing free memberships that have already been marked as expired will need to be manually reactivated. The admin can do this from the membership edit screen.

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.1 plugin for [OpenCode](https://opencode.ai) v1.3.17 with gemma4:e4b spent 7d and 43,427 tokens on this as a headless worker.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed membership expiration handling for free, non-recurring products. Lifetime memberships now correctly have no expiration date instead of expiring immediately.

* **Tests**
  * Added regression test to validate lifetime membership creation and expiration handling for free products.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->