### PR TITLE
bugfix: always show pending sites first in the All Sites view

### DIFF
--- a/inc/list-tables/class-site-list-table.php
+++ b/inc/list-tables/class-site-list-table.php
@@ -55,6 +55,11 @@ class Site_List_Table extends Base_List_Table {
 	/**
 	 * Overrides the parent method to add pending sites.
 	 *
+	 * In the "All Sites" view (type=all or no type parameter) pending sites are
+	 * always prepended to the list.  Pending sites live in membership meta rather
+	 * than in the wp_blogs table, so they are fetched separately and merged into
+	 * the result set with proper pagination awareness.
+	 *
 	 * @since 2.0.0
 	 *
 	 * @param integer $per_page Number of items to display per page.
@@ -71,6 +76,18 @@ class Site_List_Table extends Base_List_Table {
 
 			return $count ? count($pending_sites) : $pending_sites;
 		}
+
+		/*
+		 * For the "All Sites" view (type=all or no type), always fetch pending
+		 * sites so they can be prepended to the regular list.
+		 */
+		$pending_sites = [];
+
+		if ( ! $type || 'all' === $type ) {
+			$pending_sites = \WP_Ultimo\Models\Site::get_all_by_type('pending');
+		}
+
+		$pending_count = count($pending_sites);
 
 		$query = [
 			'number' => $per_page,
@@ -90,17 +107,70 @@ class Site_List_Table extends Base_List_Table {
 
 		$query = apply_filters("wu_{$this->id}_get_items", $query, $this);
 
+		if ($count) {
+			return (int) wu_get_sites($query) + $pending_count;
+		}
+
+		if (0 === $pending_count) {
+			return wu_get_sites($query);
+		}
+
+		/*
+		 * Pending sites always occupy virtual slots 0 … ($pending_count - 1).
+		 * Regular sites follow from slot $pending_count onwards.
+		 *
+		 * For the current page we calculate which portion of that virtual list
+		 * falls within the page window [$virtual_start, $virtual_start + $per_page).
+		 */
+		$virtual_start = ($page_number - 1) * $per_page;
+
+		if ($virtual_start < $pending_count) {
+			// This page starts inside the pending block.
+			$pending_offset  = $virtual_start;
+			$pending_to_show = min($pending_count - $pending_offset, $per_page);
+			$page_pending    = array_slice($pending_sites, $pending_offset, $pending_to_show);
+
+			$regular_to_show = $per_page - $pending_to_show;
+
+			if ($regular_to_show <= 0) {
+				return $page_pending;
+			}
+
+			$query['number'] = $regular_to_show;
+			$query['offset'] = 0;
+
+			return array_merge($page_pending, wu_get_sites($query));
+		}
+
+		// This page is entirely within the regular sites block; shift the offset
+		// back by the number of pending sites that precede all regular sites.
+		$query['offset'] = $virtual_start - $pending_count;
+
 		return wu_get_sites($query);
 	}
 
 	/**
 	 * Render the bulk edit checkbox.
 	 *
+	 * Pending sites displayed inside the "All Sites" view cannot be bulk-actioned
+	 * (the bulk-delete handler expects blog IDs, not membership IDs).  Return an
+	 * empty string so no checkbox is rendered for them in that context; the row
+	 * actions (Publish / Delete) remain available for individual management.
+	 *
 	 * @param \WP_Ultimo\Models\Site $item Site object.
 	 */
 	public function column_cb($item): string {
 
 		if ($item->get_type() === 'pending') {
+			/*
+			 * In the dedicated "Pending" view, bulk-delete-pending uses
+			 * membership IDs as values.  In any other view (e.g. "All Sites")
+			 * skip the checkbox to avoid mixing IDs with regular bulk-delete.
+			 */
+			if ('pending' !== wu_request('type')) {
+				return '';
+			}
+
 			return sprintf('<input type="checkbox" name="bulk-delete[]" value="%s" />', $item->get_membership_id());
 		}
 

--- a/tests/WP_Ultimo/List_Tables/Site_List_Table_Test.php
+++ b/tests/WP_Ultimo/List_Tables/Site_List_Table_Test.php
@@ -218,9 +218,12 @@ class Site_List_Table_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Test column_cb returns checkbox with membership_id for pending site.
+	 * Test column_cb returns checkbox with membership_id for pending site in the
+	 * dedicated Pending view (type=pending).
 	 */
-	public function test_column_cb_returns_membership_id_for_pending_site(): void {
+	public function test_column_cb_returns_membership_id_for_pending_site_in_pending_view(): void {
+
+		$_REQUEST['type'] = 'pending';
 
 		$item = $this->getMockBuilder( \stdClass::class )
 			->addMethods( [ 'get_type', 'get_id', 'get_membership_id' ] )
@@ -233,6 +236,45 @@ class Site_List_Table_Test extends WP_UnitTestCase {
 
 		$this->assertStringContainsString( 'type="checkbox"', $output );
 		$this->assertStringContainsString( '7', $output );
+	}
+
+	/**
+	 * Test column_cb returns no checkbox for pending site in the All Sites view,
+	 * because bulk-delete uses blog IDs and pending sites only have membership IDs.
+	 */
+	public function test_column_cb_returns_empty_for_pending_site_in_all_view(): void {
+
+		$_REQUEST['type'] = 'all';
+
+		$item = $this->getMockBuilder( \stdClass::class )
+			->addMethods( [ 'get_type', 'get_id', 'get_membership_id' ] )
+			->getMock();
+		$item->method( 'get_type' )->willReturn( 'pending' );
+		$item->method( 'get_id' )->willReturn( 3 );
+		$item->method( 'get_membership_id' )->willReturn( 7 );
+
+		$output = $this->table->column_cb( $item );
+
+		$this->assertSame( '', $output );
+	}
+
+	/**
+	 * Test column_cb returns no checkbox for pending site when no type filter is
+	 * set (equivalent to the All Sites default view).
+	 */
+	public function test_column_cb_returns_empty_for_pending_site_with_no_type(): void {
+
+		unset( $_REQUEST['type'] );
+
+		$item = $this->getMockBuilder( \stdClass::class )
+			->addMethods( [ 'get_type', 'get_id', 'get_membership_id' ] )
+			->getMock();
+		$item->method( 'get_type' )->willReturn( 'pending' );
+		$item->method( 'get_id' )->willReturn( 3 );
+
+		$output = $this->table->column_cb( $item );
+
+		$this->assertSame( '', $output );
 	}
 
 	// =========================================================================


### PR DESCRIPTION
## Summary

- Pending sites live in `wp_wu_membershipmeta`, not `wp_blogs`, so `wu_get_sites()` never returned them — the **All Sites** view showed zero pending entries.
- `get_items()` now fetches pending sites via `Site::get_all_by_type('pending')` when `type=all` or no type is set, and prepends them to the result set with correct pagination (pending slots occupy the start of the virtual list; regular-site offsets shift accordingly).
- `column_cb()` returns an empty string for pending sites in the all-view — the bulk-delete handler expects blog IDs but pending sites only have membership IDs. The dedicated **Pending** tab (`type=pending`) still renders checkboxes with membership IDs as before; row actions (Publish / Delete) remain available in all views.

## Tests

- Split the existing `test_column_cb_returns_membership_id_for_pending_site` into three targeted cases: pending-tab (membership ID checkbox), all-view (no checkbox), no-type (no checkbox).
- All 27 tests pass: `vendor/bin/phpunit --filter Site_List_Table_Test` → `OK (27 tests, 49 assertions)`.

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.22 plugin for [OpenCode](https://opencode.ai) v1.3.17 with claude-sonnet-4-6 spent 5m and 2,853 tokens on this with the user in an interactive session.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Pending sites are now visible in the "All Sites" view with pagination properly accounting for all site types.

* **Bug Fixes**
  * Pending sites no longer appear as selectable in bulk actions when not in the dedicated pending view, preventing data mishandling.

* **Tests**
  * Added comprehensive test coverage for pending site behavior across different list contexts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->