### PR TITLE
feat(template-switch): add 'Reset current template' button in customer panel

### DIFF
--- a/assets/js/template-switching.js
+++ b/assets/js/template-switching.js
@@ -140,6 +140,52 @@
 					});
 
 				},
+				/**
+				 * Re-apply the customer's current template, refreshing
+				 * the site from the source template. Triggered by the
+				 * "Reset current template" link in the form.
+				 *
+				 * Confirms with the customer first because this overwrites
+				 * the site's content. Confirmation text is supplied via
+				 * wu_template_switching_params.i18n.reset_confirm so it
+				 * is translatable.
+				 *
+				 * Setting ready = true triggers the existing watcher which
+				 * calls switch_template() — the same code path used by the
+				 * normal "Process Switch" button.
+				 */
+				reset_template() {
+
+					const params = window.wu_template_switching_params || {};
+					const message = (params.i18n && params.i18n.reset_confirm)
+						? params.i18n.reset_confirm
+						: 'Re-apply your current template? This will overwrite your site content with a fresh copy of the template. This cannot be undone.';
+
+					// Native confirm() matches the existing pattern used elsewhere
+					// in this codebase (edit-placeholders.js, tax-rates.js, dns-management.js)
+					// for destructive customer-facing actions. Avoiding the no-alert
+					// rule would mean introducing modal infrastructure that does not
+					// yet exist on this page.
+					// eslint-disable-next-line no-alert
+					if ( ! window.confirm(message)) {
+
+						return;
+
+					} // end if;
+
+					if ( ! this.original_template_id || this.original_template_id <= 0) {
+
+						return;
+
+					} // end if;
+
+					this.template_id = this.original_template_id;
+
+					this.confirm_switch = true;
+
+					this.ready = true;
+
+				},
 				switch_template() {
 
 					const that = this;
@@ -173,9 +219,9 @@
 
 							}
 
-						wu_ajax_error(errorMessage);
+							wu_ajax_error(errorMessage);
 
-						return;
+							return;
 
 						}
 
@@ -199,7 +245,7 @@
 
 						that.ready = false;
 
-					wu_ajax_error(null);
+						wu_ajax_error(null);
 
 					});
 

--- a/inc/ui/class-template-switching-element.php
+++ b/inc/ui/class-template-switching-element.php
@@ -124,6 +124,9 @@ class Template_Switching_Element extends Base_Element {
 			'wu_template_switching_params',
 			[
 				'ajaxurl' => wu_ajax_url(),
+				'i18n'    => [
+					'reset_confirm' => __('Re-apply your current template? This will overwrite your site content with a fresh copy of the template. This cannot be undone.', 'ultimate-multisite'),
+				],
 			]
 		);
 
@@ -373,6 +376,35 @@ class Template_Switching_Element extends Base_Element {
 				'desc'              => $desc,
 				'wrapper_html_attr' => [
 					'v-show'  => 'template_id == original_template_id',
+					'v-cloak' => '1',
+				],
+			];
+
+			/*
+			 * "Reset current template" — re-applies the customer's currently
+			 * assigned template, refreshing the site from the source template.
+			 * Useful when the source template has been updated, or when the
+			 * customer wants to discard their customisations and start over
+			 * without picking a different design.
+			 *
+			 * Only shows when the site is actually on a template (original_template_id > 0).
+			 * Sites created without a template (original_template_id == 0) have
+			 * nothing to reset to.
+			 */
+			// Confirmation text is provided to JS via wp_localize_script (see register_scripts())
+			// so it can be translated; the click handler in template-switching.js shows it via window.confirm().
+			$reset_link = sprintf(
+				'<div class="wu-text-right wu-mt-2"><a href="#" class="wu-no-underline wu-text-2xs wu-uppercase wu-font-semibold wu-text-red-600 hover:wu-text-red-800" v-on:click.prevent="reset_template()">%s</a></div>',
+				esc_html__('Reset current template', 'ultimate-multisite')
+			);
+
+			$checkout_fields['reset_current_template'] = [
+				'type'              => 'note',
+				'wrapper_classes'   => 'wu-w-full',
+				'classes'           => 'wu-w-full',
+				'desc'              => $reset_link,
+				'wrapper_html_attr' => [
+					'v-show'  => 'template_id == original_template_id && original_template_id > 0',
 					'v-cloak' => '1',
 				],
 			];


### PR DESCRIPTION
## Summary

Adds a "Reset current template" link in the customer panel Switch Template page that re-applies the customer'''s current template, refreshing the site from the source template.

This addresses customer feedback that the only available action was switching to a *different* template — there was no way to discard customisations and start over from the *current* template, or to pull in updates if the source template had been changed.

## Behaviour

The link renders inline below the template-selection grid, right-aligned, in red text to signal it is destructive.

It only appears when `original_template_id > 0` — i.e. when the site is actually on a template. Sites created without a template have nothing to reset to and the link stays hidden.

On click, a native `confirm()` dialog displays:

> Re-apply your current template? This will overwrite your site content with a fresh copy of the template. This cannot be undone.

If confirmed, the existing `wu_switch_template` AJAX flow runs with `template_id = original_template_id`, refreshing the site from the source template.

## Implementation notes

- **No new AJAX action.** The new Vue method `reset_template()` sets `template_id = original_template_id` and `ready = true`, which the existing watcher dispatches into `switch_template()`. The PHP-side handler is unchanged.
- **Translatable confirmation message** — supplied to JS via `wp_localize_script` (`wu_template_switching_params.i18n.reset_confirm`) so it can be translated with the rest of the plugin.
- **`window.confirm()` follows established pattern** — the same approach is used elsewhere for destructive customer-facing actions: `edit-placeholders.js`, `tax-rates.js`, `dns-management.js`. An `eslint-disable-next-line no-alert` documents this with the rationale.
- **Visibility gating** — `v-show="template_id == original_template_id && original_template_id > 0"` ensures the link only shows when the customer is on the default template selection view (not mid-switch) AND has a template to reset to.

## Verification

- `vendor/bin/phpstan analyse inc/ui/class-template-switching-element.php` → 0 errors.
- `npx eslint assets/js/template-switching.js` → 0 errors.
- `vendor/bin/phpunit --filter Template_Switching` → identical pass/fail counts before and after this change (`Tests: 31, Assertions: 42, Errors: 1, Failures: 9, Incomplete: 1, Risky: 5` — all pre-existing on `main`, none introduced).

A browser-driven end-to-end test (Elementor templates + customer signup + reset flow) is queued as the next phase of the originating debugging session and will be reported on the issue tracker.

## Out of scope

- Custom modal infrastructure to replace `window.confirm()` — would be useful but is a larger UX initiative across the plugin and not specific to this feature.
- A separate "Reset to original signup template" affordance (i.e. reset to the template the customer first picked at checkout, even if they have switched since) — would require persisting the original template separately from `wu_template_id`, which currently tracks the most recently applied template.

## Relationship to PR #1101

This branch is independent of #1101 (the AJAX hang fix). Both modify `assets/js/template-switching.js` so there will be a small textual conflict on merge — it is mechanical and the resolution is to keep both sets of changes. Either PR can land first.

<!-- aidevops:sig -->
