### PR TITLE
GH#1048: fix AGENTS.md — tracker and newsletter singleton paths from contributor insight review

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -298,6 +298,8 @@ read them will produce `read:file_not_found`:
 | `inc/class-plugin.php`, `inc/class-main.php` | Do not exist; the main plugin class is `inc/class-wp-ultimo.php` |
 | `inc/class-membership-manager.php`, `inc/class-customer-manager.php` (etc.) | Do not exist at root of `inc/`; manager classes are in `inc/managers/` (e.g. `inc/managers/class-membership-manager.php`) |
 | `inc/managers/class-orphaned-tables-manager.php`, `inc/managers/class-orphaned-users-manager.php` | Do not exist in `inc/managers/`; unlike most manager classes, these two live at the `inc/` root: `inc/class-orphaned-tables-manager.php` and `inc/class-orphaned-users-manager.php` |
+| `inc/managers/class-tracker-manager.php`, `inc/telemetry/class-tracker.php` | Do not exist; the telemetry/usage-tracking singleton is at `inc/class-tracker.php` (root of `inc/`). Background opt-in was removed in 2.5.1 — `is_tracking_enabled()` always returns `false`; do not look for an `enable_error_reporting` setting. |
+| `inc/managers/class-newsletter-manager.php`, `inc/newsletter/class-newsletter.php` | Do not exist; the newsletter opt-in singleton is at `inc/class-newsletter.php` (root of `inc/`). |
 | `inc/class-gateway.php`, `inc/class-payment-gateway.php` | Do not exist; gateway classes are in `inc/gateways/` |
 | `inc/functions/class-*.php` | Functions in `inc/functions/` are plain procedural PHP (not OOP class files); they are named `inc/functions/customer.php`, `inc/functions/checkout.php`, etc. |
 | `class-wp-ultimo.php` (at repo root) | Does not exist at root; the main plugin class is at `inc/class-wp-ultimo.php` |


### PR DESCRIPTION
## Summary

Contributor insight review for issue #1048 (7 instruction candidates from superdav42).

**Triage outcome:**
- Item #6 (remove Feedback Reports from settings): already implemented in PR #980 — `enable_error_reporting` opt-in removed, `is_tracking_enabled()` always returns `false`
- Item #4 (production bugs): Bug #1 (orphan pending_site) fixed in GH#1037 / PR #1041; bugs #2/#3 not visible (text truncated in auto-generated issue body)
- Items #1, #2, #3, #5, #7: general questions or cross-repo content — not actionable for this repo

**Changes:**

Add two entries to the AGENTS.md 'does not exist' path table, following the same pattern as the `class-orphaned-tables-manager.php` entry added in PR #1047:

- `inc/managers/class-tracker-manager.php` / `inc/telemetry/class-tracker.php` — agents looking for the telemetry singleton in a subdirectory; correct path is `inc/class-tracker.php`. Also notes the `enable_error_reporting` removal so agents don't search for that setting.
- `inc/managers/class-newsletter-manager.php` / `inc/newsletter/class-newsletter.php` — agents looking for the newsletter opt-in in a subdirectory; correct path is `inc/class-newsletter.php`.

Both classes live at the `inc/` root (like the orphaned-table/user managers documented in #1047).

## Testing

No code changes — documentation only.

```bash
# Verify entries are correct
git ls-files 'inc/class-tracker.php' 'inc/class-newsletter.php'
# Should return both files

git ls-files 'inc/managers/class-tracker-manager.php' 'inc/telemetry/class-tracker.php'
# Should return empty (paths do not exist)

git ls-files 'inc/managers/class-newsletter-manager.php' 'inc/newsletter/class-newsletter.php'
# Should return empty (paths do not exist)
```

Resolves #1048

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.17 plugin for [OpenCode](https://opencode.ai) v1.3.17 with claude-sonnet-4-6 spent 16m and 37,890 tokens on this as a headless worker.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated developer documentation to clarify system configuration and telemetry behavior. Confirms that telemetry tracking is always disabled and background opt-in was removed in version 2.5.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->