### PR TITLE
fix: show 'NOT Activated' instead of 'Activated' for failed pre-install checks

### DIFF
--- a/inc/admin-pages/class-setup-wizard-admin-page.php
+++ b/inc/admin-pages/class-setup-wizard-admin-page.php
@@ -679,12 +679,14 @@ class Setup_Wizard_Admin_Page extends Wizard_Admin_Page {
 				'name'              => __('WordPress Multisite', 'ultimate-multisite'),
 				'help'              => wu_get_documentation_url('wp-ultimo-requirements'),
 				'condition'         => __('Installed & Activated', 'ultimate-multisite'),
+				'fail_condition'    => __('NOT Installed & Activated', 'ultimate-multisite'),
 				'pass_requirements' => is_multisite(),
 			],
 			'wp-ultimo' => [
 				'name'                   => __('Ultimate Multisite', 'ultimate-multisite'),
 				'help'                   => wu_get_documentation_url('wp-ultimo-requirements'),
 				'condition'              => apply_filters('wp_ultimo_skip_network_active_check', false) ? __('Bypassed via filter', 'ultimate-multisite') : __('Network Activated', 'ultimate-multisite'),
+				'fail_condition'         => __('NOT Network Activated', 'ultimate-multisite'),
 				'pass_requirements'      => $is_network_active,
 				'can_activate'           => $can_network_activate,
 				'network_activate_nonce' => $can_network_activate ? wp_create_nonce('wu_setup_network_activate') : '',
@@ -693,6 +695,7 @@ class Setup_Wizard_Admin_Page extends Wizard_Admin_Page {
 				'name'              => __('WordPress Cron', 'ultimate-multisite'),
 				'help'              => wu_get_documentation_url('wp-ultimo-requirements'),
 				'condition'         => __('Activated', 'ultimate-multisite'),
+				'fail_condition'    => __('NOT Activated', 'ultimate-multisite'),
 				'pass_requirements' => Requirements::check_wp_cron(),
 			],
 		];

--- a/views/wizards/setup/requirements_table.php
+++ b/views/wizards/setup/requirements_table.php
@@ -66,7 +66,7 @@ defined('ABSPATH') || exit;
 		<tr class="">
 			<td><?php echo esc_html($req['name']); ?></td>
 			<td class="<?php echo $req['pass_requirements'] ? 'wu-text-green-600' : 'wu-text-red-600'; ?>">
-				<?php echo esc_html($req['condition']); ?>
+				<?php echo $req['pass_requirements'] ? esc_html($req['condition']) : esc_html($req['fail_condition'] ?? $req['condition']); ?>
 			<?php echo $req['pass_requirements'] ? '<span class="dashicons-wu-check"></span>' : '<span class="dashicons-wu-cross wu-align-middle"></span>'; ?>
 
 			<?php if ( ! $req['pass_requirements']) : ?>


### PR DESCRIPTION
## Summary

- Pre-install checks displayed "Activated x" when a requirement failed, which was confusing — it read as if the item IS activated with a mysterious x mark
- Added `fail_condition` keys to plugin requirement entries so failed checks now show "NOT Activated x", "NOT Network Activated x", etc., making it obvious the x indicates a problem
- Template falls back to `condition` if `fail_condition` is not set, so existing/third-party usage is unaffected

Resolves the UX confusion where a red "Activated x" label appeared to contradict itself.

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.3 plugin for [OpenCode](https://opencode.ai) v1.3.17 with claude-opus-4-6 spent 21m and 1,603 tokens on this as a headless worker.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved setup wizard requirements table to display specific failure messages. The setup wizard now shows distinct messaging for unmet requirements such as WordPress Multisite, Ultimate Multisite, and WordPress Cron, providing clearer feedback about why conditions are not met.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->