### PR TITLE
GH#1015: fix: guard empty-hash transient deletion in handle_site_export()

### DIFF
--- a/inc/site-exporter/class-site-exporter.php
+++ b/inc/site-exporter/class-site-exporter.php
@@ -1625,7 +1625,9 @@ final class Site_Exporter {
 
 		wu_exporter_save_generation_time($export_name, $time);
 
-		wu_exporter_delete_transient("wu_pending_site_export_{$hash}");
+		if ( ! empty($hash)) {
+			wu_exporter_delete_transient("wu_pending_site_export_{$hash}");
+		}
 
 		return true;
 	}


### PR DESCRIPTION
## Summary

Fixes the second finding from #1015: guard the transient deletion in `handle_site_export()` with `!empty($hash)` so the synchronous export path (where `$hash` defaults to `''`) does not attempt to delete the transient key `wu_pending_site_export_` which was never created.

## What Changed

### `inc/site-exporter/class-site-exporter.php`

Wrapped `wu_exporter_delete_transient()` with an `!empty($hash)` guard:

```php
if ( ! empty($hash)) {
    wu_exporter_delete_transient("wu_pending_site_export_{$hash}");
}
```

This prevents the no-op deletion of a non-existent transient when the synchronous path calls `handle_site_export()` without a hash.

## First Finding Already Fixed

The `do_action_ref_array()` extra-argument issue (finding 1 of #1015) was already resolved by commit `51ce3ceb` (PR #1024, GH#1011): that commit replaced the hook dispatch entirely with a direct call to `Site_Exporter::get_instance()->handle_site_export()`, which also captures the return value for error surfacing.

This PR delivers only the remaining unaddressed fix.

## Why This PR (Not PR #1023)

PR #1023 (`feature/auto-20260430-002624-gh1015`) had a merge conflict in `inc/functions/exporter.php` caused by the GH#1011 changes landed after the branch was created. Rather than resolving the conflict on a stale branch, this PR cherry-picks the remaining fix onto a fresh branch from `origin/main`.

## Testing

The change is defensive and has no functional impact on happy-path exports. Verified by code review:
- Async path: `$hash` is always non-empty (set by `wu_exporter_add_pending()`) → guard passes, transient is deleted as before
- Synchronous path: `$hash` defaults to `''` → guard prevents deletion of non-existent key `wu_pending_site_export_`

Resolves #1015