### PR TITLE
fix: Visit Site link has empty href when site domain includes port

### DIFF
--- a/inc/models/class-site.php
+++ b/inc/models/class-site.php
@@ -1350,9 +1350,34 @@ class Site extends Base_Model implements Limitable, Notable {
 	 */
 	public function get_site_url() {
 
-		$url = set_url_scheme(esc_url(sprintf($this->get_domain() . '/' . trim($this->get_path(), '/'))));
+		/*
+		 * For sites already saved to the database, WordPress's get_home_url()
+		 * builds the correct full URL (including scheme and port) from the
+		 * site's stored options. We cannot safely construct it ourselves from
+		 * domain + path because the `domain` column in wp_blogs may include a
+		 * port (e.g. "example.com:8080"), which causes esc_url() to
+		 * misidentify the hostname as a protocol and return an empty string.
+		 */
+		if ($this->get_id()) {
+			return get_home_url($this->get_id());
+		}
 
-		return $url;
+		/*
+		 * For new sites not yet persisted, fall back to manual construction.
+		 * Prepend the scheme explicitly so esc_url() receives a valid URL.
+		 */
+		$domain = rtrim($this->get_domain(), '/');
+		$path   = '/' . trim($this->get_path(), '/');
+
+		if (empty($domain)) {
+			return '';
+		}
+
+		if ( ! str_contains($domain, '://')) {
+			$domain = (is_ssl() ? 'https' : 'http') . '://' . $domain;
+		}
+
+		return esc_url($domain . $path);
 	}
 
 	/**


### PR DESCRIPTION
## Problem

The **Visit Site** action link on the Edit Site admin screen renders with an empty `href`.

## Root Cause

`Site::get_site_url()` built a URL by concatenating `domain + '/' + path` and calling `esc_url()` **before** adding a scheme:

```php
// Old — broken
set_url_scheme(esc_url($this->get_domain() . '/' . trim($this->get_path(), '/')))
```

The `domain` column in `wp_blogs` stores the bare hostname and may include a port (e.g. `mysite.example.com:8080`). When `esc_url()` receives `mysite.example.com:8080/`, it parses `mysite.example.com` as the protocol (everything before `:`), rejects it as not in the WordPress allowed-protocols list, and returns `''`.

Verified locally:

```
esc_url('mysite.wordpress.local:8080/')  →  ''   (invalid protocol)
get_home_url(10)                         →  'http://mysite.wordpress.local:8080'  (correct)
```

## Fix

`inc/models/class-site.php` — `Site::get_site_url()`

- **Existing sites** (have a `blog_id`): delegate to WordPress's own `get_home_url($blog_id)`, which reads the correct URL from site options and handles ports and schemes correctly.
- **New unsaved sites** (no `blog_id` yet): prepend the scheme explicitly before passing to `esc_url()`.

## Testing

```bash
wp eval '$s = wu_get_site(10); echo $s->get_site_url();'
# Before: (empty)
# After:  http://mysite.wordpress.local:8080
```

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.10 plugin for [OpenCode](https://opencode.ai) v1.3.17 with claude-sonnet-4-6 spent 8m and 16,832 tokens on this with the user in an interactive session.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved site URL construction to correctly handle domains with custom ports and properly detect URL schemes for newly created sites.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->