### PR TITLE
fix: sync WP core registration option on activation and settings save

### DIFF
--- a/inc/class-settings.php
+++ b/inc/class-settings.php
@@ -72,6 +72,12 @@ class Settings implements \WP_Ultimo\Interfaces\Singleton {
 
 		add_filter('site_option_menu_items', [$this, 'force_plugins_menu'], 10, 3);
 		add_filter('default_site_option_menu_items', [$this, 'force_plugins_menu'], 10, 3);
+
+		// Persist the registration state into the WP core site option so the
+		// Network Admin Settings page reflects reality and registration survives
+		// plugin deactivation in the correct state.
+		add_action('wu_activation', [$this, 'sync_wp_registration_option']);
+		add_action('wu_after_save_settings', [$this, 'sync_wp_registration_option']);
 	}
 
 	/**
@@ -95,6 +101,28 @@ class Settings implements \WP_Ultimo\Interfaces\Singleton {
 		$status = wu_get_setting('enable_registration', true) ? 'all' : $status;
 
 		return $status;
+	}
+
+	/**
+	 * Persist the registration state into the WordPress core site option.
+	 *
+	 * The pre_site_option_registration filter already overrides the value at
+	 * read-time, but the stored WP core option stays 'none' (the WP default).
+	 * This causes the Network Admin Settings page to show "No registrations
+	 * allowed" and means registration goes dark if the plugin is deactivated.
+	 *
+	 * Hooked to wu_activation (one-time on plugin activation) and to
+	 * wu_after_save_settings (whenever the settings form is saved) so the
+	 * stored value always matches the plugin setting.
+	 *
+	 * @since 2.0.11
+	 * @return void
+	 */
+	public function sync_wp_registration_option() {
+
+		$enabled = wu_get_setting('enable_registration', true);
+
+		update_site_option('registration', $enabled ? 'all' : 'none');
 	}
 
 	/**


### PR DESCRIPTION
## Problem

WordPress Multisite defaults the `registration` site option to `none` (no registrations). The plugin overrode this at read-time via the `pre_site_option_registration` filter, but never persisted the value to the database.

This caused three issues:

1. **Network Admin → Settings** always showed "No registrations allowed" — even when the plugin had registration enabled, confusing network admins.
2. **Deactivating the plugin** left the WP core option as `none`, silently disabling all registration.
3. The filter-only approach is fragile during early bootstrap before the `Settings` class is fully initialised.

## Solution

Adds `Settings::sync_wp_registration_option()` which calls `update_site_option('registration', 'all'|'none')` to match the `enable_registration` plugin setting.

Hooked to:
- `wu_activation` — fires once on plugin activation, immediately correcting the WP core value
- `wu_after_save_settings` — stays in sync whenever the toggle is changed in the plugin settings UI

The `pre_site_option_registration` filter is retained as a runtime safety net.

## For existing installs

Re-save the plugin settings page once, or deactivate/reactivate the plugin. Either will trigger `sync_wp_registration_option()` and correct the stored value.

## Related

- Default role fix (already merged): PR #866
- Both issues stem from the same root: WP Multisite defaults that are misaligned with WaaS plugin expectations.

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.10 plugin for [OpenCode](https://opencode.ai) v1.3.17 with claude-sonnet-4-6 spent 1h 12m and 18,932 tokens on this with the user in an interactive session.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Registration settings are now automatically synchronized between the plugin and WordPress core multisite network settings whenever the plugin is activated or settings are modified. This ensures the Network Admin Settings interface displays and behaves consistently with the plugin's registration configuration, even after deactivation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->