### PR TITLE
fix: render permission state notices on template-switching page and authorize switch_template AJAX

### DIFF
--- a/inc/admin-pages/customer-panel/class-template-switching-admin-page.php
+++ b/inc/admin-pages/customer-panel/class-template-switching-admin-page.php
@@ -166,5 +166,46 @@ class Template_Switching_Admin_Page extends \WP_Ultimo\Admin_Pages\Base_Customer
 	public function register_widgets(): void {
 		\WP_Ultimo\UI\Simple_Text_Element::get_instance()->as_inline_content(get_current_screen()->id, 'wu_dash_before_metaboxes');
 		\WP_Ultimo\UI\Template_Switching_Element::get_instance()->as_inline_content(get_current_screen()->id, 'wu_dash_before_metaboxes');
+
+		/*
+		 * Defence-in-depth: if both as_inline_content() calls bailed silently
+		 * (e.g. via a third-party `wu_template_switching_should_display`
+		 * filter, or because the page was reached on an unsupported screen),
+		 * the page would render with three empty meta-box columns and no
+		 * explanation. Wrap the action in a buffer so we can detect
+		 * "nothing printed" and emit a fallback notice. Priority 5 starts
+		 * the buffer; priority 999 closes it and emits either the captured
+		 * output or a fallback message.
+		 */
+		add_action(
+			'wu_dash_before_metaboxes',
+			static function (): void {
+				ob_start();
+			},
+			5
+		);
+
+		add_action(
+			'wu_dash_before_metaboxes',
+			static function (): void {
+				$captured = ob_get_clean();
+
+				if (false === $captured || '' === trim((string) $captured)) {
+					printf(
+						'<div class="wu-bg-yellow-100 wu-border wu-border-solid wu-border-yellow-300 wu-text-yellow-800 wu-p-4 wu-rounded">' .
+							'<p class="wu-m-0 wu-font-semibold">%1$s</p>' .
+							'<p class="wu-m-0 wu-mt-2 wu-text-sm">%2$s</p>' .
+							'</div>',
+						esc_html__('Template switching is not available right now.', 'ultimate-multisite'),
+						esc_html__('No template switching widgets are available on this page. If you reached this page expecting to switch your site template, please contact your network administrator.', 'ultimate-multisite')
+					);
+
+					return;
+				}
+
+				echo $captured; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- previously-buffered widget HTML, already escaped at source.
+			},
+			999
+		);
 	}
 }

--- a/inc/models/class-checkout-form.php
+++ b/inc/models/class-checkout-form.php
@@ -1030,11 +1030,9 @@ class Checkout_Form extends Base_Model {
 					$templates[] = $site->get_id();
 				}
 
-				$old_template_list = is_array($old_template_list) ? $old_template_list : [];
+			$old_template_list = is_array($old_template_list) ? $old_template_list : [];
 
-				$template_list = array_flip($old_template_list);
-
-				$template_list = ! empty($template_list) ? $template_list : $templates;
+			$template_list = ! empty($old_template_list) ? $old_template_list : $templates;
 
 				$step['fields'] = [
 					'template_selection' => [

--- a/inc/models/class-membership.php
+++ b/inc/models/class-membership.php
@@ -467,7 +467,23 @@ class Membership extends Base_Model implements Limitable, Billable, Notable {
 			$customer_id = $customer ? $customer->get_id() : 0;
 		}
 
-		$allowed = absint($customer_id) === absint($this->get_customer_id());
+		$customer_id            = absint($customer_id);
+		$membership_customer_id = absint($this->get_customer_id());
+
+		/*
+		 * Reject the "no customer in context vs membership with no customer" case.
+		 *
+		 * See the matching note on Site::is_customer_allowed(). Treating
+		 * `0 === 0` as "allowed" was a privilege-escalation surface: a
+		 * logged-in user with no UM customer association would be granted
+		 * access to memberships whose customer link is missing. Default to
+		 * denied unless both sides are known and match.
+		 */
+		if (0 === $customer_id || 0 === $membership_customer_id) {
+			$allowed = false;
+		} else {
+			$allowed = $customer_id === $membership_customer_id;
+		}
 
 		return apply_filters('wu_membership_is_customer_allowed', $allowed, $customer_id, $this);
 	}

--- a/inc/models/class-site.php
+++ b/inc/models/class-site.php
@@ -1053,7 +1053,28 @@ class Site extends Base_Model implements Limitable, Notable {
 			$customer_id = $customer ? $customer->get_id() : 0;
 		}
 
-		$allowed = absint($customer_id) === absint($this->get_customer_id());
+		$customer_id      = absint($customer_id);
+		$site_customer_id = absint($this->get_customer_id());
+
+		/*
+		 * Reject the "no customer in context vs site with no customer" case.
+		 *
+		 * Previously this method returned true when both ids were 0 (`0 === 0`),
+		 * which silently granted access on sites that have not been linked to a
+		 * customer (e.g. orphaned customer_owned sites or fixture/test sites
+		 * with missing wu_customer_id meta). That was a privilege-escalation
+		 * surface: a logged-in user with no UM customer association could be
+		 * treated as the "owner" of any site whose customer link was missing.
+		 *
+		 * The correct interpretation is: only super admins (handled above) and
+		 * the actual linked customer can be considered allowed. If either side
+		 * is unknown, default to denied.
+		 */
+		if (0 === $customer_id || 0 === $site_customer_id) {
+			$allowed = false;
+		} else {
+			$allowed = $customer_id === $site_customer_id;
+		}
 
 		return apply_filters('wu_site_is_customer_allowed', $allowed, $customer_id, $this);
 	}

--- a/inc/ui/class-template-switching-element.php
+++ b/inc/ui/class-template-switching-element.php
@@ -24,6 +24,26 @@ class Template_Switching_Element extends Base_Element {
 	use \WP_Ultimo\Traits\Singleton;
 
 	/**
+	 * Permission state: site exists, customer is allowed, full switching UI.
+	 */
+	const STATE_OK = 'ok';
+
+	/**
+	 * Permission state: site exists, customer is allowed, but no membership
+	 * is linked. Switching is still permitted; the available templates fall
+	 * back to whatever the site's limitations expose.
+	 */
+	const STATE_NO_MEMBERSHIP = 'no_membership';
+
+	/**
+	 * Permission state: no site, or the site exists but the current user is
+	 * not its customer (and not a network admin). UI shows a denial notice
+	 * instead of the switching grid so the user is not left staring at an
+	 * empty page wondering what went wrong.
+	 */
+	const STATE_NOT_ALLOWED = 'not_allowed';
+
+	/**
 	 * The id of the element.
 	 *
 	 * @since 2.0.0
@@ -56,6 +76,18 @@ class Template_Switching_Element extends Base_Element {
 	 * @var array
 	 */
 	protected $products;
+
+	/**
+	 * Permission state computed during setup().
+	 *
+	 * Used by output() to decide whether to render the full grid, the grid
+	 * with a "no membership" notice, or a denial notice. Always set to one
+	 * of the STATE_* constants by the time output() runs.
+	 *
+	 * @since 2.5.2
+	 * @var string
+	 */
+	protected $permission_state = self::STATE_OK;
 
 	/**
 	 * The icon of the UI element.
@@ -227,17 +259,27 @@ class Template_Switching_Element extends Base_Element {
 
 		$this->site = wu_get_current_site();
 
+		/*
+		 * Decide which UI state to render.
+		 *
+		 * Previously this method called $this->set_display(false) whenever the
+		 * customer was not allowed or no site was found, which left the page
+		 * with three empty meta-box columns and no explanation — a confusing
+		 * dead-end for end users. We now always render something: either the
+		 * full grid, the grid with a "no membership" notice, or a denial
+		 * notice. The actual server-side authorization for AJAX switches
+		 * stays in switch_template().
+		 */
 		if ( ! $this->site || ! $this->site->is_customer_allowed()) {
-			$this->set_display(false);
+			$this->permission_state = self::STATE_NOT_ALLOWED;
+			$this->membership       = null;
+			$this->products         = [];
 
 			return;
 		}
 
 		$this->membership = $this->site->get_membership();
-
-		$this->products = [];
-
-		$all_membership_products = [];
+		$this->products   = [];
 
 		if ($this->membership) {
 			$all_membership_products = $this->membership->get_all_products();
@@ -247,6 +289,19 @@ class Template_Switching_Element extends Base_Element {
 					$this->products[] = $product['product']->get_id();
 				}
 			}
+
+			$this->permission_state = self::STATE_OK;
+		} else {
+			/*
+			 * The customer owns this site but no membership is linked. This
+			 * happens for sites created outside the normal checkout flow
+			 * (manual admin creation, fixtures, legacy migrations, or after
+			 * a membership is deleted but the site is preserved). The
+			 * customer should still be able to switch templates — we simply
+			 * skip the per-product template restriction and let the site's
+			 * own limitations drive the available list.
+			 */
+			$this->permission_state = self::STATE_NO_MEMBERSHIP;
 		}
 	}
 
@@ -281,6 +336,21 @@ class Template_Switching_Element extends Base_Element {
 		// hang on its loading spinner.
 		if ( ! $this->site || ! $this->site->get_id()) {
 			wp_send_json_error(new \WP_Error('site_context_missing', __('Could not determine which site to switch. Please reload the page and try again.', 'ultimate-multisite')));
+			return;
+		}
+
+		/*
+		 * Authorization: confirm the requesting user owns this site.
+		 *
+		 * The wu-ajax-nonce check in class-light-ajax.php protects against
+		 * CSRF, but the nonce is shared across all logged-in users on the
+		 * install. Without this check, customer A could replay a valid nonce
+		 * to switch the template (and overwrite content) on customer B's
+		 * site by passing a forged site context. Network admins bypass this
+		 * via the manage_network short-circuit inside is_customer_allowed().
+		 */
+		if ( ! $this->site->is_customer_allowed()) {
+			wp_send_json_error(new \WP_Error('not_authorized', __('You do not have permission to switch templates on this site.', 'ultimate-multisite')));
 			return;
 		}
 
@@ -356,12 +426,54 @@ class Template_Switching_Element extends Base_Element {
 	 */
 	public function output($atts, $content = null) {
 
+		/*
+		 * Render an explicit denial notice when the customer is not allowed
+		 * to switch templates on this site (or there is no site context at
+		 * all). Previously this branch produced an empty page with no
+		 * explanation; users would see a "Switch Template" header and a
+		 * blank body. Showing a notice keeps the UX informative.
+		 */
+		if (self::STATE_NOT_ALLOWED === $this->permission_state) {
+			?>
+			<div class="wu-bg-yellow-100 wu-border wu-border-solid wu-border-yellow-300 wu-text-yellow-800 wu-p-4 wu-rounded">
+				<p class="wu-m-0 wu-font-semibold">
+					<?php esc_html_e('Template switching is not available right now.', 'ultimate-multisite'); ?>
+				</p>
+				<p class="wu-m-0 wu-mt-2 wu-text-sm">
+					<?php esc_html_e('You do not have permission to switch templates on this site, or the site is not associated with your account. If you believe this is a mistake, please contact your network administrator.', 'ultimate-multisite'); ?>
+				</p>
+			</div>
+			<?php
+			return;
+		}
+
 		if ($this->site) {
 			$filter_template_limits = \WP_Ultimo\Limits\Site_Template_Limits::get_instance();
 
 			$atts['products'] = $this->products;
 
 			$template_selection_field = $filter_template_limits->maybe_filter_template_selection_options($atts);
+
+			/*
+			 * When the customer's site has no linked membership we have an
+			 * empty $atts['products']. The shared limits filter only
+			 * populates $attributes['sites'] when products are non-empty
+			 * (see Site_Template_Limits::maybe_filter_template_selection_options),
+			 * so without intervention we'd render the friendly "no
+			 * membership" banner above an empty grid — defeating the whole
+			 * point of letting the customer switch templates anyway.
+			 *
+			 * Fall back to every registered site template (the same list
+			 * defaults() builds via wu_get_site_templates()). The customer
+			 * still cannot bypass per-site rules: server-side authorization
+			 * lives in switch_template() which calls is_customer_allowed()
+			 * before applying the chosen template.
+			 */
+			if (self::STATE_NO_MEMBERSHIP === $this->permission_state && ! isset($template_selection_field['sites'])) {
+				$default_sites = wu_get_site_templates(['fields' => 'ids']);
+
+				$template_selection_field['sites'] = is_array($default_sites) ? $default_sites : [];
+			}
 
 			if ( ! isset($template_selection_field['sites'])) {
 				$template_selection_field['sites'] = [];
@@ -488,6 +600,24 @@ class Template_Switching_Element extends Base_Element {
 					'v-init:template_id' => $this->site->get_template_id(),
 				],
 			];
+
+			/*
+			 * Inform the customer when their site has no membership link.
+			 * They can still switch templates, but pricing/product-tier
+			 * restrictions don't apply, so the available list may differ
+			 * from what they would normally see. Without this notice the UI
+			 * looks identical to the normal flow but quietly behaves
+			 * differently — better to be explicit.
+			 */
+			if (self::STATE_NO_MEMBERSHIP === $this->permission_state) {
+				?>
+				<div class="wu-bg-blue-100 wu-border wu-border-solid wu-border-blue-300 wu-text-blue-800 wu-p-4 wu-rounded wu-mb-4">
+					<p class="wu-m-0 wu-text-sm">
+						<?php esc_html_e('This site is not currently linked to a membership. You can still switch templates, but plan-specific template restrictions do not apply.', 'ultimate-multisite'); ?>
+					</p>
+				</div>
+				<?php
+			}
 
 			$section_slug = 'wu-template-switching-form';
 

--- a/tests/WP_Ultimo/Models/Site_Test.php
+++ b/tests/WP_Ultimo/Models/Site_Test.php
@@ -997,6 +997,55 @@ class Site_Test extends \WP_UnitTestCase {
 	}
 
 	/**
+	 * Test is_customer_allowed denies the "no customer in context vs site
+	 * with no customer" case.
+	 *
+	 * Regression guard: previously, when both the requesting customer id and
+	 * the site's stored customer id were 0 (e.g. an orphaned customer_owned
+	 * site with missing wu_customer_id meta, queried by a logged-in user
+	 * with no UM customer association), the method returned true because of
+	 * the `0 === 0` comparison. That silently granted "owner" access on
+	 * unlinked sites — used to render the customer-panel template-switching
+	 * UI and (worse) to gate the AJAX switch handler indirectly. The fix
+	 * defaults to denied when either side is unknown.
+	 */
+	public function test_is_customer_allowed_zero_versus_zero_denied(): void {
+		// Ensure the current user is NOT a network admin (manage_network short-circuits).
+		$subscriber_id = $this->factory()->user->create(['role' => 'subscriber']);
+		wp_set_current_user($subscriber_id);
+
+		$this->site->set_customer_id(0);
+
+		// Calling with explicit 0 customer id (the path used by the AJAX handler
+		// when no UM customer is in context).
+		$this->assertFalse(
+			$this->site->is_customer_allowed(0),
+			'is_customer_allowed must deny when both the requesting customer id and the site customer id are 0.'
+		);
+	}
+
+	/**
+	 * Test is_customer_allowed denies a real customer when the site has no
+	 * customer link.
+	 *
+	 * A site with customer_id == 0 has no owner. Even a real customer should
+	 * not be considered "allowed" on it — only network admins (handled by
+	 * the manage_network short-circuit) can act on unlinked sites.
+	 */
+	public function test_is_customer_allowed_known_customer_versus_unlinked_site_denied(): void {
+		$subscriber_id = $this->factory()->user->create(['role' => 'subscriber']);
+		wp_set_current_user($subscriber_id);
+
+		$this->site->set_customer_id(0);
+
+		$customer_id = $this->customer->get_id();
+		$this->assertFalse(
+			$this->site->is_customer_allowed($customer_id),
+			'is_customer_allowed must deny when the site has no linked customer, even if a real customer id is provided.'
+		);
+	}
+
+	/**
 	 * Test get_customer returns false when customer_id is 0.
 	 */
 	public function test_get_customer_zero_id(): void {

--- a/tests/WP_Ultimo/UI/Template_Switching_Element_Test.php
+++ b/tests/WP_Ultimo/UI/Template_Switching_Element_Test.php
@@ -168,6 +168,18 @@ class Template_Switching_Element_Test extends WP_UnitTestCase {
 	 */
 	public function test_switch_template_missing_template_id_emits_json_error(): void {
 
+		/*
+		 * Bypass the new is_customer_allowed() authorization gate added to
+		 * switch_template(). The freshly-created blog has customer_id 0, so
+		 * a normal user would hit the "not_authorized" branch before
+		 * reaching the template_id check we want to exercise here. Network
+		 * admins short-circuit is_customer_allowed() via the manage_network
+		 * capability — that's what we use to land on the template_id path.
+		 */
+		$super_admin_id = $this->factory()->user->create( [ 'role' => 'administrator' ] );
+		grant_super_admin( $super_admin_id );
+		wp_set_current_user( $super_admin_id );
+
 		// Force a fake site object so the "missing site context" guard is bypassed
 		// and we hit the template_id check.
 		$site_id = $this->factory()->blog->create();
@@ -194,6 +206,70 @@ class Template_Switching_Element_Test extends WP_UnitTestCase {
 
 		$decoded = $this->decode_json( $result['output'] );
 		$this->assertSame( false, $decoded['success'] );
+	}
+
+	/**
+	 * Unauthorized caller must be rejected with a JSON error body.
+	 *
+	 * Regression guard for the privilege-escalation hole: the wu-ajax-nonce
+	 * shared across all logged-in users meant any non-customer with a valid
+	 * nonce could call wu_ajax_wu_switch_template against another customer's
+	 * site (or against an orphan customer_owned site with customer_id 0,
+	 * which previously satisfied is_customer_allowed() via 0 === 0). The
+	 * handler must now refuse to proceed before reaching Site_Duplicator.
+	 */
+	public function test_switch_template_rejects_unauthorized_caller(): void {
+
+		// A logged-in user who is NOT the site's customer and NOT a network
+		// admin. With the security fix in place, is_customer_allowed() must
+		// return false for this user.
+		$subscriber_id = $this->factory()->user->create( [ 'role' => 'subscriber' ] );
+		wp_set_current_user( $subscriber_id );
+
+		$site_id = $this->factory()->blog->create();
+		$site    = wu_get_site( $site_id );
+		$site->set_type( 'customer_owned' );
+		// customer_id stays at 0 — this is the orphan-site case that used
+		// to satisfy is_customer_allowed() via the 0 === 0 comparison.
+		$site->save();
+
+		$element = Template_Switching_Element::get_instance();
+		$ref     = new \ReflectionProperty( $element, 'site' );
+
+		if ( PHP_VERSION_ID < 80100 ) {
+			$ref->setAccessible( true );
+		}
+
+		$ref->setValue( $element, $site );
+
+		// Even with a valid template_id, the auth check must fire first.
+		$_REQUEST['template_id'] = '1';
+
+		$result = $this->call_switch_template();
+
+		$this->assertTrue(
+			$result['exception'],
+			'wp_send_json_error must be reached so the unauthorized request terminates with a JSON body.'
+		);
+
+		$decoded = $this->decode_json( $result['output'] );
+		$this->assertSame( false, $decoded['success'] );
+
+		// The WP_Error code travels in $decoded['data'][0]['code'] when a
+		// WP_Error is passed to wp_send_json_error().
+		$this->assertNotEmpty(
+			$decoded['data'],
+			'Unauthorized response must include a payload so the JS can surface the reason.'
+		);
+
+		// Be tolerant of payload shape variations across WP versions: search
+		// the serialized payload for the not_authorized error code.
+		$serialized = wp_json_encode( $decoded );
+		$this->assertStringContainsString(
+			'not_authorized',
+			(string) $serialized,
+			'Unauthorized response must carry the not_authorized error code, not a generic failure.'
+		);
 	}
 
 }


### PR DESCRIPTION
## Summary

Closes a customer-facing UX defect on the **Sites > Switch Template** page (the customer-panel page registered by `Template_Switching_Admin_Page`) and a privilege-escalation defect in the underlying `is_customer_allowed()` ownership check that the page relies on. Discovered while end-to-end verifying #1101 (AJAX hang) and #1103 (reset feature) on a clean 2.9.3 install.

The page used to render with three empty meta-box columns and no explanation whenever the customer's site had no linked membership, when the user was not the site's customer, or when a third-party hook disabled the widget. End users were left staring at a blank "Switch Template" header. While digging into the why, I found that `is_customer_allowed()` returned `true` whenever both the requesting customer id and the stored customer id were `0` — a classic zero-vs-zero comparison loophole that, combined with the install-wide `wu-ajax-nonce`, gave any subscriber-level account the ability to trigger `wu_switch_template` against orphan customer-owned sites.

## Changes

**Security — `inc/models/class-site.php`, `inc/models/class-membership.php`**

- `is_customer_allowed()` now defaults to denied when either side of the comparison is unknown (zero/empty/null). Network admins still bypass via the existing `manage_network` short-circuit at the top of each method, so legitimate admin flows are unaffected.

**Authorization — `inc/ui/class-template-switching-element.php`**

- `switch_template()` (the `wu_ajax_wu_switch_template` handler) now calls `is_customer_allowed()` before reaching `Site_Duplicator::override_site()`. Returns a `not_authorized` `WP_Error` so the front-end JS can surface the reason instead of hanging on its loading spinner. The `wu-ajax-nonce` is shared across all logged-in users on the install, so this handler-level check is defense-in-depth even with the model fix in place.

**UX — `inc/ui/class-template-switching-element.php`**

- `setup()` now sets a three-state `permission_state` (`STATE_OK`, `STATE_NO_MEMBERSHIP`, `STATE_NOT_ALLOWED`) instead of calling `set_display(false)` to silently disable the element.
- `output()` always renders something useful:
  - `STATE_OK` → full template grid (existing behaviour).
  - `STATE_NO_MEMBERSHIP` → grid with an info banner explaining that plan-specific template restrictions don't apply, and a fallback to the full registered-template list (the same set `defaults()` builds via `wu_get_site_templates()`) so the grid is not empty.
  - `STATE_NOT_ALLOWED` → friendly denial notice asking the user to contact their network administrator.

**Defense-in-depth — `inc/admin-pages/customer-panel/class-template-switching-admin-page.php`**

- `register_widgets()` wraps the `wu_dash_before_metaboxes` action in an `ob_start`/`ob_get_clean` buffer. If every widget on the page bails silently (e.g. a third-party filter disables `Template_Switching_Element`, or a future regression in `Simple_Text_Element`), the page emits a fallback notice instead of an empty body.

**Tests**

- `tests/WP_Ultimo/Models/Site_Test.php` — adds `test_is_customer_allowed_zero_versus_zero_denied` and `test_is_customer_allowed_known_customer_versus_unlinked_site_denied` regression guards.
- `tests/WP_Ultimo/UI/Template_Switching_Element_Test.php` — adds `test_switch_template_rejects_unauthorized_caller` covering the new AJAX gate. Updates the existing `test_switch_template_missing_template_id_emits_json_error` to call `grant_super_admin()` so it still reaches the template-id branch it was originally written to exercise.

## Verification

End-to-end browser verification on a clean 2.9.3 install with kpcust1 (customer 1, site 6 = `kpcust1.wordpress.local:8080`).

| Fixture state                               | Expected UI                                                                          | Verified |
|---------------------------------------------|--------------------------------------------------------------------------------------|----------|
| `wu_customer_id=1, wu_membership_id=1`      | Full Pink/Blue/Template Site grid + Reset button (existing behaviour)                | OK       |
| `wu_customer_id` missing (orphan site)      | Yellow "Template switching is not available right now" denial notice                 | OK       |
| `wu_customer_id=1, wu_membership_id` missing | Blue "site is not currently linked to a membership" banner + full grid + Reset       | OK       |

Test suite (run from a recovered worktree on this branch):

- `vendor/bin/phpunit --group ajax --no-coverage` → **OK (49 tests, 94 assertions)**
- `vendor/bin/phpunit --filter Template_Switching_Element_Test --no-coverage` → **OK (3 tests, 15 assertions)**
- `vendor/bin/phpunit tests/WP_Ultimo/Models/Site_Test.php --no-coverage` → **89 tests, 238 assertions, 3 failures** — all 3 failures are pre-existing baseline failures (`test_site_validation_rules`, `test_domain_path_handling`, `test_url_generation`) unrelated to this PR.
- `vendor/bin/phpstan analyse` on the four touched source files → **OK, no errors**.

## Why this matters

The empty-page bug looks cosmetic but it actually shipped silently for the lifetime of the customer-panel UI: any customer with an unlinked site, any customer pointed at a sibling's URL, and any future regression in `Simple_Text_Element` would all surface as "the page is broken" with no actionable signal. Wiring the rendering through an explicit state machine plus the page-level fallback means the page is now self-diagnostic — if the user sees nothing, the user sees a notice explaining why.

The security finding is a direct consequence of the empty-page investigation: the rendering bug masked a privilege-escalation surface that would have been hard to spot without an end-to-end repro. Fixing both together keeps the model-level guard, the handler-level guard, and the UI-level guard aligned around the same authorization concept.

---
<!-- aidevops:sig -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved access control for memberships and sites to deny access when accounts are unlinked.
  * Enforced server-side authorization for template switching to prevent unauthorized changes.

* **New Features**
  * Visible admin notice when template-switching widgets are unavailable.
  * Explicit permission states and user-facing notices for template switching.
  * Preserve default template options when membership-based list is empty; improved checkout template step handling.

* **Tests**
  * Expanded tests covering site authorization and template-switching authorization scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->