### PR TITLE
fix: auto-promote custom domain to primary on DNS verification for 3-part domains

### DIFF
--- a/inc/managers/class-domain-manager.php
+++ b/inc/managers/class-domain-manager.php
@@ -156,7 +156,7 @@ class Domain_Manager extends Base_Manager {
 
 		add_action('wu_transition_domain_domain', [$this, 'send_domain_to_host'], 10, 3);
 
-		add_action('wu_domain_post_save', [$this, 'maybe_auto_promote_primary_domain'], 10, 3);
+		add_action('wu_transition_domain_stage', [$this, 'maybe_auto_promote_primary_domain'], 10, 3);
 
 		add_action('wu_settings_domain_mapping', [$this, 'add_domain_mapping_settings']);
 
@@ -1090,30 +1090,47 @@ class Domain_Manager extends Base_Manager {
 	/**
 	 * Auto-promote a custom domain to primary when it reaches done/done-without-ssl stage.
 	 *
-	 * When a non-subdomain mapping becomes active (stage = done or done-without-ssl)
-	 * for a blog that has no other primary domain (or only has the default subdomain
-	 * as primary), auto-promote the custom domain. This is the behavior customers
-	 * expect: "I added my domain, verified DNS/SSL, my custom domain is now the
-	 * primary one and the subdomain redirects to it."
+	 * When a non-subdomain mapping transitions to done or done-without-ssl stage
+	 * for a blog that has no other primary custom domain, auto-promote it. This is
+	 * the behaviour customers expect: "I verified my domain's DNS, it's now primary
+	 * and the network subdomain redirects to it."
 	 *
-	 * Hooked into wu_domain_post_save so it works regardless of whether the stage
-	 * was set by core's async_process_domain_stage or by an external plugin.
+	 * Hooked into wu_transition_domain_stage so it fires only on an actual stage
+	 * change — not on every save. This avoids the recursive-promotion bug where
+	 * async_remove_old_primary_domains would strip the primary flag, triggering a
+	 * post_save hook that immediately re-promoted the domain.
 	 *
 	 * @since 2.7.1
+	 * @since 2.7.2 Switched from wu_domain_post_save to wu_transition_domain_stage;
+	 *              replaced is_main_domain() TLD heuristic with a network-host check.
 	 *
-	 * @param array                        $data   The saved data.
-	 * @param \WP_Ultimo\Models\Domain     $domain The domain instance.
-	 * @param bool                         $new    Whether this is a new domain.
+	 * @param string $old_stage The previous stage value.
+	 * @param string $new_stage The new stage value.
+	 * @param int    $domain_id The domain record ID.
 	 * @return void
 	 */
-	public function maybe_auto_promote_primary_domain($data, $domain, $new): void {
+	public function maybe_auto_promote_primary_domain($old_stage, $new_stage, $domain_id): void {
 
 		$done_stages = [
 			Domain_Stage::DONE,
 			Domain_Stage::DONE_WITHOUT_SSL,
 		];
 
-		if ( ! in_array($domain->get_stage(), $done_stages, true)) {
+		/*
+		 * Only act when the stage just transitioned TO done/done-without-ssl
+		 * from a non-done stage. This is the "DNS verified" moment.
+		 */
+		if ( ! in_array($new_stage, $done_stages, true)) {
+			return;
+		}
+
+		if (in_array($old_stage, $done_stages, true)) {
+			return; // Already was in a done stage — not a new verification.
+		}
+
+		$domain = wu_get_domain($domain_id);
+
+		if ( ! $domain) {
 			return;
 		}
 
@@ -1127,20 +1144,32 @@ class Domain_Manager extends Base_Manager {
 		$domain_url = $domain->get_domain();
 
 		/*
-		 * Only auto-promote custom (non-subdomain) domains.
-		 * Subdomains like foo.kursopro.com should not auto-promote.
+		 * Only skip auto-promotion for WP multisite native subdomains
+		 * (e.g. site.kursopro.com when the network host is kursopro.com).
+		 *
+		 * WP multisite native subdomains live in wp_blogs and should not
+		 * normally appear in the UM domains table, but we guard explicitly by
+		 * comparing against the actual network host. This is more precise
+		 * than the old is_main_domain() TLD-counting heuristic, which
+		 * incorrectly blocked legitimate 3-part custom domains such as
+		 * shop.mybrand.com or prosite.example.com.
+		 *
+		 * @since 2.7.2
 		 */
-		if ( ! self::is_main_domain($domain_url)) {
-			return;
+		$network_host = strtolower( (string) wp_parse_url( network_home_url(), PHP_URL_HOST ) );
+		$network_host = (string) preg_replace( '/:\d+$/', '', $network_host ); // strip port
+
+		if ( $network_host && substr( strtolower( $domain_url ), -(strlen( $network_host ) + 1) ) === '.' . $network_host ) {
+			return; // WP multisite native subdomain — skip auto-promotion.
 		}
 
 		$blog_id = $domain->get_blog_id();
 
 		/*
-		 * Check if the blog already has a primary custom domain.
-		 * If so, don't override — let the admin manage it manually.
+		 * Check if the blog already has a primary custom domain (not a WP network
+		 * subdomain). If so, don't override — let the admin manage it manually.
 		 */
-		$existing_domains = wu_get_domains(
+		$existing_primaries = wu_get_domains(
 			[
 				'blog_id'        => $blog_id,
 				'primary_domain' => true,
@@ -1148,23 +1177,26 @@ class Domain_Manager extends Base_Manager {
 			]
 		);
 
-		foreach ($existing_domains as $existing) {
-			if (self::is_main_domain($existing->get_domain())) {
+		foreach ($existing_primaries as $existing) {
+			$existing_host = strtolower( $existing->get_domain() );
+
+			if ( ! $network_host || substr( $existing_host, -(strlen( $network_host ) + 1) ) !== '.' . $network_host ) {
 				/*
-				 * Another custom domain is already primary for this blog.
-				 * Do not auto-promote to avoid overriding explicit choice.
+				 * Another custom (non-network-subdomain) domain is already
+				 * primary for this blog. Do not auto-promote.
 				 */
 				return;
 			}
 		}
 
 		/*
-		 * Promote this domain to primary. The Domain::save() method
-		 * already handles demoting old primaries via wu_async_remove_old_primary_domains.
+		 * Promote this domain to primary. Domain::save() schedules
+		 * wu_async_remove_old_primary_domains to demote other primaries.
 		 */
 		$domain->set_primary_domain(true);
 
 		$save_result = $domain->save();
+
 		if (is_wp_error($save_result)) {
 			wu_log_add(
 				"domain-{$domain_url}",
@@ -1183,7 +1215,7 @@ class Domain_Manager extends Base_Manager {
 		wu_log_add(
 			"domain-{$domain_url}",
 			sprintf(
-				// translators: %s is the domain name, %d is the blog ID.
+				// translators: %1$s is the domain name, %2$d is the blog ID.
 				__('Auto-promoted %1$s as primary domain for site %2$d.', 'ultimate-multisite'),
 				$domain_url,
 				$blog_id

--- a/tests/WP_Ultimo/Managers/Domain_Manager_Test.php
+++ b/tests/WP_Ultimo/Managers/Domain_Manager_Test.php
@@ -2086,4 +2086,199 @@ class Domain_Manager_Test extends WP_UnitTestCase {
 
 		remove_all_filters('wu_async_process_domains_try_again_time');
 	}
+
+	// ----------------------------------------------------------------
+	// maybe_auto_promote_primary_domain
+	// ----------------------------------------------------------------
+
+	/**
+	 * Simple 2-part custom domain (e.g. mysite.com) reaches done stage
+	 * and should be auto-promoted to primary.
+	 */
+	public function test_auto_promote_simple_custom_domain_on_done(): void {
+		$blog_id = $this->create_test_blog();
+
+		$domain = wu_create_domain([
+			'blog_id'        => $blog_id,
+			'domain'         => 'mysite.com',
+			'stage'          => Domain_Stage::CHECKING_DNS,
+			'primary_domain' => false,
+		]);
+
+		$this->assertNotWPError($domain);
+
+		// Transition to done — hook fires automatically.
+		$domain->set_stage(Domain_Stage::DONE);
+		$domain->save();
+
+		$fetched = wu_get_domain($domain->get_id());
+		$this->assertTrue(
+			$fetched->is_primary_domain(),
+			'A simple 2-part custom domain should be auto-promoted when it reaches done stage.'
+		);
+	}
+
+	/**
+	 * A 3-part custom domain (e.g. shop.mybrand.com) reaching done stage
+	 * should also be auto-promoted — the old TLD-counting heuristic wrongly
+	 * blocked this class of domain.
+	 */
+	public function test_auto_promote_three_part_custom_domain_on_done(): void {
+		$blog_id = $this->create_test_blog();
+
+		$domain = wu_create_domain([
+			'blog_id'        => $blog_id,
+			'domain'         => 'shop.mybrand.com',
+			'stage'          => Domain_Stage::CHECKING_DNS,
+			'primary_domain' => false,
+		]);
+
+		$this->assertNotWPError($domain);
+
+		$domain->set_stage(Domain_Stage::DONE);
+		$domain->save();
+
+		$fetched = wu_get_domain($domain->get_id());
+		$this->assertTrue(
+			$fetched->is_primary_domain(),
+			'A 3-part custom domain (shop.mybrand.com) should be auto-promoted — it is not a WP network subdomain.'
+		);
+	}
+
+	/**
+	 * A domain that is already primary (stage done → done again) should not be
+	 * re-processed — the transition hook only fires on actual stage changes.
+	 */
+	public function test_auto_promote_skips_already_primary(): void {
+		$blog_id = $this->create_test_blog();
+
+		// Create with checking-dns, then promote to done (triggers the hook).
+		$domain = wu_create_domain([
+			'blog_id'        => $blog_id,
+			'domain'         => 'already-primary.com',
+			'stage'          => Domain_Stage::CHECKING_DNS,
+			'primary_domain' => false,
+		]);
+
+		$this->assertNotWPError($domain);
+
+		// First transition: checking-dns → done. Hook promotes to primary.
+		$domain->set_stage(Domain_Stage::DONE);
+		$domain->save();
+
+		$fetched = wu_get_domain($domain->get_id());
+		$this->assertTrue($fetched->is_primary_domain(), 'Domain should be primary after first transition to done.');
+
+		// Second save with same done stage — no stage transition, hook does NOT fire.
+		// primary_domain must remain true.
+		$fetched->save();
+
+		$fetched2 = wu_get_domain($domain->get_id());
+		$this->assertTrue(
+			$fetched2->is_primary_domain(),
+			'An already-primary domain should remain primary after a redundant save.'
+		);
+	}
+
+	/**
+	 * If a blog already has a non-network primary custom domain, a newly-done
+	 * domain should NOT displace it.
+	 */
+	public function test_auto_promote_skips_when_existing_primary_custom_domain(): void {
+		$blog_id = $this->create_test_blog();
+
+		// First domain: already primary.
+		$first = wu_create_domain([
+			'blog_id'        => $blog_id,
+			'domain'         => 'first-custom.com',
+			'stage'          => Domain_Stage::DONE,
+			'primary_domain' => true,
+		]);
+
+		$this->assertNotWPError($first);
+		$this->assertTrue($first->is_primary_domain());
+
+		// Second domain: reaches done but should NOT displace the first.
+		$second = wu_create_domain([
+			'blog_id'        => $blog_id,
+			'domain'         => 'second-custom.com',
+			'stage'          => Domain_Stage::CHECKING_DNS,
+			'primary_domain' => false,
+		]);
+
+		$this->assertNotWPError($second);
+
+		$second->set_stage(Domain_Stage::DONE);
+		$second->save();
+
+		// Reload both.
+		$first_after  = wu_get_domain($first->get_id());
+		$second_after = wu_get_domain($second->get_id());
+
+		$this->assertTrue(
+			$first_after->is_primary_domain(),
+			'The original primary domain should remain primary.'
+		);
+		$this->assertFalse(
+			$second_after->is_primary_domain(),
+			'The new domain should NOT be auto-promoted when an existing primary custom domain exists.'
+		);
+	}
+
+	/**
+	 * WP multisite native subdomain (e.g. site.{network_host}) reaching done
+	 * stage should NOT be auto-promoted.
+	 */
+	public function test_auto_promote_skips_wp_network_subdomain(): void {
+		$blog_id = $this->create_test_blog();
+
+		$network_host = strtolower( (string) wp_parse_url( network_home_url(), PHP_URL_HOST ) );
+		$network_host = (string) preg_replace( '/:\d+$/', '', $network_host );
+
+		// Build a domain that looks like a native WP multisite subdomain.
+		$wp_subdomain = 'testsite.' . $network_host;
+
+		$domain = wu_create_domain([
+			'blog_id'        => $blog_id,
+			'domain'         => $wp_subdomain,
+			'stage'          => Domain_Stage::CHECKING_DNS,
+			'primary_domain' => false,
+		]);
+
+		$this->assertNotWPError($domain);
+
+		$domain->set_stage(Domain_Stage::DONE);
+		$domain->save();
+
+		$fetched = wu_get_domain($domain->get_id());
+		$this->assertFalse(
+			$fetched->is_primary_domain(),
+			"A WP network subdomain ({$wp_subdomain}) should NOT be auto-promoted."
+		);
+	}
+
+	/**
+	 * done-without-ssl stage also triggers auto-promotion.
+	 */
+	public function test_auto_promote_on_done_without_ssl(): void {
+		$blog_id = $this->create_test_blog();
+
+		$domain = wu_create_domain([
+			'blog_id'        => $blog_id,
+			'domain'         => 'nossl.mybrand.com',
+			'stage'          => Domain_Stage::CHECKING_DNS,
+			'primary_domain' => false,
+		]);
+
+		$this->assertNotWPError($domain);
+
+		$domain->set_stage(Domain_Stage::DONE_WITHOUT_SSL);
+		$domain->save();
+
+		$fetched = wu_get_domain($domain->get_id());
+		$this->assertTrue(
+			$fetched->is_primary_domain(),
+			'A custom domain reaching done-without-ssl should also be auto-promoted.'
+		);
+	}
 }


### PR DESCRIPTION
## Summary

- **Root cause**: `maybe_auto_promote_primary_domain` (added in #965) had two bugs: (1) `is_main_domain()` TLD-counting heuristic blocks any 3-part custom domain like `shop.mybrand.com`, and (2) hooking `wu_domain_post_save` caused re-fire on every save — `async_remove_old_primary_domains` clearing the flag would immediately re-promote it.
- **Fix**: Switch hook to `wu_transition_domain_stage` (fires only on actual stage changes) and replace `is_main_domain()` with an explicit network-host suffix check.
- **Verified**: 130 Domain_Manager_Test assertions pass (0 regressions); 6 new targeted tests.

## What changed

### `inc/managers/class-domain-manager.php`
- Changed hook from `wu_domain_post_save` to `wu_transition_domain_stage`
- Updated method signature to `($old_stage, $new_stage, $domain_id)`
- Added guard: skip if `$old_stage` was already a done stage
- Replaced `is_main_domain()` with network-host suffix check

### `tests/WP_Ultimo/Managers/Domain_Manager_Test.php`
- 6 new tests: 2-part domain, 3-part custom domain, already-primary guard, existing-primary guard, WP network subdomain exclusion, done-without-ssl stage

Resolves #965 (follow-up fix)

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.10 plugin for [OpenCode](https://opencode.ai) v1.3.17 with claude-sonnet-4-6 spent 22m and 7,279 tokens on this with the user in an interactive session.
