### PR TITLE
feat(template-switch): redesign customer panel with current-template card and persistent grid

### DIFF
--- a/inc/ui/class-template-switching-element.php
+++ b/inc/ui/class-template-switching-element.php
@@ -451,42 +451,61 @@ class Template_Switching_Element extends Base_Element {
 				}
 			};
 
+			/*
+			 * Current-template summary card — rendered before the grid so the
+			 * customer can see "what they're on" plus the Reset button up front
+			 * without scrolling. The card is always visible (no v-show) because
+			 * "what is the site's current template?" remains true regardless of
+			 * what template_id the customer has clicked in the grid below.
+			 *
+			 * Reset is co-located here (instead of as a separate row at the
+			 * bottom) because the operation acts on the current template, not
+			 * on the grid selection. Pairing them avoids a stray red link
+			 * floating below the grid.
+			 */
+			$current_template_id = (int) $this->site->get_template_id();
+			$current_template    = $current_template_id > 0 ? wu_get_site($current_template_id) : false;
+
+			$current_card_renderer = function () use ($current_template, $current_template_id) {
+				wu_get_template(
+					'ui/template-switching-current',
+					[
+						'current_template'     => $current_template,
+						'original_template_id' => $current_template_id,
+					]
+				);
+			};
+
+			$checkout_fields['current_template_card'] = [
+				'type'              => 'note',
+				'wrapper_classes'   => 'wu-w-full wu-bg-transparent wu-p-0',
+				'classes'           => 'wu-w-full wu-p-0',
+				'desc'              => $current_card_renderer,
+				'wrapper_html_attr' => [
+					'v-cloak' => '1',
+				],
+			];
+
+			/*
+			 * The grid of available templates. Previously this was hidden
+			 * (v-show="template_id == original_template_id") whenever the
+			 * customer clicked a different template — which made the grid
+			 * disappear, hiding the user's other options behind a confirm
+			 * panel. The grid now stays visible during selection so the
+			 * customer can see context, change their mind, or pick a third
+			 * template without scrolling back from a hidden state.
+			 *
+			 * Selection state ("Selected" vs "Select" on the buttons inside
+			 * the grid) still updates from $parent.template_id, so the visual
+			 * cue for "this is the one you have queued for switching" is
+			 * preserved.
+			 */
 			$checkout_fields['template_element'] = [
 				'type'              => 'note',
 				'wrapper_classes'   => 'wu-w-full',
 				'classes'           => 'wu-w-full',
 				'desc'              => $desc,
 				'wrapper_html_attr' => [
-					'v-show'  => 'template_id == original_template_id',
-					'v-cloak' => '1',
-				],
-			];
-
-			/*
-			 * "Reset current template" — re-applies the customer's currently
-			 * assigned template, refreshing the site from the source template.
-			 * Useful when the source template has been updated, or when the
-			 * customer wants to discard their customisations and start over
-			 * without picking a different design.
-			 *
-			 * Only shows when the site is actually on a template (original_template_id > 0).
-			 * Sites created without a template (original_template_id == 0) have
-			 * nothing to reset to.
-			 */
-			// Confirmation text is provided to JS via wp_localize_script (see register_scripts())
-			// so it can be translated; the click handler in template-switching.js shows it via window.confirm().
-			$reset_link = sprintf(
-				'<div class="wu-text-right wu-mt-2"><a href="#" class="wu-no-underline wu-text-2xs wu-uppercase wu-font-semibold wu-text-red-600 hover:wu-text-red-800" v-on:click.prevent="reset_template()">%s</a></div>',
-				esc_html__('Reset current template', 'ultimate-multisite')
-			);
-
-			$checkout_fields['reset_current_template'] = [
-				'type'              => 'note',
-				'wrapper_classes'   => 'wu-w-full',
-				'classes'           => 'wu-w-full',
-				'desc'              => $reset_link,
-				'wrapper_html_attr' => [
-					'v-show'  => 'template_id == original_template_id && original_template_id > 0',
 					'v-cloak' => '1',
 				],
 			];

--- a/tests/WP_Ultimo/UI/Template_Switching_Element_Test.php
+++ b/tests/WP_Ultimo/UI/Template_Switching_Element_Test.php
@@ -258,4 +258,117 @@ class Template_Switching_Element_Test extends WP_UnitTestCase {
 		$this->assertSame( 'not_authorized', $decoded['data'][0]['code'] );
 	}
 
+	/**
+	 * Capture the rendered output of the element with a usable site/customer
+	 * context. Used by the layout tests below.
+	 *
+	 * @return string
+	 */
+	private function render_element_with_context(): string {
+
+		$user_id  = $this->factory()->user->create( [ 'role' => 'subscriber' ] );
+		$customer = wu_create_customer(
+			[
+				'user_id'       => $user_id,
+				'email_address' => 'render-' . uniqid() . '@example.com',
+			]
+		);
+
+		if ( is_wp_error( $customer ) ) {
+			$this->markTestSkipped( 'Customer creation failed: ' . $customer->get_error_message() );
+		}
+
+		$site_id = $this->factory()->blog->create();
+		$site    = wu_get_site( $site_id );
+		$site->set_type( 'customer_owned' );
+		$site->set_customer_id( $customer->get_id() );
+		$site->save();
+
+		WP_Ultimo()->currents->set_customer( $customer );
+		wp_set_current_user( $user_id );
+
+		$element = Template_Switching_Element::get_instance();
+
+		// Inject site and a state so output() proceeds.
+		$site_ref  = new \ReflectionProperty( $element, 'site' );
+		$state_ref = new \ReflectionProperty( $element, 'permission_state' );
+
+		if ( PHP_VERSION_ID < 80100 ) {
+			$site_ref->setAccessible( true );
+			$state_ref->setAccessible( true );
+		}
+
+		$site_ref->setValue( $element, $site );
+		$state_ref->setValue( $element, Template_Switching_Element::STATE_NO_MEMBERSHIP );
+
+		ob_start();
+		$element->output( $element->defaults() );
+
+		return (string) ob_get_clean();
+	}
+
+	/**
+	 * The current-template summary card must be present at the top of the
+	 * rendered output so the customer can see "what they're on" before
+	 * scrolling through the grid.
+	 *
+	 * Regression guard for the 2.9.4 redesign that introduced the card.
+	 */
+	public function test_render_includes_current_template_card(): void {
+
+		$html = $this->render_element_with_context();
+
+		$this->assertStringContainsString(
+			'wu-template-switching-current',
+			$html,
+			'Rendered output must include the current-template card wrapper.'
+		);
+
+		$this->assertStringContainsString(
+			'Available Templates',
+			$html,
+			'Rendered output must include the "Available Templates" heading that visually separates the card from the grid.'
+		);
+	}
+
+	/**
+	 * The grid wrapper must NOT carry a v-show that hides it when the
+	 * customer picks a different template. Hiding the grid mid-selection
+	 * was the UX regression this change fixes — the grid stays visible so
+	 * the customer can change their mind without scrolling away from a
+	 * disappeared list.
+	 *
+	 * We assert this by checking that the rendered template_element field
+	 * does not contain `v-show="template_id == original_template_id"` —
+	 * the exact directive that previously hid the grid.
+	 */
+	public function test_render_grid_is_not_hidden_during_selection(): void {
+
+		$html = $this->render_element_with_context();
+
+		$this->assertStringNotContainsString(
+			'v-show="template_id == original_template_id"',
+			$html,
+			'Grid must not be hidden when template_id != original_template_id; the customer needs to see the grid to change their mind.'
+		);
+	}
+
+	/**
+	 * The standalone "reset_current_template" red-link row must no longer
+	 * be emitted — the Reset action lives inside the current-template card
+	 * at the top of the page now. A duplicate row at the bottom would be
+	 * confusing.
+	 */
+	public function test_render_does_not_emit_legacy_bottom_reset_link(): void {
+
+		$html = $this->render_element_with_context();
+
+		// Legacy bottom-row container had this exact class chain.
+		$this->assertStringNotContainsString(
+			'wu-text-red-600 hover:wu-text-red-800',
+			$html,
+			'The legacy bottom-right "Reset current template" red link must be gone; Reset lives in the top card now.'
+		);
+	}
+
 }

--- a/views/ui/template-switching-current.php
+++ b/views/ui/template-switching-current.php
@@ -1,0 +1,87 @@
+<?php
+/**
+ * Current-template summary card for the customer-panel template-switching page.
+ *
+ * Renders the customer's currently active template with a "Reset" button to
+ * its right, kept visually distinct from the grid of available templates
+ * below it. The Vue model in assets/js/template-switching.js drives state.
+ *
+ * Expected variables:
+ *
+ * @var \WP_Ultimo\Models\Site $current_template Current template site (or false).
+ * @var int                    $original_template_id Current template ID (0 if none).
+ *
+ * @package WP_Ultimo
+ * @subpackage UI/Views
+ * @since 2.9.4
+ */
+
+// Exit if accessed directly
+defined('ABSPATH') || exit;
+
+$has_current_template = $current_template instanceof \WP_Ultimo\Models\Site && $original_template_id > 0;
+?>
+
+<div
+	class="wu-template-switching-current wu-mb-6"
+	v-cloak
+>
+
+	<?php if ($has_current_template) : ?>
+
+		<div class="wu-bg-white wu-border-solid wu-border wu-border-gray-300 wu-shadow-sm wu-rounded wu-p-4 wu-flex wu-items-center wu-gap-4">
+
+			<div class="wu-flex-shrink-0">
+				<img
+					class="wu-rounded wu-border-solid wu-border wu-border-gray-300 wu-bg-white"
+					style="width: 120px; height: 80px; object-fit: cover;"
+					src="<?php echo esc_attr($current_template->get_featured_image('wu-thumb-medium')); ?>"
+					alt="<?php echo esc_attr($current_template->get_title()); ?>"
+				/>
+			</div>
+
+			<div class="wu-flex-grow wu-min-w-0">
+				<div class="wu-text-2xs wu-uppercase wu-font-semibold wu-text-gray-500 wu-mb-1">
+					<?php esc_html_e('Current Template', 'ultimate-multisite'); ?>
+				</div>
+				<h3 class="wu-text-lg wu-font-semibold wu-m-0 wu-mb-1 wu-truncate">
+					<?php echo esc_html($current_template->get_title()); ?>
+				</h3>
+				<p class="wu-text-sm wu-text-gray-600 wu-m-0 wu-truncate">
+					<?php echo esc_html($current_template->get_description()); ?>
+				</p>
+			</div>
+
+			<div class="wu-flex-shrink-0">
+				<a
+					href="#"
+					class="button wu-no-underline"
+					v-on:click.prevent="reset_template()"
+					title="<?php esc_attr_e('Re-apply this template, overwriting the site with a fresh copy.', 'ultimate-multisite'); ?>"
+				>
+					<?php esc_html_e('Reset Current Template', 'ultimate-multisite'); ?>
+				</a>
+			</div>
+
+		</div>
+
+	<?php else : ?>
+
+		<div class="wu-bg-white wu-border-solid wu-border wu-border-gray-300 wu-shadow-sm wu-rounded wu-p-4">
+			<div class="wu-text-2xs wu-uppercase wu-font-semibold wu-text-gray-500 wu-mb-1">
+				<?php esc_html_e('Current Template', 'ultimate-multisite'); ?>
+			</div>
+			<p class="wu-text-sm wu-text-gray-600 wu-m-0">
+				<?php esc_html_e('This site is not currently based on a template. Choose one below to apply it.', 'ultimate-multisite'); ?>
+			</p>
+		</div>
+
+	<?php endif; ?>
+
+</div>
+
+<div class="wu-template-switching-divider wu-mb-4">
+	<h3 class="wu-text-base wu-font-semibold wu-text-gray-700 wu-m-0 wu-mb-2 wu-pb-2 wu-border-0 wu-border-b wu-border-solid wu-border-gray-200">
+		<?php esc_html_e('Available Templates', 'ultimate-multisite'); ?>
+	</h3>
+</div>


### PR DESCRIPTION
## Summary

Redesigns the customer-panel template-switching page so customers can see what template they are on, reset it inline, and pick a different one without losing visual context.

## Why

The previous layout had three usability gaps:

- **No "current template" affordance** — customers landing on the page saw a bare title plus a grid of templates, with no visible answer to "what template am I currently using?". The only signal was the word `Selected` on one of the cards inside the grid.
- **Reset link floated below the grid** — the `Reset current template` action lived as a small red link at the bottom-right of the page, far from the current-template state it acts on.
- **Grid disappeared on selection** — the moment a customer clicked a different template card, the grid was hidden via `v-show="template_id == original_template_id"` and replaced by the confirm panel. If the customer changed their mind or wanted to compare a third template, they had to back out and lose their selection.

## What changed

1. **Current-template summary card at the top** — thumbnail + title + description + `Reset Current Template` button, all co-located. Always visible regardless of grid selection state.
2. **`Available Templates` heading separator** between the summary card and the grid.
3. **Grid stays visible during selection** — the legacy `v-show` hide is removed. The "Selected"/"Select" state on each card still updates from `$parent.template_id`, so the visual cue for "queued for switching" is preserved.
4. **Removed the legacy bottom-right red Reset link** — the action lives inside the current-template card now.

## Files

- `inc/ui/class-template-switching-element.php` — restructure `output()`: insert `current_template_card` field that renders the new view, remove the `v-show` directive from `template_element`, remove the duplicate `reset_current_template` field.
- `views/ui/template-switching-current.php` — NEW: the current-template summary card view, loaded via `wu_get_template()` so customer-facing template-overrides work the same as for other UI views.
- `tests/WP_Ultimo/UI/Template_Switching_Element_Test.php` — three new render-level tests:
  - `test_render_includes_current_template_card`
  - `test_render_grid_is_not_hidden_during_selection`
  - `test_render_does_not_emit_legacy_bottom_reset_link`

## Verification

- `vendor/bin/phpunit --filter Template_Switching_Element_Test --no-coverage` — **6/6 pass** (3 existing AJAX tests + 3 new render tests).
- `vendor/bin/phpstan analyse` on changed files — clean.
- `php -l` on changed files — no syntax errors.
- Browser-verified on `http://kpcust1.wordpress.local:8080/wp-admin/admin.php?page=wu-template-switching` against the new branch:
  - Current-template card renders `Template Blue` thumbnail + title with `Reset Current Template` button to its right.
  - `Available Templates` heading separates the summary from the grid.
  - Clicking `Select` on `Template Pink` keeps the full grid (Pink/Blue/Site cards) visible. `Template Pink` shows `Selected`, the others show `Select`, and the confirm panel (`← BACK TO TEMPLATE SELECTION`, `CONFIRM TEMPLATE SWITCH?`) appears below the still-visible grid.
- Existing AJAX tests (`switch_template_missing_site_emits_json_error`, `switch_template_missing_template_id_emits_json_error`, `switch_template_rejects_unauthorized_caller`) still pass — the AJAX request path is unchanged.

## Backwards compatibility

- The `wu_template_switching_form` Vue model is unchanged — `template_id`, `original_template_id`, `confirm_switch`, `ready` still bind the same way.
- `assets/js/template-switching.js` is untouched. `reset_template()` is still called from `v-on:click.prevent="reset_template()"` on the new button (same handler that was on the old red link).
- `wu_get_template('ui/template-switching-current', …)` resolves through the standard view loader so customer-facing template overrides for the new view are supported.

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.14.67 plugin for [OpenCode](https://opencode.ai) v1.14.33 with claude-sonnet-4-6 spent 1d 14h on this as a headless worker.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a current template summary card in the template switching interface, displaying the active template with a reset option.

* **Updates**
  * Templates grid now remains visible during selection instead of being conditionally hidden.
  * Reorganized the reset template functionality for better visual organization.

* **Tests**
  * Added regression tests for template switching rendering and UI behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->