### PR TITLE
feat: add Status column to checkout forms list table

### DIFF
--- a/inc/list-tables/class-checkout-form-list-table.php
+++ b/inc/list-tables/class-checkout-form-list-table.php
@@ -100,6 +100,27 @@ class Checkout_Form_List_Table extends Base_List_Table {
 	}
 
 	/**
+	 * Displays the active status of the form.
+	 *
+	 * @since 2.0.21
+	 *
+	 * @param \WP_Ultimo\Models\Checkout_Form $item Checkout Form object.
+	 * @return string
+	 */
+	public function column_active($item) {
+
+		if ($item->is_active()) {
+			$label = __('Active', 'ultimate-multisite');
+			$class = 'wu-bg-green-200 wu-text-green-700';
+		} else {
+			$label = __('Inactive', 'ultimate-multisite');
+			$class = 'wu-bg-red-200 wu-text-red-700';
+		}
+
+		return "<span class='wu-py-1 wu-px-2 wu-rounded-sm wu-text-xs wu-font-mono {$class}'>{$label}</span>";
+	}
+
+	/**
 	 * Displays the number pof steps and fields.
 	 *
 	 * @since 2.0.0
@@ -194,11 +215,12 @@ class Checkout_Form_List_Table extends Base_List_Table {
 	public function get_columns() {
 
 		$columns = [
-			'cb'    => '<input type="checkbox" />',
-			'name'  => __('Form Name', 'ultimate-multisite'),
-			'slug'  => __('Form Slug', 'ultimate-multisite'),
-			'steps' => __('Steps', 'ultimate-multisite'),
-			'id'    => __('ID', 'ultimate-multisite'),
+			'cb'     => '<input type="checkbox" />',
+			'name'   => __('Form Name', 'ultimate-multisite'),
+			'active' => __('Status', 'ultimate-multisite'),
+			'slug'   => __('Form Slug', 'ultimate-multisite'),
+			'steps'  => __('Steps', 'ultimate-multisite'),
+			'id'     => __('ID', 'ultimate-multisite'),
 		];
 
 		return $columns;


### PR DESCRIPTION
## Summary

- Adds an **Active/Inactive** status badge column to the Checkout Forms list page (`wp-ultimo-checkout-forms`)
- Admins can now immediately see which forms are disabled without opening each one
- Follows the existing badge pattern used by memberships and broadcasts

The checkout element shows "Registration is not available at this time" when a form is inactive, but previously there was no way to see this from the list page.

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.6 plugin for [OpenCode](https://opencode.ai) v1.3.17 with claude-opus-4-6 spent 18m and 5,397 tokens on this with the user in an interactive session.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Status column to the checkout form list, displaying whether each form is active or inactive with visual indicators (green for active, red for inactive).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->