### PR TITLE
fix: thank-you page site card layout broken

### DIFF
--- a/assets/css/legacy-signup.css
+++ b/assets/css/legacy-signup.css
@@ -13,7 +13,8 @@ body {
   margin: 0;
 }
 .wu-thank-you-pending-site img {
-  max-width: 100%;
+  max-width: 120px;
+  height: auto;
 }
 .wu-setup #wu-thank-you-element table {
   width: 100%;
@@ -21,6 +22,9 @@ body {
 #wu-sites > div {
   max-width: 100%;
   overflow: hidden;
+}
+#wu-sites a {
+  white-space: nowrap;
 }
 .wu-setup .button .dashicons,
 .wu-setup .button .dashicons-before::before {

--- a/views/dashboard-widgets/thank-you.php
+++ b/views/dashboard-widgets/thank-you.php
@@ -250,10 +250,11 @@ defined('ABSPATH') || exit;
 
 			<div class="wu-bg-gray-100 wu-p-4 wu-rounded wu-mb-2 sm:wu-flex wu-items-center wu-w-full">
 
-					<div class="wu-flex-shrink sm:wu-mr-4">
+					<div class="wu-flex-shrink-0 sm:wu-mr-4">
 
 					<img
 					class="wu-mb-4 sm:wu-mb-0 wu-rounded"
+					style="max-width: 120px;"
 					src="<?php echo esc_attr($site->get_featured_image('thumbnail')); ?>"
 					alt="Thumbnail of Site" />
 
@@ -297,7 +298,7 @@ defined('ABSPATH') || exit;
 
 				</div>
 
-				<div class="wu-justify-align-end sm:wu-ml-4">
+				<div class="wu-flex-shrink-0 sm:wu-ml-4">
 
 					<?php if ($site->get_type() === 'pending') : ?>
 


### PR DESCRIPTION
## Summary

- **Image container** used `wu-flex-shrink` (allows shrinking) instead of `wu-flex-shrink-0` — the placeholder image rendered at natural size, consuming all horizontal space and squeezing text/links into a single-character-wide column.
- **Links container** used `wu-justify-align-end` which **does not exist in any CSS file** — replaced with `wu-flex-shrink-0` so links maintain their natural width.
- **Image max-width** constrained to 120px (CSS rule + inline style) — previously `max-width: 100%` of an unconstrained flex child was meaningless.
- **Link wrapping** prevented with `white-space: nowrap` on `#wu-sites a` — stops "Admin Panel" and "Visit" from wrapping character-by-character.

## Files Changed

- `views/dashboard-widgets/thank-you.php` — flex utility class fixes on image and links containers
- `assets/css/legacy-signup.css` — image sizing constraint and link nowrap rule

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.10 plugin for [OpenCode](https://opencode.ai) v1.3.17 with gemma4:e4b spent 9d 5h and 43,427 tokens on this as a headless worker.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Refined site listing layout to prevent images from expanding unnecessarily while maintaining proper aspect ratio consistency.
  * Fixed link display behavior in site lists to prevent text wrapping, ensuring action links remain on a single line.
  * Improved flex layout properties to prevent unnecessary shrinking of site thumbnails and action containers during responsive adjustments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->