### PR TITLE
GH#982: cancel pending membership when expired payment is cleaned up

### DIFF
--- a/inc/checkout/class-checkout.php
+++ b/inc/checkout/class-checkout.php
@@ -3316,6 +3316,13 @@ class Checkout {
 	/**
 	 * Cleans up expired draft and pending payments (older than 30 days).
 	 *
+	 * When a pending payment is cancelled, the associated membership is also
+	 * cancelled if it is still in the `pending` state. This ensures that any
+	 * `pending_site` record stored in membership meta is cleaned up via the
+	 * `wu_transition_membership_status` → `handle_pending_site_on_cancellation`
+	 * chain, preventing orphaned pending_site rows from accumulating in the
+	 * database. Fixes: GH#982.
+	 *
 	 * @since 2.1.4
 	 * @return void
 	 */
@@ -3343,6 +3350,23 @@ class Checkout {
 			if ($payment->get_status() === Payment_Status::PENDING) {
 				$payment->set_status(Payment_Status::CANCELLED);
 				$payment->save();
+
+				/*
+				 * Also cancel the associated membership if it is still in
+				 * `pending` state. A 30-day-old unconfirmed payment means the
+				 * customer never completed the signup; keeping the membership
+				 * in `pending` would leave any pending_site meta orphaned
+				 * because no active membership owns it. Cancelling via
+				 * cancel() fires wu_transition_membership_status, which
+				 * invokes handle_pending_site_on_cancellation() to move the
+				 * pending_site to a 24-hour transient for potential reclaim
+				 * before deleting it from membership meta. GH#982.
+				 */
+				$membership = $payment->get_membership();
+
+				if ($membership && Membership_Status::PENDING === $membership->get_status()) {
+					$membership->cancel();
+				}
 			} else {
 				$payment->delete();
 			}

--- a/inc/managers/class-site-manager.php
+++ b/inc/managers/class-site-manager.php
@@ -1014,11 +1014,31 @@ class Site_Manager extends Base_Manager {
 	/**
 	 * Delete pending sites from non-pending memberships
 	 *
+	 * Runs daily via `wu_daily`. Cleans up stale `pending_site` records in two
+	 * scenarios:
+	 *
+	 * 1. Active/trialing membership with a pending_site older than 1 day: the
+	 *    site was supposed to be published but the async job never ran or was
+	 *    lost. Remove the stale record so the membership does not remain stuck.
+	 *
+	 * 2. Membership still in `pending` state with a pending_site older than
+	 *    1 day: the customer never completed payment. `cleanup_expired_drafts`
+	 *    (primary fix, GH#982) cancels the membership after 30 days, which
+	 *    triggers `handle_pending_site_on_cancellation()` automatically. This
+	 *    branch acts as a safety net for records that slip through — for
+	 *    example if the cron payment cleanup ran before the hook was in place,
+	 *    or if the membership was put into `pending` state via a code path
+	 *    that did not call `cancel()`. In this case we directly delete the
+	 *    pending_site from membership meta; no site was ever created, so
+	 *    there is nothing to reclaim. GH#982.
+	 *
 	 * @since 2.1.3
 	 */
 	public function delete_pending_sites(): void {
 
 		$pending_sites = \WP_Ultimo\Models\Site::get_all_by_type('pending');
+
+		$one_day_ago = gmdate('Y-m-d H:i:s', strtotime('-1 days'));
 
 		foreach ($pending_sites as $site) {
 			if ($site->is_publishing()) {
@@ -1027,10 +1047,33 @@ class Site_Manager extends Base_Manager {
 
 			$membership = $site->get_membership();
 
+			// Guard against pending_site objects that lack a valid membership_id
+			// (e.g. created without one in an unusual code path, or serialised
+			// before GH#982 normalised the data).
+			if ( ! $membership) {
+				continue;
+			}
+
 			if ($membership->is_active() || $membership->is_trialing()) {
 
 				// Check if the last modify has more than some time, to avoid the deletion of sites on creation process
-				if ($membership->get_date_modified() < gmdate('Y-m-d H:i:s', strtotime('-1 days'))) {
+				if ($membership->get_date_modified() < $one_day_ago) {
+					$membership->delete_pending_site();
+				}
+			} elseif (Membership_Status::PENDING === $membership->get_status()) {
+
+				/*
+				 * Safety net for orphaned pending_sites on `pending` memberships.
+				 *
+				 * The primary fix (cleanup_expired_drafts) cancels the membership
+				 * after 30 days, which triggers handle_pending_site_on_cancellation.
+				 * This branch catches records that predate that fix or were created
+				 * via a code path that skipped the payment watchdog (e.g. manual
+				 * gateway, admin-created memberships without a payment). We wait at
+				 * least 1 day before deleting to avoid removing sites that are in
+				 * the process of being published. GH#982.
+				 */
+				if ($membership->get_date_modified() < $one_day_ago) {
 					$membership->delete_pending_site();
 				}
 			}

--- a/tests/WP_Ultimo/Checkout/Checkout_Test.php
+++ b/tests/WP_Ultimo/Checkout/Checkout_Test.php
@@ -5078,6 +5078,182 @@ class Checkout_Test extends WP_UnitTestCase {
 	}
 
 	// -------------------------------------------------------------------------
+	// cleanup_expired_drafts — GH#982 membership cancellation regression
+	// -------------------------------------------------------------------------
+
+	/**
+	 * GH#982: cleanup_expired_drafts must also cancel the associated membership
+	 * when it is still in `pending` state, so the pending_site metadata is
+	 * cleaned up via the wu_transition_membership_status hook chain.
+	 */
+	public function test_cleanup_expired_drafts_cancels_pending_membership(): void {
+
+		$checkout = Checkout::get_instance();
+
+		$customer = self::$customer;
+
+		$membership = wu_create_membership([
+			'customer_id' => $customer->get_id(),
+			'plan_id'     => 0,
+			'status'      => Membership_Status::PENDING,
+		]);
+
+		$this->assertNotWPError($membership);
+
+		$payment = wu_create_payment([
+			'customer_id'   => $customer->get_id(),
+			'membership_id' => $membership->get_id(),
+			'status'        => Payment_Status::PENDING,
+			'total'         => 10,
+		]);
+
+		$this->assertNotWPError($payment);
+
+		// Backdate the payment so the cron watchdog picks it up.
+		global $wpdb;
+		$old_date = gmdate('Y-m-d H:i:s', strtotime('-31 days'));
+		$wpdb->update(
+			"{$wpdb->prefix}wu_payments",
+			['date_created' => $old_date],
+			['id' => $payment->get_id()]
+		);
+
+		$checkout->cleanup_expired_drafts();
+
+		// Payment should be cancelled.
+		$found_payment = wu_get_payment($payment->get_id());
+		$this->assertNotFalse($found_payment, 'Payment should still exist after cleanup (cancelled, not deleted).');
+		$this->assertEquals(Payment_Status::CANCELLED, $found_payment->get_status(), 'Expired pending payment should be cancelled.');
+
+		// Membership should also be cancelled (GH#982 fix).
+		$found_membership = wu_get_membership($membership->get_id());
+		$this->assertNotFalse($found_membership, 'Membership should still exist after cleanup.');
+		$this->assertEquals(
+			Membership_Status::CANCELLED,
+			$found_membership->get_status(),
+			'Membership associated with an expired pending payment must be cancelled to prevent orphaned pending_site records (GH#982).'
+		);
+
+		$found_payment->delete();
+		$found_membership->delete();
+	}
+
+	/**
+	 * GH#982: cleanup_expired_drafts must NOT cancel the membership when it is
+	 * already active (e.g. the payment expired but the membership was activated
+	 * via a different payment or gateway). Only `pending` memberships are targets.
+	 */
+	public function test_cleanup_expired_drafts_does_not_cancel_active_membership(): void {
+
+		$checkout = Checkout::get_instance();
+
+		$customer = self::$customer;
+
+		$membership = wu_create_membership([
+			'customer_id' => $customer->get_id(),
+			'plan_id'     => 0,
+			'status'      => Membership_Status::ACTIVE,
+		]);
+
+		$this->assertNotWPError($membership);
+
+		$payment = wu_create_payment([
+			'customer_id'   => $customer->get_id(),
+			'membership_id' => $membership->get_id(),
+			'status'        => Payment_Status::PENDING,
+			'total'         => 10,
+		]);
+
+		$this->assertNotWPError($payment);
+
+		global $wpdb;
+		$old_date = gmdate('Y-m-d H:i:s', strtotime('-31 days'));
+		$wpdb->update(
+			"{$wpdb->prefix}wu_payments",
+			['date_created' => $old_date],
+			['id' => $payment->get_id()]
+		);
+
+		$checkout->cleanup_expired_drafts();
+
+		// Membership should remain active — it is not in `pending` state.
+		$found_membership = wu_get_membership($membership->get_id());
+		$this->assertNotFalse($found_membership);
+		$this->assertEquals(
+			Membership_Status::ACTIVE,
+			$found_membership->get_status(),
+			'Active memberships must not be cancelled by cleanup_expired_drafts (GH#982).'
+		);
+
+		$found_payment = wu_get_payment($payment->get_id());
+		if ($found_payment) {
+			$found_payment->delete();
+		}
+		$found_membership->delete();
+	}
+
+	/**
+	 * GH#982: when cleanup_expired_drafts cancels a pending membership that has
+	 * a pending_site, the pending_site must be removed from membership meta
+	 * (via the wu_transition_membership_status hook chain).
+	 */
+	public function test_cleanup_expired_drafts_cleans_up_pending_site(): void {
+
+		$checkout = Checkout::get_instance();
+
+		$customer = self::$customer;
+
+		$membership = wu_create_membership([
+			'customer_id' => $customer->get_id(),
+			'plan_id'     => 0,
+			'status'      => Membership_Status::PENDING,
+		]);
+
+		$this->assertNotWPError($membership);
+
+		// Simulate the checkout creating a pending_site in membership meta.
+		$membership->create_pending_site([
+			'title' => 'Orphan Pending Site',
+			'path'  => '/orphan/',
+		]);
+
+		$this->assertNotFalse($membership->get_pending_site(), 'pending_site should exist before cleanup.');
+
+		$payment = wu_create_payment([
+			'customer_id'   => $customer->get_id(),
+			'membership_id' => $membership->get_id(),
+			'status'        => Payment_Status::PENDING,
+			'total'         => 10,
+		]);
+
+		$this->assertNotWPError($payment);
+
+		global $wpdb;
+		$old_date = gmdate('Y-m-d H:i:s', strtotime('-31 days'));
+		$wpdb->update(
+			"{$wpdb->prefix}wu_payments",
+			['date_created' => $old_date],
+			['id' => $payment->get_id()]
+		);
+
+		$checkout->cleanup_expired_drafts();
+
+		// pending_site must be gone from the membership meta after cancellation.
+		$found_membership = wu_get_membership($membership->get_id());
+		$this->assertNotFalse($found_membership);
+		$this->assertFalse(
+			$found_membership->get_pending_site(),
+			'pending_site must be removed from membership meta after cleanup_expired_drafts cancels the membership (GH#982).'
+		);
+
+		$found_payment = wu_get_payment($payment->get_id());
+		if ($found_payment) {
+			$found_payment->delete();
+		}
+		$found_membership->delete();
+	}
+
+	// -------------------------------------------------------------------------
 	// Teardown
 	// -------------------------------------------------------------------------
 

--- a/tests/WP_Ultimo/Managers/Site_Manager_Test.php
+++ b/tests/WP_Ultimo/Managers/Site_Manager_Test.php
@@ -4601,4 +4601,136 @@ class Site_Manager_Test extends \WP_UnitTestCase {
 		$this->assertIsString($date);
 		$this->assertNotEmpty($date);
 	}
+
+	// ========================================================================
+	// delete_pending_sites — GH#982 safety-net for orphaned pending_site records
+	// ========================================================================
+
+	/**
+	 * GH#982 safety-net: delete_pending_sites must clean up a pending_site record
+	 * stored in membership meta when the membership is still in `pending` state
+	 * and was last modified more than 1 day ago.
+	 *
+	 * This covers the case where the primary fix (cleanup_expired_drafts) was not
+	 * in place yet (pre-existing orphans) or where the membership was put into
+	 * `pending` state via a code path that did not call cancel() on the payment.
+	 */
+	public function test_delete_pending_sites_removes_orphaned_pending_site_for_pending_membership(): void {
+
+		$customer = wu_create_customer([
+			'username' => 'orphan_pending_test_' . wp_rand(),
+			'email'    => 'orphan' . wp_rand() . '@example.com',
+			'password' => 'password123',
+		]);
+
+		if (is_wp_error($customer)) {
+			$this->markTestSkipped('Could not create customer: ' . $customer->get_error_message());
+			return;
+		}
+
+		$membership = wu_create_membership([
+			'customer_id'     => $customer->get_id(),
+			'plan_id'         => 0,
+			'status'          => \WP_Ultimo\Database\Memberships\Membership_Status::PENDING,
+			'skip_validation' => true,
+		]);
+
+		if (is_wp_error($membership)) {
+			$customer->delete();
+			$this->markTestSkipped('Could not create membership: ' . $membership->get_error_message());
+			return;
+		}
+
+		// Create a pending_site record in membership meta.
+		// Pass membership_id so that Site::get_membership() can look up the
+		// owning membership when delete_pending_sites iterates get_all_by_type.
+		$membership->create_pending_site([
+			'title'         => 'Orphan Site GH982',
+			'path'          => '/gh982/',
+			'membership_id' => $membership->get_id(),
+		]);
+
+		$this->assertNotFalse($membership->get_pending_site(), 'pending_site should exist before cleanup.');
+
+		// Backdate the membership's date_modified to more than 1 day ago so the
+		// safety-net condition in delete_pending_sites fires.
+		global $wpdb;
+		$old_date = gmdate('Y-m-d H:i:s', strtotime('-2 days'));
+		$wpdb->update(
+			"{$wpdb->prefix}wu_memberships",
+			['date_modified' => $old_date],
+			['id' => $membership->get_id()]
+		);
+
+		$manager = $this->get_manager_instance();
+		$manager->delete_pending_sites();
+
+		// After the daily cron run, the pending_site must be removed.
+		$refreshed = wu_get_membership($membership->get_id());
+		$this->assertNotFalse($refreshed, 'Membership should still exist.');
+		$this->assertFalse(
+			$refreshed->get_pending_site(),
+			'pending_site must be removed by the safety-net in delete_pending_sites for pending-state memberships (GH#982).'
+		);
+
+		$membership->delete();
+		$customer->delete();
+	}
+
+	/**
+	 * GH#982 safety-net: delete_pending_sites must NOT remove the pending_site
+	 * when the membership was modified less than 1 day ago (site creation may
+	 * still be in progress).
+	 */
+	public function test_delete_pending_sites_preserves_recent_pending_site_for_pending_membership(): void {
+
+		$customer = wu_create_customer([
+			'username' => 'recent_pending_test_' . wp_rand(),
+			'email'    => 'recent' . wp_rand() . '@example.com',
+			'password' => 'password123',
+		]);
+
+		if (is_wp_error($customer)) {
+			$this->markTestSkipped('Could not create customer: ' . $customer->get_error_message());
+			return;
+		}
+
+		$membership = wu_create_membership([
+			'customer_id'     => $customer->get_id(),
+			'plan_id'         => 0,
+			'status'          => \WP_Ultimo\Database\Memberships\Membership_Status::PENDING,
+			'skip_validation' => true,
+		]);
+
+		if (is_wp_error($membership)) {
+			$customer->delete();
+			$this->markTestSkipped('Could not create membership: ' . $membership->get_error_message());
+			return;
+		}
+
+		// Create a pending_site record — the membership was just modified (now).
+		// Pass membership_id so that Site::get_membership() can look up the
+		// owning membership when delete_pending_sites iterates get_all_by_type.
+		$membership->create_pending_site([
+			'title'         => 'Recent Pending Site GH982',
+			'path'          => '/gh982-recent/',
+			'membership_id' => $membership->get_id(),
+		]);
+
+		$this->assertNotFalse($membership->get_pending_site(), 'pending_site should exist before cleanup.');
+
+		$manager = $this->get_manager_instance();
+		$manager->delete_pending_sites();
+
+		// The pending_site must still be there — it is less than 1 day old.
+		$refreshed = wu_get_membership($membership->get_id());
+		$this->assertNotFalse($refreshed);
+		$this->assertNotFalse(
+			$refreshed->get_pending_site(),
+			'A recently created pending_site must not be removed by delete_pending_sites (GH#982).'
+		);
+
+		$membership->delete();
+		$customer->delete();
+	}
 }


### PR DESCRIPTION
## Summary

Fixes orphaned `pending_site` records that accumulate when the payment watchdog (cleanup_expired_drafts) cancels an expired pending payment but leaves the associated membership in `pending` state.

## Root cause

`cleanup_expired_drafts` (daily cron, 30-day threshold) only cancelled the **payment**; it did not cancel the **membership**. A membership in `pending` state with a `pending_site` record in its meta is not handled by:

- `handle_pending_site_on_cancellation` — only fires when membership transitions to `cancelled`
- `delete_pending_sites` — only cleaned up active/trialing memberships, not `pending` ones

## Changes

### Primary fix — `inc/checkout/class-checkout.php`

`cleanup_expired_drafts` now cancels the associated membership (via `$membership->cancel()`) when a 30-day-old pending payment is cancelled **and** the membership is still in `pending` state. This fires the existing `wu_transition_membership_status` → `handle_pending_site_on_cancellation` chain, which moves the `pending_site` to a 24-hour transient (for potential reclaim) and removes it from membership meta.

### Safety net — `inc/managers/class-site-manager.php`

`delete_pending_sites` (daily cron) now also cleans up `pending_site` records for memberships still in `pending` state and unmodified for more than 1 day. This catches pre-existing orphans and records created via code paths that bypass the payment watchdog.

A null guard for `get_membership()` returning `false` is also added to both branches.

## Tests

Five new tests added:

**`Checkout_Test`:**
- `test_cleanup_expired_drafts_cancels_pending_membership` — primary fix happy path
- `test_cleanup_expired_drafts_does_not_cancel_active_membership` — active memberships are not touched
- `test_cleanup_expired_drafts_cleans_up_pending_site` — hook chain removes the pending_site meta

**`Site_Manager_Test`:**
- `test_delete_pending_sites_removes_orphaned_pending_site_for_pending_membership` — safety net fires after 1 day
- `test_delete_pending_sites_preserves_recent_pending_site_for_pending_membership` — recent records are preserved

All 7 `cleanup_expired_drafts` and 4 `delete_pending_sites` tests pass.

Resolves #982

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.10 plugin for [OpenCode](https://opencode.ai) v1.3.17 with claude-sonnet-4-6 spent 19m and 50,213 tokens on this as a headless worker.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Expired draft payment cleanup now cancels associated pending memberships
  * Automatic cleanup removes orphaned pending site records from incomplete payment setups
  * Stale pending site configuration records are properly cleaned when memberships transition to cancelled status

* **Tests**
  * Added comprehensive test coverage for payment cleanup and pending site removal behavior

<!-- end of auto-generated comment: release notes by coderabbit.ai -->