### PR TITLE
fix(template-switch): emit JSON on AJAX failure so UI never hangs

### DIFF
--- a/assets/js/template-switching.js
+++ b/assets/js/template-switching.js
@@ -151,6 +151,27 @@
 					}, function(results) {
 
 						/*
+             * Defensive guard — if the server responds with an empty,
+             * non-JSON, or otherwise malformed body (which previously
+             * happened on the override_site() failure path), treat it
+             * as a generic failure so the customer is not left staring
+             * at the loading spinner forever.
+             */
+						if ( ! results || typeof results !== 'object') {
+
+							that.unblock();
+
+							that.confirm_switch = false;
+
+							that.ready = false;
+
+							wu_ajax_error('An error occurred while switching templates.');
+
+							return;
+
+						}
+
+						/*
              * Handle error responses.
              */
 						if (results.success === false) {
@@ -173,20 +194,37 @@
 
 							}
 
-						wu_ajax_error(errorMessage);
+							wu_ajax_error(errorMessage);
 
-						return;
+							return;
 
 						}
 
 						/*
-             * Redirect of we get a redirect URL back.
+             * Redirect if we get a redirect URL back. Guard against
+             * a missing or malformed data payload so a server that
+             * answers success without a redirect URL does not throw
+             * inside this callback (which would silently leave the
+             * page-blocking spinner active).
              */
-						if (typeof results.data.redirect_url === 'string') {
+						if (results.data && typeof results.data.redirect_url === 'string') {
 
 							window.location.href = results.data.redirect_url;
 
+							return;
+
 						} // end if;
+
+						/*
+             * Success without a redirect URL — unblock and reset
+             * state so the customer can try again instead of being
+             * stuck on a loading overlay.
+             */
+						that.unblock();
+
+						that.confirm_switch = false;
+
+						that.ready = false;
 
 					}, function() {
 
@@ -199,7 +237,7 @@
 
 						that.ready = false;
 
-					wu_ajax_error(null);
+						wu_ajax_error(null);
 
 					});
 

--- a/inc/ui/class-template-switching-element.php
+++ b/inc/ui/class-template-switching-element.php
@@ -272,6 +272,15 @@ class Template_Switching_Element extends Base_Element {
 			$this->site = wu_get_current_site();
 		}
 
+		// Defensive guard — wu_get_current_site() can return false when the request
+		// runs outside a customer-site context. Without this, dereferencing
+		// $this->site below would emit no JSON body and the AJAX caller would
+		// hang on its loading spinner.
+		if ( ! $this->site || ! $this->site->get_id()) {
+			wp_send_json_error(new \WP_Error('site_context_missing', __('Could not determine which site to switch. Please reload the page and try again.', 'ultimate-multisite')));
+			return;
+		}
+
 		$template_id = (int) wu_request('template_id', '');
 
 		// false means MODE_DEFAULT (no restriction) — all templates are allowed.
@@ -279,6 +288,7 @@ class Template_Switching_Element extends Base_Element {
 
 		if (false !== $available_templates && ! in_array($template_id, array_map('intval', $available_templates), true)) {
 			wp_send_json_error(new \WP_Error('not_authorized', __('You are not allowed to use this template.', 'ultimate-multisite')));
+			return;
 		}
 
 		if ( ! $template_id) {
@@ -288,28 +298,44 @@ class Template_Switching_Element extends Base_Element {
 
 		$switch = \WP_Ultimo\Helpers\Site_Duplicator::override_site($template_id, $this->site->get_id());
 
+		if ( ! $switch) {
+			/*
+			 * Site_Duplicator::override_site() returns false on any failure
+			 * (user cap missing, copy_data error, Elementor Kit copy failure,
+			 * etc.) without surfacing a reason. Without an explicit error
+			 * response here, the AJAX call would close with an empty body,
+			 * the JS success handler would throw on results.data.redirect_url,
+			 * and the customer would see an indefinite loading spinner.
+			 */
+			wp_send_json_error(new \WP_Error('switch_failed', __('Could not switch the template. Please contact your network administrator.', 'ultimate-multisite')));
+			return;
+		}
+
 		/**
-		 * Allow plugin developers to hook functions after a user or super admin switches the site template
+		 * Allow plugin developers to hook functions after a user or super admin switches the site template.
+		 *
+		 * Only fires on a successful switch — previously this fired even on failure,
+		 * which caused hooked code (cache clears, notifications, audit logs) to run
+		 * for switches that did not actually happen.
 		 *
 		 * @since 1.9.8
 		 * @param int $id Site ID
 		 * @return void
 		 */
 		do_action('wu_after_switch_template', $this->site->get_id());
+
 		$referer = isset($_SERVER['HTTP_REFERER']) ? sanitize_url(wp_unslash($_SERVER['HTTP_REFERER'])) : '';
 
-		if ($switch) {
-			wp_send_json_success(
-				[
-					'redirect_url' => add_query_arg(
-						[
-							'updated' => 1,
-						],
-						$referer
-					),
-				]
-			);
-		}
+		wp_send_json_success(
+			[
+				'redirect_url' => add_query_arg(
+					[
+						'updated' => 1,
+					],
+					$referer
+				),
+			]
+		);
 	}
 
 	/**

--- a/tests/WP_Ultimo/UI/Template_Switching_Element_Test.php
+++ b/tests/WP_Ultimo/UI/Template_Switching_Element_Test.php
@@ -1,0 +1,199 @@
+<?php
+/**
+ * Tests for Template_Switching_Element class.
+ *
+ * Specifically focused on the AJAX failure paths in switch_template(): the
+ * handler must always emit a JSON body (success or error) so the front-end
+ * JS in assets/js/template-switching.js can call unblock() and clear its
+ * loading spinner. Previously, the failure branch returned void, leaving
+ * the customer staring at an indefinite spinner.
+ *
+ * @package WP_Ultimo\Tests
+ */
+
+namespace WP_Ultimo\UI;
+
+use WP_UnitTestCase;
+
+/**
+ * Test class for Template_Switching_Element AJAX flow.
+ *
+ * @group ajax
+ */
+class Template_Switching_Element_Test extends WP_UnitTestCase {
+
+	/**
+	 * Set up.
+	 */
+	public function set_up(): void {
+
+		parent::set_up();
+
+		// Reset request globals between tests.
+		foreach ( [ 'template_id' ] as $key ) {
+			unset( $_REQUEST[ $key ], $_GET[ $key ], $_POST[ $key ] );
+		}
+	}
+
+	/**
+	 * Tear down.
+	 */
+	public function tear_down(): void {
+
+		foreach ( [ 'template_id' ] as $key ) {
+			unset( $_REQUEST[ $key ], $_GET[ $key ], $_POST[ $key ] );
+		}
+
+		// Reset element state — clear any site we set during tests.
+		$element = Template_Switching_Element::get_instance();
+		$ref     = new \ReflectionProperty( $element, 'site' );
+
+		if ( PHP_VERSION_ID < 80100 ) {
+			$ref->setAccessible( true );
+		}
+
+		$ref->setValue( $element, null );
+
+		parent::tear_down();
+	}
+
+	/**
+	 * Install AJAX die handler so wp_send_json_* don't kill PHPUnit.
+	 *
+	 * @return callable The installed handler.
+	 */
+	private function install_ajax_die_handler(): callable {
+
+		add_filter( 'wp_doing_ajax', '__return_true' );
+
+		$handler = function () {
+			return function ( $message ) {
+				throw new \WPAjaxDieContinueException( (string) $message );
+			};
+		};
+
+		add_filter( 'wp_die_ajax_handler', $handler, 1 );
+
+		return $handler;
+	}
+
+	/**
+	 * Remove the AJAX die handler.
+	 *
+	 * @param callable $handler The handler returned by install_ajax_die_handler().
+	 */
+	private function remove_ajax_die_handler( callable $handler ): void {
+
+		remove_filter( 'wp_doing_ajax', '__return_true' );
+		remove_filter( 'wp_die_ajax_handler', $handler, 1 );
+	}
+
+	/**
+	 * Call switch_template() inside an AJAX context, capturing JSON output.
+	 *
+	 * @return array{output: string, exception: bool}
+	 */
+	private function call_switch_template(): array {
+
+		$handler          = $this->install_ajax_die_handler();
+		$exception_caught = false;
+
+		ob_start();
+
+		try {
+			Template_Switching_Element::get_instance()->switch_template();
+		} catch ( \WPAjaxDieContinueException $e ) {
+			$exception_caught = true;
+		}
+
+		$output = ob_get_clean();
+
+		$this->remove_ajax_die_handler( $handler );
+
+		return [
+			'output'    => $output,
+			'exception' => $exception_caught,
+		];
+	}
+
+	/**
+	 * Decode a JSON response body, asserting it is a non-empty array.
+	 *
+	 * @param string $output Raw output from the AJAX handler.
+	 * @return array
+	 */
+	private function decode_json( string $output ): array {
+
+		$this->assertNotEmpty(
+			$output,
+			'AJAX handler emitted an empty body. The front-end JS will hang on its loading spinner without a parsable JSON response.'
+		);
+
+		$decoded = json_decode( $output, true );
+
+		$this->assertIsArray(
+			$decoded,
+			'AJAX handler emitted output that was not valid JSON: ' . $output
+		);
+
+		return $decoded;
+	}
+
+	/**
+	 * Missing site context must yield a JSON error body, not silence.
+	 *
+	 * Regression guard for the indefinite-spinner bug: a NULL $this->site
+	 * with no current-site fallback used to dereference NULL and produce
+	 * no body at all.
+	 */
+	public function test_switch_template_missing_site_emits_json_error(): void {
+
+		$_REQUEST['template_id'] = '0';
+
+		$result = $this->call_switch_template();
+
+		$this->assertTrue(
+			$result['exception'],
+			'wp_send_json_error must be reached so the AJAX response terminates cleanly.'
+		);
+
+		$decoded = $this->decode_json( $result['output'] );
+
+		$this->assertSame( false, $decoded['success'] );
+		$this->assertNotEmpty( $decoded['data'], 'Error payload must include a message for the JS to display.' );
+	}
+
+	/**
+	 * Empty template_id must yield a JSON error body, not silence.
+	 */
+	public function test_switch_template_missing_template_id_emits_json_error(): void {
+
+		// Force a fake site object so the "missing site context" guard is bypassed
+		// and we hit the template_id check.
+		$site_id = $this->factory()->blog->create();
+		$site    = wu_get_site( $site_id );
+		$site->set_type( 'customer_owned' );
+		$site->save();
+
+		$element = Template_Switching_Element::get_instance();
+		$ref     = new \ReflectionProperty( $element, 'site' );
+
+		if ( PHP_VERSION_ID < 80100 ) {
+			$ref->setAccessible( true );
+		}
+
+		$ref->setValue( $element, $site );
+
+		// No template_id set in $_REQUEST.
+		$result = $this->call_switch_template();
+
+		$this->assertTrue(
+			$result['exception'],
+			'wp_send_json_error must be reached for missing template_id.'
+		);
+
+		$decoded = $this->decode_json( $result['output'] );
+		$this->assertSame( false, $decoded['success'] );
+	}
+
+}


### PR DESCRIPTION
## Summary

Reported by a customer running 2.9.3 in production: clicking "Switch Template" in the customer panel hangs indefinitely with the loading spinner active and no error displayed. Root cause is a missing else-branch in the AJAX handler combined with brittle front-end JS — neither was touched by #1082 / #1083 (those PRs only modified `Site_Duplicator::override_site()`).

## Symptoms

When `Site_Duplicator::override_site()` returns `false` (which happens for a number of reasons — missing user cap, copy_data error, Elementor Kit copy failure, …), the AJAX handler in `Template_Switching_Element::switch_template()` falls off the end of the function with no JSON body emitted. On the JS side:

- `results.success` is `undefined` (not `false`), so the error branch never runs.
- `results.data.redirect_url` throws `TypeError: Cannot read properties of undefined (reading 'redirect_url')`.
- The exception is swallowed inside jQuery'''s success callback.
- `unblock()` is never called → the page-blocking spinner stays on screen forever.

The customer report ("AJAX hangs, no completion, loads indefinitely") matches this pattern exactly. The bug pre-dates 2.9.3 and is independent of the `override_site()` rewrite.

## Changes

### `inc/ui/class-template-switching-element.php`

1. **Site context guard** — `wu_get_current_site()` can return `null` outside a customer-site context. Without this, dereferencing `$this->site->get_limitations()` would emit no JSON body. Now returns `wp_send_json_error('site_context_missing')` cleanly.
2. **Missing `return` after `not_authorized`** — execution previously continued past the error response into the `override_site()` call, potentially double-emitting output.
3. **Explicit `switch_failed` error response** when `override_site()` returns `false`. This is the headline fix — the AJAX call now always terminates with a parsable JSON body, success or error.
4. **`wu_after_switch_template` only fires on success.** Previously it fired even on failure, causing hooked code (cache clears, audit logs, notifications) to run for switches that did not actually happen. Backwards-compatible for hooks that ran successfully — they still fire in the same place, just gated on success.

### `assets/js/template-switching.js`

Defensive guards in the success callback so a future regression in the PHP contract cannot leave the spinner stuck:

- Check for empty / non-object response → unblock + show generic error.
- Check `results.data` exists before dereferencing `redirect_url`.
- Add an `unblock()` fallback for "success without redirect URL" so even an unusual response shape resets the UI.

### `tests/WP_Ultimo/UI/Template_Switching_Element_Test.php`

New test class with two contract tests asserting that the input-validation failure paths (`site_context_missing`, `template_id_required`) emit parsable JSON error bodies. These document the expected contract going forward.

## Verification

- `vendor/bin/phpunit --filter Template_Switching_Element_Test` → 2 tests, 9 assertions, all pass.
- `vendor/bin/phpunit --filter "Template_Switching|Site_Duplicator|Site_Template"` → identical pass/fail counts before and after this change (`Tests: 125, Assertions: 249, Errors: 1, Failures: 20, Incomplete: 1, Risky: 5` — all pre-existing on `main`, none introduced by this change).
- `vendor/bin/phpstan analyse inc/ui/class-template-switching-element.php tests/WP_Ultimo/UI/Template_Switching_Element_Test.php` → 0 errors.
- `npx eslint assets/js/template-switching.js` → 0 errors.

## Out of scope (filed separately)

- The "Reset current template" button — this does not exist in core. The customer'''s report assumed it had been removed; it was never there. Will be filed as a feature request, not a regression fix.
- Nonce / capability hardening on `wu_switch_template` — the current implementation relies on the AJAX URL being enqueued only on the customer-panel page where the cap check runs implicitly. A defence-in-depth nonce check would be a separate hardening PR.

## Why this is low-risk

- Single AJAX action, single front-end script. No model / schema / DB changes.
- Adds explicit error responses where there was previously silence — strictly more information to the client, never less.
- The one behavioural change (`wu_after_switch_template` only firing on success) is unambiguously the intended behaviour — any hooks that today rely on the action firing on failure are observing a bug.
- Front-end guards are additive — the existing happy-path code still runs first.

<!-- aidevops:sig -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error handling to prevent the loading overlay from remaining stuck when template switching fails
  * Improved defensive validation for incomplete or malformed server responses
  * Fixed error messaging during failed template switches

* **Tests**
  * Added test coverage for template switching with regression guards

<!-- end of auto-generated comment: release notes by coderabbit.ai -->