### PR TITLE
fix: invalidate object cache after network-activate sitemeta write

### DIFF
--- a/inc/installers/class-multisite-network-installer.php
+++ b/inc/installers/class-multisite-network-installer.php
@@ -267,6 +267,12 @@ class Multisite_Network_Installer extends Base_Installer {
 	 * sitemeta guarantees network-wide activation regardless of whether
 	 * multisite constants are loaded in this process.
 	 *
+	 * After the write, the WordPress object-cache entry for
+	 * active_sitewide_plugins is explicitly deleted so that
+	 * is_plugin_active_for_network() and wp_get_active_and_valid_plugins()
+	 * return fresh data from the database on the next request — even when a
+	 * persistent object cache (Redis, Memcached, APC) is in use.
+	 *
 	 * @since 2.0.0
 	 * @throws \Exception When the sitemeta write fails.
 	 * @return void
@@ -276,13 +282,14 @@ class Multisite_Network_Installer extends Base_Installer {
 		global $wpdb;
 
 		$sitemeta_table = $wpdb->base_prefix . 'sitemeta';
+		$network_id     = get_current_network_id();
 
 		// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
 		$existing = $wpdb->get_row(
 			$wpdb->prepare(
 				"SELECT meta_id, meta_value FROM {$sitemeta_table} WHERE meta_key = %s AND site_id = %d",
 				'active_sitewide_plugins',
-				1
+				$network_id
 			)
 		);
 		// phpcs:enable
@@ -293,8 +300,12 @@ class Multisite_Network_Installer extends Base_Installer {
 			$active_plugins = [];
 		}
 
-		// Already network-activated — nothing to do.
+		// Already network-activated — but still flush the cache so that
+		// is_plugin_active_for_network() returns true even when a persistent
+		// object cache is holding a stale (empty or outdated) plugins list.
 		if (isset($active_plugins[ WP_ULTIMO_PLUGIN_BASENAME ])) {
+			wp_cache_delete( "{$network_id}:active_sitewide_plugins", 'site-options' );
+
 			return;
 		}
 
@@ -314,7 +325,7 @@ class Multisite_Network_Installer extends Base_Installer {
 			$result = $wpdb->insert(
 				$sitemeta_table,
 				[
-					'site_id'    => 1,
+					'site_id'    => $network_id,
 					'meta_key'   => 'active_sitewide_plugins', // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_key
 					'meta_value' => $serialized, // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_value
 				]
@@ -324,5 +335,17 @@ class Multisite_Network_Installer extends Base_Installer {
 		if (false === $result) {
 			throw new \Exception(esc_html__('Failed to network-activate Ultimate Multisite: could not write to the sitemeta table.', 'ultimate-multisite'));
 		}
+
+		/*
+		 * Invalidate the WordPress object-cache entry so the next call to
+		 * get_site_option( 'active_sitewide_plugins' ) reads the updated
+		 * value from the database rather than returning the stale cached
+		 * value.  This matters on any site using a persistent object cache
+		 * (Redis, Memcached, APC) — without this, is_plugin_active_for_network()
+		 * returns false on the very next page load even though the DB row is
+		 * correct, causing the "Network Activate" button to appear to do
+		 * nothing (sends success JSON, page reloads, still shows NOT activated).
+		 */
+		wp_cache_delete( "{$network_id}:active_sitewide_plugins", 'site-options' );
 	}
 }

--- a/tests/WP_Ultimo/Installers/Multisite_Network_Installer_Test.php
+++ b/tests/WP_Ultimo/Installers/Multisite_Network_Installer_Test.php
@@ -436,4 +436,30 @@ class Multisite_Network_Installer_Test extends \WP_UnitTestCase {
 		$after = $this->get_active_sitewide_plugins();
 		$this->assertArrayHasKey( WP_ULTIMO_PLUGIN_BASENAME, $after );
 	}
+
+	/**
+	 * _install_network_activate() invalidates the object-cache entry so that
+	 * is_plugin_active_for_network() returns true immediately after the write.
+	 *
+	 * This is a regression test for the persistent-object-cache bug: direct
+	 * sitemeta writes without a corresponding wp_cache_delete() left a stale
+	 * active_sitewide_plugins entry in the cache, causing the "Network
+	 * Activate" button to appear to do nothing — the AJAX returned success and
+	 * the page reloaded, but the plugin still showed "NOT Network Activated"
+	 * because get_site_option() returned the cached (pre-write) value.
+	 */
+	public function test_install_network_activate_invalidates_object_cache(): void {
+
+		// Prime the cache with an empty plugins list (simulates a persistent
+		// cache that was populated before our write).
+		$network_id = get_current_network_id();
+		wp_cache_set( "{$network_id}:active_sitewide_plugins", array(), 'site-options' );
+
+		$this->call_install_network_activate();
+
+		// After the write+cache-invalidation, is_plugin_active_for_network()
+		// must return true even if it was previously returning false due to
+		// a stale cache entry.
+		$this->assertTrue( is_plugin_active_for_network( WP_ULTIMO_PLUGIN_BASENAME ) );
+	}
 }


### PR DESCRIPTION
## Summary

The **Network Activate** button on the setup wizard requirements page appeared to do nothing: the AJAX call returned `{success:true}`, `window.location.reload()` fired, but after the reload the plugin still showed **NOT Network Activated**.

### Root cause

`_install_network_activate()` writes the plugin entry into `wp_sitemeta` via direct `$wpdb` calls, which bypass WordPress's object-cache update path. On sites with a **persistent object cache** (Redis, Memcached, APC), the `active_sitewide_plugins` cache entry remained stale after the DB write. On the next page load `is_plugin_active_for_network()` read the stale cache and returned `false` even though the DB row was correct.

There was a second form of the same bug in the early-return path ("already activated — nothing to do"), which also skipped the cache delete. If the plugin was already in the DB but the cache held an empty/stale list, the early return left the bad entry in place.

## Changes

**`inc/installers/class-multisite-network-installer.php`**
- Replace hardcoded `site_id = 1` with `get_current_network_id()` so the SELECT/INSERT use the actual network ID (handles non-default multisite configurations)
- Add `wp_cache_delete("{$network_id}:active_sitewide_plugins", 'site-options')` in the write path after a successful DB update/insert
- Add the same cache delete in the early-return ("already activated") path so a stale cache is always corrected when this function is called

**`tests/WP_Ultimo/Installers/Multisite_Network_Installer_Test.php`**
- New test `test_install_network_activate_invalidates_object_cache` primes the cache with an empty plugins array (simulating a stale persistent cache), calls `_install_network_activate()`, and asserts `is_plugin_active_for_network()` returns `true` — it fails without the fix and passes with it

## Verification

```
vendor/bin/phpunit --filter Multisite_Network_Installer_Test
# OK (17 tests, 50 assertions)
```

Resolves #995

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.10 plugin for [OpenCode](https://opencode.ai) v1.3.17 with claude-sonnet-4-6 spent 34m and 90,007 tokens on this with the user in an interactive session.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed a critical caching issue in multisite environments where network plugin activation status would not immediately reflect after plugin activation when using persistent object caching. Cache entries are now properly invalidated to ensure accurate plugin status visibility throughout the system. Network ID scoping has also been improved for better multi-network support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->