### PR TITLE
bugfix: switch screenshot provider to Microlink with thum.io fallback

### DIFF
--- a/inc/helpers/class-screenshot.php
+++ b/inc/helpers/class-screenshot.php
@@ -2,6 +2,9 @@
 /**
  * Takes screenshots from websites.
  *
+ * Uses Microlink as the primary screenshot provider (free, no API key, supports
+ * viewport dimensions) with thum.io as a fallback.
+ *
  * @package WP_Ultimo
  * @subpackage Helper
  * @since 2.0.0
@@ -22,57 +25,121 @@ defined('ABSPATH') || exit;
 class Screenshot {
 
 	/**
-	 * JPEG file signature (magic bytes). Every valid JPEG starts with these three bytes.
+	 * PNG file signature (magic bytes).
+	 *
+	 * @since 2.0.0
+	 */
+	const PNG_MAGIC = "\x89\x50\x4e\x47\x0d\x0a\x1a\x0a";
+
+	/**
+	 * JPEG file signature (magic bytes).
 	 *
 	 * @since 2.0.11
 	 */
 	const JPEG_MAGIC = "\xFF\xD8\xFF";
 
 	/**
-	 * GIF file signature (magic bytes). mShots returns an 8.7 KB GIF "loading"
-	 * placeholder while the real screenshot is being generated.
+	 * Default viewport width for screenshots.
 	 *
 	 * @since 2.0.11
 	 */
-	const GIF_MAGIC = "\x47\x49\x46";
+	const DEFAULT_WIDTH = 1024;
 
 	/**
-	 * Returns the api link for the screenshot.
+	 * Default viewport height for screenshots.
 	 *
-	 * @since 2.0.0
+	 * @since 2.0.11
+	 */
+	const DEFAULT_HEIGHT = 768;
+
+	/**
+	 * Returns the primary (Microlink) API URL for a screenshot.
+	 *
+	 * Microlink returns a PNG image directly when the `embed=screenshot.url`
+	 * parameter is used. Free tier allows 50 requests/day without an API key.
+	 *
+	 * @since 2.0.11
 	 *
 	 * @param string $domain Original site domain.
+	 * @param int    $width  Viewport width.  Default 1024.
+	 * @param int    $height Viewport height. Default 768.
 	 */
-	public static function api_url($domain): string {
+	public static function api_url($domain, int $width = self::DEFAULT_WIDTH, int $height = self::DEFAULT_HEIGHT): string {
 
-		$url = 'https://s.wordpress.com/mshots/v1/' . rawurlencode('https://' . $domain) . '?w=1280';
+		$url = add_query_arg(
+			[
+				'url'              => 'https://' . $domain,
+				'screenshot'       => 'true',
+				'viewport.width'   => $width,
+				'viewport.height'  => $height,
+				'embed'            => 'screenshot.url',
+			],
+			'https://api.microlink.io/'
+		);
 
 		return apply_filters('wu_screenshot_api_url', $url, $domain);
 	}
 
 	/**
+	 * Returns the fallback (thum.io) API URL for a screenshot.
+	 *
+	 * @since 2.0.11
+	 *
+	 * @param string $domain Original site domain.
+	 * @param int    $width  Image width. Default 1024.
+	 * @param int    $height Crop height. Default 768.
+	 */
+	public static function fallback_api_url($domain, int $width = self::DEFAULT_WIDTH, int $height = self::DEFAULT_HEIGHT): string {
+
+		$url = 'https://image.thum.io/get/width/' . $width . '/crop/' . $height . '/noanimate/' . $domain;
+
+		/**
+		 * Filters the fallback screenshot API URL.
+		 *
+		 * @since 2.0.11
+		 *
+		 * @param string $url    The fallback API URL.
+		 * @param string $domain The site domain.
+		 */
+		return apply_filters('wu_screenshot_fallback_api_url', $url, $domain);
+	}
+
+	/**
 	 * Takes in a URL and creates it as an attachment.
+	 *
+	 * Tries the primary provider (Microlink) first, then falls back to thum.io
+	 * if the primary fails.
 	 *
 	 * @since 2.0.0
 	 *
 	 * @param string $url Image URL to download.
-	 * @return string|false
+	 * @return int|false Attachment ID on success, false on failure.
 	 */
 	public static function take_screenshot($url) {
 
-		$url = self::api_url($url);
+		$primary_api_url = self::api_url($url);
 
-		return self::save_image_from_url($url);
+		$result = self::save_image_from_url($primary_api_url);
+
+		if (false !== $result) {
+			return $result;
+		}
+
+		wu_log_add('screenshot-generator', __('Primary provider (Microlink) failed, trying fallback (thum.io).', 'ultimate-multisite'));
+
+		$fallback_api_url = self::fallback_api_url($url);
+
+		return self::save_image_from_url($fallback_api_url);
 	}
 
 	/**
 	 * Downloads the image from the URL and saves it as a WordPress attachment.
 	 *
-	 * Delegates the HTTP fetch (with mShots GIF-placeholder retry) to
-	 * {@see Screenshot::fetch_image_body()}.
+	 * Accepts both PNG and JPEG responses — the file extension and MIME type
+	 * are determined from the actual response body, not assumed.
 	 *
 	 * @since 2.0.0
-	 * @since 2.0.11 HTTP fetch extracted into fetch_image_body() with GIF retry logic.
+	 * @since 2.0.11 Accepts both PNG and JPEG; format auto-detected from response body.
 	 *
 	 * @param string $url Image URL to download.
 	 * @return int|false Attachment ID on success, false on failure.
@@ -82,13 +149,42 @@ class Screenshot {
 		// translators: %s is the API URL.
 		$log_prefix = sprintf(__('Downloading image from "%s":', 'ultimate-multisite'), $url) . ' ';
 
-		$body = self::fetch_image_body($url, $log_prefix);
+		$response = wp_remote_get(
+			$url,
+			[
+				'timeout'    => 50,
+				'user-agent' => 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36',
+			]
+		);
 
-		if (false === $body) {
+		if (is_wp_error($response)) {
+			wu_log_add('screenshot-generator', $log_prefix . $response->get_error_message(), LogLevel::ERROR);
+
 			return false;
 		}
 
-		$upload = wp_upload_bits('screenshot-' . gmdate('Y-m-d-H-i-s') . '.jpg', null, $body);
+		if (wp_remote_retrieve_response_code($response) !== 200) {
+			wu_log_add('screenshot-generator', $log_prefix . wp_remote_retrieve_response_message($response), LogLevel::ERROR);
+
+			return false;
+		}
+
+		$body = $response['body'];
+
+		/*
+		 * Detect image format from magic bytes.
+		 */
+		if (str_starts_with($body, self::PNG_MAGIC)) {
+			$extension = 'png';
+		} elseif (str_starts_with($body, self::JPEG_MAGIC)) {
+			$extension = 'jpg';
+		} else {
+			wu_log_add('screenshot-generator', $log_prefix . __('Result is not a valid image file (expected PNG or JPEG).', 'ultimate-multisite'), LogLevel::ERROR);
+
+			return false;
+		}
+
+		$upload = wp_upload_bits('screenshot-' . gmdate('Y-m-d-H-i-s') . '.' . $extension, null, $body);
 
 		if ( ! empty($upload['error'])) {
 			wu_log_add('screenshot-generator', $log_prefix . wp_json_encode($upload['error']), LogLevel::ERROR);
@@ -125,125 +221,5 @@ class Screenshot {
 		wu_log_add('screenshot-generator', $log_prefix . __('Success!', 'ultimate-multisite'));
 
 		return $attach_id;
-	}
-
-	/**
-	 * Fetches the raw image body from a URL, retrying when mShots returns a GIF placeholder.
-	 *
-	 * mShots (s.wordpress.com/mshots/v1/) returns an ~8.7 KB GIF "loading" placeholder on the
-	 * first request to a URL it has not recently cached; the real JPEG arrives 2–30 seconds
-	 * later on subsequent requests. This method detects the GIF signature and retries up to
-	 * five times with increasing wait intervals before giving up.
-	 *
-	 * HTTP errors (non-200 status or WP_Error) abort immediately without further retries.
-	 *
-	 * The retry schedule can be customised via the {@see 'wu_mshots_retry_delays'} filter.
-	 *
-	 * @since 2.0.11
-	 *
-	 * @param string $url        Image URL to fetch.
-	 * @param string $log_prefix Log message prefix for contextual logging.
-	 * @return string|false Raw JPEG image bytes on success, false on failure.
-	 */
-	protected static function fetch_image_body(string $url, string $log_prefix) {
-
-		/**
-		 * Filters the retry delay schedule (in seconds) used when mShots returns a GIF placeholder.
-		 *
-		 * The array defines wait times before each successive retry attempt.  The first HTTP
-		 * request is always immediate; each element adds one retry attempt after sleeping the
-		 * given number of seconds.  Pass an empty array to disable retries entirely.
-		 *
-		 * Example — shorten delays for unit tests:
-		 *   add_filter( 'wu_mshots_retry_delays', fn() => [ 0, 0 ] );
-		 *
-		 * @since 2.0.11
-		 *
-		 * @param int[] $delays Seconds to wait before each successive retry. Default [3, 5, 8, 12, 15].
-		 */
-		$retry_delays = (array) apply_filters('wu_mshots_retry_delays', [3, 5, 8, 12, 15]);
-
-		/*
-		 * Build the full attempt schedule: one immediate first attempt (delay 0) followed
-		 * by one attempt per entry in $retry_delays.
-		 *   e.g. [0, 3, 5, 8, 12, 15] → 6 total attempts.
-		 */
-		$all_delays  = array_merge([0], $retry_delays);
-		$total       = count($all_delays);
-
-		foreach ($all_delays as $attempt_index => $delay) {
-
-			if ($delay > 0) {
-				sleep($delay); // phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.sleep_sleep
-			}
-
-			$response = wp_remote_get(
-				$url,
-				[
-					'timeout'    => 50,
-					'user-agent' => 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36',
-				]
-			);
-
-			if (is_wp_error($response)) {
-				wu_log_add('screenshot-generator', $log_prefix . $response->get_error_message(), LogLevel::ERROR);
-
-				return false;
-			}
-
-			if (wp_remote_retrieve_response_code($response) !== 200) {
-				wu_log_add('screenshot-generator', $log_prefix . wp_remote_retrieve_response_message($response), LogLevel::ERROR);
-
-				return false;
-			}
-
-			$body = $response['body'];
-
-			/*
-			 * Success: the response is a JPEG — return the body for saving.
-			 */
-			if (str_starts_with($body, self::JPEG_MAGIC)) {
-				return $body;
-			}
-
-			/*
-			 * mShots GIF placeholder detected. Log and retry if attempts remain,
-			 * otherwise log the final failure and fall through to return false.
-			 */
-			if (str_starts_with($body, self::GIF_MAGIC)) {
-
-				$is_last_attempt = ($attempt_index + 1 >= $total);
-
-				if ($is_last_attempt) {
-					wu_log_add(
-						'screenshot-generator',
-						$log_prefix . __('mShots still returning loading placeholder after all retries.', 'ultimate-multisite'),
-						LogLevel::ERROR
-					);
-				} else {
-					wu_log_add(
-						'screenshot-generator',
-						$log_prefix . sprintf(
-							/* translators: 1: current attempt number, 2: total attempts, 3: seconds until next retry */
-							__('mShots loading placeholder on attempt %1$d of %2$d, retrying in %3$ds.', 'ultimate-multisite'),
-							$attempt_index + 1,
-							$total,
-							$retry_delays[$attempt_index]
-						)
-					);
-				}
-
-				continue;
-			}
-
-			/*
-			 * Unexpected body format — neither JPEG nor GIF. Do not retry.
-			 */
-			wu_log_add('screenshot-generator', $log_prefix . __('Result is not a JPEG file.', 'ultimate-multisite'), LogLevel::ERROR);
-
-			return false;
-		}
-
-		return false;
 	}
 }

--- a/readme.txt
+++ b/readme.txt
@@ -154,11 +154,11 @@ For a private server with a dedicated IP, the webserver can be setup to serve th
 
 = Site screenshots show a Cloudflare challenge page instead of the actual site =
 
-Ultimate Multisite uses [WordPress.com mShots](https://mshots.wordpress.com/) to generate site screenshots. If your network is behind Cloudflare with Bot Fight Mode or similar protections enabled, the screenshot service may be blocked and return a Cloudflare challenge page instead of your site screenshot.
+Ultimate Multisite uses [Microlink](https://microlink.io/) as its primary screenshot provider and falls back to [thum.io](https://www.thum.io/) if Microlink is unavailable. If your network is behind Cloudflare with Bot Fight Mode or similar protections enabled, the screenshot service may be blocked and return a Cloudflare challenge page instead of your site screenshot.
 
-**Solution:** Create a Cloudflare WAF exception rule to allow the mShots crawler, or temporarily disable Bot Fight Mode for screenshot generation.
+**Solution:** Create a Cloudflare WAF exception rule to allow the screenshot service crawlers, or temporarily disable Bot Fight Mode for screenshot generation.
 
-**Note:** Screenshots require sites to be publicly accessible. Local development environments cannot generate screenshots regardless of Cloudflare settings.
+**Note:** Screenshots require sites to be publicly accessible. Local development environments cannot generate screenshots regardless of Cloudflare settings. Microlink's free tier allows 50 screenshot requests per day without an API key — this is generally sufficient since screenshots are only taken once per site at creation time.
 
 == Requirements ==
 
@@ -210,6 +210,19 @@ This plugin connects to external services to provide optional functionality. All
 - Processes PayPal payments
 - https://www.paypal.com/us/legalhub/privacy-full
 
+= Site Screenshots =
+
+**Microlink** (primary)
+- Generates site thumbnail screenshots using a headless browser
+- Sends only the target site URL; no user data is transmitted
+- Free tier: 50 requests per day without an API key
+- https://microlink.io/privacy
+
+**thum.io** (fallback)
+- Used as a fallback when Microlink is unavailable
+- Sends only the target site URL; no user data is transmitted
+- https://www.thum.io/
+
 = Hosting Integrations =
 
 Integrations may send site configuration data and API credentials only when explicitly enabled.
@@ -238,7 +251,7 @@ Version [2.9.1] - Released on 2026-05-01
 - Fix: Trial period now correctly applied for returning customers whose cancelled subscription had zero renewals
 - Fix: Site import no longer fails when the target URL has no http:// scheme
 - Fix: Export modal now downloads the ZIP file immediately on synchronous export
-- Fix: mShots screenshot capture now retries when the service returns a loading placeholder
+- Improved: Screenshot provider switched to Microlink (free, 1024x768 viewport) with thum.io fallback, replacing unreliable mShots
 
 Version [2.9.0] - Released on 2026-04-30
 - New: Single-site export and import added under Tools > Export & Import

--- a/tests/WP_Ultimo/Helpers/Screenshot_Test.php
+++ b/tests/WP_Ultimo/Helpers/Screenshot_Test.php
@@ -21,58 +21,68 @@ class Screenshot_Test extends WP_UnitTestCase {
 	 */
 	public function tear_down() {
 		remove_all_filters('wu_screenshot_api_url');
-		remove_all_filters('wu_mshots_retry_delays');
+		remove_all_filters('wu_screenshot_fallback_api_url');
 		remove_all_filters('pre_http_request');
 		parent::tear_down();
 	}
 
 	// ------------------------------------------------------------------
-	// api_url
+	// Helper stubs
 	// ------------------------------------------------------------------
 
-	/**
-	 * Test api_url returns a string.
-	 */
+	private function png_body() {
+		return "\x89\x50\x4e\x47\x0d\x0a\x1a\x0a" . str_repeat("\x00", 100);
+	}
+
+	private function jpeg_body() {
+		return "\xFF\xD8\xFF\xE0\x00\x10JFIF\x00";
+	}
+
+	// ------------------------------------------------------------------
+	// api_url (Microlink — primary)
+	// ------------------------------------------------------------------
+
 	public function test_api_url_returns_string() {
 		$url = Screenshot::api_url('example.com');
 		$this->assertIsString($url);
 	}
 
-	/**
-	 * Test api_url contains the domain.
-	 */
 	public function test_api_url_contains_domain() {
 		$url = Screenshot::api_url('example.com');
 		$this->assertStringContainsString('example.com', $url);
 	}
 
-	/**
-	 * Test api_url uses WordPress.com mShots service.
-	 */
-	public function test_api_url_uses_mshots() {
+	public function test_api_url_uses_microlink() {
 		$url = Screenshot::api_url('example.com');
-		$this->assertStringContainsString('s.wordpress.com/mshots/v1/', $url);
+		$this->assertStringContainsString('api.microlink.io', $url);
 	}
 
-	/**
-	 * Test api_url includes width query parameter.
-	 */
-	public function test_api_url_includes_width_parameter() {
+	public function test_api_url_includes_screenshot_param() {
 		$url = Screenshot::api_url('example.com');
-		$this->assertStringContainsString('w=1280', $url);
+		$this->assertStringContainsString('screenshot=true', $url);
 	}
 
-	/**
-	 * Test api_url prepends https:// to the domain before encoding.
-	 */
-	public function test_api_url_prepends_https_to_domain() {
+	public function test_api_url_includes_embed_param() {
 		$url = Screenshot::api_url('example.com');
-		$this->assertStringContainsString(rawurlencode('https://example.com'), $url);
+		$this->assertStringContainsString('embed=screenshot.url', $url);
 	}
 
-	/**
-	 * Test api_url filter can override the URL.
-	 */
+	public function test_api_url_includes_default_viewport_width() {
+		$url = Screenshot::api_url('example.com');
+		$this->assertStringContainsString('viewport.width=1024', $url);
+	}
+
+	public function test_api_url_includes_default_viewport_height() {
+		$url = Screenshot::api_url('example.com');
+		$this->assertStringContainsString('viewport.height=768', $url);
+	}
+
+	public function test_api_url_accepts_custom_dimensions() {
+		$url = Screenshot::api_url('example.com', 1920, 1080);
+		$this->assertStringContainsString('viewport.width=1920', $url);
+		$this->assertStringContainsString('viewport.height=1080', $url);
+	}
+
 	public function test_api_url_filter_can_override() {
 		add_filter(
 			'wu_screenshot_api_url',
@@ -88,284 +98,217 @@ class Screenshot_Test extends WP_UnitTestCase {
 	}
 
 	// ------------------------------------------------------------------
-	// take_screenshot / save_image_from_url — non-retry paths
+	// fallback_api_url (thum.io)
 	// ------------------------------------------------------------------
 
-	/**
-	 * Test take_screenshot returns false when response body is not a JPEG.
-	 */
-	public function test_take_screenshot_returns_false_for_invalid_url() {
-		// Will fail because the mock body is not a valid JPEG.
+	public function test_fallback_api_url_uses_thum_io() {
+		$url = Screenshot::fallback_api_url('example.com');
+		$this->assertStringContainsString('image.thum.io', $url);
+	}
+
+	public function test_fallback_api_url_includes_default_width() {
+		$url = Screenshot::fallback_api_url('example.com');
+		$this->assertStringContainsString('width/1024', $url);
+	}
+
+	public function test_fallback_api_url_includes_default_crop() {
+		$url = Screenshot::fallback_api_url('example.com');
+		$this->assertStringContainsString('crop/768', $url);
+	}
+
+	public function test_fallback_api_url_includes_noanimate() {
+		$url = Screenshot::fallback_api_url('example.com');
+		$this->assertStringContainsString('noanimate', $url);
+	}
+
+	public function test_fallback_api_url_accepts_custom_dimensions() {
+		$url = Screenshot::fallback_api_url('example.com', 1920, 1080);
+		$this->assertStringContainsString('width/1920', $url);
+		$this->assertStringContainsString('crop/1080', $url);
+	}
+
+	public function test_fallback_api_url_filter_can_override() {
+		add_filter(
+			'wu_screenshot_fallback_api_url',
+			function ( $url, $domain ) {
+				return 'https://other-fallback.com/' . $domain;
+			},
+			10,
+			2
+		);
+
+		$url = Screenshot::fallback_api_url('example.com');
+		$this->assertEquals('https://other-fallback.com/example.com', $url);
+	}
+
+	// ------------------------------------------------------------------
+	// save_image_from_url — image format detection
+	// ------------------------------------------------------------------
+
+	public function test_save_image_returns_false_for_non_image_body() {
 		add_filter(
 			'pre_http_request',
 			function () {
 				return [
-					'response' => [
-						'code'    => 200,
-						'message' => 'OK',
-					],
-					'body'     => 'not a jpeg',
+					'response' => [ 'code' => 200, 'message' => 'OK' ],
+					'body'     => 'not an image',
 				];
 			}
 		);
 
-		$result = Screenshot::take_screenshot('http://nonexistent.invalid');
+		$result = Screenshot::save_image_from_url('https://example.com/test');
 		$this->assertFalse($result);
 	}
 
-	/**
-	 * Test take_screenshot returns false on HTTP error.
-	 */
-	public function test_take_screenshot_returns_false_on_http_error() {
+	public function test_save_image_returns_false_on_http_error() {
 		add_filter(
 			'pre_http_request',
 			function () {
 				return [
-					'response' => [
-						'code'    => 500,
-						'message' => 'Server Error',
-					],
-					'body'     => '',
-				];
-			}
-		);
-
-		$result = Screenshot::take_screenshot('http://example.com');
-		$this->assertFalse($result);
-	}
-
-	// ------------------------------------------------------------------
-	// mShots GIF placeholder retry logic
-	// ------------------------------------------------------------------
-
-	/**
-	 * Helper — build a GIF89a stub body (passes GIF magic-byte check).
-	 *
-	 * @return string
-	 */
-	private function gif_body() {
-		return "GIF89a\x01\x00\x01\x00\x00\x00\x00;";
-	}
-
-	/**
-	 * Helper — build a minimal JPEG stub body (passes JPEG magic-byte check).
-	 *
-	 * @return string
-	 */
-	private function jpeg_body() {
-		return "\xFF\xD8\xFF\xE0\x00\x10JFIF\x00";
-	}
-
-	/**
-	 * Helper — register a pre_http_request filter that returns $gif_count GIF responses
-	 * and then switches to JPEG for all subsequent requests.
-	 *
-	 * @param int &$call_count Reference to call counter (incremented on each request).
-	 * @param int  $gif_count  Number of initial GIF responses before switching to JPEG.
-	 */
-	private function mock_gif_then_jpeg( &$call_count, $gif_count ) {
-		$gif_body  = $this->gif_body();
-		$jpeg_body = $this->jpeg_body();
-
-		add_filter(
-			'pre_http_request',
-			function () use ( &$call_count, $gif_body, $jpeg_body, $gif_count ) {
-				$call_count++;
-				$body = ( $call_count <= $gif_count ) ? $gif_body : $jpeg_body;
-
-				return [
-					'response' => [
-						'code'    => 200,
-						'message' => 'OK',
-					],
-					'body'     => $body,
-				];
-			}
-		);
-	}
-
-	/**
-	 * Helper — register a pre_http_request filter that always returns a GIF.
-	 *
-	 * @param int &$call_count Reference to call counter.
-	 */
-	private function mock_always_gif( &$call_count ) {
-		$gif_body = $this->gif_body();
-
-		add_filter(
-			'pre_http_request',
-			function () use ( &$call_count, $gif_body ) {
-				$call_count++;
-
-				return [
-					'response' => [
-						'code'    => 200,
-						'message' => 'OK',
-					],
-					'body'     => $gif_body,
-				];
-			}
-		);
-	}
-
-	/**
-	 * When the first response is a GIF placeholder and the second is a JPEG,
-	 * save_image_from_url must make exactly 2 HTTP requests.
-	 */
-	public function test_gif_placeholder_triggers_one_retry() {
-		// Zero-second delays so the test does not actually sleep.
-		add_filter('wu_mshots_retry_delays', function() { return [0]; });
-
-		$call_count = 0;
-		$this->mock_gif_then_jpeg($call_count, 1);
-
-		Screenshot::save_image_from_url('https://example.com/test');
-
-		$this->assertSame(2, $call_count, 'Expected exactly 2 HTTP calls: 1 GIF + 1 JPEG retry.');
-	}
-
-	/**
-	 * When all responses are GIF placeholders, save_image_from_url returns false and
-	 * makes exactly (1 + count(delays)) HTTP requests before giving up.
-	 */
-	public function test_all_gif_responses_return_false_after_retries() {
-		// Use 3 retries (delays: 0, 0, 0) → 4 total attempts.
-		add_filter('wu_mshots_retry_delays', function() { return [0, 0, 0]; });
-
-		$call_count = 0;
-		$this->mock_always_gif($call_count);
-
-		$result = Screenshot::save_image_from_url('https://example.com/test');
-
-		$this->assertFalse($result, 'Expected false when all retries return GIF placeholder.');
-		$this->assertSame(4, $call_count, 'Expected 4 HTTP calls: 1 initial + 3 retries.');
-	}
-
-	/**
-	 * When wu_mshots_retry_delays returns an empty array, no retries are performed:
-	 * a GIF on the first (and only) attempt must immediately return false.
-	 */
-	public function test_empty_retry_delays_disables_retries() {
-		add_filter('wu_mshots_retry_delays', function() { return []; });
-
-		$call_count = 0;
-		$this->mock_always_gif($call_count);
-
-		$result = Screenshot::save_image_from_url('https://example.com/test');
-
-		$this->assertFalse($result);
-		$this->assertSame(1, $call_count, 'Expected exactly 1 HTTP call when retries are disabled.');
-	}
-
-	/**
-	 * A non-200 response after a GIF placeholder must abort immediately without
-	 * further retries.
-	 */
-	public function test_non_200_response_after_gif_aborts_immediately() {
-		add_filter('wu_mshots_retry_delays', function() { return [0, 0, 0]; });
-
-		$call_count = 0;
-		$gif_body   = $this->gif_body();
-
-		add_filter(
-			'pre_http_request',
-			function () use ( &$call_count, $gif_body ) {
-				$call_count++;
-				// First request returns GIF, second returns 503.
-				if ( $call_count === 1 ) {
-					return [
-						'response' => [ 'code' => 200, 'message' => 'OK' ],
-						'body'     => $gif_body,
-					];
-				}
-
-				return [
-					'response' => [ 'code' => 503, 'message' => 'Service Unavailable' ],
+					'response' => [ 'code' => 500, 'message' => 'Server Error' ],
 					'body'     => '',
 				];
 			}
 		);
 
 		$result = Screenshot::save_image_from_url('https://example.com/test');
-
 		$this->assertFalse($result);
-		$this->assertSame(2, $call_count, 'Expected 2 HTTP calls: 1 GIF + 1 non-200, then stop.');
 	}
 
-	/**
-	 * A WP_Error response on a retry attempt must abort immediately without
-	 * further retries.
-	 */
-	public function test_wp_error_on_retry_aborts_immediately() {
-		add_filter('wu_mshots_retry_delays', function() { return [0, 0, 0]; });
-
-		$call_count = 0;
-		$gif_body   = $this->gif_body();
-
+	public function test_save_image_returns_false_on_wp_error() {
 		add_filter(
 			'pre_http_request',
-			function () use ( &$call_count, $gif_body ) {
-				$call_count++;
-				if ( $call_count === 1 ) {
-					return [
-						'response' => [ 'code' => 200, 'message' => 'OK' ],
-						'body'     => $gif_body,
-					];
-				}
-
+			function () {
 				return new \WP_Error('http_request_failed', 'Connection timed out.');
 			}
 		);
 
 		$result = Screenshot::save_image_from_url('https://example.com/test');
-
 		$this->assertFalse($result);
-		$this->assertSame(2, $call_count, 'Expected 2 HTTP calls: 1 GIF + 1 WP_Error, then stop.');
 	}
 
-	/**
-	 * A non-GIF, non-JPEG body (e.g. plain text) must return false immediately,
-	 * without triggering any retries.
-	 */
-	public function test_non_gif_non_jpeg_body_does_not_retry() {
-		add_filter('wu_mshots_retry_delays', function() { return [0, 0, 0]; });
-
-		$call_count = 0;
-
+	public function test_save_image_accepts_png_body() {
 		add_filter(
 			'pre_http_request',
-			function () use ( &$call_count ) {
-				$call_count++;
-
+			function () {
 				return [
 					'response' => [ 'code' => 200, 'message' => 'OK' ],
-					'body'     => 'unexpected plain-text body',
+					'body'     => $this->png_body(),
 				];
 			}
 		);
 
 		$result = Screenshot::save_image_from_url('https://example.com/test');
 
+		// Returns an attachment ID (integer) on success.
+		$this->assertIsInt($result);
+		$this->assertGreaterThan(0, $result);
+	}
+
+	public function test_save_image_accepts_jpeg_body() {
+		add_filter(
+			'pre_http_request',
+			function () {
+				return [
+					'response' => [ 'code' => 200, 'message' => 'OK' ],
+					'body'     => $this->jpeg_body(),
+				];
+			}
+		);
+
+		$result = Screenshot::save_image_from_url('https://example.com/test');
+
+		$this->assertIsInt($result);
+		$this->assertGreaterThan(0, $result);
+	}
+
+	// ------------------------------------------------------------------
+	// take_screenshot — fallback behaviour
+	// ------------------------------------------------------------------
+
+	public function test_take_screenshot_returns_false_when_both_providers_fail() {
+		add_filter(
+			'pre_http_request',
+			function () {
+				return [
+					'response' => [ 'code' => 200, 'message' => 'OK' ],
+					'body'     => 'not an image',
+				];
+			}
+		);
+
+		$result = Screenshot::take_screenshot('example.com');
 		$this->assertFalse($result);
-		$this->assertSame(1, $call_count, 'Expected exactly 1 HTTP call for non-GIF unexpected body.');
 	}
 
-	/**
-	 * The default delay schedule contains exactly 5 entries (one per retry).
-	 * Verify the filter default value shape without relying on timing.
-	 */
-	public function test_default_retry_delays_contains_five_entries() {
-		$delays = apply_filters('wu_mshots_retry_delays', [3, 5, 8, 12, 15]);
-		$this->assertCount(5, $delays, 'Default retry schedule should have 5 delay entries.');
+	public function test_take_screenshot_succeeds_on_primary_provider() {
+		$png_body = $this->png_body();
+
+		add_filter(
+			'pre_http_request',
+			function () use ( $png_body ) {
+				return [
+					'response' => [ 'code' => 200, 'message' => 'OK' ],
+					'body'     => $png_body,
+				];
+			}
+		);
+
+		$result = Screenshot::take_screenshot('example.com');
+		$this->assertIsInt($result);
+		$this->assertGreaterThan(0, $result);
 	}
 
-	/**
-	 * The default delay schedule uses ascending values (increasing backoff).
-	 */
-	public function test_default_retry_delays_are_ascending() {
-		$delays = apply_filters('wu_mshots_retry_delays', [3, 5, 8, 12, 15]);
-		$sorted = $delays;
-		sort($sorted);
-		$this->assertSame($sorted, $delays, 'Default retry delays should be in ascending order.');
+	public function test_take_screenshot_falls_back_to_thum_io_on_primary_failure() {
+		$call_count = 0;
+		$png_body   = $this->png_body();
+
+		add_filter(
+			'pre_http_request',
+			function ( $preempt, $args, $url ) use ( &$call_count, $png_body ) {
+				$call_count++;
+
+				// First call (Microlink) fails, second call (thum.io) succeeds.
+				if (strpos($url, 'microlink') !== false) {
+					return [
+						'response' => [ 'code' => 429, 'message' => 'Too Many Requests' ],
+						'body'     => '',
+					];
+				}
+
+				return [
+					'response' => [ 'code' => 200, 'message' => 'OK' ],
+					'body'     => $png_body,
+				];
+			},
+			10,
+			3
+		);
+
+		$result = Screenshot::take_screenshot('example.com');
+
+		$this->assertIsInt($result, 'Expected fallback (thum.io) to succeed after Microlink failure.');
+		$this->assertSame(2, $call_count, 'Expected 2 HTTP calls: 1 Microlink (failed) + 1 thum.io.');
+	}
+
+	public function test_take_screenshot_does_not_call_fallback_when_primary_succeeds() {
+		$call_count = 0;
+		$png_body   = $this->png_body();
+
+		add_filter(
+			'pre_http_request',
+			function () use ( &$call_count, $png_body ) {
+				$call_count++;
+
+				return [
+					'response' => [ 'code' => 200, 'message' => 'OK' ],
+					'body'     => $png_body,
+				];
+			}
+		);
+
+		Screenshot::take_screenshot('example.com');
+
+		$this->assertSame(1, $call_count, 'Expected only 1 HTTP call when primary succeeds.');
 	}
 }


### PR DESCRIPTION
## Summary

Replace mShots (WordPress.com) with Microlink as the primary screenshot provider, restoring thum.io as fallback. Follow-up to #997, #1022, and #1065.

**Why:** mShots was slow, unreliable (GIF loading placeholders requiring retry logic), and the service quality degraded over time. Microlink is free (50 req/day without API key), supports viewport dimensions, and returns screenshots directly.

## Changes

**`inc/helpers/class-screenshot.php`**
- **`api_url()`** — now generates Microlink API URL with `viewport.width` and `viewport.height` params (default 1024x768)
- **`fallback_api_url()`** — new method returning thum.io URL (the original provider before #997)
- **`take_screenshot()`** — tries Microlink first, falls back to thum.io on failure
- **`save_image_from_url()`** — simplified, accepts both PNG and JPEG (auto-detected from magic bytes), no retry logic needed
- Removed mShots GIF-placeholder retry logic (`fetch_image_body()`) — not needed with Microlink/thum.io
- New filters: `wu_screenshot_fallback_api_url`
- Existing filter preserved: `wu_screenshot_api_url`

**`tests/WP_Ultimo/Helpers/Screenshot_Test.php`**
- 20 test cases covering: Microlink URL shape, thum.io fallback URL shape, custom viewport dimensions, PNG acceptance, JPEG acceptance, fallback on primary failure, filter overrides, error handling

## Provider Comparison

| Feature | mShots (removed) | Microlink (primary) | thum.io (fallback) |
|---|---|---|---|
| API key required | No | No | No |
| Viewport control | Width only | Width + Height | Width + Crop |
| Response format | JPEG (with GIF placeholder) | PNG | PNG |
| Reliability | Poor (GIF placeholders, slow) | Good | Good (Cloudflare may block) |
| Free tier | Unlimited | 50/day | Unlimited |

## Testing

- PHP syntax: clean (`php -l`)
- PHPStan level 0: clean
- Unit tests: 20 tests (PHPUnit env has a pre-existing WP 7.0-RC2 stubs conflict unrelated to this change)

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.89 plugin for [OpenCode](https://opencode.ai) v1.3.17 with claude-opus-4-6 spent 4h 42m and 23,013 tokens on this with the user in an interactive session.