### PR TITLE
fix: guard against null expiration in calculate_expiration on PHP 8.4

### DIFF
--- a/inc/models/class-membership.php
+++ b/inc/models/class-membership.php
@@ -1292,7 +1292,7 @@ class Membership extends Base_Model implements Limitable, Billable, Notable {
 			return null;
 		}
 
-		if (wu_validate_date($expiration)) {
+		if ($expiration && wu_validate_date($expiration)) {
 			$expiration_timestamp = wu_date($expiration)->format('U');
 		}
 


### PR DESCRIPTION
## Summary

Fatal error on membership renewal when the membership had no prior expiration date stored:

```
Fatal Error: Uncaught Error: Call to a member function format() on false
in inc/models/class-membership.php:1296
```

## Root Cause

`wu_validate_date(null)` intentionally returns `true` (null = lifetime/no-expiration is a valid state). However this caused `wu_date(null)` to be called, which passes `null` straight to `DateTime::createFromFormat('Y-m-d H:i:s', null)`. PHP 8.4 rejects `null` strictly and returns `false`. Calling `->format('U')` on `false` produced the fatal.

**Call chain:**
1. `get_date_expiration()` returns `null` (recurring membership with no prior expiration stored)
2. `wu_validate_date(null)` returns `true` — by design, but lets null through
3. `wu_date(null)` calls `DateTime::createFromFormat(..., null)` — returns `false` in PHP 8.4
4. `false->format('U')` — **Fatal**

## Fix

Add `$expiration &&` guard before `wu_validate_date()` in `calculate_expiration()`:

```php
// Before
if (wu_validate_date($expiration)) {

// After
if ($expiration && wu_validate_date($expiration)) {
```

When `$expiration` is null/empty, `$expiration_timestamp` stays `0`. The existing fallback at line 1300-1304 then correctly uses the current time as the renewal base.

## Impact

- **Affected:** Renewing a recurring membership with no `date_expiration` stored (e.g. first renewal after admin manually marks a payment as paid via the Payment Edit admin page)
- **Unaffected:** Normal renewal paths with a valid stored expiration — the guard is falsy-only, valid date strings pass through unchanged

## Environment Reported

- PHP 8.4.20 / WordPress 7.0-RC2 / Ultimate Multisite 2.7.0

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.8 plugin for [OpenCode](https://opencode.ai) v1.3.17 with claude-sonnet-4-6 spent 4m and 7,895 tokens on this with the user in an interactive session.