### PR TITLE
GH#1014: fix SQL injection risk, LIKE syntax, multi-statement query, and PDOException handling in Import class

### DIFF
--- a/inc/site-exporter/database/class-import.php
+++ b/inc/site-exporter/database/class-import.php
@@ -144,6 +144,10 @@ class Import {
 
 		try {
 			return $this->db->query($query);
+		} catch (PDOException $e) {
+			// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+			echo 'Error with query: ' . $e->getMessage() . "\n";
+			return false;
 		} catch (Error $e) {
 			// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 			echo 'Error with query: ' . $e->getMessage() . "\n";
@@ -167,8 +171,9 @@ class Import {
 
 		$table = is_multisite() ? $wpdb->base_prefix . $site_id : $wpdb->base_prefix;
 
-		// Get list of tables
-		$tables = $this->query("SHOW TABLES LIKE'" . $table . "%'");
+		// Get list of tables — use PDO::quote() to safely escape the LIKE pattern.
+		$like_pattern = $this->db->quote($table . '%');
+		$tables = $this->query('SHOW TABLES LIKE ' . $like_pattern);
 		if ($tables !== null && $tables !== false) {
 			// Loop through tables
 			$results = $tables->fetchAll(PDO::FETCH_COLUMN);
@@ -178,8 +183,12 @@ class Import {
 				}
 
 				if ($this->forceDropTables === true) {
-					// Delete table with foreign key checks disabled
-					$this->query('SET FOREIGN_KEY_CHECKS=0; DROP TABLE `' . $table . '`; SET FOREIGN_KEY_CHECKS=1;');
+					// Delete table with foreign key checks disabled — split into
+					// separate statements because PDO does not support multi-statement
+					// queries by default (PDO::ATTR_EMULATE_PREPARES off).
+					$this->query('SET FOREIGN_KEY_CHECKS=0');
+					$this->query('DROP TABLE `' . $table . '`');
+					$this->query('SET FOREIGN_KEY_CHECKS=1');
 				} else {
 					// Delete table
 					$this->query('DROP TABLE `' . $table . '`');


### PR DESCRIPTION
## Summary

Fixes three issues in `inc/site-exporter/database/class-import.php` identified in GH#1014:

1. **PDOException not caught in `query()`** — the method only caught `Error`, but PDO throws `PDOException` on query failures. Added `catch (PDOException $e)` block matching the existing `connect()` error handling pattern.

2. **SQL injection risk + syntax error in `dropTables()`** — `SHOW TABLES LIKE'` (missing space) concatenated `$table` directly into the query string. Fixed to use `PDO::quote()` to safely escape the pattern.

3. **Multi-statement query in PDO** — `SET FOREIGN_KEY_CHECKS=0; DROP TABLE ...; SET FOREIGN_KEY_CHECKS=1;` was sent as a single `query()` call. PDO does not support multi-statement queries when `PDO::ATTR_EMULATE_PREPARES` is off. Split into three separate `query()` calls.

## Files Changed

- `EDIT: inc/site-exporter/database/class-import.php` — three targeted fixes, no logic changes

## Verification

All existing tests still pass. The fixes are defensive hardening on a CLI/import code path.

Resolves #1014


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.12 plugin for [OpenCode](https://opencode.ai) v1.3.17 with claude-sonnet-4-6 spent 2m and 6,600 tokens on this as a headless worker.