### PR TITLE
bugfix: revert wordpress-stubs autoload-dev entry that broke unit tests

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -68,6 +68,7 @@
         "maxmind-db/reader": "^1.12"
     },
     "require-dev": {
+
         "composer/installers": "^1.9.0",
         "phpunit/phpunit": "^9.6.22",
         "yoast/phpunit-polyfills": "^1.1.3",
@@ -202,10 +203,7 @@
         "psr-4": {
             "Utils\\Rector\\": "utils/rector/src",
             "Utils\\Rector\\Tests\\": "utils/rector/tests"
-        },
-        "files": [
-            "vendor/php-stubs/wordpress-stubs/wordpress-stubs.php"
-        ]
+        }
     },
     "replace": {
         "paragonie/random_compat": "9.99.99"


### PR DESCRIPTION
## Summary

Reverts commit bec236677b6a9e5668b08455bd59e7275c3b865e which added `vendor/php-stubs/wordpress-stubs/wordpress-stubs.php` to the `autoload-dev.files` array in `composer.json`.

## Problem

The commit added wordpress-stubs to the `autoload-dev` `files` autoloader so the phpactor LSP could index WordPress symbols. However this causes the stubs file to be loaded during PHPUnit bootstrapping, which conflicts with the WordPress test environment stubs already loaded by `/tmp/wordpress-tests-lib`, breaking the test suite.

## Changes

- Reverts `composer.json` to remove `vendor/php-stubs/wordpress-stubs/wordpress-stubs.php` from `autoload-dev.files`
- Restores the blank line before `require-dev` that was also removed in the original commit

## Verification

```bash
composer install
vendor/bin/phpunit --filter Cart_Test
```

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.89 plugin for [OpenCode](https://opencode.ai) v1.3.17 with claude-sonnet-4-6 spent 1m and 2,135 tokens on this as a headless worker.
