### PR TITLE
GH#1009: Fix import cron schedule circular dependency

### DIFF
--- a/inc/site-exporter/class-site-exporter.php
+++ b/inc/site-exporter/class-site-exporter.php
@@ -70,11 +70,11 @@ final class Site_Exporter {
 
 		add_action('wu_export_site', [$this, 'handle_site_export'], 10, 3);
 
-		add_action('wu_import_site', [$this, 'handle_site_import'], 10, 3);
+		add_action('wu_import_site', [$this, 'handle_site_import']);
 
 		add_filter('wu_site_exporter_files_to_zip', [$this, 'maybe_exclude_wp_ultimo_plugins']);
 
-		add_action('cron_schedules', [$this, 'maybe_add_schedule']);
+		add_filter('cron_schedules', [$this, 'maybe_add_schedule']);
 
 		add_action('init', [$this, 'maybe_run_imports']);
 
@@ -1457,7 +1457,16 @@ final class Site_Exporter {
 	}
 
 	/**
-	 * Maybe adds a new schedule.
+	 * Adds the custom cron schedule interval.
+	 *
+	 * Always registers the wu_site_every_minute interval so that
+	 * wp_schedule_event() can succeed regardless of whether there are
+	 * pending imports at the time the cron_schedules filter runs.
+	 * Previously this method returned early when no imports were pending,
+	 * creating a circular dependency: the schedule was only registered when
+	 * imports existed, but the event could not be scheduled until the
+	 * interval was registered — meaning the very first import might never
+	 * be processed.
 	 *
 	 * @since 2.5.0
 	 *
@@ -1465,12 +1474,6 @@ final class Site_Exporter {
 	 * @return array
 	 */
 	public function maybe_add_schedule(array $schedules): array {
-
-		$pending_imports = wu_exporter_get_pending_imports();
-
-		if (empty($pending_imports)) {
-			return $schedules;
-		}
 
 		$schedules['wu_site_every_minute'] = [
 			'interval' => 60,


### PR DESCRIPTION
## Summary

Fixes the circular dependency in the import cron schedule registration that caused async imports to silently never execute.

## Root Cause

`maybe_add_schedule()` (hooked to `cron_schedules` filter) returned early when no pending imports existed. Since WordPress evaluates the `cron_schedules` filter *inside* `wp_schedule_event()`, this meant:

1. On a fresh site (no imports queued), `maybe_run_imports()` runs on `init` and calls `wp_schedule_event()`.
2. Inside `wp_schedule_event()`, the `cron_schedules` filter fires.
3. `maybe_add_schedule()` finds no pending imports → returns early → `wu_site_every_minute` is never registered.
4. `wp_schedule_event()` cannot validate the schedule name and silently fails.
5. No WP cron event is ever scheduled for imports.

When an import is finally queued, the cron event needed to process it was never registered.

## Changes

**`inc/site-exporter/class-site-exporter.php`**

- **`maybe_add_schedule()`**: Remove the pending-imports guard — always register the `wu_site_every_minute` interval. The `handle_site_import()` callback already returns `false` early when there are no pending imports, so an idle recurring event is safe.

- **`setup()`**: Use `add_filter()` for `cron_schedules` (it is a filter, not an action).

- **`setup()`**: Remove the incorrect `$accepted_args=3` from the `wu_import_site` → `handle_site_import` registration. `handle_site_import()` accepts no parameters.

## Verification

- PHP syntax: `php -l inc/site-exporter/class-site-exporter.php` — clean
- The `wu_site_every_minute` schedule is now always available, so `wp_schedule_event()` in `maybe_run_imports()` will succeed on every request.

Resolves #1009

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.12 plugin for [OpenCode](https://opencode.ai) v1.3.17 with claude-sonnet-4-6 spent 7m and 11,567 tokens on this as a headless worker.