### PR TITLE
GH#1017: fix unprepared SQL and column alias mismatch in pending export/import queries

### DIFF
--- a/inc/functions/exporter.php
+++ b/inc/functions/exporter.php
@@ -183,7 +183,7 @@ function wu_exporter_add_pending(int $site_id, array $options = [], bool $async 
 
 	$hash = md5(serialize($base)); // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.serialize_serialize
 
-	wu_exporter_set_transient("wu_pending_site_export_{$hash}", $site_id, 2 * HOUR_IN_SECONDS);
+	wu_exporter_set_transient("wu_pending_site_export_{$hash}", $base, 2 * HOUR_IN_SECONDS);
 
 	return $hash;
 }
@@ -200,11 +200,24 @@ function wu_exporter_get_pending(): array {
 
 	$table = is_multisite() ? "{$wpdb->base_prefix}sitemeta" : "{$wpdb->base_prefix}options";
 
-	$like = is_multisite() ? '\\_site\\_transient\\_wu\\_pending\\_site\\_export\\_%' : '\\_transient\\_wu\\_pending\\_site\\_export\\_%';
+	$like = is_multisite()
+		? $wpdb->esc_like('_site_transient_wu_pending_site_export_') . '%'
+		: $wpdb->esc_like('_transient_wu_pending_site_export_') . '%';
 
-	$query = "SELECT meta_key, meta_value as site_id FROM {$table} WHERE meta_key LIKE '{$like}'";
+	// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- $table is built from $wpdb->base_prefix, not user input.
+	$query = $wpdb->prepare("SELECT meta_key, meta_value as options FROM {$table} WHERE meta_key LIKE %s", $like);
 
-	return $wpdb->get_results($query); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.DirectDatabaseQuery
+	$results = $wpdb->get_results($query); // phpcs:ignore WordPress.DB.DirectDatabaseQuery
+
+	return array_map(
+		function ($item) {
+
+			$item->options = maybe_unserialize($item->options);
+
+			return $item;
+		},
+		$results
+	);
 }
 
 /**

--- a/inc/functions/importer.php
+++ b/inc/functions/importer.php
@@ -87,15 +87,19 @@ function wu_exporter_get_pending_imports(): array {
 
 	if (is_multisite()) {
 		$table = "{$wpdb->base_prefix}sitemeta";
+		$like  = $wpdb->esc_like('_site_transient_wu_pending_site_import_') . '%';
 
-		$query = "SELECT meta_key, meta_value as options FROM {$table} WHERE meta_key LIKE '\\_site\\_transient\\_wu\\_pending\\_site\\_import\\_%'";
+		// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- $table is built from $wpdb->base_prefix, not user input.
+		$query = $wpdb->prepare("SELECT meta_key, meta_value as options FROM {$table} WHERE meta_key LIKE %s", $like);
 	} else {
 		$table = "{$wpdb->base_prefix}options";
+		$like  = $wpdb->esc_like('_transient_wu_pending_site_import_') . '%';
 
-		$query = "SELECT option_name, option_value as options FROM {$table} WHERE option_name LIKE '\\_transient\\_wu\\_pending\\_site\\_import\\_%'";
+		// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- $table is built from $wpdb->base_prefix, not user input.
+		$query = $wpdb->prepare("SELECT option_name, option_value as options FROM {$table} WHERE option_name LIKE %s", $like);
 	}
 
-	$results = $wpdb->get_results($query); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.DirectDatabaseQuery
+	$results = $wpdb->get_results($query); // phpcs:ignore WordPress.DB.DirectDatabaseQuery
 
 	$results = array_map(
 		function ($item) {


### PR DESCRIPTION
## Summary

Fixes three related bugs in the site export/import pending-query functions.

### 1. `wu_exporter_add_pending` — wrong value stored

`wu_exporter_add_pending` was storing only `$site_id` (integer) as the transient value, but the dashboard template at `class-site-exporter.php:395` accesses it as `$pending->options[0]` — expecting an indexed array. This mirrors how `wu_exporter_add_pending_import` stores `$base = [$file_name, $options, $hash]`. Fix: store `$base = [$site_id, $options, $async]`.

### 2. `wu_exporter_get_pending` — unprepared SQL, wrong alias, missing unserialize

- Raw LIKE query without `$wpdb->prepare()` — WordPress coding standards violation
- Column alias was `site_id`; the dashboard reads `$pending->options`, so the alias must be `options`
- `maybe_unserialize()` was missing (present in the importer equivalent)

Fix: use `$wpdb->prepare()` + `$wpdb->esc_like()`, rename alias to `options`, add `maybe_unserialize` post-processing.

### 3. `wu_exporter_get_pending_imports` — unprepared SQL

Both the multisite and single-site query paths used raw LIKE strings. Fixed to use `$wpdb->prepare()` + `$wpdb->esc_like()`.

## Files Modified

- `EDIT: inc/functions/exporter.php:180-220`
- `EDIT: inc/functions/importer.php:84-111`

## Verification

- `vendor/bin/phpcs --standard=WordPress inc/functions/exporter.php inc/functions/importer.php` — zero `PreparedSQL` or `DirectDatabaseQuery` violations
- Both pending-export and pending-import dashboard views will now correctly display the site ID (`$pending->options[0]`) and import filename respectively

Resolves #1017

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.12 plugin for [OpenCode](https://opencode.ai) v1.3.17 with claude-sonnet-4-6 spent 7m and 14,605 tokens on this as a headless worker.