### PR TITLE
fix: silence PHP 8.1 null-to-string deprecation notices in domain mapping and customer creation

### DIFF
--- a/inc/class-domain-mapping.php
+++ b/inc/class-domain-mapping.php
@@ -613,6 +613,14 @@ class Domain_Mapping {
 			return $url;
 		}
 
+		// Bail if the URL is not a usable string. WordPress filters such as
+		// `home_url` and `site_url` can occasionally pass null/false/empty
+		// values, and on PHP 8.1+ passing those into preg_quote()/parse_url()
+		// emits deprecation notices.
+		if (! is_string($url) || '' === $url) {
+			return $url;
+		}
+
 		// Get the site associated with the mapping
 		$path = $current_mapping->get_path();
 
@@ -625,7 +633,14 @@ class Domain_Mapping {
 		// wp_parse_url not available because this happens very early in the WP loading process.
 		// phpcs:ignore WordPress.WP.AlternativeFunctions.parse_url_parse_url
 		$domain_base = parse_url($url, PHP_URL_HOST);
-		$domain      = preg_quote($domain_base, '#') . '(?::\d+)?';
+
+		// Relative URLs (no host) cannot be re-mapped — return as-is rather
+		// than feeding null into preg_quote() (deprecated on PHP 8.1+).
+		if (! is_string($domain_base) || '' === $domain_base) {
+			return $url;
+		}
+
+		$domain = preg_quote($domain_base, '#') . '(?::\d+)?';
 
 		if ('/' !== $path) {
 			$domain = rtrim($domain . '/' . preg_quote(ltrim($path, '/'), '#'), '/');

--- a/inc/functions/customer.php
+++ b/inc/functions/customer.php
@@ -148,8 +148,11 @@ function wu_create_customer($customer_data) {
 	 * operate on the same normalized value. Without this, subtle
 	 * format differences (e.g. trailing whitespace) can cause
 	 * get_user_by() to miss an existing user and create a duplicate.
+	 *
+	 * Cast to string first — `wp_parse_args` defaults `email` to `false`,
+	 * and PHP 8.1+ deprecates passing non-strings to sanitize_email().
 	 */
-	if ($customer_data['email']) {
+	if (! empty($customer_data['email']) && is_string($customer_data['email'])) {
 		$customer_data['email'] = sanitize_email($customer_data['email']);
 	}
 
@@ -166,7 +169,7 @@ function wu_create_customer($customer_data) {
 			$sanitized_username = strtolower($sanitized_username);
 		}
 
-		$customer_data['email'] = sanitize_email($customer_data['email']);
+		$customer_data['email'] = is_string($customer_data['email']) ? sanitize_email($customer_data['email']) : '';
 		if (! is_email($customer_data['email'])) {
 			return new \WP_Error(
 				'invalid_email',

--- a/tests/WP_Ultimo/Domain_Mapping_Test.php
+++ b/tests/WP_Ultimo/Domain_Mapping_Test.php
@@ -485,6 +485,65 @@ class Domain_Mapping_Test extends WP_UnitTestCase {
 		$this->domain_mapping->current_mapping = null;
 	}
 
+	/**
+	 * Test replace_url with null URL returns null without emitting deprecations.
+	 *
+	 * WordPress filters such as `home_url` can occasionally pass null values
+	 * to filter callbacks. PHP 8.1+ deprecates passing null to internal string
+	 * functions like preg_quote() / parse_url(), so the method must short-circuit
+	 * before reaching them.
+	 */
+	public function test_replace_url_null_url_returns_null(): void {
+
+		$blog_id = get_current_blog_id();
+
+		$mapping = new Domain();
+		$mapping->set_domain('mapped.example.com');
+		$mapping->set_blog_id($blog_id);
+		$mapping->set_active(true);
+
+		$result = $this->domain_mapping->replace_url(null, $mapping);
+
+		$this->assertNull($result);
+	}
+
+	/**
+	 * Test replace_url with empty string returns empty string.
+	 */
+	public function test_replace_url_empty_url_returns_empty(): void {
+
+		$blog_id = get_current_blog_id();
+
+		$mapping = new Domain();
+		$mapping->set_domain('mapped.example.com');
+		$mapping->set_blog_id($blog_id);
+		$mapping->set_active(true);
+
+		$result = $this->domain_mapping->replace_url('', $mapping);
+
+		$this->assertSame('', $result);
+	}
+
+	/**
+	 * Test replace_url with a host-less (relative) URL returns it unchanged.
+	 *
+	 * parse_url('/foo', PHP_URL_HOST) returns null. Without a host guard,
+	 * preg_quote(null, '#') triggers a PHP 8.1 deprecation notice.
+	 */
+	public function test_replace_url_relative_url_returns_original(): void {
+
+		$blog_id = get_current_blog_id();
+
+		$mapping = new Domain();
+		$mapping->set_domain('mapped.example.com');
+		$mapping->set_blog_id($blog_id);
+		$mapping->set_active(true);
+
+		$result = $this->domain_mapping->replace_url('/relative/path', $mapping);
+
+		$this->assertSame('/relative/path', $result);
+	}
+
 	// ----------------------------------------------------------------
 	// mangle_url
 	// ----------------------------------------------------------------


### PR DESCRIPTION
## Summary

Fixes two PHP 8.1+ "passing null to parameter of type string is deprecated" notices that were rendering above page content on customer-reported sites (visible at the top of the template-previewer page above the menu).

## Root cause

### Notice 1 — `inc/class-domain-mapping.php:628`

```
Deprecated: preg_quote(): Passing null to parameter #1 ($str) of type string is deprecated
```

`Domain_Mapping::replace_url()` filters URLs via `home_url`, `site_url`, `option_home`, etc. When the filter chain produces a **relative URL** (no host), a **null**, or a **false**, `parse_url($url, PHP_URL_HOST)` returns `null`, and the next line `preg_quote($domain_base, '#')` triggers the deprecation.

### Notice 2 — `wp-includes/formatting.php:3771`

```
Deprecated: strlen(): Passing null to parameter #1 ($string) of type string is deprecated
```

Line 3771 in WP core is `if ( strlen( $email ) < 6 )` inside `sanitize_email()`. In `wu_create_customer()`, `wp_parse_args` defaults the `email` key to `false`. The second `sanitize_email()` call (line 169) was unconditional and passed `false` straight through.

## Fix

**`inc/class-domain-mapping.php`** — guard `replace_url()` against:
- non-string / empty `$url` (early return before `parse_url`)
- non-string / empty `$domain_base` (relative URL — return original)

**`inc/functions/customer.php`** — only call `sanitize_email()` when the value is actually a string. The downstream `is_email()` check still rejects invalid emails with a `WP_Error`.

## Tests

Three new regression tests in `tests/WP_Ultimo/Domain_Mapping_Test.php`:

- `test_replace_url_null_url_returns_null`
- `test_replace_url_empty_url_returns_empty`
- `test_replace_url_relative_url_returns_original`

All pass:

```
$ vendor/bin/phpunit --filter 'Domain_Mapping_Test' --no-coverage
OK (277 tests, 426 assertions)

$ vendor/bin/phpunit --filter 'Customer_Functions_Test' --no-coverage
OK (21 tests, 34 assertions)
```

PHPStan: clean.

## Impact

- No behaviour change on PHP 7.4 / 8.0 — the new guards short-circuit only on null/empty/relative URLs that previously reached `parse_url`/`preg_quote` anyway and produced unusable regex patterns.
- Eliminates two front-end-visible deprecation banners on PHP 8.1+ sites that have `WP_DEBUG_DISPLAY = true` (or a hosting-default `display_errors = On`).

## Files

- `inc/class-domain-mapping.php` — two early-return guards in `replace_url()`
- `inc/functions/customer.php` — string-type guards around two `sanitize_email()` calls
- `tests/WP_Ultimo/Domain_Mapping_Test.php` — three regression tests

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.14.59 plugin for [OpenCode](https://opencode.ai) v1.14.33 with claude-sonnet-4-6 spent 1d 2h on this as a headless worker.
