### PR TITLE
t531: fix(checkout): rebind password strength checker after inline login prompt dismissed

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -121,6 +121,10 @@ Overall coverage: **35%** (20,720 / 59,212 statements). 90 files at 0% coverage.
 - [x] GH#813 fix: guard false return from get_available_site_templates() in switch_template() — TypeError on PHP 8.0+ ref:GH#813 pr:#819 completed:2026-04-13
 - [x] GH#814 test(reactivation): add unit tests verifying all PR #751 review findings were addressed ref:GH#814 pr:#817 completed:2026-04-13
 
+## Production Bugs (2026-04-28)
+
+- [ ] t531 fix(checkout): password fields and strength meter stop working after inline login popup + email change — Vue 2 recycles login-prompt DOM node as password-div, detaching jQuery bindings on #field-password #bug #auto-dispatch ~3h ref:GH#973 logged:2026-04-28
+
 ## Production Bugs (2026-04-22)
 
 - [ ] t529 fix(membership): orphan pending_site after membership cancellation — watchdog cancels membership but pending_site meta stays, customer retries checkout and gets no site #bug #auto-dispatch ~4h ref:GH#902

--- a/assets/js/checkout.js
+++ b/assets/js/checkout.js
@@ -1562,9 +1562,28 @@
 					// Setup inline login handlers if prompt is visible
 					this.setup_inline_login_handlers();
 
-					// Re-initialize password strength if field appeared after mount
-					if (! this.password_strength_checker && jQuery('#field-password').length) {
-						this.init_password_strength();
+					// Re-initialize password strength when:
+					// (a) checker was never created, or
+					// (b) the checker's DOM element no longer matches the current
+					//     #field-password element.
+					//
+					// Case (b) occurs when the inline login prompt is shown then
+					// hidden: Vue 2 recycles the adjacent sibling DOM node (the
+					// login-prompt wrapper <div>) for the password field wrapper,
+					// creating a fresh #field-password <input> that the old
+					// jQuery .on() bindings never touch.
+					const passEl = jQuery('#field-password');
+					if (passEl.length) {
+						const checkerEl = this.password_strength_checker &&
+							this.password_strength_checker.options.pass1 &&
+							this.password_strength_checker.options.pass1[ 0 ];
+						if (! this.password_strength_checker || checkerEl !== passEl[ 0 ]) {
+							if (this.password_strength_checker) {
+								this.password_strength_checker.destroy();
+								this.password_strength_checker = null;
+							}
+							this.init_password_strength();
+						}
 					}
 
 				});

--- a/assets/js/wu-password-strength.js
+++ b/assets/js/wu-password-strength.js
@@ -125,7 +125,7 @@
 			// unnecessary CPU usage once the user has had time to fill the form.
 			this._lastPass1Val = '';
 			this._autofillPoll = setInterval(function() {
-				var currentVal = self.options.pass1.val();
+				const currentVal = self.options.pass1.val();
 				if (currentVal !== self._lastPass1Val) {
 					self._lastPass1Val = currentVal;
 					self.checkStrength();
@@ -410,14 +410,14 @@
 		 * super_strong — a reward for users who go above and beyond.
 		 *
 		 * @param {string} password
-		 * @return {boolean}
+		 * @return {boolean} True if password meets all super-strong criteria.
 		 */
 		checkSuperStrongRules(password) {
-			return password.length >= 12
-				&& /[A-Z]/.test(password)
-				&& /[a-z]/.test(password)
-				&& /[0-9]/.test(password)
-				&& /[!@#$%^&*()_+\-={};:'",.<>?~\[\]\/|`\\]/.test(password);
+			return password.length >= 12 &&
+				/[A-Z]/.test(password) &&
+				/[a-z]/.test(password) &&
+				/[0-9]/.test(password) &&
+				/[!@#$%^&*()_+\-={};:'",.<>?~\[\]\/|`\\]/.test(password);
 		},
 
 		/**
@@ -455,6 +455,30 @@
 		 */
 		isValid() {
 			return this.isPasswordValid;
+		},
+
+		/**
+		 * Destroy the strength checker and remove event listeners.
+		 *
+		 * Call before re-initializing to prevent duplicate handlers when
+		 * the password field DOM element is replaced by a Vue update cycle
+		 * (e.g. the inline login prompt being shown/hidden causes Vue 2 to
+		 * recycle adjacent sibling DOM nodes, creating a fresh #field-password
+		 * element whose jQuery bindings are missing).
+		 *
+		 * @since 2.5.2
+		 */
+		destroy() {
+			if (this.options.pass1 && this.options.pass1.length) {
+				this.options.pass1.off('keyup input change');
+			}
+			if (this.options.pass2 && this.options.pass2.length) {
+				this.options.pass2.off('keyup input change');
+			}
+			if (this._autofillPoll) {
+				clearInterval(this._autofillPoll);
+				this._autofillPoll = null;
+			}
 		}
 	};
 


### PR DESCRIPTION
## Summary

Fixes the Vue 2 DOM reuse bug that causes the password strength meter to stop working after the inline login popup is shown and the user then changes the email address.

### Root Cause

When `show_login_prompt` transitions `true → false`, Vue 2's keyless sibling-element diff recycles the login-prompt `<div>` node as the password-field wrapper `<div>`. This creates a **new** `#field-password` `<input>` element, leaving `init_password_strength()`'s original jQuery `.on('keyup input change')` listeners attached to the now-detached original element. Typing in the (new) password field never fires `checkStrength()`, so `valid_password` stays `false` and form submission is blocked.

### Fix

**`assets/js/wu-password-strength.js`** — Adds `WU_PasswordStrength.prototype.destroy()`:
- Unbinds `keyup input change` listeners from `pass1`/`pass2`
- Clears the Safari-autofill `setInterval` poll

**`assets/js/checkout.js` (`updated()`)** — Replaces the simple `!checker` guard with a DOM identity check:
- Compares `checker.options.pass1[0]` to the current `jQuery('#field-password')[0]`
- If they differ (stale element), calls `destroy()`, nulls the reference, and re-inits
- If no checker exists at all, inits as before

Resolves #973

<!-- aidevops:sig -->