### PR TITLE
GH#1097: docs: document gh signature gate recovery

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -478,6 +478,27 @@ If `php` is not available, omit the `php -d ...` prefix and call `vendor/bin/php
 (syntax check) or `php -l` before running. A typo in a bash heredoc or PHP string will cause
 `bash:other`.
 
+**GitHub write commands blocked by the signature gate** — aidevops blocks `gh pr create`,
+`gh issue create`, and comment/review writes when `--body` is built from heredocs, process
+substitution, or command substitution because the signature validator cannot inspect the final
+body safely. Write the Markdown to a temporary file first, then pass `--body-file` to `gh`:
+
+```bash
+BODY_FILE=$(mktemp /tmp/pr-body-XXXXXX.md)
+python3 - <<'PY' > "$BODY_FILE"
+print('''## Summary
+
+- Explain the implementation.
+
+---
+<!-- aidevops:sig -->''')
+PY
+gh pr create --title "fix: describe change" --body-file "$BODY_FILE"
+```
+
+Do not use `--body "$(cat <<'EOF' ... EOF)"`, `<(cat <<'EOF' ... EOF)`, or inline heredoc
+expansions for GitHub writes; they trigger the same `bash:other` signature-gate failure.
+
 **WordPress test suite not installed** — `vendor/bin/phpunit` requires a WordPress test
 environment. Without it, it fails with database connection errors or missing `bootstrap.php`
 messages. Install it once with:


### PR DESCRIPTION
## Summary

Documented the safe --body-file workflow for gh write commands blocked by the aidevops signature gate, including the heredoc/process-substitution patterns to avoid.

## Files Changed

AGENTS.md

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** Ran git diff --check -- AGENTS.md and reviewed the AGENTS.md diff/stat.

Resolves #1097


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.14.58 plugin for [OpenCode](https://opencode.ai) v1.14.33 with gpt-5.5 spent 1m and 35,859 tokens on this as a headless worker.