### PR TITLE
bugfix: fix import failing when new_url has no http scheme

### DIFF
--- a/inc/site-exporter/class-site-exporter.php
+++ b/inc/site-exporter/class-site-exporter.php
@@ -1446,9 +1446,16 @@ final class Site_Exporter {
 			);
 		}
 
+		/*
+		 * Background export queued. Redirect to the sites list and pass
+		 * message=export_started so display_export_notices() (hooked to
+		 * network_admin_notices) displays the correct success banner.
+		 * Using 'updated' here would be invisible — the list view only
+		 * handles 'deleted', and the export notice handler reads 'message'.
+		 */
 		wp_send_json_success(
 			[
-				'redirect_url' => wu_network_admin_url('wp-ultimo-sites', ['updated' => __('Export started in background...', 'ultimate-multisite')]),
+				'redirect_url' => wu_network_admin_url('wp-ultimo-sites', ['message' => 'export_started']),
 			]
 		);
 	}
@@ -1565,7 +1572,7 @@ final class Site_Exporter {
 
 		wp_send_json_success(
 			[
-				'redirect_url' => wu_network_admin_url('wp-ultimo-sites', ['updated' => __('Import process started.', 'ultimate-multisite')]),
+				'redirect_url' => wu_network_admin_url('wp-ultimo-sites', ['message' => 'import_started']),
 			]
 		);
 	}

--- a/inc/site-exporter/mu-migration/includes/commands/class-mu-migration-import.php
+++ b/inc/site-exporter/mu-migration/includes/commands/class-mu-migration-import.php
@@ -651,7 +651,18 @@ class ImportCommand extends MUMigrationBase {
 	 * @return bool|false|int
 	 */
 	private function create_new_site($meta_data) {
-		$parsed_url = parse_url(esc_url($meta_data->url));
+		$url = $meta_data->url;
+
+		// esc_url() strips URLs whose scheme is not in the allowed list.
+		// Users (and the import modal form) often provide just a domain
+		// like "newsite.example.com" or "newsite.example.com:8080" without
+		// a scheme. Ensure a scheme is present so esc_url() and parse_url()
+		// both return a 'host' key.
+		if ( ! preg_match( '#^https?://#i', $url ) ) {
+			$url = 'http://' . $url;
+		}
+
+		$parsed_url = parse_url(esc_url($url));
 		$site_id    = get_main_network_id();
 
 		$parsed_url['path'] = isset($parsed_url['path']) ? $parsed_url['path'] : '/';

--- a/inc/site-exporter/mu-migration/includes/commands/class-mu-migration-import.php
+++ b/inc/site-exporter/mu-migration/includes/commands/class-mu-migration-import.php
@@ -451,6 +451,25 @@ class ImportCommand extends MUMigrationBase {
 
 		$old_url = $site_meta_data->url;
 
+		/*
+		 * Normalise new_url once here so every downstream path receives a
+		 * consistent, scheme-qualified URL.  The import modal placeholder
+		 * shows bare-domain format ("newsite.example.com" / "newsite.example.com:8080"),
+		 * so users commonly omit the scheme.  esc_url() treats the leading
+		 * subdomain segment as the URL scheme when no "://" is present and
+		 * silently returns ""; parse_url() then returns no 'host' key, which
+		 * causes create_new_site() and the search-replace path to fail.
+		 *
+		 * Prepending "http://" once here means:
+		 *  - $site_meta_data->url passed to create_new_site() is scheme-qualified.
+		 *  - $tables_assoc_args['new_url'] = esc_url($assoc_args['new_url']) (line ~484)
+		 *    produces a well-formed URL instead of an empty string.
+		 *  - Helpers\parse_url_for_search_replace() receives a usable value.
+		 */
+		if ( ! empty($assoc_args['new_url']) && ! preg_match( '#^https?://#i', $assoc_args['new_url'] ) ) {
+			$assoc_args['new_url'] = 'http://' . $assoc_args['new_url'];
+		}
+
 		if ( ! empty($assoc_args['new_url']) ) {
 			$site_meta_data->url = $assoc_args['new_url'];
 		}
@@ -664,6 +683,23 @@ class ImportCommand extends MUMigrationBase {
 
 		$parsed_url = parse_url(esc_url($url));
 		$site_id    = get_main_network_id();
+
+		/*
+		 * parse_url() returns false for seriously malformed input, and omits
+		 * the 'host' key when the URL has no scheme (esc_url() silently strips
+		 * scheme-less URLs).  The caller normalises new_url before setting
+		 * $meta_data->url, so this should only trigger for unexpected inputs;
+		 * fail early with a clear message rather than an "Undefined index" notice.
+		 */
+		if ( empty($parsed_url['host']) ) {
+			WP_CLI::error(
+				sprintf(
+					/* translators: %s: the URL that could not be parsed */
+					__( 'Unable to parse host from URL "%s". Ensure new_url includes a valid scheme (e.g. http://newsite.example.com).', 'mu-migration' ),
+					$meta_data->url
+				)
+			);
+		}
 
 		$parsed_url['path'] = isset($parsed_url['path']) ? $parsed_url['path'] : '/';
 


### PR DESCRIPTION
## Summary

Importing a site via the modal fails with `Error: Unable to create new site` when the "New Site URL" field contains a bare domain (e.g. `newsite.example.com` or `newsite.example.com:8080`) without an `http://` scheme.

## Root Cause

`create_new_site()` passes the URL through `esc_url()` before `parse_url()`. `esc_url()` checks for allowed schemes — it treats `importtest.wordpress.local:8080` as having scheme `importtest.wordpress.local` (anything before the first colon), which is not in the allowed list, so it returns an empty string. `parse_url('')` returns no `host` key, causing `domain_exists()` and `wp_insert_site()` to receive `$parsed_url['host']` as undefined → PHP warning + `Unable to create new site`.

The import modal's own placeholder text (`newsite.example.com`) demonstrates that domain-only input without a scheme is the expected format, so every user hits this path.

## Fix

In `create_new_site()`, prepend `http://` to the URL before passing it to `esc_url()` and `parse_url()` when no `http(s)://` scheme is present. This ensures the host and path are correctly extracted regardless of user input format.

## Verified

End-to-end test with agent-browser:
1. Exported site 17 (`teste.wordpress.local:8080`) via the Export modal — ZIP downloaded immediately (fix from #1057)
2. Opened Import modal, entered ZIP URL + `importtest.wordpress.local:8080` as New Site URL
3. Import queued, triggered via `do_action('wu_import_site')`
4. Site 19 created at `importtest.wordpress.local` with correct URL replacement and imported posts

Before fix: `Error: Unable to create new site` + PHP warning `Undefined array key "host"`  
After fix: site created, tables imported, URL replaced correctly

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.65 plugin for [OpenCode](https://opencode.ai) v1.3.17 with claude-sonnet-4-6 spent 12h 9m and 72,933 tokens on this with the user in an interactive session.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed site migration import to properly handle URLs that lack a scheme (http:// or https://), improving reliability during the import process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->