### PR TITLE
GH#1005: fix: replace Alchemy\Zippy with native ZipArchive in mu-migration helpers

### DIFF
--- a/inc/site-exporter/mu-migration/includes/helpers.php
+++ b/inc/site-exporter/mu-migration/includes/helpers.php
@@ -4,8 +4,6 @@
  */
 namespace TenUp\MU_Migration\Helpers;
 
-use Alchemy\Zippy\Zippy;
-
 /**
  * Checks if WooCommerce is active.
  *
@@ -275,30 +273,72 @@ function maybe_restore_current_blog() {
 /**
  * Extracts a zip file to the $dest_dir.
  *
- * @uses Zippy
+ * Uses PHP's built-in ZipArchive (available since PHP 5.2, required by WP 5.3+).
  *
  * @param string $filename
  * @param string $dest_dir
  */
 function extract($filename, $dest_dir) {
-	$zippy = Zippy::load();
+	$zip = new \ZipArchive();
 
-	$site_package = $zippy->open($filename);
-	mkdir($dest_dir);
-	$site_package->extract($dest_dir);
+	if ( $zip->open($filename) !== true ) {
+		return;
+	}
+
+	if ( ! file_exists($dest_dir) ) {
+		mkdir($dest_dir, 0755, true);
+	}
+
+	$zip->extractTo($dest_dir);
+	$zip->close();
 }
 
 /**
- * Creates a zip files with the provided files/folder to zip
+ * Creates a zip file with the provided files/folders.
  *
- * @param string $zip_files    The name of the zip file
- * @param array  $files_to_zip The files to include in the zip file
+ * Uses PHP's built-in ZipArchive (available since PHP 5.2, required by WP 5.3+).
+ * The $files_to_zip array maps archive entry names (keys) to filesystem paths (values).
+ * When key equals value (both are the same filesystem path), the basename is used as
+ * the archive entry name (e.g. individual export files like .sql, .csv, .json).
+ * When the key is a relative path (e.g. 'wp-content/plugins'), all contents of the
+ * filesystem directory (value) are added recursively under that prefix.
  *
- * @return void
+ * @param string $zip_file    The path of the zip file to create.
+ * @param array  $files_to_zip Archive-entry => filesystem-path pairs.
+ *
+ * @return bool True on success, false on failure.
  */
 function zip($zip_file, $files_to_zip) {
 	$files_to_zip = apply_filters('wu_site_exporter_files_to_zip', $files_to_zip);
-	return Zippy::load()->create($zip_file, $files_to_zip, true);
+
+	$zip = new \ZipArchive();
+
+	if ( $zip->open($zip_file, \ZipArchive::CREATE | \ZipArchive::OVERWRITE) !== true ) {
+		return false;
+	}
+
+	foreach ( $files_to_zip as $archive_path => $filesystem_path ) {
+		if ( is_file($filesystem_path) ) {
+			// When key === value both are the full filesystem path; store by basename.
+			$entry_name = ( $archive_path === $filesystem_path ) ? basename($filesystem_path) : $archive_path;
+			$zip->addFile($filesystem_path, $entry_name);
+		} elseif ( is_dir($filesystem_path) ) {
+			$filesystem_path  = rtrim($filesystem_path, DIRECTORY_SEPARATOR);
+			$base_path_length = strlen($filesystem_path) + 1;
+
+			$dir_iterator = new \RecursiveIteratorIterator(
+				new \RecursiveDirectoryIterator($filesystem_path, \RecursiveDirectoryIterator::SKIP_DOTS),
+				\RecursiveIteratorIterator::LEAVES_ONLY
+			);
+
+			foreach ( $dir_iterator as $file_item ) {
+				$relative_path = substr($file_item->getPathname(), $base_path_length);
+				$zip->addFile($file_item->getPathname(), $archive_path . DIRECTORY_SEPARATOR . $relative_path);
+			}
+		}
+	}
+
+	return $zip->close();
 }
 
 /**


### PR DESCRIPTION
## Summary

The `Alchemy\Zippy\Zippy` library used by mu-migration's `zip()` and `extract()` helpers is not available at runtime — the `mu-migration/vendor/` directory is untracked and the package is not in the main `composer.json`. This meant both functions would crash with a fatal error on every export/import attempt.

## Changes

**EDIT: `inc/site-exporter/mu-migration/includes/helpers.php`**

- Removed `use Alchemy\Zippy\Zippy;` import
- Rewrote `extract()` to use `\ZipArchive::open()` + `extractTo()` with a guard that creates the destination directory if it doesn't exist
- Rewrote `zip()` to use `\ZipArchive::open(CREATE|OVERWRITE)` + `addFile()`, handling both individual files (key === value → use basename as archive entry) and directory mappings (key is a relative path like `'wp-content/plugins'` → recursive `RecursiveIteratorIterator` walk)

## Verification

- `php -l inc/site-exporter/mu-migration/includes/helpers.php` → no syntax errors
- Archive structure produced by `zip()` matches what `import` expects:
  - Individual export files (`.sql`, `.csv`, `.json`) stored at root by basename
  - Directories stored recursively under their `wp-content/...` prefix key

## Why ZipArchive and not alchemy/zippy

`ZipArchive` is a PHP core extension (bundled since PHP 5.2, mandatory for WordPress since WP 5.3+). Using it eliminates the external dependency entirely, making export/import self-contained.

Resolves #1005