### PR TITLE
GH#1006 GH#1007: fix: WP-CLI command registration + Site_Exporter before requirements gate

### DIFF
--- a/inc/class-wp-ultimo.php
+++ b/inc/class-wp-ultimo.php
@@ -174,6 +174,20 @@ final class WP_Ultimo {
 		\WP_Ultimo\Credits::get_instance();
 
 		/*
+		 * Loads the Site Exporter early so export/import is available even when
+		 * Ultimate Multisite is not fully set up (e.g. during migration from
+		 * other multisite solutions). The Site Exporter's WordPress-native
+		 * integration (Sites page row actions, Export & Import admin menu) uses
+		 * only WordPress core functions and has no dependency on WP Ultimo being
+		 * configured. The Singleton trait guarantees init() runs only once even
+		 * when the boot sequence reaches the component a second time.
+		 *
+		 * All helper functions it depends on (wu_request, wu_maybe_create_folder,
+		 * wu_exporter_*) are loaded above via load_public_apis() and inc/functions/fs.php.
+		 */
+		\WP_Ultimo\Site_Exporter\Site_Exporter::get_instance();
+
+		/*
 		 * Check if the Ultimate Multisite requirements are present.
 		 *
 		 * Everything we need to run our setup install needs top be loaded before this
@@ -577,11 +591,6 @@ final class WP_Ultimo {
 		 * Loads the Tax functionality
 		 */
 		\WP_Ultimo\Tax\Tax::get_instance();
-
-		/*
-		 * Loads the Site Exporter
-		 */
-		\WP_Ultimo\Site_Exporter\Site_Exporter::get_instance();
 
 		/*
 		 * Loads the template placeholders

--- a/inc/site-exporter/class-site-exporter.php
+++ b/inc/site-exporter/class-site-exporter.php
@@ -68,6 +68,28 @@ final class Site_Exporter {
 	 */
 	public function setup(): void {
 
+		/*
+		 * Register the mu-migration WP-CLI commands early so WP-CLI discovers
+		 * them during the command bootstrap phase.
+		 *
+		 * Each mu-migration class file ends with a bare `WP_CLI::add_command()`
+		 * call that executes at file-include time. Those files are only loaded
+		 * via `load_dependencies()`, which is normally called lazily from
+		 * `handle_site_export()` / `handle_site_import()` — far too late for
+		 * WP-CLI's command discovery. Calling `load_dependencies()` here when
+		 * WP-CLI is active means the commands are registered before WP-CLI
+		 * finishes bootstrapping.
+		 *
+		 * The `require_once` calls inside `load_dependencies()` are idempotent,
+		 * so calling it again later from `handle_site_export()` is harmless.
+		 *
+		 * This check mirrors the pattern used by the `WP_CLI` trait in
+		 * `inc/apis/trait-wp-cli.php` (see `enable_wp_cli()`).
+		 */
+		if ( defined('WP_CLI') && WP_CLI ) {
+			$this->load_dependencies();
+		}
+
 		add_action('wu_export_site', [$this, 'handle_site_export'], 10, 3);
 
 		add_action('wu_import_site', [$this, 'handle_site_import']);


### PR DESCRIPTION
## Summary

This PR combines two closely related fixes for the Site Exporter:

1. **GH#1007** — Site Exporter was initialized after the Requirements gate, making export unavailable during migration scenarios
2. **GH#1006** — mu-migration WP-CLI commands were not registered because `load_dependencies()` was called too late for WP-CLI command discovery

These two issues compound each other: #1007 means the Site_Exporter never loads in migration scenarios; #1006 means even when it does load, the WP-CLI commands are never registered.

## Changes

**`EDIT: inc/class-wp-ultimo.php`** (GH#1007)
- Move `\WP_Ultimo\Site_Exporter\Site_Exporter::get_instance()` from the fully-loaded section (~line 584) to immediately before the requirements gate
- Remove the now-redundant call in the fully-loaded section
- Add an explanatory comment describing why this is safe and intentional

**`EDIT: inc/site-exporter/class-site-exporter.php`** (GH#1006)
- Add early `load_dependencies()` call in `setup()` guarded by `defined('WP_CLI') && WP_CLI`
- Each mu-migration class file ends with a bare `WP_CLI::add_command()` call that fires at include-time; calling `load_dependencies()` early ensures these run before WP-CLI finishes its bootstrap phase
- The `require_once` calls inside `load_dependencies()` are idempotent, so the lazy call from `handle_site_export()` is harmless

## Testing

```bash
# WP-CLI commands should now be discoverable
wp help mu-migration
wp mu-migration export all /tmp/export.zip --blog_id=2 --url=http://wordpress.local:8080
wp mu-migration import all /tmp/export.zip --new_url=http://newsite.example.com

# Syntax check
php -l inc/site-exporter/class-site-exporter.php
```

Resolves #1006
Resolves #1007