### PR TITLE
GH#1111: fix: remove obsolete WPCS sniffs

### DIFF
--- a/.phpcs.xml.dist
+++ b/.phpcs.xml.dist
@@ -47,16 +47,6 @@
 		<exclude-pattern>/tests/</exclude-pattern>
 	</rule>
 
-	<!-- Test files may use inline arrays for readability. -->
-	<rule ref="WordPress.Arrays.ArrayDeclaration.MultiLineNotAllowed">
-		<exclude-pattern>/tests/</exclude-pattern>
-	</rule>
-	<rule ref="WordPress.Arrays.ArrayDeclaration.CloseBraceNewLine">
-		<exclude-pattern>/tests/</exclude-pattern>
-	</rule>
-	<rule ref="WordPress.Arrays.ArrayDeclaration.AssociativeKeyFound">
-		<exclude-pattern>/tests/</exclude-pattern>
-	</rule>
 	<rule ref="WordPress.Arrays.ArrayKeySpacingRestrictions">
 		<exclude-pattern>/tests/</exclude-pattern>
 	</rule>


### PR DESCRIPTION
## Summary

Removed the three WPCS 2.x ArrayDeclaration sniff exclusions from .phpcs.xml.dist so PHPCS can load the WPCS 3.x ruleset instead of failing with a config error.

## Files Changed

.phpcs.xml.dist

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** composer install; vendor/bin/phpcs --version; vendor/bin/phpcs inc/ui/class-template-switching-element.php (PHPCS ran and reported one existing warning, not exit 3); vendor/bin/phpcs --config-show; git diff --check -- .phpcs.xml.dist

Resolves #1111


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.14.70 plugin for [OpenCode](https://opencode.ai) v1.14.33 with gpt-5.5 spent 1m and 25,377 tokens on this as a headless worker.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated PHP code style validation configuration by removing three array-declaration related code style rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->