### PR TITLE
GH#1092: fix: strip ports from cookie domains

### DIFF
--- a/inc/managers/class-domain-manager.php
+++ b/inc/managers/class-domain-manager.php
@@ -247,6 +247,13 @@ class Domain_Manager extends Base_Manager {
 	 */
 	public function determine_cookie_domain(string $host, string $network_domain): ?string {
 
+		$host           = $this->normalize_cookie_domain_host($host);
+		$network_domain = $this->normalize_cookie_domain_host($network_domain);
+
+		if ('' === $host || '' === $network_domain) {
+			return null;
+		}
+
 		// Case 1: Mapped domain — host does not belong to the network domain at all.
 		if ( ! preg_match('/' . preg_quote($network_domain, '/') . '$/', '.' . $host)) {
 			return '.' . $host;
@@ -263,6 +270,35 @@ class Domain_Manager extends Base_Manager {
 
 		// Host is the network root domain itself — no override needed.
 		return null;
+	}
+
+	/**
+	 * Normalizes a host before using it as a cookie domain.
+	 *
+	 * Browser cookie domain attributes must contain only the hostname. Non-standard
+	 * local/staging ports in HTTP_HOST (for example, example.com:8080) must not be
+	 * copied into COOKIE_DOMAIN because browsers reject malformed domain attributes.
+	 *
+	 * @since 2.4.8
+	 *
+	 * @param string $host The raw host value.
+	 * @return string The host without a port suffix or trailing dot.
+	 */
+	protected function normalize_cookie_domain_host(string $host): string {
+
+		$host = trim($host);
+
+		if ('' === $host) {
+			return '';
+		}
+
+		$parsed_host = wp_parse_url('http://' . $host, PHP_URL_HOST);
+
+		if (is_string($parsed_host) && '' !== $parsed_host) {
+			$host = $parsed_host;
+		}
+
+		return rtrim($host, '.');
 	}
 
 	/**

--- a/tests/WP_Ultimo/Managers/Domain_Manager_Test.php
+++ b/tests/WP_Ultimo/Managers/Domain_Manager_Test.php
@@ -2058,6 +2058,30 @@ class Domain_Manager_Test extends WP_UnitTestCase {
 		$this->assertEquals('.www.ultimatemultisite.com', $result, 'www subdomain should use specific cookie domain');
 	}
 
+	/**
+	 * HTTP_HOST values with non-standard ports must not copy the port into COOKIE_DOMAIN.
+	 */
+	public function test_determine_cookie_domain_strips_port_from_mapped_domain(): void {
+		$result = $this->domain_manager->determine_cookie_domain('translate.example.com:8080', 'ultimatemultisite.com');
+		$this->assertEquals('.translate.example.com', $result, 'Mapped domain cookie attribute must not include a port');
+	}
+
+	/**
+	 * Subdomain subsites on non-standard ports should keep the specific host without the port.
+	 */
+	public function test_determine_cookie_domain_strips_port_from_subdomain_subsite(): void {
+		$result = $this->domain_manager->determine_cookie_domain('translate.ultimatemultisite.com:8080', 'ultimatemultisite.com');
+		$this->assertEquals('.translate.ultimatemultisite.com', $result, 'Subdomain subsite cookie attribute must not include a port');
+	}
+
+	/**
+	 * Network root hosts with a port should still use the default WordPress cookie domain.
+	 */
+	public function test_determine_cookie_domain_network_root_with_port_returns_null(): void {
+		$result = $this->domain_manager->determine_cookie_domain('ultimatemultisite.com:8080', 'ultimatemultisite.com');
+		$this->assertNull($result, 'Network root with a port should not require a COOKIE_DOMAIN override');
+	}
+
 	// ----------------------------------------------------------------
 	// NEW: try_again_time filter
 	// ----------------------------------------------------------------


### PR DESCRIPTION
## Summary

Normalize Domain_Manager cookie-domain hosts before comparison so HTTP_HOST values like sub.test:8080 define COOKIE_DOMAIN without the invalid port suffix. Added Domain_Manager tests for mapped domains, subdomain subsites, and network-root hosts on non-standard ports.

## Files Changed

inc/managers/class-domain-manager.php,tests/WP_Ultimo/Managers/Domain_Manager_Test.php

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** WP_TESTS_DIR=/tmp/wordpress-tests-lib vendor/bin/phpunit --filter Domain_Manager_Test (pass: 133 tests, 311 assertions); php -l inc/managers/class-domain-manager.php && php -l tests/WP_Ultimo/Managers/Domain_Manager_Test.php (pass); vendor/bin/phpcs inc/managers/class-domain-manager.php tests/WP_Ultimo/Managers/Domain_Manager_Test.php (blocked by project PHPCS config: referenced WordPress.Arrays.ArrayDeclaration sniffs do not exist)

Resolves #1092


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.14.58 plugin for [OpenCode](https://opencode.ai) v1.14.33 with gpt-5.5 spent 2m and 68,469 tokens on this as a headless worker.