### PR TITLE
GH#1105: fix: preserve blank site identity options

### DIFF
--- a/inc/helpers/class-site-duplicator.php
+++ b/inc/helpers/class-site-duplicator.php
@@ -202,20 +202,7 @@ class Site_Duplicator {
 			return false;
 		}
 
-		/*
-		 * Restore identity options immediately after copy_data overwrote them.
-		 *
-		 * Guard with false !== (not empty()) so intentionally blank values
-		 * like an empty blogdescription are preserved. get_blog_option()
-		 * returns false when the option does not exist.
-		 *
-		 * @since 2.4.0
-		 */
-		foreach ($identity_snapshot as $opt_key => $opt_val) {
-			if ( false !== $opt_val ) {
-				update_blog_option($to_site_id, $opt_key, $opt_val);
-			}
-		}
+		self::restore_identity_options($to_site_id, $identity_snapshot);
 
 		$new_to_site = wu_get_site($duplicate_site_id);
 
@@ -283,6 +270,26 @@ class Site_Duplicator {
 		// request in the network root context.
 		if ( get_current_blog_id() !== $caller_blog_id ) {
 			switch_to_blog($caller_blog_id);
+		}
+	}
+
+	/**
+	 * Restore site identity options after an override table copy.
+	 *
+	 * Blank values are valid identity settings, particularly an intentionally
+	 * empty blogdescription, so only missing option sentinels are skipped.
+	 *
+	 * @since 2.4.0
+	 *
+	 * @param int   $to_site_id        Target site blog ID.
+	 * @param array $identity_snapshot Snapshot of identity option values keyed by option name.
+	 */
+	private static function restore_identity_options($to_site_id, $identity_snapshot) {
+
+		foreach ($identity_snapshot as $opt_key => $opt_val) {
+			if ( false !== $opt_val && null !== $opt_val ) {
+				update_blog_option($to_site_id, $opt_key, $opt_val);
+			}
 		}
 	}
 

--- a/tests/WP_Ultimo/Helpers/Site_Duplicator_Test.php
+++ b/tests/WP_Ultimo/Helpers/Site_Duplicator_Test.php
@@ -189,6 +189,40 @@ class Site_Duplicator_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Test identity option restoration preserves intentionally blank values.
+	 */
+	public function test_restore_identity_options_preserves_blank_values() {
+		$target_site_id = self::factory()->blog->create(
+			[
+				'domain' => 'blank-description.example.com',
+				'path'   => '/',
+				'title'  => 'Blank Description',
+			]
+		);
+
+		update_blog_option($target_site_id, 'blogdescription', 'Template description');
+		update_blog_option($target_site_id, 'admin_email', 'template@example.com');
+
+		$method = new \ReflectionMethod(Site_Duplicator::class, 'restore_identity_options');
+		$method->setAccessible(true);
+		$method->invoke(
+			null,
+			$target_site_id,
+			[
+				'blogdescription' => '',
+				'admin_email'     => false,
+				'blogname'        => null,
+			]
+		);
+
+		$this->assertSame('', get_blog_option($target_site_id, 'blogdescription'));
+		$this->assertSame('template@example.com', get_blog_option($target_site_id, 'admin_email'));
+		$this->assertSame('Blank Description', get_blog_option($target_site_id, 'blogname'));
+
+		wpmu_delete_blog($target_site_id, true);
+	}
+
+	/**
 	 * Test override with invalid target site.
 	 */
 	public function test_override_invalid_target_site() {


### PR DESCRIPTION
## Summary

Extracted site identity restoration into a dedicated helper that preserves intentionally blank option values while skipping missing sentinels. Added a regression test covering blank blogdescription restoration and false/null skip behavior.

## Files Changed

inc/helpers/class-site-duplicator.php,tests/WP_Ultimo/Helpers/Site_Duplicator_Test.php

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** WP_TESTS_DIR=/tmp/wordpress-tests-lib vendor/bin/phpunit --filter test_restore_identity_options_preserves_blank_values (pass). php -l inc/helpers/class-site-duplicator.php && php -l tests/WP_Ultimo/Helpers/Site_Duplicator_Test.php (pass). vendor/bin/phpcs inc/helpers/class-site-duplicator.php tests/WP_Ultimo/Helpers/Site_Duplicator_Test.php could not run because the project PHPCS config references missing WordPress.Arrays.ArrayDeclaration sniffs in the installed standards.

Resolves #1105


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.14.59 plugin for [OpenCode](https://opencode.ai) v1.14.33 with gpt-5.5 spent 3m and 66,207 tokens on this as a headless worker.