### PR TITLE
GH#1091: fix: normalize redirect hosts with ports

### DIFF
--- a/inc/class-domain-mapping.php
+++ b/inc/class-domain-mapping.php
@@ -226,43 +226,82 @@ class Domain_Mapping {
 			return $allowed_hosts;
 		}
 
-		$host = strtolower($host);
+		$allowed_hosts = (array) $allowed_hosts;
+		$host          = strtolower($host);
+		$host_no_port  = preg_replace('/:\d+$/', '', $host);
 
-		// If already allowed, bail early
-		if (in_array($host, (array) $allowed_hosts, true)) {
-			return $allowed_hosts;
+		foreach ($allowed_hosts as $allowed_host) {
+			$allowed_host_no_port = preg_replace('/:\d+$/', '', strtolower($allowed_host));
+
+			if (
+				$allowed_host_no_port !== $allowed_host
+				&& ! in_array($allowed_host_no_port, $allowed_hosts, true)
+			) {
+				$allowed_hosts[] = $allowed_host_no_port;
+			}
 		}
 
+		// If already allowed, bail early
+		if (
+			in_array($host, $allowed_hosts, true)
+			|| in_array($host_no_port, $allowed_hosts, true)
+		) {
+			return array_values(array_unique($allowed_hosts));
+		}
+
+		$hosts_to_allow = array_values(array_unique([$host, $host_no_port]));
+
 		// 1) Check mapped domains (including www/no-www variants)
-		$domains_to_check = $this->get_www_and_nowww_versions($host);
+		$domains_to_check = [];
+
+		foreach ($hosts_to_allow as $host_to_check) {
+			$domains_to_check = array_merge(
+				$domains_to_check,
+				$this->get_www_and_nowww_versions($host_to_check)
+			);
+		}
+
+		$domains_to_check = array_values(array_unique($domains_to_check));
 		$mapping          = Domain::get_by_domain($domains_to_check);
 
 		if ($mapping && ! is_wp_error($mapping)) {
-			$allowed_hosts[] = $host;
+			$allowed_hosts = array_merge($allowed_hosts, $hosts_to_allow);
 			return array_values(array_unique($allowed_hosts));
 		}
 
 		// 2) Check if any site is registered with this domain on the network
-		$site = function_exists('get_site_by_path') ? get_site_by_path($host, '/') : null;
+		$site = null;
+
+		if (function_exists('get_site_by_path')) {
+			foreach ($hosts_to_allow as $host_to_check) {
+				$site = get_site_by_path($host_to_check, '/');
+
+				if ($site instanceof \WP_Site) {
+					break;
+				}
+			}
+		}
 
 		if ($site instanceof \WP_Site) {
-			$allowed_hosts[] = $host;
+			$allowed_hosts = array_merge($allowed_hosts, $hosts_to_allow);
 			return array_values(array_unique($allowed_hosts));
 		}
 
 		// Fallback: try a lightweight site query by domain (if available in this context)
 		if (function_exists('get_sites')) {
-			$maybe = get_sites(
-				[
-					'number' => 1,
-					'domain' => $host,
-					'fields' => 'ids',
-				]
-			);
+			foreach ($hosts_to_allow as $host_to_check) {
+				$maybe = get_sites(
+					[
+						'number' => 1,
+						'domain' => $host_to_check,
+						'fields' => 'ids',
+					]
+				);
 
-			if (! empty($maybe)) {
-				$allowed_hosts[] = $host;
-				return array_values(array_unique($allowed_hosts));
+				if (! empty($maybe)) {
+					$allowed_hosts = array_merge($allowed_hosts, $hosts_to_allow);
+					return array_values(array_unique($allowed_hosts));
+				}
 			}
 		}
 

--- a/tests/WP_Ultimo/Domain_Mapping_Test.php
+++ b/tests/WP_Ultimo/Domain_Mapping_Test.php
@@ -208,6 +208,18 @@ class Domain_Mapping_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Test allow_network_redirect_hosts strips ports from existing allowed hosts.
+	 */
+	public function test_allow_network_redirect_hosts_adds_port_stripped_existing_host(): void {
+
+		$allowed = ['main.test:8080'];
+		$result  = $this->domain_mapping->allow_network_redirect_hosts($allowed, 'main.test');
+
+		$this->assertContains('main.test:8080', $result);
+		$this->assertContains('main.test', $result);
+	}
+
+	/**
 	 * Test allow_network_redirect_hosts with unknown host not added.
 	 */
 	public function test_allow_network_redirect_hosts_unknown_host_not_added(): void {


### PR DESCRIPTION
## Summary

Normalize allowed redirect hosts by appending port-stripped variants, and allow mapped/site host lookups to consider both port-suffixed and stripped host forms so wp_validate_redirect strict host comparison accepts non-standard-port SSO redirects.

## Files Changed

inc/class-domain-mapping.php,tests/WP_Ultimo/Domain_Mapping_Test.php

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** WP_TESTS_DIR=/tmp/wordpress-tests-lib vendor/bin/phpunit --filter Domain_Mapping_Test (passes: 273 tests, 422 assertions); php -l inc/class-domain-mapping.php && php -l tests/WP_Ultimo/Domain_Mapping_Test.php (passes); vendor/bin/phpcs inc/class-domain-mapping.php tests/WP_Ultimo/Domain_Mapping_Test.php blocked by existing project config references to missing WordPress.Arrays.ArrayDeclaration sniffs after composer install

Resolves #1091


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.14.58 plugin for [OpenCode](https://opencode.ai) v1.14.33 with gpt-5.5 spent 3m and 75,121 tokens on this as a headless worker.