### PR TITLE
GH#1012: fix HTTP/HTTPS scheme mismatch in Site_Exporter::url_to_path()

### DIFF
--- a/inc/site-exporter/class-site-exporter.php
+++ b/inc/site-exporter/class-site-exporter.php
@@ -1359,22 +1359,39 @@ final class Site_Exporter {
 	/**
 	 * Convert URL to local file path.
 	 *
+	 * Normalises URL schemes before comparison so that HTTP/HTTPS mismatches
+	 * (common when the media library returns HTTP while the site runs HTTPS, or
+	 * vice-versa) do not prevent the conversion from succeeding.
+	 *
+	 * Falls back to wu_exporter_url_to_path() which uses site_url() for a
+	 * broader scheme-normalised replacement and, as a last resort, queries the
+	 * WP media library via attachment_url_to_postid().
+	 *
 	 * @since 2.5.0
 	 *
 	 * @param string $url The URL to convert.
-	 * @return string|false
+	 * @return string|false The local filesystem path, or false on failure.
 	 */
 	private function url_to_path(string $url) {
 
 		$upload_dir = wp_upload_dir();
-		$base_url   = $upload_dir['baseurl'];
-		$base_dir   = $upload_dir['basedir'];
 
-		if (strpos($url, $base_url) === 0) {
-			return str_replace($base_url, $base_dir, $url);
+		// Normalise both sides to HTTPS to survive HTTP/HTTPS mismatches.
+		$base_url   = set_url_scheme($upload_dir['baseurl'], 'https');
+		$base_dir   = $upload_dir['basedir'];
+		$normalized = set_url_scheme($url, 'https');
+
+		if (strpos($normalized, $base_url) === 0) {
+			return str_replace($base_url, $base_dir, $normalized);
 		}
 
-		return false;
+		/*
+		 * Fall back to the site-wide helper which normalises via site_url() and
+		 * queries the media library as a last resort.
+		 */
+		$path = wu_exporter_url_to_path($url);
+
+		return ! empty($path) ? $path : false;
 	}
 
 	/**


### PR DESCRIPTION
## Summary

Fixes `Site_Exporter::url_to_path()` which silently returned `false` when the media library's stored `baseurl` used a different scheme than the URL being converted (e.g. HTTP stored, HTTPS current or vice versa). This caused the import handler to show the misleading **"ZIP file not found"** error even when the file existed on disk.

## What Changed

**EDIT: `inc/site-exporter/class-site-exporter.php` — `url_to_path()` method (line ~1367)**

1. **Scheme normalization** — Both `$upload_dir['baseurl']` and the incoming `$url` are now normalized to HTTPS via `set_url_scheme()` before the `strpos()` prefix check. This fixes the common HTTP/HTTPS mismatch.

2. **Fallback to `wu_exporter_url_to_path()`** — When the uploads-prefix check still does not match (e.g. custom upload dir, CDN URLs), the method now delegates to the existing `wu_exporter_url_to_path()` helper (`inc/functions/importer.php:139`) which uses `site_url()` normalization and, as a last resort, queries the WP Media Library via `attachment_url_to_postid()` + `get_attached_file()`.

## Testing

Verified by inspecting the modified method against the bug conditions described in the issue:
- HTTP/HTTPS mismatch: `set_url_scheme()` on both sides makes the `strpos()` check scheme-agnostic.
- Fallback path: `wu_exporter_url_to_path()` covers custom upload directories and CDN URLs.

Resolves #1012

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.12 plugin for [OpenCode](https://opencode.ai) v1.3.17 with claude-sonnet-4-6 spent 5m and 8,544 tokens on this as a headless worker.