### PR TITLE
GH#1104: fix: respect filtered sso path

### DIFF
--- a/inc/sso/class-sso.php
+++ b/inc/sso/class-sso.php
@@ -648,7 +648,7 @@ class SSO {
 				parse_str($parsed, $query_params);
 
 				if ( ! empty($query_params['return_url']) ) {
-					$return_url = $query_params['return_url'];
+					$return_url = esc_url_raw($query_params['return_url']);
 				}
 			}
 		}
@@ -807,7 +807,7 @@ class SSO {
 		}
 
 		// Check if this is an SSO flow (sso param or return_url param present)
-		$sso_action = $this->input('sso', '');
+		$sso_action = $this->input($this->get_url_path(), '');
 		$return_url = $this->get_sso_return_url();
 
 		// Check for SSO flow - either sso param or return_url pointing to different domain

--- a/tests/WP_Ultimo/SSO/SSO_Test.php
+++ b/tests/WP_Ultimo/SSO/SSO_Test.php
@@ -44,6 +44,8 @@ class SSO_Test extends \WP_UnitTestCase {
 		unset($_REQUEST['return_type']);
 		unset($_REQUEST['broker']);
 		unset($_REQUEST['sso_verify']);
+		unset($_REQUEST['return_url']);
+		unset($_REQUEST['redirect_to']);
 		unset($_COOKIE['wu_sso_denied']);
 
 		parent::tearDown();
@@ -126,6 +128,43 @@ class SSO_Test extends \WP_UnitTestCase {
 
 		$this->assertSame('mysso', $sso->get_url_path());
 		$this->assertSame('mysso-grant', $sso->get_url_path('grant'));
+	}
+
+	/**
+	 * Test nested return_url values are extracted from redirect_to.
+	 */
+	public function test_get_sso_return_url_extracts_nested_return_url_from_redirect_to(): void {
+		$sso        = SSO::get_instance();
+		$return_url = 'https://customer.example.com/wp/wp-admin/';
+
+		$_REQUEST['redirect_to'] = add_query_arg(
+			'return_url',
+			$return_url,
+			home_url('/wp-login.php')
+		);
+
+		$method = new \ReflectionMethod($sso, 'get_sso_return_url');
+		$method->setAccessible(true);
+
+		$this->assertSame($return_url, $method->invoke($sso));
+	}
+
+	/**
+	 * Test nested return_url values are sanitized when extracted from redirect_to.
+	 */
+	public function test_get_sso_return_url_sanitizes_nested_return_url_from_redirect_to(): void {
+		$sso = SSO::get_instance();
+
+		$_REQUEST['redirect_to'] = add_query_arg(
+			'return_url',
+			'javascript:alert(1)',
+			home_url('/wp-login.php')
+		);
+
+		$method = new \ReflectionMethod($sso, 'get_sso_return_url');
+		$method->setAccessible(true);
+
+		$this->assertSame('', $method->invoke($sso));
 	}
 
 	// ------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Respect the filtered SSO URL path when detecting already-authenticated SSO login requests and sanitize nested return_url values extracted from redirect_to. Added targeted coverage for nested return_url extraction and sanitization.

## Files Changed

inc/sso/class-sso.php,tests/WP_Ultimo/SSO/SSO_Test.php

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** WP_TESTS_DIR=/tmp/wordpress-tests-lib vendor/bin/phpunit --filter 'test_get_sso_return_url_(extracts|sanitizes)_nested_return_url_from_redirect_to' (pass); php -l inc/sso/class-sso.php && php -l tests/WP_Ultimo/SSO/SSO_Test.php (pass); git diff --check (pass). vendor/bin/phpcs inc/sso/class-sso.php tests/WP_Ultimo/SSO/SSO_Test.php is blocked by existing .phpcs.xml.dist references to missing WordPress.Arrays.ArrayDeclaration sniffs; full WP_Ultimo\SSO\SSO_Test has an existing JSONP header count failure unrelated to this change.

Resolves #1104


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.14.59 plugin for [OpenCode](https://opencode.ai) v1.14.33 with gpt-5.5 spent 3m and 72,773 tokens on this as a headless worker.