### PR TITLE
GH#1004: fix: always load helpers.php and command files in Site_Exporter::load_dependencies()

### DIFF
--- a/inc/site-exporter/class-site-exporter.php
+++ b/inc/site-exporter/class-site-exporter.php
@@ -1619,15 +1619,16 @@ final class Site_Exporter {
 
 		$base_path = wu_path('inc/site-exporter/mu-migration');
 
+		require_once $base_path . '/includes/helpers.php';
+		require_once $base_path . '/includes/commands/class-mu-migration.php';
+		require_once $base_path . '/includes/commands/class-mu-migration-base.php';
+		require_once $base_path . '/includes/commands/class-mu-migration-export.php';
+		require_once $base_path . '/includes/commands/class-mu-migration-import.php';
+		require_once $base_path . '/includes/commands/class-mu-migration-posts.php';
+		require_once $base_path . '/includes/commands/class-mu-migration-users.php';
+
 		if (file_exists($base_path . '/vendor/autoload.php')) {
 			require_once $base_path . '/vendor/autoload.php';
-			require_once $base_path . '/includes/helpers.php';
-			require_once $base_path . '/includes/commands/class-mu-migration.php';
-			require_once $base_path . '/includes/commands/class-mu-migration-base.php';
-			require_once $base_path . '/includes/commands/class-mu-migration-export.php';
-			require_once $base_path . '/includes/commands/class-mu-migration-import.php';
-			require_once $base_path . '/includes/commands/class-mu-migration-posts.php';
-			require_once $base_path . '/includes/commands/class-mu-migration-users.php';
 		}
 	}
 


### PR DESCRIPTION
## Summary

Previously, `Site_Exporter::load_dependencies()` gated ALL file loading (including `helpers.php` and the command class files) behind a `file_exists()` check for `vendor/autoload.php`. Since that vendor directory is not tracked in git and never exists, no files were ever loaded — causing a fatal error when `wu_exporter_export()` tried to call helper functions.

The command class files and `helpers.php` have no external dependencies and should always be loaded. Only the `vendor/autoload.php` (Zippy) require is gated behind the `file_exists` check.

## Changes

- `EDIT: inc/site-exporter/class-site-exporter.php` — moved `require_once` statements for `helpers.php` and command files outside the `file_exists` check; only the `vendor/autoload.php` include remains conditional

## Testing

```bash
php -l inc/site-exporter/class-site-exporter.php
# No syntax errors detected
```

Resolves #1004

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.12 plugin for [OpenCode](https://opencode.ai) v1.3.17 with claude-sonnet-4-6 spent 4m and 13,584 tokens on this as a headless worker.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved the dependency loading mechanism to ensure migration helper files are consistently available during initialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->