### PR TITLE
GH#1015: fix do_action_ref_array extra arg and guard empty-hash transient deletion

### DIFF
--- a/inc/functions/exporter.php
+++ b/inc/functions/exporter.php
@@ -47,8 +47,7 @@ function wu_exporter_export(int $site_id, array $options = [], bool $async = fal
 			[
 				'site_id' => $site_id,
 				'options' => $options,
-			],
-			'site-exporter'
+			]
 		);
 	}
 

--- a/inc/site-exporter/class-site-exporter.php
+++ b/inc/site-exporter/class-site-exporter.php
@@ -1524,7 +1524,9 @@ final class Site_Exporter {
 
 		wu_exporter_save_generation_time($export_name, $time);
 
-		wu_exporter_delete_transient("wu_pending_site_export_{$hash}");
+		if ( ! empty($hash)) {
+			wu_exporter_delete_transient("wu_pending_site_export_{$hash}");
+		}
 
 		return true;
 	}


### PR DESCRIPTION
## Summary

Fixes two code-quality issues in the site exporter's synchronous export path.

### Changes

**`inc/functions/exporter.php`** — remove spurious third argument from `do_action_ref_array()`

`do_action_ref_array()` only accepts two arguments: the hook name and an array of args. The third `'site-exporter'` argument was silently discarded by WordPress, creating a misleading API call.

**`inc/site-exporter/class-site-exporter.php`** — guard empty-hash transient deletion

`handle_site_export()` is invoked from both the async path (where `$hash` is a valid md5 string) and the synchronous path (where `$hash` defaults to `''`). On the synchronous path the transient `wu_pending_site_export_` (with an empty suffix) was never created, so the deletion was a no-op. Adding the `!empty($hash)` guard makes the intent explicit and avoids the confusing empty-suffix deletion attempt.

## Impact

Low — both issues were no-ops at runtime. This is a code quality / correctness fix.

## Verification

Changes are minimal and targeted to the exact lines identified in the issue. The diff touches 2 files, 4 lines changed.

Resolves #1015

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.12 plugin for [OpenCode](https://opencode.ai) v1.3.17 with claude-sonnet-4-6 spent 4m and 5,544 tokens on this as a headless worker.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed export handler to prevent erroneous deletion of export state data, improving stability of site export operations.
  * Refined internal export function structure for consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->