### PR TITLE
GH#1090: fix: prevent duplicate mapped domain ports

### DIFF
--- a/inc/class-domain-mapping.php
+++ b/inc/class-domain-mapping.php
@@ -625,16 +625,21 @@ class Domain_Mapping {
 		// wp_parse_url not available because this happens very early in the WP loading process.
 		// phpcs:ignore WordPress.WP.AlternativeFunctions.parse_url_parse_url
 		$domain_base = parse_url($url, PHP_URL_HOST);
-		$domain      = rtrim($domain_base . '/' . $path, '/');
-		$regex       = '#^(\w+://)' . preg_quote($domain, '#') . '#i';
+		$domain      = preg_quote($domain_base, '#') . '(?::\d+)?';
+
+		if ('/' !== $path) {
+			$domain = rtrim($domain . '/' . preg_quote(ltrim($path, '/'), '#'), '/');
+		}
+
+		$regex       = '#^(\w+://)' . $domain . '#i';
 		$mangled     = preg_replace($regex, '${1}' . $current_mapping->get_domain(), $url);
 
 		/*
 		 * Another try if we don't need to deal with subdirectory.
 		 */
 		if ($mangled === $url && $this->current_mapping !== $current_mapping) {
-			$domain  = rtrim($domain_base, '/');
-			$regex   = '#^(\w+://)' . preg_quote($domain, '#') . '#i';
+			$domain  = preg_quote($domain_base, '#') . '(?::\d+)?';
+			$regex   = '#^(\w+://)' . $domain . '#i';
 			$mangled = preg_replace($regex, '${1}' . $current_mapping->get_domain(), $url);
 		}
 

--- a/tests/WP_Ultimo/Domain_Mapping_Test.php
+++ b/tests/WP_Ultimo/Domain_Mapping_Test.php
@@ -398,6 +398,25 @@ class Domain_Mapping_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Test replace_url does not duplicate non-standard ports.
+	 */
+	public function test_replace_url_with_mapping_does_not_duplicate_port(): void {
+
+		$blog_id = get_current_blog_id(); // Always 1 in test env.
+		$site    = get_site($blog_id);
+
+		$mapping = new Domain();
+		$mapping->set_domain('mapped.example.com:8080');
+		$mapping->set_blog_id($blog_id);
+		$mapping->set_active(true);
+		$mapping->set_secure(false);
+
+		$result = $this->domain_mapping->replace_url('http://' . $site->domain . ':8080' . $site->path . 'wp-login.php', $mapping);
+
+		$this->assertSame('http://mapped.example.com:8080/wp-login.php', $result);
+	}
+
+	/**
 	 * Test replace_url with secure mapping uses https scheme.
 	 *
 	 * Uses the main blog (ID 1) which always exists in the test environment.


### PR DESCRIPTION
## Summary

Updated Domain_Mapping::replace_url() to consume an existing source URL port while replacing the host, preventing mapped domains with non-standard ports from producing doubled port suffixes. Added a targeted regression test for :8080 mapped-domain URLs.

## Files Changed

inc/class-domain-mapping.php,tests/WP_Ultimo/Domain_Mapping_Test.php

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** WP_TESTS_DIR=/tmp/wordpress-tests-lib vendor/bin/phpunit --no-coverage --filter test_replace_url_with_mapping_does_not_duplicate_port passed. vendor/bin/phpcs inc/class-domain-mapping.php tests/WP_Ultimo/Domain_Mapping_Test.php could not run because the installed PHPCS/WPCS set reports missing configured WordPress.Arrays.ArrayDeclaration sniffs.

Resolves #1090


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.14.58 plugin for [OpenCode](https://opencode.ai) v1.14.33 with gpt-5.5 spent 4m and 83,732 tokens on this as a headless worker.