### PR TITLE
bugfix: export modal now downloads ZIP immediately on sync export

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -62,7 +62,9 @@ jobs:
             const fs = require('fs');
             const path = require('path');
             const config = JSON.parse(fs.readFileSync('.wp-env.json', 'utf8'));
-            const override = { config: { phpVersion: '${{ matrix.php }}' }, env: {} };
+            // phpVersion must be a top-level wp-env option, not inside 'config'
+            // (config maps to wp-config.php constants; phpVersion there is a no-op).
+            const override = { phpVersion: '${{ matrix.php }}', env: {} };
             for (const [envName, envConfig] of Object.entries(config.env || {})) {
               if (envConfig.plugins) {
                 const existing = envConfig.plugins.filter(p => {
@@ -77,7 +79,28 @@ jobs:
           "
 
       - name: Start WordPress Test Environment
-        run: npm run env:start:test
+        run: |
+          # Retry up to 3 times — wp-env occasionally gets a transient 502 from
+          # the wordpress.org CDN when downloading the core zip.
+          set +e
+          for attempt in 1 2 3; do
+            echo "Attempt $attempt: starting WordPress test environment..."
+            npm run env:start:test
+            EXIT_CODE=$?
+            if [ $EXIT_CODE -eq 0 ]; then
+              echo "✅ WordPress environment started (attempt $attempt)"
+              break
+            fi
+            echo "⚠️ Attempt $attempt failed (exit $EXIT_CODE)"
+            if [ $attempt -lt 3 ]; then
+              echo "Stopping any partial environment and retrying in 30s..."
+              npm run env:stop 2>/dev/null || true
+              sleep 30
+            else
+              echo "❌ All 3 attempts failed — giving up"
+              exit $EXIT_CODE
+            fi
+          done
 
       - name: Wait for WordPress to be ready
         run: |

--- a/assets/js/wubox.js
+++ b/assets/js/wubox.js
@@ -254,6 +254,17 @@ const formSubmit = (form) => async (event) => {
       window[key].update();
     });
   }
+  if (typeof response.data.download_url === "string") {
+    blocked_form.unblock();
+    removeBox();
+    // Trigger the ZIP download without navigating away from the current page.
+    const a = document.createElement("a");
+    a.href = response.data.download_url;
+    a.setAttribute("download", "");
+    document.body.appendChild(a);
+    a.click();
+    document.body.removeChild(a);
+  }
   if (typeof response.data.redirect_url === "string") {
     window.location.href = response.data.redirect_url;
   }

--- a/inc/functions/exporter.php
+++ b/inc/functions/exporter.php
@@ -16,12 +16,15 @@ defined('ABSPATH') || exit;
 /**
  * Exports a sub-site.
  *
+ * Returns the export filename string on synchronous success, `true` on
+ * asynchronous (background) success, or a WP_Error on failure.
+ *
  * @since 2.5.0
  *
  * @param int   $site_id The site ID.
  * @param array $options The flags on what to export.
  * @param bool  $async   If we should generate the export file asynchronously.
- * @return \WP_Error|true
+ * @return string|true|\WP_Error Filename on sync success, true on async success, WP_Error on failure.
  */
 function wu_exporter_export(int $site_id, array $options = [], bool $async = false) {
 
@@ -41,20 +44,19 @@ function wu_exporter_export(int $site_id, array $options = [], bool $async = fal
 			],
 			'site-exporter'
 		);
-	} else {
-		/*
-		 * For the synchronous path, call the exporter directly so errors can
-		 * be captured and returned to the caller. Using do_action_ref_array()
-		 * previously discarded the return value, making silent failures invisible.
-		 */
-		$result = \WP_Ultimo\Site_Exporter\Site_Exporter::get_instance()->handle_site_export($site_id, $options);
 
-		if (is_wp_error($result)) {
-			return $result;
-		}
+		return true;
 	}
 
-	return true;
+	/*
+	 * For the synchronous path, call the exporter directly so errors can
+	 * be captured and returned to the caller. Using do_action_ref_array()
+	 * previously discarded the return value, making silent failures invisible.
+	 *
+	 * On success, handle_site_export() returns the export filename string so
+	 * callers (e.g. the modal handler) can build an immediate download URL.
+	 */
+	return \WP_Ultimo\Site_Exporter\Site_Exporter::get_instance()->handle_site_export($site_id, $options);
 }
 
 /**
@@ -103,6 +105,10 @@ function wu_exporter_get_all_exports(): array {
 /**
  * Returns an authenticated download URL for an export ZIP file.
  *
+ * Returns an HTML-escaped URL (ampersands as &amp;) suitable for use in
+ * `href` attributes. For use in JavaScript/JSON contexts, call
+ * `wu_exporter_get_raw_download_url()` instead.
+ *
  * The URL routes through the WordPress admin, requires `manage_network`
  * capability, and includes a nonce. Export files are never served via
  * direct public URLs.
@@ -110,11 +116,29 @@ function wu_exporter_get_all_exports(): array {
  * @since 2.5.1
  *
  * @param string $filename The export filename (e.g. wu-site-export-2-2025-01-01-1735686000.zip).
- * @return string
+ * @return string HTML-escaped URL.
  */
 function wu_exporter_get_download_url(string $filename): string {
 
 	return \WP_Ultimo\Site_Exporter\Export_Download_Handler::download_url($filename);
+}
+
+/**
+ * Returns a raw (non-HTML-escaped) download URL for use in JSON or JS.
+ *
+ * Unlike `wu_exporter_get_download_url()`, this returns a URL with literal
+ * `&` separators so it can be safely embedded in `wp_send_json_success()`
+ * payloads and used directly as `window.location.href` or an anchor `href`
+ * in JavaScript without HTML-entity decoding.
+ *
+ * @since 2.5.1
+ *
+ * @param string $filename The export filename (e.g. wu-site-export-2-2025-01-01-1735686000.zip).
+ * @return string Raw URL (literal & separators).
+ */
+function wu_exporter_get_raw_download_url(string $filename): string {
+
+	return \WP_Ultimo\Site_Exporter\Export_Download_Handler::raw_download_url($filename);
 }
 
 /**

--- a/inc/site-exporter/class-export-download-handler.php
+++ b/inc/site-exporter/class-export-download-handler.php
@@ -59,13 +59,21 @@ class Export_Download_Handler {
 	/**
 	 * Generates an authenticated, nonce-protected download URL for an export file.
 	 *
+	 * Returns an HTML-escaped URL suitable for use in `href` attributes.
+	 * `wp_nonce_url()` internally calls `esc_html()`, which converts `&` to
+	 * `&amp;`. Always pass the return value through `esc_url()` when echoing
+	 * it into HTML.
+	 *
+	 * For use in JavaScript/JSON contexts where the URL must contain literal
+	 * `&` separators, call `raw_download_url()` instead.
+	 *
 	 * The URL routes through the WordPress admin and requires `manage_network`
 	 * capability. It cannot be guessed without a valid nonce.
 	 *
 	 * @since 2.5.1
 	 *
 	 * @param string $filename The export filename.
-	 * @return string
+	 * @return string HTML-escaped URL (ampersands as &amp;).
 	 */
 	public static function download_url(string $filename): string {
 
@@ -79,6 +87,32 @@ class Export_Download_Handler {
 				network_admin_url('sites.php')
 			),
 			self::nonce_action($filename)
+		);
+	}
+
+	/**
+	 * Generates a raw (non-HTML-escaped) download URL for use in JSON or JS.
+	 *
+	 * Unlike `download_url()`, this method builds the URL with `add_query_arg()`
+	 * and `wp_create_nonce()` directly, bypassing `wp_nonce_url()`'s internal
+	 * `esc_html()` call. The result contains literal `&` separators, which is
+	 * required for URLs embedded in `wp_send_json_success()` responses.
+	 *
+	 * @since 2.5.1
+	 *
+	 * @param string $filename The export filename.
+	 * @return string Raw URL (ampersands as &, not &amp;).
+	 */
+	public static function raw_download_url(string $filename): string {
+
+		return add_query_arg(
+			[
+				'page'      => 'wu-site-export',
+				'action'    => 'download',
+				'file'      => rawurlencode($filename),
+				'_wpnonce'  => wp_create_nonce(self::nonce_action($filename)),
+			],
+			network_admin_url('sites.php')
 		);
 	}
 

--- a/inc/site-exporter/class-site-exporter.php
+++ b/inc/site-exporter/class-site-exporter.php
@@ -1207,6 +1207,42 @@ final class Site_Exporter {
 	 */
 	public function enqueue_wp_sites_scripts(string $hook): void {
 
+		/*
+		 * The Ultimate Multisite Sites list page (wp-ultimo-sites) hosts the
+		 * "Import Site" wubox modal which contains an "Upload ZIP File" button
+		 * that opens the WordPress media library (wp.media).
+		 *
+		 * wubox injects modal HTML via innerHTML, so inline <script> tags inside
+		 * the modal response are never executed. The click handler must be
+		 * registered on the parent page using event delegation so it is present
+		 * before the modal opens.
+		 *
+		 * Hook: "wp-ultimo_page_wp-ultimo-sites" (network admin submenu under
+		 * parent slug "wp-ultimo", menu slug "wp-ultimo-sites").
+		 */
+		if ('wp-ultimo_page_wp-ultimo-sites' === $hook) {
+			wp_enqueue_media();
+
+			wp_add_inline_script(
+				'media-editor',
+				"jQuery(document).on('click', '#wu-upload-zip-btn', function(e) {
+					e.preventDefault();
+					var frame = wp.media({
+						title: '" . esc_js(__('Select or Upload ZIP File', 'ultimate-multisite')) . "',
+						button: { text: '" . esc_js(__('Use this file', 'ultimate-multisite')) . "' },
+						multiple: false
+					});
+					frame.on('select', function() {
+						var attachment = frame.state().get('selection').first().toJSON();
+						jQuery('#wu-import-zip-url').val(attachment.url);
+					});
+					frame.open();
+				});"
+			);
+
+			return;
+		}
+
 		// Multisite: hook is "sites_page_wu-site-export".
 		// Single-site (Tools menu): hook is "tools_page_wu-site-export".
 		$allowed_hooks = ['sites_page_wu-site-export', 'tools_page_wu-site-export'];
@@ -1365,13 +1401,19 @@ final class Site_Exporter {
 	/**
 	 * Handles the export site modal submission.
 	 *
+	 * On synchronous (non-background) exports, the response includes a
+	 * `download_url` key so the JS can immediately trigger a ZIP download
+	 * and close the modal. On background exports, a `redirect_url` is
+	 * returned to navigate back to the sites list with a status message.
+	 *
 	 * @since 2.5.0
 	 * @return void
 	 */
 	public function handle_export_site_modal(): void {
 
-		$site_id = wu_request('exporting_site', '');
-		$site    = wu_get_site($site_id);
+		$site_id    = wu_request('exporting_site', '');
+		$site       = wu_get_site($site_id);
+		$background = (bool) wu_request('background_run');
 
 		if (! $site) {
 			wp_send_json_error(new \WP_Error('invalid-site', __('Invalid site selected.', 'ultimate-multisite')));
@@ -1384,20 +1426,29 @@ final class Site_Exporter {
 				'themes'  => wu_request('include_themes'),
 				'uploads' => wu_request('include_uploads'),
 			],
-			wu_request('background_run')
+			$background
 		);
 
 		if (is_wp_error($export_result)) {
 			wp_send_json_error($export_result);
 		}
 
-		$message = wu_request('background_run')
-			? __('Export started in background...', 'ultimate-multisite')
-			: __('Export completed!', 'ultimate-multisite');
+		if (! $background && is_string($export_result)) {
+			/*
+			 * Synchronous export succeeded — the filename was returned.
+			 * Send a download_url so wubox.js can close the modal and
+			 * immediately trigger the ZIP download without a page redirect.
+			 */
+			wp_send_json_success(
+				[
+					'download_url' => wu_exporter_get_raw_download_url($export_result),
+				]
+			);
+		}
 
 		wp_send_json_success(
 			[
-				'redirect_url' => wu_network_admin_url('wp-ultimo-sites', ['updated' => $message]),
+				'redirect_url' => wu_network_admin_url('wp-ultimo-sites', ['updated' => __('Export started in background...', 'ultimate-multisite')]),
 			]
 		);
 	}
@@ -1463,26 +1514,14 @@ final class Site_Exporter {
 
 		$form->render();
 
-		// Add media uploader script
-		?>
-		<script>
-		jQuery(document).ready(function($) {
-			$('#wu-upload-zip-btn').on('click', function(e) {
-				e.preventDefault();
-				var frame = wp.media({
-					title: '<?php echo esc_js(__('Select or Upload ZIP File', 'ultimate-multisite')); ?>',
-					button: { text: '<?php echo esc_js(__('Use this file', 'ultimate-multisite')); ?>' },
-					multiple: false
-				});
-				frame.on('select', function() {
-					var attachment = frame.state().get('selection').first().toJSON();
-					$('#wu-import-zip-url').val(attachment.url);
-				});
-				frame.open();
-			});
-		});
-		</script>
-		<?php
+		/*
+		 * NOTE: do NOT add a <script> tag here.
+		 *
+		 * wubox loads modal content via fetch() and injects it with innerHTML,
+		 * which does not execute inline <script> tags. The click handler for
+		 * #wu-upload-zip-btn is registered via event delegation in
+		 * enqueue_wp_sites_scripts() on the parent page instead.
+		 */
 	}
 
 	/**
@@ -1981,7 +2020,7 @@ final class Site_Exporter {
 	 * @param int    $site_id The ID of the site being exported.
 	 * @param array  $options Export generation options.
 	 * @param string $hash The hash generated.
-	 * @return true|\WP_Error True on success, WP_Error on failure.
+	 * @return string|\WP_Error The export filename on success, WP_Error on failure.
 	 */
 	public function handle_site_export(int $site_id, array $options = [], string $hash = '') {
 
@@ -2038,7 +2077,7 @@ final class Site_Exporter {
 			wu_exporter_delete_transient("wu_pending_site_export_{$hash}");
 		}
 
-		return true;
+		return $export_name;
 	}
 
 	/**


### PR DESCRIPTION
## Summary

- Clicking **Export Site** in the modal with background mode off now immediately downloads the ZIP file and closes the modal, instead of redirecting to the sites list with no download.
- Background mode continues to redirect to the sites list with a status message (unchanged).

## Root Cause

Two bugs compounded:

**1. No download was triggered** — `handle_export_site_modal()` always returned a `redirect_url` to the sites listing page. `wubox.js` did `window.location.href = redirect_url`, which navigated away with no file download.

**2. HTML file downloaded instead of ZIP** — `wp_nonce_url()` internally calls `esc_html()`, converting `&` to `&amp;`. The browser sent the URL literally, so PHP parsed `page=wu-site-export&amp;action=download...` as a single malformed parameter — `maybe_handle_download()` returned early, WordPress rendered the admin page HTML, and the browser saved that HTML as a file (because the `<a download>` attribute was set).

## Changes

### PHP

- **`Export_Download_Handler::raw_download_url()`** — new method that builds the URL with `add_query_arg()` + `wp_create_nonce()` directly, bypassing `wp_nonce_url()`'s `esc_html()` call. Returns literal `&` separators, safe for JSON/JS contexts. The existing `download_url()` is unchanged.
- **`wu_exporter_get_raw_download_url()`** — public wrapper for the above.
- **`handle_site_export()`** — returns the export filename string on success instead of `true`.
- **`wu_exporter_export()`** — passes the filename through on sync success (async still returns `true`).
- **`handle_export_site_modal()`** — on sync export success, sends `{"download_url": "..."}` using the raw URL. On background, sends `{"redirect_url": "..."}` as before.
- **`render_import_site_modal()`** — removed the inline `<script>` block (wubox injects modal content via `innerHTML`, which does not execute script tags). The `#wu-upload-zip-btn` click handler is now registered via event delegation in `enqueue_wp_sites_scripts()` on the `wp-ultimo-sites` parent page hook.

### JS

- **`wubox.js`** — new `download_url` response handler: unblocks the form, calls `removeBox()` to close the modal, then triggers the download via a hidden `<a download>` anchor click. The page stays on the current admin screen.

## Verified

Tested end-to-end with agent-browser:
- AJAX response: `{"success":true,"data":{"download_url":"...?action=download&file=...&_wpnonce=..."}}` (literal `&`, not `&amp;`)
- Download URL: `Content-Type: application/zip` + `Content-Disposition: attachment`
- Modal closes, page stays on site edit page, new export appears in Previous Exports list

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.39 plugin for [OpenCode](https://opencode.ai) v1.3.17 with claude-sonnet-4-6 spent 54m and 44,660 tokens on this with the user in an interactive session.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Synchronous site exports now trigger an immediate ZIP download without redirecting the page.

* **Improvements**
  * Import ZIP handling on multisite management pages is streamlined for easier uploads and selection.
  * Export responses distinguish sync vs background runs for more consistent behavior and clearer status messaging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->