### PR TITLE
fix: use !empty() for delete_file option to honour ZIP-delete preference (Fixes #1008)

### DIFF
--- a/inc/site-exporter/class-site-exporter.php
+++ b/inc/site-exporter/class-site-exporter.php
@@ -1598,7 +1598,7 @@ final class Site_Exporter {
 
 		wu_exporter_delete_transient("wu_pending_site_import_{$hash}");
 
-		$delete_file = isset($options['delete_file']);
+		$delete_file = !empty($options['delete_file']);
 
 		if ($delete_file) {
 			$attachment_id = attachment_url_to_postid($options['zip_url']);


### PR DESCRIPTION
## Summary

Fixes the `isset` vs `!empty` bug in `handle_site_import()` that caused ZIP files to always be deleted after import, regardless of the user's "Delete ZIP After Import" preference.

## Root Cause

`isset($options['delete_file'])` returns `true` whenever the key exists in the array — even when its value is `false` or `''`. Both callers set the key unconditionally:

- `handle_import_site_modal()` → `'delete_file' => wu_request('remove_zip')` (returns `false`/`''` when unchecked)
- WordPress Sites import handler → `'delete_file' => $delete_zip` (where `$delete_zip = !empty($_POST['delete_zip'])`, so `false` when unchecked)

Because the key always exists, `isset()` always returned `true`, so the ZIP was always deleted.

## Fix

**`inc/site-exporter/class-site-exporter.php:1601`** — `isset()` → `!empty()`

```php
// Before
$delete_file = isset($options['delete_file']);

// After
$delete_file = !empty($options['delete_file']);
```

`!empty()` correctly evaluates falsy values (`false`, `''`, `0`, `null`) as `false`, so the ZIP is only deleted when the option is explicitly truthy.

## Testing

1. Go to any subsite import UI with a ZIP file.
2. Uncheck "Delete ZIP After Import" and run the import.
3. Verify the ZIP file is **preserved** after import.
4. Re-check the box and import again — ZIP should be deleted.

Resolves #1008