### PR TITLE
GH#1010: Security: serve export ZIPs through authenticated download endpoint

### DIFF
--- a/inc/functions/exporter.php
+++ b/inc/functions/exporter.php
@@ -58,6 +58,9 @@ function wu_exporter_export(int $site_id, array $options = [], bool $async = fal
 /**
  * Gets a list of all the exports generated to date.
  *
+ * Each export entry includes an authenticated download URL that requires
+ * `manage_network` capability — no direct public URL is exposed.
+ *
  * @since 2.5.0
  * @return array
  */
@@ -79,8 +82,7 @@ function wu_exporter_get_all_exports(): array {
 		}
 	);
 
-	$results  = [];
-	$base_url = wu_exporter_get_folder();
+	$results = [];
 
 	foreach ($zip_files as $filepath) {
 		$filename  = basename($filepath);
@@ -89,11 +91,28 @@ function wu_exporter_get_all_exports(): array {
 			'path' => $filepath,
 			'date' => wp_date(get_option('date_format') . ' ' . get_option('time_format'), filemtime($filepath)),
 			'size' => size_format(filesize($filepath)),
-			'url'  => trailingslashit($base_url) . $filename,
+			'url'  => wu_exporter_get_download_url($filename),
 		];
 	}
 
 	return $results;
+}
+
+/**
+ * Returns an authenticated download URL for an export ZIP file.
+ *
+ * The URL routes through the WordPress admin, requires `manage_network`
+ * capability, and includes a nonce. Export files are never served via
+ * direct public URLs.
+ *
+ * @since 2.5.1
+ *
+ * @param string $filename The export filename (e.g. wu-site-export-2-2025-01-01-1735686000.zip).
+ * @return string
+ */
+function wu_exporter_get_download_url(string $filename): string {
+
+	return \WP_Ultimo\Site_Exporter\Export_Download_Handler::download_url($filename);
 }
 
 /**

--- a/inc/site-exporter/class-export-download-handler.php
+++ b/inc/site-exporter/class-export-download-handler.php
@@ -1,0 +1,195 @@
+<?php
+/**
+ * Export Download Handler
+ *
+ * Serves export ZIP files through an authenticated WordPress endpoint,
+ * preventing direct public URL access to sensitive site export archives.
+ *
+ * @package WP_Ultimo\Site_Exporter
+ * @subpackage Site_Exporter
+ * @author      WP Ultimo
+ * @category    Security
+ * @since       2.5.1
+ */
+
+namespace WP_Ultimo\Site_Exporter;
+
+// Exit if accessed directly
+defined('ABSPATH') || exit;
+
+/**
+ * Export Download Handler.
+ *
+ * Registers a secure download endpoint for site export ZIP files that
+ * streams files through PHP after verifying user capability and nonce.
+ * This prevents direct web-server-level access to exported archives,
+ * which may contain database dumps, user credentials, and media files.
+ *
+ * @package WP_Ultimo\Site_Exporter
+ * @since   2.5.1
+ */
+class Export_Download_Handler {
+
+	use \WP_Ultimo\Traits\Singleton;
+
+	/**
+	 * Sets up the download handler hooks.
+	 *
+	 * @since 2.5.1
+	 * @return void
+	 */
+	public function init(): void {
+
+		add_action('admin_init', [$this, 'maybe_handle_download']);
+	}
+
+	/**
+	 * Returns the nonce action string for a given export filename.
+	 *
+	 * @since 2.5.1
+	 *
+	 * @param string $filename The export filename.
+	 * @return string
+	 */
+	public static function nonce_action(string $filename): string {
+
+		return 'wu_download_export_' . $filename;
+	}
+
+	/**
+	 * Generates an authenticated, nonce-protected download URL for an export file.
+	 *
+	 * The URL routes through the WordPress admin and requires `manage_network`
+	 * capability. It cannot be guessed without a valid nonce.
+	 *
+	 * @since 2.5.1
+	 *
+	 * @param string $filename The export filename.
+	 * @return string
+	 */
+	public static function download_url(string $filename): string {
+
+		return wp_nonce_url(
+			add_query_arg(
+				[
+					'page'   => 'wu-site-export',
+					'action' => 'download',
+					'file'   => rawurlencode($filename),
+				],
+				network_admin_url('sites.php')
+			),
+			self::nonce_action($filename)
+		);
+	}
+
+	/**
+	 * Checks if the current request is an authenticated export download.
+	 *
+	 * Verifies `manage_network` capability, nonce, filename format, and file
+	 * existence before streaming the file. Calls `wp_die()` on any failure.
+	 *
+	 * @since 2.5.1
+	 * @return void
+	 */
+	public function maybe_handle_download(): void {
+
+		$page   = wu_request('page', '');
+		$action = wu_request('action', '');
+
+		if ('wu-site-export' !== $page || 'download' !== $action) {
+			return;
+		}
+
+		if (! current_user_can('manage_network')) {
+			wp_die(
+				esc_html__('You do not have permission to download exports.', 'ultimate-multisite'),
+				esc_html__('Forbidden', 'ultimate-multisite'),
+				['response' => 403]
+			);
+		}
+
+		$file = sanitize_file_name(rawurldecode(wu_request('file', '')));
+
+		if (! wp_verify_nonce(wu_request('_wpnonce'), self::nonce_action($file))) {
+			wp_die(
+				esc_html__('Security check failed.', 'ultimate-multisite'),
+				esc_html__('Forbidden', 'ultimate-multisite'),
+				['response' => 403]
+			);
+		}
+
+		/*
+		 * Validate filename format.
+		 * Only allow files matching: wu-site-export-{ID}-{YYYY-MM-DD}-{timestamp}.zip
+		 * This prevents path traversal and access to arbitrary files.
+		 */
+		if (! preg_match('/^wu-site-export-[0-9]+-[0-9]{4}-[0-9]{2}-[0-9]{2}-[0-9]+\.zip$/', $file)) {
+			wp_die(
+				esc_html__('Invalid export file name.', 'ultimate-multisite'),
+				esc_html__('Bad Request', 'ultimate-multisite'),
+				['response' => 400]
+			);
+		}
+
+		$file_path = trailingslashit(wu_maybe_create_folder('wu-site-exports')) . $file;
+
+		if (! file_exists($file_path)) {
+			wp_die(
+				esc_html__('Export file not found.', 'ultimate-multisite'),
+				esc_html__('Not Found', 'ultimate-multisite'),
+				['response' => 404]
+			);
+		}
+
+		$this->stream_file($file_path, $file);
+	}
+
+	/**
+	 * Streams a file to the browser as a forced download.
+	 *
+	 * Sends appropriate HTTP headers and streams the file in 8 KB chunks,
+	 * then exits. Does not allow the web server to serve the file directly.
+	 *
+	 * @since 2.5.1
+	 *
+	 * @param string $file_path The absolute server path to the file.
+	 * @param string $filename  The filename to present in the Content-Disposition header.
+	 * @return void
+	 */
+	private function stream_file(string $file_path, string $filename): void {
+
+		if (headers_sent()) {
+			wp_die(esc_html__('Cannot stream file: headers already sent.', 'ultimate-multisite'));
+		}
+
+		$file_size = (int) filesize($file_path);
+
+		nocache_headers();
+
+		header('Content-Type: application/zip');
+		header('Content-Disposition: attachment; filename="' . rawurlencode($filename) . '"');
+		header('Content-Length: ' . $file_size);
+		header('Content-Transfer-Encoding: binary');
+
+		/*
+		 * Flush any buffered output before streaming to avoid memory issues
+		 * with large export files.
+		 */
+		if (ob_get_level()) {
+			ob_end_clean();
+		}
+
+		$handle = fopen($file_path, 'rb'); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fopen
+
+		if ($handle) {
+			while (! feof($handle)) {
+				echo fread($handle, 8192); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped, WordPress.WP.AlternativeFunctions.file_system_operations_fread
+				flush();
+			}
+
+			fclose($handle); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fclose
+		}
+
+		exit;
+	}
+}

--- a/inc/site-exporter/class-site-exporter.php
+++ b/inc/site-exporter/class-site-exporter.php
@@ -94,8 +94,52 @@ final class Site_Exporter {
 		add_filter('wu_site_bulk_actions', [$this, 'add_bulk_export_action']);
 		add_action('wu_handle_bulk_action_form_site_export', [$this, 'handle_bulk_export'], 10, 3);
 
+		// Authenticated file download handler (GH#1010)
+		Export_Download_Handler::get_instance()->init();
+
+		// Protect the export folder for sites upgrading from versions that lacked .htaccess protection.
+		add_action('admin_init', [$this, 'maybe_protect_export_folder']);
+
 		// WordPress default Sites page integration (works without Ultimate Multisite setup)
 		$this->setup_wordpress_sites_integration();
+	}
+
+	/**
+	 * Ensures the export folder has .htaccess and index.html protection files.
+	 *
+	 * `wu_maybe_create_folder()` adds these files when creating the folder, but
+	 * existing installations may have the folder without them. This method is
+	 * idempotent — it only writes the protection files when they are absent.
+	 *
+	 * @since 2.5.1
+	 * @return void
+	 */
+	public function maybe_protect_export_folder(): void {
+
+		// wu_maybe_create_folder() returns a path with a trailing slash already.
+		$folder_path = wu_maybe_create_folder('wu-site-exports');
+
+		$htaccess = $folder_path . '.htaccess';
+
+		if (! file_exists($htaccess)) {
+			$fp = @fopen($htaccess, 'w'); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fopen, WordPress.PHP.NoSilencedErrors.Discouraged
+
+			if ($fp) {
+				@fwrite($fp, 'deny from all'); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fwrite, WordPress.PHP.NoSilencedErrors.Discouraged
+				@fclose($fp); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fclose, WordPress.PHP.NoSilencedErrors.Discouraged
+			}
+		}
+
+		$index = $folder_path . 'index.html';
+
+		if (! file_exists($index)) {
+			$fp = @fopen($index, 'w'); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fopen, WordPress.PHP.NoSilencedErrors.Discouraged
+
+			if ($fp) {
+				@fwrite($fp, ''); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fwrite, WordPress.PHP.NoSilencedErrors.Discouraged
+				@fclose($fp); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fclose, WordPress.PHP.NoSilencedErrors.Discouraged
+			}
+		}
 	}
 
 	/**


### PR DESCRIPTION
## Summary

Fixes a critical security issue where site export ZIP files (containing full database dumps, user credentials, and media) were served via direct public URLs with no authentication.

## Root Cause

`wu_exporter_get_folder()` returned a public uploads URL, and all download links in the admin UI pointed directly to `wp-content/uploads/wu-site-exports/*.zip`. Anyone who could guess or discover the URL could download sensitive data without authentication.

## Changes

**New: `inc/site-exporter/class-export-download-handler.php`**
- Singleton `Export_Download_Handler` class registered on `admin_init`
- Intercepts `page=wu-site-export&action=download` requests
- Requires `manage_network` capability + valid nonce
- Validates filename pattern (`wu-site-export-{ID}-{YYYY-MM-DD}-{timestamp}.zip`)
- Streams file via PHP headers — web server never serves the file directly

**Modified: `inc/functions/exporter.php`**
- Added `wu_exporter_get_download_url(string $filename): string` helper
- Updated `wu_exporter_get_all_exports()` to use authenticated URLs

**Modified: `inc/site-exporter/class-site-exporter.php`**
- Initializes `Export_Download_Handler` singleton in `setup()`
- Adds `maybe_protect_export_folder()` to backfill `.htaccess` + `index.html` for existing folders

Resolves #1010

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.12 plugin for [OpenCode](https://opencode.ai) v1.3.17 with claude-sonnet-4-6 spent 8m and 24,289 tokens on this as a headless worker. Overall, 6h since this issue was created.