### PR TITLE
Fix: Enable Registration and Default Role defaults on fresh install

### DIFF
--- a/inc/class-settings.php
+++ b/inc/class-settings.php
@@ -200,6 +200,16 @@ class Settings implements \WP_Ultimo\Interfaces\Singleton {
 	 */
 	public function get_all_with_defaults($check_caps = false) {
 		$all_settings = $this->get_all($check_caps);
+
+		/*
+		 * Seed defaults from get_setting_defaults() for any key not yet saved to
+		 * the database. This ensures the Vue data-state used by the settings UI
+		 * shows the correct initial values on a fresh install instead of leaving
+		 * fields like enable_registration and default_role blank/off.
+		 * Saved values from the DB always win over the defaults.
+		 */
+		$all_settings = array_merge(static::get_setting_defaults(), $all_settings);
+
 		foreach ($this->get_sections() as $section_slug => $section) {
 			foreach ($section['fields'] ?? [] as $field_slug => $field_atts) {
 				if (is_callable($field_atts['value'])) {
@@ -294,7 +304,13 @@ class Settings implements \WP_Ultimo\Interfaces\Singleton {
 
 		foreach ($sections as $section_slug => $section) {
 			foreach ($section['fields'] ?? [] as $field_slug => $field_atts) {
-				$existing_value = $saved_settings[ $field_slug ] ?? false;
+				$field_default = $field_atts['default'] ?? false;
+
+				if (is_callable($field_default)) {
+					$field_default = call_user_func($field_default);
+				}
+
+				$existing_value = $saved_settings[ $field_slug ] ?? $field_default;
 
 				$field = new Field($field_slug, $field_atts);
 

--- a/inc/class-settings.php
+++ b/inc/class-settings.php
@@ -1874,6 +1874,17 @@ class Settings implements \WP_Ultimo\Interfaces\Singleton {
 
 		$this->add_field(
 			'other',
+			'enable_jumper',
+			[
+				'title'   => __('Enable Jumper', 'ultimate-multisite'),
+				'desc'    => __('The Jumper is a command-palette overlay that lets network admins quickly navigate to any site or admin page. Disable it here if you prefer not to show it.', 'ultimate-multisite'),
+				'type'    => 'toggle',
+				'default' => 1,
+			]
+		);
+
+		$this->add_field(
+			'other',
 			'error_reporting_header',
 			[
 				'title' => __('Logging', 'ultimate-multisite'),
@@ -2054,6 +2065,7 @@ class Settings implements \WP_Ultimo\Interfaces\Singleton {
 			// Other
 			'hide_tours'                         => 0,
 			'disable_image_zoom'                 => 0,
+			'enable_jumper'                      => 1,
 			'error_logging_level'                => 'default',
 			'security_mode'                      => 0,
 			'uninstall_wipe_tables'              => 0,


### PR DESCRIPTION
## Summary

- **Fix:** On fresh install, the Login & Registration settings showed registration disabled and default role blank — both should default to enabled/administrator
- **Root cause:** `save_settings()` used `false` as fallback for fields not yet in the DB, overwriting the registered `default` values when the setup wizard saved unrelated sections
- **Also includes:** Enable Jumper toggle in Other Options settings (pre-existing commit on this branch)

## Changes

1. `save_settings()` now falls back to the field's registered `default` (resolving callables) instead of `false` when no DB value exists
2. `get_all_with_defaults()` seeds with `get_setting_defaults()` so the settings UI renders correct initial values on fresh installs
3. Adds `enable_jumper` toggle to Other Options section

## Testing

- `vendor/bin/phpunit --filter Settings_Test` — 47 tests, 63 assertions pass
- Fresh install: Login & Registration now shows Enable Registration ON and Default Role = Administrator