### PR TITLE
t531: fix(checkout): rebind password strength checker after inline login prompt dismissed

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -121,6 +121,10 @@ Overall coverage: **35%** (20,720 / 59,212 statements). 90 files at 0% coverage.
 - [x] GH#813 fix: guard false return from get_available_site_templates() in switch_template() — TypeError on PHP 8.0+ ref:GH#813 pr:#819 completed:2026-04-13
 - [x] GH#814 test(reactivation): add unit tests verifying all PR #751 review findings were addressed ref:GH#814 pr:#817 completed:2026-04-13
 
+## Production Bugs (2026-04-28)
+
+- [ ] t531 fix(checkout): password fields and strength meter stop working after inline login popup + email change — Vue 2 recycles login-prompt DOM node as password-div, detaching jQuery bindings on #field-password #bug #auto-dispatch ~3h ref:GH#973 logged:2026-04-28
+
 ## Production Bugs (2026-04-22)
 
 - [ ] t529 fix(membership): orphan pending_site after membership cancellation — watchdog cancels membership but pending_site meta stays, customer retries checkout and gets no site #bug #auto-dispatch ~4h ref:GH#902

--- a/assets/js/checkout.js
+++ b/assets/js/checkout.js
@@ -1562,9 +1562,28 @@
 					// Setup inline login handlers if prompt is visible
 					this.setup_inline_login_handlers();
 
-					// Re-initialize password strength if field appeared after mount
-					if (! this.password_strength_checker && jQuery('#field-password').length) {
-						this.init_password_strength();
+					// Re-initialize password strength when:
+					// (a) checker was never created, or
+					// (b) the checker's DOM element no longer matches the current
+					//     #field-password element.
+					//
+					// Case (b) occurs when the inline login prompt is shown then
+					// hidden: Vue 2 recycles the adjacent sibling DOM node (the
+					// login-prompt wrapper <div>) for the password field wrapper,
+					// creating a fresh #field-password <input> that the old
+					// jQuery .on() bindings never touch.
+					const passEl = jQuery('#field-password');
+					if (passEl.length) {
+						const checkerEl = this.password_strength_checker &&
+							this.password_strength_checker.options.pass1 &&
+							this.password_strength_checker.options.pass1[ 0 ];
+						if (! this.password_strength_checker || checkerEl !== passEl[ 0 ]) {
+							if (this.password_strength_checker) {
+								this.password_strength_checker.destroy();
+								this.password_strength_checker = null;
+							}
+							this.init_password_strength();
+						}
 					}
 
 				});

--- a/assets/js/wu-password-strength.js
+++ b/assets/js/wu-password-strength.js
@@ -125,7 +125,7 @@
 			// unnecessary CPU usage once the user has had time to fill the form.
 			this._lastPass1Val = '';
 			this._autofillPoll = setInterval(function() {
-				var currentVal = self.options.pass1.val();
+				const currentVal = self.options.pass1.val();
 				if (currentVal !== self._lastPass1Val) {
 					self._lastPass1Val = currentVal;
 					self.checkStrength();
@@ -410,14 +410,14 @@
 		 * super_strong — a reward for users who go above and beyond.
 		 *
 		 * @param {string} password
-		 * @return {boolean}
+		 * @return {boolean} True if password meets all super-strong criteria.
 		 */
 		checkSuperStrongRules(password) {
-			return password.length >= 12
-				&& /[A-Z]/.test(password)
-				&& /[a-z]/.test(password)
-				&& /[0-9]/.test(password)
-				&& /[!@#$%^&*()_+\-={};:'",.<>?~\[\]\/|`\\]/.test(password);
+			return password.length >= 12 &&
+				/[A-Z]/.test(password) &&
+				/[a-z]/.test(password) &&
+				/[0-9]/.test(password) &&
+				/[!@#$%^&*()_+\-={};:'",.<>?~\[\]\/|`\\]/.test(password);
 		},
 
 		/**
@@ -455,6 +455,30 @@
 		 */
 		isValid() {
 			return this.isPasswordValid;
+		},
+
+		/**
+		 * Destroy the strength checker and remove event listeners.
+		 *
+		 * Call before re-initializing to prevent duplicate handlers when
+		 * the password field DOM element is replaced by a Vue update cycle
+		 * (e.g. the inline login prompt being shown/hidden causes Vue 2 to
+		 * recycle adjacent sibling DOM nodes, creating a fresh #field-password
+		 * element whose jQuery bindings are missing).
+		 *
+		 * @since 2.5.2
+		 */
+		destroy() {
+			if (this.options.pass1 && this.options.pass1.length) {
+				this.options.pass1.off('keyup input change');
+			}
+			if (this.options.pass2 && this.options.pass2.length) {
+				this.options.pass2.off('keyup input change');
+			}
+			if (this._autofillPoll) {
+				clearInterval(this._autofillPoll);
+				this._autofillPoll = null;
+			}
 		}
 	};
 


### PR DESCRIPTION
## Summary

Fixes password field and strength meter becoming unresponsive after the inline login popup is shown and then the email address is changed.

## Root Cause

**Vue 2 DOM element reuse across a `v-if` boundary.**

The inline login prompt wrapper uses `v-if="show_login_prompt && login_prompt_field === 'email'"`. When `show_login_prompt` transitions `true → false`, the DOM sibling order is:

- Before: `email-div` → `login-prompt-div` → `password-div`
- After: `email-div` → `password-div`

Vue 2's virtual-DOM differ, with no `key` on the wrappers, recycles `login-prompt-div`'s real DOM node and patches it with the password-field VNode — then removes the original `password-div`. This creates a **new** `#field-password` `<input>` element.

`init_password_strength()` bound its `keyup/input/change` listeners to the **old** element (now detached). The new element has no listeners, so the strength meter never fires, `valid_password` stays `false`, and form submission is blocked.

## Changes

### `assets/js/wu-password-strength.js`
- Added `WU_PasswordStrength.prototype.destroy()` — removes `keyup/input/change` event listeners from `pass1`/`pass2` and clears the autofill `setInterval` poll. Prevents duplicate handlers when the checker is re-initialized.
- Fixed pre-existing `checkSuperStrongRules()` JSDoc missing `@return` description.

### `assets/js/checkout.js`
- Replaced the `!this.password_strength_checker` guard in `updated()` with a DOM-element identity check: compares `checker.options.pass1[ 0 ]` against the current `jQuery('#field-password')[ 0 ]`. When they differ (recycled element), the stale checker is destroyed and a new one is initialized for the fresh DOM node.

## Testing

1. Open a checkout form with email + password fields and inline login enabled.
2. Enter an existing user's email → inline login popup appears.
3. Clear/change the email to a non-existing address → popup disappears.
4. Type in the password field → strength meter updates correctly ✓
5. Submit the form → password validation passes ✓

Resolves #973

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.10 plugin for [OpenCode](https://opencode.ai) v1.3.17 with claude-sonnet-4-6 spent 13m and 15,268 tokens on this with the user in an interactive session.