### PR TITLE
bugfix: switch screenshot provider from thum.io to WordPress.com mShots

### DIFF
--- a/inc/helpers/class-screenshot.php
+++ b/inc/helpers/class-screenshot.php
@@ -30,7 +30,7 @@ class Screenshot {
 	 */
 	public static function api_url($domain): string {
 
-		$url = 'https://image.thum.io/get/width/1280/crop/960/noanimate/' . $domain;
+		$url = 'https://s.wordpress.com/mshots/v1/' . rawurlencode('https://' . $domain) . '?w=1280';
 
 		return apply_filters('wu_screenshot_api_url', $url, $domain);
 	}
@@ -83,15 +83,15 @@ class Screenshot {
 		}
 
 		/*
-		 * Check if the results contain a PNG header.
+		 * Check if the results contain a JPEG header.
 		 */
-		if (! str_starts_with($response['body'], "\x89\x50\x4e\x47\x0d\x0a\x1a\x0a")) {
-			wu_log_add('screenshot-generator', $log_prefix . __('Result is not a PNG file.', 'ultimate-multisite'), LogLevel::ERROR);
+		if (! str_starts_with($response['body'], "\xFF\xD8\xFF")) {
+			wu_log_add('screenshot-generator', $log_prefix . __('Result is not a JPEG file.', 'ultimate-multisite'), LogLevel::ERROR);
 
 			return false;
 		}
 
-		$upload = wp_upload_bits('screenshot-' . gmdate('Y-m-d-H-i-s') . '.png', null, $response['body']);
+		$upload = wp_upload_bits('screenshot-' . gmdate('Y-m-d-H-i-s') . '.jpg', null, $response['body']);
 
 		if ( ! empty($upload['error'])) {
 			wu_log_add('screenshot-generator', $log_prefix . wp_json_encode($upload['error']), LogLevel::ERROR);

--- a/tests/WP_Ultimo/Helpers/Screenshot_Test.php
+++ b/tests/WP_Ultimo/Helpers/Screenshot_Test.php
@@ -45,35 +45,27 @@ class Screenshot_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Test api_url uses thum.io service.
+	 * Test api_url uses WordPress.com mShots service.
 	 */
-	public function test_api_url_uses_thum_io() {
+	public function test_api_url_uses_mshots() {
 		$url = Screenshot::api_url('example.com');
-		$this->assertStringContainsString('thum.io', $url);
+		$this->assertStringContainsString('s.wordpress.com/mshots/v1/', $url);
 	}
 
 	/**
-	 * Test api_url includes width parameter.
+	 * Test api_url includes width query parameter.
 	 */
 	public function test_api_url_includes_width_parameter() {
 		$url = Screenshot::api_url('example.com');
-		$this->assertStringContainsString('width/1280', $url);
+		$this->assertStringContainsString('w=1280', $url);
 	}
 
 	/**
-	 * Test api_url includes crop parameter.
+	 * Test api_url prepends https:// to the domain before encoding.
 	 */
-	public function test_api_url_includes_crop_parameter() {
+	public function test_api_url_prepends_https_to_domain() {
 		$url = Screenshot::api_url('example.com');
-		$this->assertStringContainsString('crop/960', $url);
-	}
-
-	/**
-	 * Test api_url includes noanimate parameter.
-	 */
-	public function test_api_url_includes_noanimate() {
-		$url = Screenshot::api_url('example.com');
-		$this->assertStringContainsString('noanimate', $url);
+		$this->assertStringContainsString(rawurlencode('https://example.com'), $url);
 	}
 
 	/**
@@ -98,10 +90,10 @@ class Screenshot_Test extends WP_UnitTestCase {
 	// ------------------------------------------------------------------
 
 	/**
-	 * Test take_screenshot returns false for invalid URL.
+	 * Test take_screenshot returns false when response body is not a JPEG.
 	 */
 	public function test_take_screenshot_returns_false_for_invalid_url() {
-		// Will fail because the API won't return a valid PNG
+		// Will fail because the mock body is not a valid JPEG.
 		add_filter(
 			'pre_http_request',
 			function () {
@@ -110,7 +102,7 @@ class Screenshot_Test extends WP_UnitTestCase {
 						'code'    => 200,
 						'message' => 'OK',
 					],
-					'body'     => 'not a png',
+					'body'     => 'not a jpeg',
 				];
 			}
 		);


### PR DESCRIPTION
## Summary

thum.io was returning 404 errors for screenshots. Switches to WordPress.com mShots (`s.wordpress.com/mshots/v1/`) which is free, requires no API key, and works regardless of customer hosting type.

## Changes

- **`inc/helpers/class-screenshot.php`**
  - `api_url()`: replace thum.io URL with mShots (`s.wordpress.com/mshots/v1/{rawurlencode(url)}?w=1280`)
  - `rawurlencode()` instead of `urlencode()` for RFC 3986 compliance
  - Image validation: PNG magic bytes → JPEG magic bytes (`\xFF\xD8\xFF`) — mShots returns JPEG
  - Upload filename: `.png` → `.jpg`

- **`tests/WP_Ultimo/Helpers/Screenshot_Test.php`**
  - Replace thum.io-specific assertions with mShots equivalents
  - Add `test_api_url_prepends_https_to_domain` asserting the domain is rawurlencoded with `https://` prefix
  - Update `take_screenshot` test comment to reference JPEG instead of PNG

The `wu_screenshot_api_url` filter is unaffected — existing overrides continue to work.

## Testing

```
vendor/bin/phpunit --filter Screenshot_Test
# OK (8 tests, 8 assertions)
```

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.10 plugin for [OpenCode](https://opencode.ai) v1.3.17 with claude-sonnet-4-6 spent 56m and 23,959 tokens on this with the user in an interactive session.
