### PR TITLE
fix: use customer subsite for account URL in duplicate signup guard

### DIFF
--- a/inc/checkout/class-checkout.php
+++ b/inc/checkout/class-checkout.php
@@ -786,7 +786,19 @@ class Checkout {
 					);
 
 					if ( ! $allow) {
-						$account_url = get_admin_url(wu_get_main_site_id(), 'admin.php?page=account');
+						/*
+						 * Build the account URL on the customer's own subsite
+						 * rather than the main network site. The "account" admin
+						 * page lives in each subsite's wp-admin. Using
+						 * wu_get_main_site_id() would force the main-site domain
+						 * which breaks when domain mapping is active.
+						 *
+						 * Falls back to the main site only if the membership has
+						 * no published sites yet (pending site scenario).
+						 */
+						$membership_sites = $existing_membership->get_sites();
+						$account_blog_id  = ! empty($membership_sites) ? $membership_sites[0]->get_id() : wu_get_main_site_id();
+						$account_url      = get_admin_url($account_blog_id, 'admin.php?page=account');
 
 						return new \WP_Error(
 							'duplicate_signup',


### PR DESCRIPTION
## Summary

Fixes the account page URL in the duplicate signup guard added by #963.

### Finding: verified and fixed

The duplicate signup guard built the account URL with `wu_get_main_site_id()`:

```php
$account_url = get_admin_url(wu_get_main_site_id(), 'admin.php?page=account');
```

This forces the main network site domain. When domain mapping is active, the URL sends the customer to the wrong domain and can break auth cookies.

The existing pattern at `class-checkout-element.php:442` uses the customer's own subsite:

```php
get_admin_url($published_sites[0]->get_id(), 'admin.php?page=account')
```

### Fix

Use `$existing_membership->get_sites()` (already in scope from the guard logic) to get the customer's subsite and build the URL on the correct domain. Falls back to main site only when the membership has no published sites (pending site scenario).

### Verification

- `vendor/bin/phpstan analyse inc/checkout/class-checkout.php` — passes clean

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.8 plugin for [OpenCode](https://opencode.ai) v1.3.17 with gemma4:e4b spent 8d 8h and 43,427 tokens on this as a headless worker.
