### PR TITLE
feat: add Checkout Forms to admin bar quick links

### DIFF
--- a/inc/admin-pages/class-top-admin-nav-menu.php
+++ b/inc/admin-pages/class-top-admin-nav-menu.php
@@ -132,6 +132,18 @@ class Top_Admin_Nav_Menu {
 			],
 		];
 
+		// Checkout Forms
+		$checkout_forms = [
+			'id'     => 'wp-ultimo-checkout-forms',
+			'parent' => 'wp-ultimo',
+			'title'  => __('Checkout Forms', 'ultimate-multisite'),
+			'href'   => network_admin_url('admin.php?page=wp-ultimo-checkout-forms'),
+			'meta'   => [
+				'class' => 'wp-ultimo-top-menu',
+				'title' => __('Go to the checkout forms page', 'ultimate-multisite'),
+			],
+		];
+
 		$container = [
 			'id'     => 'wp-ultimo-settings-group',
 			'parent' => 'wp-ultimo',
@@ -183,6 +195,10 @@ class Top_Admin_Nav_Menu {
 
 		if (current_user_can('wu_read_discount_codes')) {
 			$wp_admin_bar->add_node($discount_codes);
+		}
+
+		if (current_user_can('wu_read_checkout_forms')) {
+			$wp_admin_bar->add_node($checkout_forms);
 		}
 
 		if (current_user_can('wu_read_settings')) {


### PR DESCRIPTION
## Summary

Adds a **Checkout Forms** entry to the Ultimate Multisite admin bar quick links menu, consistent with the existing Sites, Memberships, Customers, Products, Payments, and Discount Codes entries.

## Changes

- `inc/admin-pages/class-top-admin-nav-menu.php`: adds `$checkout_forms` node definition and a `wu_read_checkout_forms`-gated `add_node` call, positioned after Discount Codes and before the Settings group.

## Behaviour

- Only visible to users with the `wu_read_checkout_forms` capability (same gate used by the Checkout Forms list page itself).
- Links to `network_admin_url('admin.php?page=wp-ultimo-checkout-forms')`.

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.80 plugin for [OpenCode](https://opencode.ai) v1.3.17 with claude-sonnet-4-6 spent 43m and 4,960 tokens on this with the user in an interactive session.
