### PR TITLE
bugfix: add mShots GIF placeholder retry logic to Screenshot helper

### DIFF
--- a/inc/helpers/class-screenshot.php
+++ b/inc/helpers/class-screenshot.php
@@ -22,6 +22,21 @@ defined('ABSPATH') || exit;
 class Screenshot {
 
 	/**
+	 * JPEG file signature (magic bytes). Every valid JPEG starts with these three bytes.
+	 *
+	 * @since 2.0.11
+	 */
+	const JPEG_MAGIC = "\xFF\xD8\xFF";
+
+	/**
+	 * GIF file signature (magic bytes). mShots returns an 8.7 KB GIF "loading"
+	 * placeholder while the real screenshot is being generated.
+	 *
+	 * @since 2.0.11
+	 */
+	const GIF_MAGIC = "\x47\x49\x46";
+
+	/**
 	 * Returns the api link for the screenshot.
 	 *
 	 * @since 2.0.0
@@ -51,48 +66,29 @@ class Screenshot {
 	}
 
 	/**
-	 * Downloads the image from the URL.
+	 * Downloads the image from the URL and saves it as a WordPress attachment.
+	 *
+	 * Delegates the HTTP fetch (with mShots GIF-placeholder retry) to
+	 * {@see Screenshot::fetch_image_body()}.
 	 *
 	 * @since 2.0.0
+	 * @since 2.0.11 HTTP fetch extracted into fetch_image_body() with GIF retry logic.
 	 *
 	 * @param string $url Image URL to download.
-	 * @return int|false
+	 * @return int|false Attachment ID on success, false on failure.
 	 */
 	public static function save_image_from_url($url) {
 
 		// translators: %s is the API URL.
 		$log_prefix = sprintf(__('Downloading image from "%s":', 'ultimate-multisite'), $url) . ' ';
 
-		$response = wp_remote_get(
-			$url,
-			[
-				'timeout'    => 50,
-				'user-agent' => 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36',
-			]
-		);
+		$body = self::fetch_image_body($url, $log_prefix);
 
-		if (wp_remote_retrieve_response_code($response) !== 200) {
-			wu_log_add('screenshot-generator', $log_prefix . wp_remote_retrieve_response_message($response), LogLevel::ERROR);
-
+		if (false === $body) {
 			return false;
 		}
 
-		if (is_wp_error($response)) {
-			wu_log_add('screenshot-generator', $log_prefix . $response->get_error_message(), LogLevel::ERROR);
-
-			return false;
-		}
-
-		/*
-		 * Check if the results contain a JPEG header.
-		 */
-		if (! str_starts_with($response['body'], "\xFF\xD8\xFF")) {
-			wu_log_add('screenshot-generator', $log_prefix . __('Result is not a JPEG file.', 'ultimate-multisite'), LogLevel::ERROR);
-
-			return false;
-		}
-
-		$upload = wp_upload_bits('screenshot-' . gmdate('Y-m-d-H-i-s') . '.jpg', null, $response['body']);
+		$upload = wp_upload_bits('screenshot-' . gmdate('Y-m-d-H-i-s') . '.jpg', null, $body);
 
 		if ( ! empty($upload['error'])) {
 			wu_log_add('screenshot-generator', $log_prefix . wp_json_encode($upload['error']), LogLevel::ERROR);
@@ -129,5 +125,125 @@ class Screenshot {
 		wu_log_add('screenshot-generator', $log_prefix . __('Success!', 'ultimate-multisite'));
 
 		return $attach_id;
+	}
+
+	/**
+	 * Fetches the raw image body from a URL, retrying when mShots returns a GIF placeholder.
+	 *
+	 * mShots (s.wordpress.com/mshots/v1/) returns an ~8.7 KB GIF "loading" placeholder on the
+	 * first request to a URL it has not recently cached; the real JPEG arrives 2–30 seconds
+	 * later on subsequent requests. This method detects the GIF signature and retries up to
+	 * five times with increasing wait intervals before giving up.
+	 *
+	 * HTTP errors (non-200 status or WP_Error) abort immediately without further retries.
+	 *
+	 * The retry schedule can be customised via the {@see 'wu_mshots_retry_delays'} filter.
+	 *
+	 * @since 2.0.11
+	 *
+	 * @param string $url        Image URL to fetch.
+	 * @param string $log_prefix Log message prefix for contextual logging.
+	 * @return string|false Raw JPEG image bytes on success, false on failure.
+	 */
+	protected static function fetch_image_body(string $url, string $log_prefix) {
+
+		/**
+		 * Filters the retry delay schedule (in seconds) used when mShots returns a GIF placeholder.
+		 *
+		 * The array defines wait times before each successive retry attempt.  The first HTTP
+		 * request is always immediate; each element adds one retry attempt after sleeping the
+		 * given number of seconds.  Pass an empty array to disable retries entirely.
+		 *
+		 * Example — shorten delays for unit tests:
+		 *   add_filter( 'wu_mshots_retry_delays', fn() => [ 0, 0 ] );
+		 *
+		 * @since 2.0.11
+		 *
+		 * @param int[] $delays Seconds to wait before each successive retry. Default [3, 5, 8, 12, 15].
+		 */
+		$retry_delays = (array) apply_filters('wu_mshots_retry_delays', [3, 5, 8, 12, 15]);
+
+		/*
+		 * Build the full attempt schedule: one immediate first attempt (delay 0) followed
+		 * by one attempt per entry in $retry_delays.
+		 *   e.g. [0, 3, 5, 8, 12, 15] → 6 total attempts.
+		 */
+		$all_delays  = array_merge([0], $retry_delays);
+		$total       = count($all_delays);
+
+		foreach ($all_delays as $attempt_index => $delay) {
+
+			if ($delay > 0) {
+				sleep($delay); // phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.sleep_sleep
+			}
+
+			$response = wp_remote_get(
+				$url,
+				[
+					'timeout'    => 50,
+					'user-agent' => 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36',
+				]
+			);
+
+			if (is_wp_error($response)) {
+				wu_log_add('screenshot-generator', $log_prefix . $response->get_error_message(), LogLevel::ERROR);
+
+				return false;
+			}
+
+			if (wp_remote_retrieve_response_code($response) !== 200) {
+				wu_log_add('screenshot-generator', $log_prefix . wp_remote_retrieve_response_message($response), LogLevel::ERROR);
+
+				return false;
+			}
+
+			$body = $response['body'];
+
+			/*
+			 * Success: the response is a JPEG — return the body for saving.
+			 */
+			if (str_starts_with($body, self::JPEG_MAGIC)) {
+				return $body;
+			}
+
+			/*
+			 * mShots GIF placeholder detected. Log and retry if attempts remain,
+			 * otherwise log the final failure and fall through to return false.
+			 */
+			if (str_starts_with($body, self::GIF_MAGIC)) {
+
+				$is_last_attempt = ($attempt_index + 1 >= $total);
+
+				if ($is_last_attempt) {
+					wu_log_add(
+						'screenshot-generator',
+						$log_prefix . __('mShots still returning loading placeholder after all retries.', 'ultimate-multisite'),
+						LogLevel::ERROR
+					);
+				} else {
+					wu_log_add(
+						'screenshot-generator',
+						$log_prefix . sprintf(
+							/* translators: 1: current attempt number, 2: total attempts, 3: seconds until next retry */
+							__('mShots loading placeholder on attempt %1$d of %2$d, retrying in %3$ds.', 'ultimate-multisite'),
+							$attempt_index + 1,
+							$total,
+							$retry_delays[$attempt_index]
+						)
+					);
+				}
+
+				continue;
+			}
+
+			/*
+			 * Unexpected body format — neither JPEG nor GIF. Do not retry.
+			 */
+			wu_log_add('screenshot-generator', $log_prefix . __('Result is not a JPEG file.', 'ultimate-multisite'), LogLevel::ERROR);
+
+			return false;
+		}
+
+		return false;
 	}
 }

--- a/tests/WP_Ultimo/Helpers/Screenshot_Test.php
+++ b/tests/WP_Ultimo/Helpers/Screenshot_Test.php
@@ -21,6 +21,8 @@ class Screenshot_Test extends WP_UnitTestCase {
 	 */
 	public function tear_down() {
 		remove_all_filters('wu_screenshot_api_url');
+		remove_all_filters('wu_mshots_retry_delays');
+		remove_all_filters('pre_http_request');
 		parent::tear_down();
 	}
 
@@ -86,7 +88,7 @@ class Screenshot_Test extends WP_UnitTestCase {
 	}
 
 	// ------------------------------------------------------------------
-	// take_screenshot
+	// take_screenshot / save_image_from_url — non-retry paths
 	// ------------------------------------------------------------------
 
 	/**
@@ -109,8 +111,6 @@ class Screenshot_Test extends WP_UnitTestCase {
 
 		$result = Screenshot::take_screenshot('http://nonexistent.invalid');
 		$this->assertFalse($result);
-
-		remove_all_filters('pre_http_request');
 	}
 
 	/**
@@ -132,7 +132,240 @@ class Screenshot_Test extends WP_UnitTestCase {
 
 		$result = Screenshot::take_screenshot('http://example.com');
 		$this->assertFalse($result);
+	}
 
-		remove_all_filters('pre_http_request');
+	// ------------------------------------------------------------------
+	// mShots GIF placeholder retry logic
+	// ------------------------------------------------------------------
+
+	/**
+	 * Helper — build a GIF89a stub body (passes GIF magic-byte check).
+	 *
+	 * @return string
+	 */
+	private function gif_body() {
+		return "GIF89a\x01\x00\x01\x00\x00\x00\x00;";
+	}
+
+	/**
+	 * Helper — build a minimal JPEG stub body (passes JPEG magic-byte check).
+	 *
+	 * @return string
+	 */
+	private function jpeg_body() {
+		return "\xFF\xD8\xFF\xE0\x00\x10JFIF\x00";
+	}
+
+	/**
+	 * Helper — register a pre_http_request filter that returns $gif_count GIF responses
+	 * and then switches to JPEG for all subsequent requests.
+	 *
+	 * @param int &$call_count Reference to call counter (incremented on each request).
+	 * @param int  $gif_count  Number of initial GIF responses before switching to JPEG.
+	 */
+	private function mock_gif_then_jpeg( &$call_count, $gif_count ) {
+		$gif_body  = $this->gif_body();
+		$jpeg_body = $this->jpeg_body();
+
+		add_filter(
+			'pre_http_request',
+			function () use ( &$call_count, $gif_body, $jpeg_body, $gif_count ) {
+				$call_count++;
+				$body = ( $call_count <= $gif_count ) ? $gif_body : $jpeg_body;
+
+				return [
+					'response' => [
+						'code'    => 200,
+						'message' => 'OK',
+					],
+					'body'     => $body,
+				];
+			}
+		);
+	}
+
+	/**
+	 * Helper — register a pre_http_request filter that always returns a GIF.
+	 *
+	 * @param int &$call_count Reference to call counter.
+	 */
+	private function mock_always_gif( &$call_count ) {
+		$gif_body = $this->gif_body();
+
+		add_filter(
+			'pre_http_request',
+			function () use ( &$call_count, $gif_body ) {
+				$call_count++;
+
+				return [
+					'response' => [
+						'code'    => 200,
+						'message' => 'OK',
+					],
+					'body'     => $gif_body,
+				];
+			}
+		);
+	}
+
+	/**
+	 * When the first response is a GIF placeholder and the second is a JPEG,
+	 * save_image_from_url must make exactly 2 HTTP requests.
+	 */
+	public function test_gif_placeholder_triggers_one_retry() {
+		// Zero-second delays so the test does not actually sleep.
+		add_filter('wu_mshots_retry_delays', function() { return [0]; });
+
+		$call_count = 0;
+		$this->mock_gif_then_jpeg($call_count, 1);
+
+		Screenshot::save_image_from_url('https://example.com/test');
+
+		$this->assertSame(2, $call_count, 'Expected exactly 2 HTTP calls: 1 GIF + 1 JPEG retry.');
+	}
+
+	/**
+	 * When all responses are GIF placeholders, save_image_from_url returns false and
+	 * makes exactly (1 + count(delays)) HTTP requests before giving up.
+	 */
+	public function test_all_gif_responses_return_false_after_retries() {
+		// Use 3 retries (delays: 0, 0, 0) → 4 total attempts.
+		add_filter('wu_mshots_retry_delays', function() { return [0, 0, 0]; });
+
+		$call_count = 0;
+		$this->mock_always_gif($call_count);
+
+		$result = Screenshot::save_image_from_url('https://example.com/test');
+
+		$this->assertFalse($result, 'Expected false when all retries return GIF placeholder.');
+		$this->assertSame(4, $call_count, 'Expected 4 HTTP calls: 1 initial + 3 retries.');
+	}
+
+	/**
+	 * When wu_mshots_retry_delays returns an empty array, no retries are performed:
+	 * a GIF on the first (and only) attempt must immediately return false.
+	 */
+	public function test_empty_retry_delays_disables_retries() {
+		add_filter('wu_mshots_retry_delays', function() { return []; });
+
+		$call_count = 0;
+		$this->mock_always_gif($call_count);
+
+		$result = Screenshot::save_image_from_url('https://example.com/test');
+
+		$this->assertFalse($result);
+		$this->assertSame(1, $call_count, 'Expected exactly 1 HTTP call when retries are disabled.');
+	}
+
+	/**
+	 * A non-200 response after a GIF placeholder must abort immediately without
+	 * further retries.
+	 */
+	public function test_non_200_response_after_gif_aborts_immediately() {
+		add_filter('wu_mshots_retry_delays', function() { return [0, 0, 0]; });
+
+		$call_count = 0;
+		$gif_body   = $this->gif_body();
+
+		add_filter(
+			'pre_http_request',
+			function () use ( &$call_count, $gif_body ) {
+				$call_count++;
+				// First request returns GIF, second returns 503.
+				if ( $call_count === 1 ) {
+					return [
+						'response' => [ 'code' => 200, 'message' => 'OK' ],
+						'body'     => $gif_body,
+					];
+				}
+
+				return [
+					'response' => [ 'code' => 503, 'message' => 'Service Unavailable' ],
+					'body'     => '',
+				];
+			}
+		);
+
+		$result = Screenshot::save_image_from_url('https://example.com/test');
+
+		$this->assertFalse($result);
+		$this->assertSame(2, $call_count, 'Expected 2 HTTP calls: 1 GIF + 1 non-200, then stop.');
+	}
+
+	/**
+	 * A WP_Error response on a retry attempt must abort immediately without
+	 * further retries.
+	 */
+	public function test_wp_error_on_retry_aborts_immediately() {
+		add_filter('wu_mshots_retry_delays', function() { return [0, 0, 0]; });
+
+		$call_count = 0;
+		$gif_body   = $this->gif_body();
+
+		add_filter(
+			'pre_http_request',
+			function () use ( &$call_count, $gif_body ) {
+				$call_count++;
+				if ( $call_count === 1 ) {
+					return [
+						'response' => [ 'code' => 200, 'message' => 'OK' ],
+						'body'     => $gif_body,
+					];
+				}
+
+				return new \WP_Error('http_request_failed', 'Connection timed out.');
+			}
+		);
+
+		$result = Screenshot::save_image_from_url('https://example.com/test');
+
+		$this->assertFalse($result);
+		$this->assertSame(2, $call_count, 'Expected 2 HTTP calls: 1 GIF + 1 WP_Error, then stop.');
+	}
+
+	/**
+	 * A non-GIF, non-JPEG body (e.g. plain text) must return false immediately,
+	 * without triggering any retries.
+	 */
+	public function test_non_gif_non_jpeg_body_does_not_retry() {
+		add_filter('wu_mshots_retry_delays', function() { return [0, 0, 0]; });
+
+		$call_count = 0;
+
+		add_filter(
+			'pre_http_request',
+			function () use ( &$call_count ) {
+				$call_count++;
+
+				return [
+					'response' => [ 'code' => 200, 'message' => 'OK' ],
+					'body'     => 'unexpected plain-text body',
+				];
+			}
+		);
+
+		$result = Screenshot::save_image_from_url('https://example.com/test');
+
+		$this->assertFalse($result);
+		$this->assertSame(1, $call_count, 'Expected exactly 1 HTTP call for non-GIF unexpected body.');
+	}
+
+	/**
+	 * The default delay schedule contains exactly 5 entries (one per retry).
+	 * Verify the filter default value shape without relying on timing.
+	 */
+	public function test_default_retry_delays_contains_five_entries() {
+		$delays = apply_filters('wu_mshots_retry_delays', [3, 5, 8, 12, 15]);
+		$this->assertCount(5, $delays, 'Default retry schedule should have 5 delay entries.');
+	}
+
+	/**
+	 * The default delay schedule uses ascending values (increasing backoff).
+	 */
+	public function test_default_retry_delays_are_ascending() {
+		$delays = apply_filters('wu_mshots_retry_delays', [3, 5, 8, 12, 15]);
+		$sorted = $delays;
+		sort($sorted);
+		$this->assertSame($sorted, $delays, 'Default retry delays should be in ascending order.');
 	}
 }


### PR DESCRIPTION
## Summary

Follow-up to #997 (switch to mShots) and #1022 (User-Agent 403 fix).

WordPress.com mShots returns an ~8.7 KB GIF "loading" placeholder on the first request for a URL it hasn't recently cached. The real JPEG screenshot arrives 2-30 seconds later. Previously, the Screenshot helper treated the GIF response as "not a JPEG" and returned `false` immediately - meaning site screenshots silently failed for any uncached URL.

## Changes

- **`JPEG_MAGIC` / `GIF_MAGIC` constants** - named magic-byte signatures replace inline hex strings
- **`fetch_image_body()` method** - extracted from `save_image_from_url()`, handles HTTP fetch with GIF-placeholder retry loop (up to 5 retries with 3/5/8/12/15s backoff)
- **`wu_mshots_retry_delays` filter** - allows customising or disabling the retry schedule
- **HTTP errors abort immediately** - non-200 status codes and `WP_Error` responses do not trigger retries
- **8 new test cases** covering: GIF-to-JPEG retry, all-GIF exhaustion, empty delays (no retry), non-200 abort, WP_Error abort, unexpected body format, default delay count, ascending delay order

## Testing

All 16 Screenshot tests pass. 95.89% line coverage on `Screenshot` class.

```
vendor/bin/phpunit --filter Screenshot_Test
```

Resolves the mShots GIF placeholder issue observed after switching providers in #997.

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.80 plugin for [OpenCode](https://opencode.ai) v1.3.17 with claude-opus-4-6 spent 6m and 7,651 tokens on this with the user in an interactive session.