### PR TITLE
t532: fix pending site not published when admin manually verifies email

### DIFF
--- a/inc/admin-pages/class-customer-edit-admin-page.php
+++ b/inc/admin-pages/class-customer-edit-admin-page.php
@@ -1327,6 +1327,17 @@ class Customer_Edit_Admin_Page extends Edit_Admin_Page {
 				$membership->set_status(Membership_Status::ACTIVE);
 
 				$membership->save();
+
+				/*
+				 * Explicitly publish any pending site here rather than relying on
+				 * the wu_transition_membership_status hook. That hook bails out
+				 * when the customer's email_verification is still "pending" in the
+				 * DB — which it is at this point because parent::handle_save() has
+				 * not yet persisted the new value. publish_pending_site_async() is
+				 * idempotent: if the site is already publishing the inner guard
+				 * in publish_pending_site() returns early.
+				 */
+				$membership->publish_pending_site_async();
 			}
 		}
 	}


### PR DESCRIPTION
## Problem

When an admin sets a customer's email verification to **Verified** and checks the **Transition Membership** checkbox on the customer edit page, the pending site stays pending — it is never published.

## Root Cause

`confirm_memberships()` transitions the membership `pending → active` (firing `wu_transition_membership_status`) **before** `parent::handle_save()` persists the new `email_verification = verified` value to the DB. The hook handler in `Membership_Manager::transition_membership_status()` reads the stale customer record, sees `email_verification = pending`, and bails out — so `publish_pending_site_async()` is never called.

```php
// Membership_Manager::transition_membership_status() line 346
if ($customer && $customer->get_email_verification() === 'pending') {
    return; // fires because DB still has old value at this point
}
```

## Fix

Call `$membership->publish_pending_site_async()` directly inside `confirm_memberships()` after `save()`, instead of relying on the hook. One line added.

`confirm_memberships()` is an explicit admin override — it should be self-sufficient, not depend on save-ordering side effects. `publish_pending_site_async()` is safe to call directly because `publish_pending_site()` guards against double-execution via the `is_publishing` flag.

## Changes

- `EDIT: inc/admin-pages/class-customer-edit-admin-page.php` — `confirm_memberships()` method

## Testing

- `Customer_Edit_Admin_Page_Test` — all 77 tests pass, no failures

Resolves #1053

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.17 plugin for [OpenCode](https://opencode.ai) v1.3.17 with claude-sonnet-4-6 spent 52m and 60,342 tokens on this with the user in an interactive session.
