### PR TITLE
fix: block duplicate signup when customer has an active membership

### DIFF
--- a/inc/checkout/class-checkout.php
+++ b/inc/checkout/class-checkout.php
@@ -730,6 +730,78 @@ class Checkout {
 		$this->type = $cart->get_cart_type();
 
 		/*
+		 * Block duplicate signup for logged-in users with active memberships.
+		 *
+		 * When a customer with an active subscription goes through the
+		 * registration form again as a "new" checkout (rather than
+		 * upgrade/downgrade), the new subscription replaces the old one
+		 * and any applied coupons or custom pricing are lost.
+		 *
+		 * This guard fires early — before any customer, membership, or
+		 * payment records are created — so there are no orphaned records
+		 * to clean up when the checkout is blocked.
+		 *
+		 * Filterable via `wu_allow_duplicate_signup` for sites that
+		 * intentionally permit re-registration (e.g. multi-membership).
+		 *
+		 * @since 2.5.1
+		 */
+		if ('new' === $this->type && is_user_logged_in()) {
+			$existing_customer = wu_get_current_customer();
+
+			if ($existing_customer) {
+				$active_memberships = wu_get_memberships([
+					'customer_id' => $existing_customer->get_id(),
+					'status__in'  => [
+						Membership_Status::ACTIVE,
+						Membership_Status::TRIALING,
+						Membership_Status::ON_HOLD,
+					],
+					'number'      => 1,
+				]);
+
+				if ( ! empty($active_memberships)) {
+					$existing_membership = reset($active_memberships);
+
+					/**
+					 * Filters whether to allow a duplicate signup when the
+					 * customer already has an active membership.
+					 *
+					 * Return `true` to allow the checkout to proceed. The
+					 * default is `false` (block the signup).
+					 *
+					 * @since 2.5.1
+					 *
+					 * @param bool                          $allow     Whether to allow the duplicate signup.
+					 * @param \WP_Ultimo\Models\Membership  $membership The existing active membership.
+					 * @param \WP_Ultimo\Models\Customer    $customer   The current customer.
+					 * @param \WP_Ultimo\Checkout\Cart      $cart       The cart being processed.
+					 */
+					$allow = apply_filters(
+						'wu_allow_duplicate_signup',
+						false,
+						$existing_membership,
+						$existing_customer,
+						$cart
+					);
+
+					if ( ! $allow) {
+						$account_url = get_admin_url(wu_get_main_site_id(), 'admin.php?page=account');
+
+						return new \WP_Error(
+							'duplicate_signup',
+							sprintf(
+								/* translators: %s is a link to the account page. */
+								__('You already have an active subscription. To manage your existing subscription, <a href="%s">visit your account page</a>. If you need help, please contact support.', 'ultimate-multisite'),
+								esc_url($account_url)
+							)
+						);
+					}
+				}
+			}
+		}
+
+		/*
 		 * Gets the gateway object we want to use.
 		 *
 		 * This will have been set on a previous step (session)

--- a/inc/checkout/class-checkout.php
+++ b/inc/checkout/class-checkout.php
@@ -786,7 +786,19 @@ class Checkout {
 					);
 
 					if ( ! $allow) {
-						$account_url = get_admin_url(wu_get_main_site_id(), 'admin.php?page=account');
+						/*
+						 * Build the account URL on the customer's own subsite
+						 * rather than the main network site. The "account" admin
+						 * page lives in each subsite's wp-admin. Using
+						 * wu_get_main_site_id() would force the main-site domain
+						 * which breaks when domain mapping is active.
+						 *
+						 * Falls back to the main site only if the membership has
+						 * no published sites yet (pending site scenario).
+						 */
+						$membership_sites = $existing_membership->get_sites();
+						$account_blog_id  = ! empty($membership_sites) ? $membership_sites[0]->get_id() : wu_get_main_site_id();
+						$account_url      = get_admin_url($account_blog_id, 'admin.php?page=account');
 
 						return new \WP_Error(
 							'duplicate_signup',


### PR DESCRIPTION
## Summary

- Prevents logged-in customers with active/trialing/on-hold memberships from going through the registration form as a "new" checkout, which would replace their existing subscription and lose any applied coupons or custom pricing.
- The guard fires in `process_order()` **before** any customer, membership, or payment records are created — no orphaned records when the checkout is blocked.
- Adds a `wu_allow_duplicate_signup` filter for sites that intentionally allow re-registration (e.g. multi-membership setups).

## Problem

When a customer with an active subscription (e.g. $64/mo with coupon "web35") visits the registration page again and completes a "new" checkout:

1. UMS creates a new cart **without** the original coupon (the customer didn't re-enter it)
2. The WooCommerce gateway creates a new WC subscription at full price ($99/mo)
3. `process_subscription_created()` cancels the old subscription ("Auto-cancelled: Replaced by subscription #XXXXX")
4. The customer's coupon pricing is permanently lost

The root cause is that logged-in users bypass the "email already in use" check at `maybe_create_customer()` (line 1081), and there was no guard against creating a "new" checkout when an active membership already exists.

## Fix

Added a check in `class-checkout.php::process_order()` (after cart type is determined, before any data creation) that returns a `WP_Error('duplicate_signup', ...)` when all three conditions are met:

1. `cart_type` is `'new'`
2. User is logged in
3. User has at least one membership with status `active`, `trialing`, or `on-hold`

The error message directs the customer to their account page and suggests contacting support.

## How to test

1. Create a customer with an active subscription (with or without a coupon)
2. Log in as that customer
3. Navigate to the registration/checkout page and attempt a new signup
4. **Expected:** checkout is blocked with "You already have an active subscription" error
5. **Expected:** upgrade/downgrade/addon flows continue to work normally (they use `cart_type='upgrade'` etc., not `'new'`)
6. **Expected:** a site can override via `add_filter('wu_allow_duplicate_signup', '__return_true')`

## Context

A customer (KursoPro) built a custom workaround ("kp-prevent-duplicate-signup") that hooks into `wu_checkout_after_validate` and `woocommerce_checkout_process` to block this scenario. However, their UMS-level hook (`wu_checkout_after_validate`) doesn't actually exist in UMS core — only their WC-level hook was active, and it fires late (after UMS has already created pending records). This fix addresses the issue at the correct level in the checkout pipeline.

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.5 plugin for [OpenCode](https://opencode.ai) v1.3.17 with gemma4:e4b spent 7d 8h and 43,427 tokens on this as a headless worker.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced checkout to prevent duplicate membership signups for logged-in users with existing active memberships. Users attempting duplicate signups receive a message directing them to their account management page to review their existing memberships.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->