### PR TITLE
GH#977: remove error-reporting opt-in from settings page

### DIFF
--- a/inc/class-settings.php
+++ b/inc/class-settings.php
@@ -736,22 +736,6 @@ class Settings implements \WP_Ultimo\Interfaces\Singleton {
 
 		$this->add_field(
 			'general',
-			'enable_error_reporting',
-			[
-				'title'   => __('Help Improve Ultimate Multisite', 'ultimate-multisite'),
-				'desc'    => sprintf(
-				/* translators: %s is a link to the privacy policy */
-					__('Allow Ultimate Multisite to collect anonymous usage data and error reports to help us improve the plugin. We collect: PHP version, WordPress version, plugin version, network type (subdomain/subdirectory), aggregate counts (sites, memberships), active gateways, and error logs. We never collect personal data, customer information, or domain names. <a href="%s" target="_blank" rel="noopener noreferrer">Learn more</a>.', 'ultimate-multisite'),
-					esc_url('https://ultimatemultisite.com/privacy-policy/')
-				),
-				'type'    => 'toggle',
-				'default' => 0,
-			],
-			130
-		);
-
-		$this->add_field(
-			'general',
 			'enable_beta_updates',
 			[
 				'title'   => __('Beta Updates', 'ultimate-multisite'),
@@ -2013,7 +1997,6 @@ class Settings implements \WP_Ultimo\Interfaces\Singleton {
 			'decimal_separator'                  => '.',
 			'thousand_separator'                 => ',',
 			'precision'                          => '2',
-			'enable_error_reporting'             => 0,
 			'enable_beta_updates'                => 0,
 
 			// Login & Registration

--- a/inc/class-tracker.php
+++ b/inc/class-tracker.php
@@ -18,6 +18,11 @@ defined('ABSPATH') || exit;
 /**
  * Tracker class for anonymous usage data collection.
  *
+ * Background telemetry (opt-in toggle) was removed in 2.5.1 — consent is now
+ * obtained per-feedback-send rather than as a global setting. The crash support
+ * link feature (build_support_url / customize_fatal_error_message) remains and
+ * requires no opt-in since the admin must click the link to send data.
+ *
  * @since 2.5.0
  */
 class Tracker implements \WP_Ultimo\Interfaces\Singleton {
@@ -66,20 +71,9 @@ class Tracker implements \WP_Ultimo\Interfaces\Singleton {
 	 */
 	public function init(): void {
 
-		// Create the weekly schedule
-		add_action('init', [$this, 'create_weekly_schedule']);
-
-		// Hook into weekly cron for usage data
-		add_action('wu_weekly', [$this, 'maybe_send_tracking_data']);
-
-		// Hook into Logger for error reporting (now receives log level as 3rd param)
-		add_action('wu_log_add', [$this, 'maybe_send_error'], 10, 3);
-
-		// Customize fatal error message for network sites
+		// Customize fatal error message for network sites (no opt-in required —
+		// the admin must click the support link to send any data).
 		add_filter('wp_php_error_message', [$this, 'customize_fatal_error_message'], 10, 2);
-
-		// Send initial data when tracking is first enabled
-		add_action('wu_settings_update', [$this, 'maybe_send_initial_data'], 10, 2);
 	}
 
 	/**
@@ -98,18 +92,26 @@ class Tracker implements \WP_Ultimo\Interfaces\Singleton {
 	}
 
 	/**
-	 * Check if tracking is enabled.
+	 * Check if background telemetry is enabled.
+	 *
+	 * Background telemetry (the opt-in toggle) was removed in 2.5.1.
+	 * Consent is now obtained per-feedback-send rather than as a global
+	 * setting, so this method always returns false. It is kept for
+	 * backwards-compatibility with add-ons that may call it directly.
 	 *
 	 * @since 2.5.0
 	 * @return bool
 	 */
 	public function is_tracking_enabled(): bool {
 
-		return (bool) wu_get_setting('enable_error_reporting', false);
+		return false;
 	}
 
 	/**
 	 * Send tracking data if enabled and due.
+	 *
+	 * Background telemetry was removed in 2.5.1 (opt-in toggle replaced by
+	 * per-send consent). This method is a no-op and will always return early.
 	 *
 	 * @since 2.5.0
 	 * @return void
@@ -130,7 +132,10 @@ class Tracker implements \WP_Ultimo\Interfaces\Singleton {
 	}
 
 	/**
-	 * Send initial data when tracking is first enabled.
+	 * No-op: sending initial data on settings-toggle was removed in 2.5.1.
+	 *
+	 * The wu_settings_update hook for this method was also removed in init().
+	 * The method signature is preserved so callers are not fatally broken.
 	 *
 	 * @since 2.5.0
 	 * @param string $setting_id The setting being updated.
@@ -139,20 +144,7 @@ class Tracker implements \WP_Ultimo\Interfaces\Singleton {
 	 */
 	public function maybe_send_initial_data(string $setting_id, $value): void {
 
-		if ('enable_error_reporting' !== $setting_id) {
-			return;
-		}
-
-		if ( ! $value) {
-			return;
-		}
-
-		// Check if we've never sent data before
-		$last_send = get_site_option(self::LAST_SEND_OPTION, 0);
-
-		if (0 === $last_send) {
-			$this->send_tracking_data();
-		}
+		// No-op: background telemetry opt-in was removed in 2.5.1.
 	}
 
 	/**

--- a/inc/installers/class-migrator.php
+++ b/inc/installers/class-migrator.php
@@ -782,7 +782,6 @@ class Migrator extends Base_Installer {
 			'domain_options',
 
 			// Dev Options
-			'enable_error_reporting',
 			'uninstall_wipe_tables',
 
 			// Registration

--- a/tests/WP_Ultimo/Tracker_Test.php
+++ b/tests/WP_Ultimo/Tracker_Test.php
@@ -54,13 +54,13 @@ class Tracker_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Test is_tracking_enabled returns bool.
+	 * Test is_tracking_enabled always returns false (background telemetry removed in 2.5.1).
 	 */
 	public function test_is_tracking_enabled(): void {
 
 		$result = $this->get_tracker()->is_tracking_enabled();
 
-		$this->assertIsBool($result);
+		$this->assertFalse($result);
 	}
 
 	/**
@@ -587,21 +587,13 @@ class Tracker_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Test maybe_send_initial_data does nothing for wrong setting.
+	 * Test maybe_send_initial_data is a no-op (background telemetry removed in 2.5.1).
 	 */
-	public function test_maybe_send_initial_data_wrong_setting(): void {
+	public function test_maybe_send_initial_data_is_noop(): void {
 
-		$this->get_tracker()->maybe_send_initial_data('other_setting', true);
-
-		$this->assertTrue(true);
-	}
-
-	/**
-	 * Test maybe_send_initial_data does nothing when value is false.
-	 */
-	public function test_maybe_send_initial_data_false_value(): void {
-
-		$this->get_tracker()->maybe_send_initial_data('enable_error_reporting', false);
+		// Both calls must complete without errors — the method is now a no-op.
+		$this->get_tracker()->maybe_send_initial_data('any_setting', true);
+		$this->get_tracker()->maybe_send_initial_data('any_setting', false);
 
 		$this->assertTrue(true);
 	}

--- a/views/settings/widget-settings-body.php
+++ b/views/settings/widget-settings-body.php
@@ -263,38 +263,6 @@ defined('ABSPATH') || exit;
 	</tbody>
 </table>
 
-<div id="error_reporting" data-type="heading">
-	<h3>Error Reporting</h3>
-	<p>Help us make Ultimate Multisite better by automatically reporting fatal errors and warnings so we can fix them as
-		soon
-		as possible.</p>
-</div>
-
-<table class="form-table">
-	<tbody>
-
-
-	<tr>
-		<th scope="row"><label for="enable_error_reporting"><?php esc_html_e('Help Improve Ultimate Multisite', 'ultimate-multisite'); ?></label></th>
-		<td>
-
-			<label for="enable_error_reporting">
-				<input name="enable_error_reporting" type="checkbox" id="enable_error_reporting" value="1">
-				<?php esc_html_e('Help Improve Ultimate Multisite', 'ultimate-multisite'); ?>
-			</label>
-
-			<p class="description" id="enable_error_reporting-desc">
-				<?php esc_html_e('Allow Ultimate Multisite to collect anonymous usage data and error reports to help us improve the plugin. We collect: PHP version, WordPress version, plugin version, network type, aggregate counts, active gateways, and error logs. We never collect personal data, customer information, or domain names.', 'ultimate-multisite'); ?>
-				<a href="https://ultimatemultisite.com/privacy-policy/" target="_blank"><?php esc_html_e('Learn more', 'ultimate-multisite'); ?></a>.
-			</p>
-
-		</td>
-	</tr>
-
-
-	</tbody>
-</table>
-
 <div id="uninstall" data-type="heading">
 	<h3>Uninstall Options</h3>
 	<p>Change the plugin behavior on uninstall.</p>


### PR DESCRIPTION
## Summary

Removes the global **Help Improve Ultimate Multisite** opt-in toggle (`enable_error_reporting`) from the Settings page. Per the contributor insight from `superdav42` (issue #977), consent should be obtained per-feedback-send rather than as a persistent global setting, and no API key is needed since the endpoint is fixed.

## What changed

| File | Change |
|---|---|
| `inc/class-settings.php` | Removed `enable_error_reporting` field from `default_sections()` and `get_setting_defaults()` |
| `views/settings/widget-settings-body.php` | Removed the "Error Reporting" section and checkbox row |
| `inc/class-tracker.php` | `is_tracking_enabled()` always returns `false`; removed `wu_settings_update` / `wu_weekly` / `wu_log_add` hooks from `init()`; `maybe_send_initial_data()` is now a no-op (kept for back-compat) |
| `inc/installers/class-migrator.php` | Removed `enable_error_reporting` from the v1->v2 migration key list |
| `tests/WP_Ultimo/Tracker_Test.php` | Updated tests to assert the new always-false / no-op behaviour |

## What is preserved

The **crash support link** feature (`Tracker::customize_fatal_error_message` / `build_support_url`) is unchanged — it builds a pre-filled support URL that a super admin must click to send data, so it requires no opt-in.

## Testing

```bash
WP_TESTS_DIR=/tmp/wordpress-tests-lib vendor/bin/phpunit --filter Tracker_Test
# OK (48 tests, 101 assertions)
vendor/bin/phpstan analyse inc/class-tracker.php inc/class-settings.php
# No errors
```

Resolves #977

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.10 plugin for [OpenCode](https://opencode.ai) v1.3.17 with claude-sonnet-4-6 spent 9m and 28,073 tokens on this as a headless worker.
