### PR TITLE
GH#1096: docs: add contributor insight guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -171,6 +171,13 @@ Save with `$model->save()` which returns `true` or `WP_Error`.
 Use `WP_Error` for validation/operation failures — not exceptions.
 `Runtime_Exception` exists but is rarely used. Check `is_wp_error()` on return values.
 
+### Recurring Product Context
+- Signup/payment timeout reports may involve a pre-created pending membership and
+  `pending_site` cleanup. Inspect the checkout, membership, payment gateway, and
+  orphaned-site cleanup paths together before changing watchdog or cancellation logic.
+- Do not reference an `ultimate-multisite-woocommerce` addon release as v2.0.23; the
+  latest known released version is v2.0.10 unless repository evidence says otherwise.
+
 ### Tests
 - Extend `WP_UnitTestCase`. Tests run in a WordPress Multisite environment
   (`WP_TESTS_MULTISITE=1`).


### PR DESCRIPTION
## Summary

Added AGENTS.md guidance for recurring signup timeout/pending_site investigations and corrected the known ultimate-multisite-woocommerce addon release reference to v2.0.10.

## Files Changed

AGENTS.md

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** Ran git diff --check -- AGENTS.md and verified the linked worktree diff/status.

Resolves #1096


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.14.58 plugin for [OpenCode](https://opencode.ai) v1.14.33 with gpt-5.5 spent 1m and 63,822 tokens on this as a headless worker.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated guidance for handling recurring product context, including clarification on payment timeout reports and site cleanup workflows.
  * Added version guidance for addon compatibility reference.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->