### PR TITLE
fix: clone media files not copied due to empty copy_media setting

### DIFF
--- a/inc/compat/class-elementor-compat.php
+++ b/inc/compat/class-elementor-compat.php
@@ -41,8 +41,9 @@ class Elementor_Compat {
 	/**
 	 * Makes sure we force Elementor to regenerate styles after site duplication.
 	 *
-	 * Uses the Elementor API when available, otherwise clears the CSS cache
-	 * via direct database operations. This fallback is important because
+	 * Deletes stale compiled CSS files from disk (copied verbatim from the
+	 * template site's uploads), clears CSS metadata, and uses the Elementor
+	 * API to regenerate when available. This fallback is important because
 	 * Elementor classes are typically not loaded in the network admin
 	 * context where site duplication runs.
 	 *
@@ -56,11 +57,24 @@ class Elementor_Compat {
 			return;
 		}
 
-		switch_to_blog($site['site_id']);
+		$blog_id = (int) $site['site_id'];
 
-		// Try the Elementor API if available.
+		switch_to_blog($blog_id);
+
+		// Step 1: Delete stale compiled CSS files from disk.
+		// MUCD_Files copies the template's upload directory including
+		// pre-compiled post-*.css and global.css files. These contain
+		// hardcoded template URLs and must be deleted so Elementor
+		// rebuilds them with the correct cloned-site URLs.
+		self::delete_stale_css_files();
+
+		// Step 2: Try the Elementor API if available.
 		if (class_exists('\Elementor\Plugin') && ! empty(\Elementor\Plugin::$instance->files_manager)) {
 			\Elementor\Plugin::$instance->files_manager->clear_cache(); // phpcs:ignore
+
+			// Ensure external CSS mode for subsequent requests.
+			update_option('elementor_css_print_method', 'external');
+
 			restore_current_blog();
 
 			return;
@@ -79,13 +93,58 @@ class Elementor_Compat {
 			['%s']
 		);
 
+		// Also delete inline SVG cache metadata.
+		$wpdb->delete( // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+			$wpdb->postmeta,
+			['meta_key' => '_elementor_inline_svg'], // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_key
+			['%s']
+		);
+
 		// Clear the global CSS option so Elementor rebuilds it.
 		delete_option('_elementor_global_css');
 
-		// Reset the CSS print timestamp to force full regeneration.
-		delete_option('elementor_css_print_method');
+		// Ensure external CSS mode so Elementor generates CSS files on
+		// the first frontend visit rather than falling back to inline.
+		update_option('elementor_css_print_method', 'external');
 
 		restore_current_blog();
+	}
+
+	/**
+	 * Delete stale compiled Elementor CSS files from the uploads directory.
+	 *
+	 * When MUCD_Files copies the template's uploads, it includes pre-compiled
+	 * post-*.css and global.css files in elementor/css/. These files contain
+	 * hardcoded template-site URLs (in background-image, font-face, etc.)
+	 * that won't match the cloned site. Deleting them forces Elementor to
+	 * rebuild from the corrected postmeta on the first frontend visit.
+	 *
+	 * @since 2.3.3
+	 * @return void
+	 */
+	private static function delete_stale_css_files(): void {
+
+		$upload  = wp_upload_dir();
+		$css_dir = rtrim($upload['basedir'], '/\\') . '/elementor/css';
+
+		if ( ! is_dir($css_dir)) {
+			return;
+		}
+
+		$files = glob($css_dir . '/post-*.css');
+
+		if (is_array($files)) {
+			foreach ($files as $file) {
+				wp_delete_file($file);
+			}
+		}
+
+		// Also remove global.css.
+		$global_css = $css_dir . '/global.css';
+
+		if (file_exists($global_css)) {
+			wp_delete_file($global_css);
+		}
 	}
 
 	/**

--- a/inc/helpers/class-site-duplicator.php
+++ b/inc/helpers/class-site-duplicator.php
@@ -196,7 +196,7 @@ class Site_Duplicator {
 				'keep_users'   => true,
 				'public'       => true,
 				'domain'       => $current_site->domain,
-				'copy_files'   => wu_get_setting('copy_media', true),
+				'copy_files'   => '' !== wu_get_setting('copy_media', true) ? (bool) wu_get_setting('copy_media', true) : true,
 				'network_id'   => get_current_network_id(),
 				'meta'         => [],
 				'user_id'      => 0,
@@ -406,18 +406,19 @@ class Site_Duplicator {
 		self::backfill_nav_menu_postmeta($from_site_id, $to_site_id);
 		self::backfill_attachment_postmeta($from_site_id, $to_site_id);
 		self::backfill_elementor_postmeta($from_site_id, $to_site_id);
+		self::backfill_all_postmeta($from_site_id, $to_site_id);
 		self::backfill_kit_settings($from_site_id, $to_site_id);
 	}
 
 	/**
-	 * Rewrite source-site URLs to target-site URLs in backfilled postmeta rows.
+	 * Rewrite source-site URLs to target-site URLs across all cloned tables.
 	 *
 	 * backfill_postmeta() inserts rows after MUCD_Data::copy_data() has already
 	 * run its source→target URL replacement pass (db_update_data()), so those
 	 * rows contain raw template-site URLs. This method applies the same URL
-	 * substitution to the target's postmeta table, correcting any template
-	 * references left by the backfill (e.g. _menu_item_url custom links,
-	 * _elementor_* JSON containing the template domain).
+	 * substitution to the target's postmeta, posts, options, termmeta, and
+	 * commentmeta tables, correcting any template references left by the
+	 * backfill or missed by MUCD's pass.
 	 *
 	 * Safe to run after MUCD has already rewritten the copied rows: those rows
 	 * no longer contain the source URL, so REPLACE() is a no-op for them.
@@ -460,22 +461,99 @@ class Site_Duplicator {
 			str_replace('/', '\\/', $from_clean) => str_replace('/', '\\/', $to_clean),
 		];
 
-		// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.InterpolatedNotPrepared
-		foreach ($replacements as $from => $to) {
+		/*
+		 * Tables and columns to rewrite. postmeta is the primary target
+		 * (backfilled rows), but posts.post_content, options.option_value,
+		 * termmeta.meta_value, and commentmeta.meta_value may also contain
+		 * stale template URLs — either from the backfill or from MUCD's
+		 * pass missing a JSON-encoded variant.
+		 */
+		$tables = [
+			"{$to_prefix}postmeta"    => 'meta_value',
+			"{$to_prefix}posts"       => 'post_content',
+			"{$to_prefix}options"     => 'option_value',
+			"{$to_prefix}termmeta"    => 'meta_value',
+			"{$to_prefix}commentmeta" => 'meta_value',
+		];
 
-			if ($from === $to) {
+		// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+		foreach ($tables as $table => $column) {
+
+			// Skip tables that don't exist (e.g. termmeta on older WP versions).
+			$exists = $wpdb->get_var(
+				$wpdb->prepare(
+					'SELECT 1 FROM information_schema.TABLES WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = %s LIMIT 1',
+					$table
+				)
+			);
+
+			if ( ! $exists) {
 				continue;
 			}
 
-			$wpdb->query(
-				$wpdb->prepare(
-					"UPDATE {$to_prefix}postmeta SET meta_value = REPLACE(meta_value, %s, %s) WHERE meta_value LIKE %s",
-					$from,
-					$to,
-					'%' . $wpdb->esc_like($from) . '%'
-				)
-			);
+			foreach ($replacements as $from => $to) {
+
+				if ($from === $to) {
+					continue;
+				}
+
+				$wpdb->query(
+					$wpdb->prepare(
+						"UPDATE `{$table}` SET `{$column}` = REPLACE(`{$column}`, %s, %s) WHERE `{$column}` LIKE %s",
+						$from,
+						$to,
+						'%' . $wpdb->esc_like($from) . '%'
+					)
+				);
+			}
 		}
+		// phpcs:enable
+	}
+
+	/**
+	 * Catch-all: backfill ANY missing postmeta for ANY post type.
+	 *
+	 * Final safety net after the targeted backfill methods (nav_menu,
+	 * attachment, Elementor). Copies every postmeta row from the source
+	 * that exists for a post present in the target but is missing from
+	 * the target's postmeta table.
+	 *
+	 * Covers: _thumbnail_id, _wp_page_template, page-builder meta,
+	 * LMS course meta, WooCommerce product meta, and any custom fields
+	 * not handled by the specific backfill methods above.
+	 *
+	 * NOT EXISTS guard makes it idempotent — safe to re-run, never duplicates.
+	 *
+	 * @since 2.3.3
+	 * @see https://github.com/Ultimate-Multisite/ultimate-multisite/issues/820
+	 *
+	 * @param int $from_site_id Source blog ID.
+	 * @param int $to_site_id   Target blog ID.
+	 */
+	protected static function backfill_all_postmeta($from_site_id, $to_site_id) {
+
+		global $wpdb;
+
+		$from_prefix = $wpdb->get_blog_prefix((int) $from_site_id);
+		$to_prefix   = $wpdb->get_blog_prefix((int) $to_site_id);
+
+		if ($from_prefix === $to_prefix) {
+			return;
+		}
+
+		// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+		$wpdb->query(
+			"INSERT INTO {$to_prefix}postmeta (post_id, meta_key, meta_value)
+			SELECT src.post_id, src.meta_key, src.meta_value
+			FROM {$from_prefix}postmeta src
+			INNER JOIN {$to_prefix}posts tgt
+					ON tgt.ID = src.post_id
+			WHERE NOT EXISTS (
+				SELECT 1 FROM {$to_prefix}postmeta tpm
+				WHERE tpm.post_id = src.post_id
+				  AND tpm.meta_key = src.meta_key
+			)"
+		);
 		// phpcs:enable
 	}
 

--- a/tests/WP_Ultimo/Helpers/Site_Duplicator_Postmeta_Test.php
+++ b/tests/WP_Ultimo/Helpers/Site_Duplicator_Postmeta_Test.php
@@ -356,6 +356,115 @@ class Site_Duplicator_Postmeta_Test extends WP_UnitTestCase {
 	}
 
 	// =========================================================================
+	// General catch-all — backfill_all_postmeta
+	// =========================================================================
+
+	/**
+	 * Test that backfill_all_postmeta copies ALL missing postmeta for any post type.
+	 *
+	 * This is the final safety net — after specific backfills (nav_menu,
+	 * attachment, elementor), this method copies any remaining missing
+	 * postmeta for pages, CPTs, WooCommerce products, LMS courses, etc.
+	 */
+	public function test_all_postmeta_catch_all_copies_missing_meta() {
+		// Create a page on the source site with various meta keys.
+		switch_to_blog($this->from_blog_id);
+		$page_id = self::factory()->post->create(
+			[
+				'post_type'  => 'page',
+				'post_title' => 'Page with custom meta',
+			]
+		);
+		update_post_meta($page_id, '_thumbnail_id', '42');
+		update_post_meta($page_id, '_wp_page_template', 'full-width.php');
+		update_post_meta($page_id, '_custom_field', 'custom-value');
+		restore_current_blog();
+
+		// Mirror the post to target (simulates MUCD's post copy).
+		switch_to_blog($this->to_blog_id);
+		self::factory()->post->create(
+			[
+				'import_id'  => $page_id,
+				'post_type'  => 'page',
+				'post_title' => 'Page with custom meta',
+			]
+		);
+		restore_current_blog();
+
+		// Run the catch-all backfill.
+		Testable_Site_Duplicator::backfill_all_postmeta($this->from_blog_id, $this->to_blog_id);
+
+		// Verify all meta was copied.
+		switch_to_blog($this->to_blog_id);
+		$this->assertEquals('42', get_post_meta($page_id, '_thumbnail_id', true));
+		$this->assertEquals('full-width.php', get_post_meta($page_id, '_wp_page_template', true));
+		$this->assertEquals('custom-value', get_post_meta($page_id, '_custom_field', true));
+		restore_current_blog();
+	}
+
+	/**
+	 * Test that backfill_all_postmeta does not overwrite existing meta (NOT EXISTS guard).
+	 */
+	public function test_all_postmeta_catch_all_does_not_overwrite_existing() {
+		// Create a page on the source site with meta.
+		switch_to_blog($this->from_blog_id);
+		$page_id = self::factory()->post->create(
+			[
+				'post_type'  => 'page',
+				'post_title' => 'Existing meta page',
+			]
+		);
+		update_post_meta($page_id, '_custom_field', 'source-value');
+		restore_current_blog();
+
+		// Mirror the post to target with a different meta value.
+		switch_to_blog($this->to_blog_id);
+		self::factory()->post->create(
+			[
+				'import_id'  => $page_id,
+				'post_type'  => 'page',
+				'post_title' => 'Existing meta page',
+			]
+		);
+		update_post_meta($page_id, '_custom_field', 'target-value');
+		restore_current_blog();
+
+		// Run the catch-all backfill.
+		Testable_Site_Duplicator::backfill_all_postmeta($this->from_blog_id, $this->to_blog_id);
+
+		// Existing target meta must be preserved — NOT overwritten.
+		switch_to_blog($this->to_blog_id);
+		$this->assertEquals('target-value', get_post_meta($page_id, '_custom_field', true));
+		restore_current_blog();
+	}
+
+	/**
+	 * Test that backfill_all_postmeta only copies meta for posts that exist in target.
+	 */
+	public function test_all_postmeta_catch_all_skips_orphaned_posts() {
+		// Create a post on source that does NOT exist on target.
+		switch_to_blog($this->from_blog_id);
+		$orphan_id = self::factory()->post->create(
+			[
+				'post_type'  => 'post',
+				'post_title' => 'Orphan post',
+			]
+		);
+		update_post_meta($orphan_id, '_orphan_meta', 'should-not-copy');
+		restore_current_blog();
+
+		// Do NOT create a matching post on the target.
+
+		// Run the catch-all backfill.
+		Testable_Site_Duplicator::backfill_all_postmeta($this->from_blog_id, $this->to_blog_id);
+
+		// No meta should exist on the target for the orphan post.
+		switch_to_blog($this->to_blog_id);
+		$this->assertEmpty(get_post_meta($orphan_id, '_orphan_meta', true));
+		restore_current_blog();
+	}
+
+	// =========================================================================
 	// Bug 1 — backfill_kit_settings
 	// =========================================================================
 
@@ -1053,5 +1162,19 @@ class Testable_Site_Duplicator extends Site_Duplicator {
 	 */
 	public static function verify_kit_integrity($from_site_id, $to_site_id) {
 		parent::verify_kit_integrity($from_site_id, $to_site_id);
+	}
+
+	/**
+	 * Expose backfill_all_postmeta.
+	 */
+	public static function backfill_all_postmeta($from_site_id, $to_site_id) {
+		parent::backfill_all_postmeta($from_site_id, $to_site_id);
+	}
+
+	/**
+	 * Expose rewrite_backfilled_postmeta_urls.
+	 */
+	public static function rewrite_backfilled_postmeta_urls($from_site_id, $to_site_id) {
+		parent::rewrite_backfilled_postmeta_urls($from_site_id, $to_site_id);
 	}
 }


### PR DESCRIPTION
## Summary

- **Root cause fix**: `copy_media` toggle stored as `""` in settings DB — `wu_get_setting()` returned empty string (key exists, bypasses default) — `MUCD_Files::copy_files()` never ran — **zero media files copied on any clone**
- **Safety net backfills**: general postmeta catch-all + expanded URL rewriting across all tables
- **Elementor CSS hardening**: delete stale compiled CSS files from disk before regeneration

## Context

A customer (KursoPro) reported broken images after site cloning and built a 5-layer mu-plugin mitigation (`kp-elementor-css-on-clone v3.1.0`). We verified the same bug on a fresh install — the uploads directory for cloned sites was completely empty.

## Changes

### `inc/helpers/class-site-duplicator.php`

| Change | Detail |
|---|---|
| **`copy_files` default fix** | Empty-string toggle value (`""`) now falls back to `true` instead of being falsy. This is the primary fix. |
| **`backfill_all_postmeta()`** | New catch-all copies ALL missing postmeta for ALL post types (`_thumbnail_id`, `_wp_page_template`, WooCommerce/LMS meta, custom fields). NOT EXISTS guard = idempotent. |
| **`rewrite_backfilled_postmeta_urls()` expanded** | Now rewrites URLs across 5 tables (postmeta, posts, options, termmeta, commentmeta) with both plain and JSON-escaped variants. Skips tables that don't exist. |

### `inc/compat/class-elementor-compat.php`

| Change | Detail |
|---|---|
| **`delete_stale_css_files()`** | Deletes `post-*.css` and `global.css` from `uploads/elementor/css/` — these are copied verbatim from the template and contain hardcoded template URLs |
| **`_elementor_inline_svg` cleanup** | Clears inline SVG cache metadata |
| **`elementor_css_print_method`** | Set to `external` so Elementor generates fresh CSS files on first visit |

### `tests/WP_Ultimo/Helpers/Site_Duplicator_Postmeta_Test.php`

- 3 new tests: `test_all_postmeta_catch_all_copies_missing_meta`, `test_all_postmeta_catch_all_does_not_overwrite_existing`, `test_all_postmeta_catch_all_skips_orphaned_posts`
- Testable subclass expanded with `backfill_all_postmeta()` and `rewrite_backfilled_postmeta_urls()`

## Verification

- **Unit tests**: 50/56 pass (6 pre-existing failures, 0 new)
- **PHPStan**: clean
- **Live clone test** (site 2 to site 13):
  - 14/14 media files copied to `wp-content/uploads/sites/13/`
  - Attachment URLs correctly rewritten (`sites/2/` to `sites/13/`)
  - `file_exists=YES` for all attachments
  - 0 stale template URLs across postmeta, posts, and options tables

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.10 plugin for [OpenCode](https://opencode.ai) v1.3.17 with gemma4:e4b spent 9d 4h and 43,427 tokens on this as a headless worker.
