### PR TITLE
GH#978: expand AGENTS.md to address recurring contributor error patterns

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -68,8 +68,11 @@ inc/
   traits/                # Shared traits (Singleton, deprecated compat)
   exception/             # Runtime_Exception
 tests/
-  WP_Ultimo/             # Unit tests mirroring inc/ structure
+  WP_Ultimo/             # Unit tests mirroring inc/ structure (main test suite)
   Admin_Pages/           # Admin page tests
+  Builders/              # Block editor / widget builder tests
+  functional/            # Functional/integration tests (e.g. SSO)
+  unit/                  # Standalone unit tests (API schema, checkout request, etc.)
   e2e/                   # Cypress E2E tests
   bootstrap.php          # WP test bootstrap (loads plugin via muplugins_loaded)
 views/                   # PHP template files
@@ -267,6 +270,9 @@ read them will produce `read:file_not_found`:
 | `inc/class-site.php` | Does not exist at root of `inc/`; model classes are in `inc/models/` |
 | `inc/class-domain.php` | Does not exist at root of `inc/`; model classes are in `inc/models/` |
 | `lang/*.po`, `lang/*.mo` | Compiled translation files are not tracked; only `lang/ultimate-multisite.pot` is in the repo |
+| `inc/bootstrap.php` | Does not exist; plugin bootstraps from `ultimate-multisite.php` at repo root |
+| `tests/WP_Ultimo/bootstrap.php` | Does not exist; test bootstrap is at `tests/bootstrap.php` |
+| `inc/class-plugin.php`, `inc/class-main.php` | Do not exist; the main plugin class is `inc/class-wp-ultimo.php` |
 
 Always verify a file is tracked before reading it with `git ls-files '<path>'`. An empty result means the file does not exist in the repo.
 


### PR DESCRIPTION
## Summary

Triage of contributor-insight issue #978 (4 recurring error patterns from superdav42).

**Worker triage assessment:** Premise verified — error patterns are real. Outcome B: AGENTS.md already covers the four patterns comprehensively, but the repo file lagged behind the canonical target state. This PR fills the documented gaps.

## Changes

**`AGENTS.md` — Project Structure:**
- Added three missing test directories: `tests/Builders/`, `tests/functional/`, `tests/unit/`
- These subdirectories exist in the repo but were absent from the project map, causing `read:file_not_found` errors when contributors searched for test files

**`AGENTS.md` — Non-existent paths table:**
- Added `inc/bootstrap.php` — commonly attempted; plugin entry point is `ultimate-multisite.php`
- Added `tests/WP_Ultimo/bootstrap.php` — commonly attempted; actual bootstrap is `tests/bootstrap.php`
- Added `inc/class-plugin.php` / `inc/class-main.php` — common WP plugin naming convention that doesn't apply here; main class is `inc/class-wp-ultimo.php`

## Error patterns addressed

| Pattern | Count | Fix |
|---|---|---|
| `read:file_not_found` | 38x | 3 new not-exist table entries + full test structure documented |
| `bash:other` | 75x | Clearer test structure reduces navigation mistakes |
| `edit:not_read_first` | 46x | Already covered in AGENTS.md; no new gap found |
| `webfetch:other` | 39x | Already covered in AGENTS.md; no new gap found |

## Testing

Documentation-only change — no PHP/JS code modified.

```bash
git ls-files 'tests/Builders/' | head -1         # non-empty confirms directory exists
git ls-files 'inc/bootstrap.php'                  # empty confirms path correctly non-existent
git ls-files 'tests/WP_Ultimo/bootstrap.php'      # empty confirms path correctly non-existent
```

Resolves #978

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.10 plugin for [OpenCode](https://opencode.ai) v1.3.17 with claude-sonnet-4-6 spent 6m and 17,830 tokens on this as a headless worker.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated repository documentation to clarify test organization structure, including test suite layout and key file location references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->