### PR TITLE
Add Enable Jumper toggle to Other Options settings

### DIFF
--- a/inc/class-settings.php
+++ b/inc/class-settings.php
@@ -1874,6 +1874,17 @@ class Settings implements \WP_Ultimo\Interfaces\Singleton {
 
 		$this->add_field(
 			'other',
+			'enable_jumper',
+			[
+				'title'   => __('Enable Jumper', 'ultimate-multisite'),
+				'desc'    => __('The Jumper is a command-palette overlay that lets network admins quickly navigate to any site or admin page. Disable it here if you prefer not to show it.', 'ultimate-multisite'),
+				'type'    => 'toggle',
+				'default' => 1,
+			]
+		);
+
+		$this->add_field(
+			'other',
 			'error_reporting_header',
 			[
 				'title' => __('Logging', 'ultimate-multisite'),
@@ -2054,6 +2065,7 @@ class Settings implements \WP_Ultimo\Interfaces\Singleton {
 			// Other
 			'hide_tours'                         => 0,
 			'disable_image_zoom'                 => 0,
+			'enable_jumper'                      => 1,
 			'error_logging_level'                => 'default',
 			'security_mode'                      => 0,
 			'uninstall_wipe_tables'              => 0,


### PR DESCRIPTION
## What

Adds an **Enable Jumper** toggle to **Settings → Other Options**, wiring up the `enable_jumper` setting key that `Toolbox::is_toolbox_enabled()` already reads but was never registered as an actual settings field.

## Why

`wu_get_setting('enable_jumper', true)` always returned the hardcoded default `true` because the key was never saved — the UI toggle didn't exist. There was no way to disable the Jumper from the admin panel.

## Changes

- `inc/class-settings.php` — registers `enable_jumper` as a toggle field under the Miscellaneous sub-section of Other Options (after "Disable Hover to Zoom"), default on.
- `inc/class-settings.php` — adds `enable_jumper => 1` to the static defaults map so `wu_get_setting()` returns the correct default before the user saves anything.

## Testing

1. Go to **Network Admin → Ultimate Multisite → Settings → Other Options**.
2. Confirm the **Enable Jumper** toggle is visible and defaults to enabled.
3. Toggle it off and save — the Jumper overlay should no longer appear on subsite admin pages.
4. Toggle it back on — Jumper returns.

The `wu_is_jumper_enabled` filter (used on the template previewer and checkout form editor pages) continues to work independently of this setting.

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.10 plugin for [OpenCode](https://opencode.ai) v1.3.17 with claude-sonnet-4-6 spent 18m and 6,054 tokens on this with the user in an interactive session.