### PR TITLE
GH#1114: fix(current): lazy-load currents before init

### DIFF
--- a/inc/class-current.php
+++ b/inc/class-current.php
@@ -70,6 +70,14 @@ class Current implements \WP_Ultimo\Interfaces\Singleton {
 	protected $membership_set_via_request = false;
 
 	/**
+	 * Whether or not the current objects have been loaded.
+	 *
+	 * @since 2.5.3
+	 * @var boolean
+	 */
+	protected $loaded = false;
+
+	/**
 	 * Called when the singleton is first initialized.
 	 *
 	 * @since 2.0.0
@@ -222,6 +230,8 @@ class Current implements \WP_Ultimo\Interfaces\Singleton {
 	 */
 	public function load_currents(): void {
 
+		$this->loaded = true;
+
 		// On the wp hook, only re-run if we're on the frontend
 		// (query var overrides from pretty URLs only work there).
 		// On admin or AJAX, the init run already set everything.
@@ -313,6 +323,10 @@ class Current implements \WP_Ultimo\Interfaces\Singleton {
 	 */
 	public function get_site() {
 
+		if ( ! $this->loaded && null === $this->site) {
+			$this->load_currents();
+		}
+
 		return $this->site;
 	}
 
@@ -359,6 +373,10 @@ class Current implements \WP_Ultimo\Interfaces\Singleton {
 	 */
 	public function get_customer() {
 
+		if ( ! $this->loaded && null === $this->customer) {
+			$this->load_currents();
+		}
+
 		return $this->customer;
 	}
 
@@ -393,6 +411,10 @@ class Current implements \WP_Ultimo\Interfaces\Singleton {
 	 * @return \WP_Ultimo\Models\Membership
 	 */
 	public function get_membership() {
+
+		if ( ! $this->loaded && null === $this->membership) {
+			$this->load_currents();
+		}
 
 		return $this->membership;
 	}

--- a/inc/managers/class-site-manager.php
+++ b/inc/managers/class-site-manager.php
@@ -233,7 +233,7 @@ class Site_Manager extends Base_Manager {
 			if ($checkout->is_last_step()) {
 				$membership = WP_Ultimo()->currents->get_membership();
 
-				$customer = wu_get_current_customer();
+				$customer = WP_Ultimo()->currents->get_customer();
 
 				/*
 				 * Fallback for the wu-ajax light-ajax pipeline.
@@ -466,7 +466,6 @@ class Site_Manager extends Base_Manager {
 		}
 
 		if (false === $can_access) {
-
 			/*
 			 * Allow plugins to provide a reactivation URL for blocked sites.
 			 *
@@ -1096,7 +1095,6 @@ class Site_Manager extends Base_Manager {
 					$membership->delete_pending_site();
 				}
 			} elseif (Membership_Status::PENDING === $membership->get_status()) {
-
 				/*
 				 * Safety net for orphaned pending_sites on `pending` memberships.
 				 *

--- a/tests/WP_Ultimo/Current_Test.php
+++ b/tests/WP_Ultimo/Current_Test.php
@@ -139,6 +139,66 @@ class Current_Test extends \WP_UnitTestCase {
 	}
 
 	/**
+	 * Test that accessors lazy-load currents when read before the init hook cache is populated.
+	 */
+	public function test_accessors_lazy_load_currents(): void {
+
+		$user_id = $this->factory()->user->create(['role' => 'subscriber']);
+
+		$customer = wu_create_customer(
+			[
+				'user_id'       => $user_id,
+				'email_address' => 'current-lazy-load@example.com',
+			]
+		);
+
+		$product = wu_create_product(
+			[
+				'name'          => 'Current Lazy Load Product',
+				'slug'          => 'current-lazy-load-product-' . wp_rand(),
+				'type'          => 'plan',
+				'amount'        => 10,
+				'duration'      => 1,
+				'duration_unit' => 'month',
+				'pricing_type'  => 'paid',
+			]
+		);
+
+		$membership = wu_create_membership(
+			[
+				'customer_id'     => $customer->get_id(),
+				'plan_id'         => $product->get_id(),
+				'status'          => \WP_Ultimo\Database\Memberships\Membership_Status::ACTIVE,
+				'amount'          => 10,
+				'currency'        => 'USD',
+				'skip_validation' => true,
+			]
+		);
+
+		wp_set_current_user($user_id);
+
+		$this->current->set_site(null);
+		$this->current->set_customer(null);
+		$this->current->set_membership(null);
+		$this->set_loaded_state(false);
+
+		$this->assertSame($customer->get_id(), $this->current->get_customer()->get_id());
+		$this->assertSame($membership->get_id(), $this->current->get_membership()->get_id());
+	}
+
+	/**
+	 * Sets the protected loaded flag for lazy-load tests.
+	 *
+	 * @param bool $loaded Whether the current cache should be marked loaded.
+	 */
+	protected function set_loaded_state($loaded): void {
+
+		$property = new \ReflectionProperty(Current::class, 'loaded');
+		$property->setAccessible(true);
+		$property->setValue($this->current, $loaded);
+	}
+
+	/**
 	 * Test param_key returns expected defaults.
 	 */
 	public function test_param_key_returns_defaults(): void {


### PR DESCRIPTION
## Summary

Added a loaded guard to Current so get_site(), get_customer(), and get_membership() populate caches on first read before init, and switched add-new-site validation back to the Current customer accessor now that it is resilient.

## Files Changed

inc/class-current.php,inc/managers/class-site-manager.php,tests/WP_Ultimo/Current_Test.php

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** vendor/bin/phpcs inc/class-current.php inc/managers/class-site-manager.php tests/WP_Ultimo/Current_Test.php; WP_TESTS_DIR=/tmp/wordpress-tests-lib vendor/bin/phpunit --filter Current_Test; vendor/bin/phpstan analyse inc/class-current.php inc/managers/class-site-manager.php

Resolves #1114


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.14.72 plugin for [OpenCode](https://opencode.ai) v1.14.33 with gpt-5.5 spent 4m and 97,156 tokens on this as a headless worker.