### PR TITLE
fix: bump sunrise to v2.0.0.11

### DIFF
--- a/sunrise.php
+++ b/sunrise.php
@@ -3,7 +3,7 @@
 /**
  * Ultimate Multisite Sunrise
  * Plugin URI: https://ultimatemultisite.com
- * Version: 2.0.0.10
+ * Version: 2.0.0.11
  * License: GPLv2
  * License URI: http://www.gnu.org/licenses/gpl-2.0.html
  *
@@ -18,16 +18,17 @@
  * @since 2.0.0.5 Change return statement to a continue statement to prevent an early exit from the file.
  * @since 2.0.0.9 Rename plugin file.
  * @since 2.0.0.10 Rename plugin file, again!
+ * @since 2.0.0.11 Use WP_PLUGIN_DIR/WPMU_PLUGIN_DIR constants when defined; remove multi-tenancy cookie domain override (moved to multi-tenancy plugin).
  *
  * @author      Arindo Duque
  * @category    WP_Ultimo
  * @package     WP_Ultimo/Sunrise
- * @version     2.0.0.10
+ * @version     2.0.0.11
  */
 
 defined('ABSPATH') || exit;
 
-const WP_ULTIMO_SUNRISE_VERSION = '2.0.0.10';
+const WP_ULTIMO_SUNRISE_VERSION = '2.0.0.11';
 
 $wu_sunrise = defined('WP_PLUGIN_DIR')
 	? WP_PLUGIN_DIR . '/ultimate-multisite/inc/class-sunrise.php'


### PR DESCRIPTION
## What

Bump `sunrise.php` to version 2.0.0.11.

## Why

Two behavioural changes landed in the live dropin that weren't yet reflected as a version increment in the plugin source:

1. **Use `WP_PLUGIN_DIR`/`WPMU_PLUGIN_DIR` when defined** — falls back to `WP_CONTENT_DIR`-based paths when the constants are absent. This is the correct behaviour for non-standard plugin directory configurations.
2. **Remove multi-tenancy cookie domain override** — the `COOKIE_DOMAIN` override block (which relied on `Ultimate_Multisite_Multi_Tenancy\Database_Router`) has been moved to the multi-tenancy plugin where it belongs. Keeping it in the shared sunrise caused it to run even on installs without multi-tenancy.

## Changes

- `sunrise.php`: version header, `@version` tag, `WP_ULTIMO_SUNRISE_VERSION` constant all bumped `2.0.0.10` → `2.0.0.11`
- `@since 2.0.0.11` changelog entry added to docblock

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.89 plugin for [OpenCode](https://opencode.ai) v1.3.17 with claude-sonnet-4-6 spent 2m and 7,662 tokens on this as a headless worker.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Sunrise plugin version to 2.0.0.11 with improved WordPress core compatibility.
  * Enhanced directory path resolution to use standard WordPress APIs for better integration.
  * Removed redundant multi-tenancy cookie configuration; now exclusively managed by the multi-tenancy plugin for improved plugin separation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->