### PR TITLE
fix: use checkout domain for email verification URLs

### DIFF
--- a/inc/checkout/class-checkout.php
+++ b/inc/checkout/class-checkout.php
@@ -1116,6 +1116,17 @@ class Checkout {
 		}
 
 		/*
+		 * Store the current blog ID so the verification email
+		 * links back to the same domain the customer used to
+		 * check out. Without this, the verification URL would
+		 * always point to the main site, where the customer's
+		 * auth cookie may not be valid.
+		 *
+		 * @since 2.5.0
+		 */
+		$customer->set_checkout_blog_id(get_current_blog_id());
+
+		/*
 		 * Updates IP, and country
 		 */
 		$customer->update_last_login(true, true);

--- a/inc/models/class-customer.php
+++ b/inc/models/class-customer.php
@@ -51,6 +51,16 @@ class Customer extends Base_Model implements Billable, Notable {
 	const META_VERIFICATION_KEY = 'wu_verification_key';
 
 	/**
+	 * Meta key for the blog ID where the customer checked out.
+	 *
+	 * Used to build verification URLs on the same domain the
+	 * customer originally used, so their auth cookie is valid.
+	 *
+	 * @since 2.5.0
+	 */
+	const META_CHECKOUT_BLOG_ID = 'wu_checkout_blog_id';
+
+	/**
 	 * User ID of the associated user.
 	 *
 	 * @since 2.0.0
@@ -882,6 +892,12 @@ class Customer extends Base_Model implements Billable, Notable {
 	/**
 	 * Returns the link of the email verification endpoint.
 	 *
+	 * When the customer checked out on a domain other than the main site
+	 * (e.g. a checkout form hosted on a mapped domain), the verification
+	 * URL must point back to that same domain so the auth cookie set
+	 * during checkout is valid. Falls back to the main site when no
+	 * checkout blog ID is stored.
+	 *
 	 * @since 2.0.0
 	 * @return string|bool
 	 */
@@ -889,8 +905,21 @@ class Customer extends Base_Model implements Billable, Notable {
 
 		$key = $this->get_verification_key();
 
+		$blog_id = $this->get_checkout_blog_id() ?: wu_get_main_site_id();
+
+		/**
+		 * Filters the base URL used for the email verification link.
+		 *
+		 * @since 2.5.0
+		 *
+		 * @param string   $base_url The base URL (home URL of the checkout site).
+		 * @param Customer $customer The customer object.
+		 * @param int      $blog_id  The blog ID used to build the URL.
+		 */
+		$base_url = apply_filters('wu_customer_verification_base_url', get_home_url($blog_id), $this, $blog_id);
+
 		if ( ! $key) {
-			return get_site_url(wu_get_main_site_id());
+			return $base_url;
 		}
 
 		return add_query_arg(
@@ -898,8 +927,32 @@ class Customer extends Base_Model implements Billable, Notable {
 				'email-verification-key' => $key,
 				'customer'               => $this->get_hash(),
 			],
-			get_site_url(wu_get_main_site_id())
+			$base_url
 		);
+	}
+
+	/**
+	 * Get the blog ID of the site where the customer checked out.
+	 *
+	 * @since 2.5.0
+	 * @return int The blog ID, or 0 if not set.
+	 */
+	public function get_checkout_blog_id() {
+
+		return absint($this->get_meta(self::META_CHECKOUT_BLOG_ID, 0));
+	}
+
+	/**
+	 * Set the blog ID of the site where the customer checked out.
+	 *
+	 * @since 2.5.0
+	 *
+	 * @param int $blog_id The blog ID.
+	 * @return bool
+	 */
+	public function set_checkout_blog_id($blog_id) {
+
+		return $this->update_meta(self::META_CHECKOUT_BLOG_ID, absint($blog_id));
 	}
 
 	/**


### PR DESCRIPTION
## Summary

- Store the checkout site's blog ID on the customer during registration so email verification links point back to the same domain the customer used — not always the main site
- Fixes cross-domain checkout where the customer's auth cookie is set for `example2.com` but the verification email links to `example.com`, causing an authentication failure when clicking the link

## Problem

When a checkout form lives on a domain other than the main site (e.g. `example2.com`), the verification email always linked to the main site (`example.com`). The customer's auth cookie was set for the checkout domain during `login_customer_after_checkout()`, so clicking the verification link on the main site hit the `is_user_logged_in()` guard in `maybe_verify_email_address()` and died with a login prompt — on the wrong domain.

## Changes

### `inc/models/class-customer.php`
- Add `META_CHECKOUT_BLOG_ID` constant (`wu_checkout_blog_id`)
- Add `get_checkout_blog_id()` / `set_checkout_blog_id()` methods using existing meta system
- Modify `get_verification_url()` to use `get_home_url($blog_id)` with the stored checkout blog ID, falling back to `wu_get_main_site_id()` for existing customers without the meta
- Add `wu_customer_verification_base_url` filter for full override control

### `inc/checkout/class-checkout.php`
- In `maybe_create_customer()`, store `get_current_blog_id()` on the customer before the verification email is triggered

## Backward Compatibility

Existing customers without the meta key get `0` from `get_checkout_blog_id()`, which is falsy, so the fallback to `wu_get_main_site_id()` preserves the old behavior. No database migration needed.

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.3 plugin for [OpenCode](https://opencode.ai) v1.3.17 with claude-opus-4-6 spent 15m and 23,186 tokens on this with the user in an interactive session.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed verification email URLs to reference the correct checkout domain in multisite setups, instead of defaulting to the main site.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->