### PR TITLE
fix: use explicit null check for date_expiration in checkout (GH#964)

### DIFF
--- a/inc/checkout/class-checkout.php
+++ b/inc/checkout/class-checkout.php
@@ -1319,8 +1319,8 @@ class Checkout {
 		 */
 		$billing_start_date = $this->order->get_billing_start_date();
 
-		$membership_data['date_expiration'] = $billing_start_date
-			? gmdate('Y-m-d 23:59:59', $billing_start_date)
+		$membership_data['date_expiration'] = null !== $billing_start_date
+			? gmdate('Y-m-d 23:59:59', (int) $billing_start_date)
 			: null;
 
 		$membership = wu_create_membership($membership_data);


### PR DESCRIPTION
## Summary

Fixes the truthy check on `$billing_start_date` that incorrectly treated `0`/`'0'` as "no date", causing lifetime memberships when the billing start date was zero. The fix uses an explicit `null !== $billing_start_date` check and adds an `(int)` cast for type safety.

## Changes

- **EDIT**: `inc/checkout/class-checkout.php:1322-1324` — replace truthy ternary with explicit null check

## Before / After

```diff
-$membership_data['date_expiration'] = $billing_start_date
-    ? gmdate('Y-m-d 23:59:59', $billing_start_date)
+$membership_data['date_expiration'] = null !== $billing_start_date
+    ? gmdate('Y-m-d 23:59:59', (int) $billing_start_date)
     : null;
```

Resolves #964


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.8 plugin for [OpenCode](https://opencode.ai) v1.3.17 with claude-sonnet-4-6 spent 1m and 3,006 tokens on this as a headless worker.