### PR TITLE
GH#1116: fix: show empty billing address prompt

### DIFF
--- a/inc/objects/class-billing-address.php
+++ b/inc/objects/class-billing-address.php
@@ -94,7 +94,24 @@ class Billing_Address implements \JsonSerializable {
 	 */
 	public function exists() {
 
-		return ! empty(array_filter($this->attributes));
+		return ! empty(array_filter($this->attributes, [$this, 'has_value']));
+	}
+
+	/**
+	 * Checks if a field value should be rendered as present.
+	 *
+	 * @since 2.5.2
+	 *
+	 * @param mixed $value The value to check.
+	 * @return boolean
+	 */
+	protected function has_value($value) {
+
+		if (is_string($value)) {
+			$value = trim($value);
+		}
+
+		return '' !== $value && null !== $value && false !== $value && [] !== $value;
 	}
 
 	/**
@@ -188,10 +205,10 @@ class Billing_Address implements \JsonSerializable {
 		$fields = self::fields();
 
 		foreach ($fields as $field_key => $field) {
-			if ( ! empty($this->{$field_key})) {
+			if ($this->has_value($this->{$field_key})) {
 				$key = $labels ? $field['title'] : $field_key;
 
-				$address_array[ $key ] = $this->{$field_key};
+				$address_array[ $key ] = is_string($this->{$field_key}) ? trim($this->{$field_key}) : $this->{$field_key};
 			}
 		}
 

--- a/tests/WP_Ultimo/Objects/Billing_Address_Test.php
+++ b/tests/WP_Ultimo/Objects/Billing_Address_Test.php
@@ -81,6 +81,20 @@ class Billing_Address_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Test exists treats whitespace-only fields as empty.
+	 */
+	public function test_exists_returns_false_for_whitespace_only_fields(): void {
+
+		$address = new Billing_Address([
+			'billing_email'          => ' ',
+			'billing_address_line_1' => "\t",
+			'billing_country'        => "\n",
+		]);
+
+		$this->assertFalse($address->exists());
+	}
+
+	/**
 	 * Test magic getter returns empty string for missing attributes.
 	 */
 	public function test_magic_getter_returns_empty_for_missing(): void {
@@ -182,6 +196,22 @@ class Billing_Address_Test extends WP_UnitTestCase {
 		$this->assertArrayHasKey('billing_email', $array);
 		$this->assertArrayNotHasKey('company_name', $array);
 		$this->assertArrayNotHasKey('billing_state', $array);
+	}
+
+	/**
+	 * Test to_array trims values and excludes whitespace-only fields.
+	 */
+	public function test_to_array_trims_and_excludes_whitespace_only_fields(): void {
+
+		$address = new Billing_Address([
+			'billing_email'          => ' billing@example.com ',
+			'billing_address_line_1' => ' ',
+			'billing_country'        => "\t",
+		]);
+
+		$array = $address->to_array();
+
+		$this->assertSame(['billing_email' => 'billing@example.com'], $array);
 	}
 
 	/**

--- a/views/dashboard-widgets/billing-info.php
+++ b/views/dashboard-widgets/billing-info.php
@@ -6,8 +6,10 @@
  */
 defined('ABSPATH') || exit;
 
+$billing_address_fields = $billing_address->to_array(true);
+
 ?>
-<div class="wu-styling <?php echo esc_attr($className); ?>">
+<div class="wu-styling <?php echo esc_attr($className); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase ?>">
 
 	<div class="<?php echo esc_attr(wu_env_picker('', 'wu-widget-inset')); ?>">
 
@@ -45,14 +47,23 @@ defined('ABSPATH') || exit;
 		</div>
 		<!-- Title Element - End -->
 
-		<?php if ( ! $billing_address->exists()) : ?>
+		<?php if (empty($billing_address_fields)) : ?>
 
 		<div class="wu-p-4 wu-border-t wu-border-solid wu-border-0 wu-border-gray-200">
 
 			<div class="wu-p-4 wu-bg-gray-100 wu-rounded">
 
-			<?php // translators: %s: Billing address link. ?>
-			<?php printf(wp_kses_post(__('No billing address found. Click <a title="%1$s" href="%2$s" class="wubox wu-no-underline">here</a> to add one.', 'ultimate-multisite')), esc_html__('Update Billing Address', 'ultimate-multisite'), esc_url($update_billing_address_link)); ?>
+			<p class="wu-m-0 wu-mb-3">
+				<?php esc_html_e('No billing address found. Add one now so your invoices and payment details stay up to date.', 'ultimate-multisite'); ?>
+			</p>
+
+			<a
+				title="<?php esc_attr_e('Update Billing Address', 'ultimate-multisite'); ?>"
+				class="wubox button wu-no-underline"
+				href="<?php echo esc_attr($update_billing_address_link); ?>"
+			>
+				<?php esc_html_e('Add Billing Address', 'ultimate-multisite'); ?>
+			</a>
 
 			</div>
 
@@ -62,7 +73,7 @@ defined('ABSPATH') || exit;
 
 		<div class="wu-overflow-hidden">
 
-			<?php foreach ($billing_address->to_array(true) as $label => $value) : ?>
+			<?php foreach ($billing_address_fields as $label => $value) : ?>
 
 			<div class="wu-border-t wu-border-solid wu-border-0 wu-border-gray-200 wu-px-4 wu-py-2 sm:wu-p-0">
 
@@ -89,7 +100,7 @@ defined('ABSPATH') || exit;
 
 	<!-- Billing Address - End -->
 
-	<?php if ($membership->is_recurring() && false) : ?>
+	<?php if ($membership->is_recurring() && false) : // phpcs:ignore Generic.CodeAnalysis.UnconditionalIfStatement.Found ?>
 
 		<!-- Payment Method -->
 
@@ -98,7 +109,7 @@ defined('ABSPATH') || exit;
 		<!-- Title Element -->
 		<div class="wu-p-4 wu-flex wu-items-center <?php echo esc_attr(wu_env_picker('', 'wu-bg-gray-100 wu-border-solid wu-border-0 wu-border-b wu-border-t wu-border-gray-200')); ?>">
 
-			<?php if (true) : ?>
+			<?php if (true) : // phpcs:ignore Generic.CodeAnalysis.UnconditionalIfStatement.Found ?>
 
 			<h3 class="wu-m-0 <?php echo esc_attr(wu_env_picker('', 'wu-widget-title')); ?>">
 


### PR DESCRIPTION
## Summary

Normalised billing-address display values so whitespace-only saved fields count as empty, and rendered the billing-info widget from the normalised field list with a clear add-address call to action.

## Files Changed

inc/objects/class-billing-address.php,tests/WP_Ultimo/Objects/Billing_Address_Test.php,views/dashboard-widgets/billing-info.php

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** WP_TESTS_DIR=/tmp/wordpress-tests-lib vendor/bin/phpunit --filter Billing_Address_Test; vendor/bin/phpcs inc/objects/class-billing-address.php views/dashboard-widgets/billing-info.php tests/WP_Ultimo/Objects/Billing_Address_Test.php

Resolves #1116


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.14.72 plugin for [OpenCode](https://opencode.ai) v1.14.33 with gpt-5.5 spent 3m and 96,446 tokens on this as a headless worker.