### PR TITLE
Fix mShots 403: add browser User-Agent to wp_remote_get in Screenshot…

### DIFF
--- a/inc/helpers/class-screenshot.php
+++ b/inc/helpers/class-screenshot.php
@@ -66,7 +66,8 @@ class Screenshot {
 		$response = wp_remote_get(
 			$url,
 			[
-				'timeout' => 50,
+				'timeout'    => 50,
+				'user-agent' => 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36',
 			]
 		);
 


### PR DESCRIPTION
… helper

WordPress.com mShots returns HTTP 403 when the request carries no User-Agent header, causing save_image_from_url() to silently return false and store the placeholder instead of the real screenshot JPEG.

Add a Chrome UA string to the wp_remote_get args so mShots treats the request as a legitimate browser fetch and returns 200 + valid image data.