### PR TITLE
GH#1115: fix: validate site override inputs

### DIFF
--- a/inc/helpers/class-site-duplicator.php
+++ b/inc/helpers/class-site-duplicator.php
@@ -93,10 +93,25 @@ class Site_Duplicator {
 	 */
 	public static function override_site($from_site_id, $to_site_id, $args = []) {
 
+		$from_site = wu_get_site($from_site_id);
+
+		if ( ! $from_site) {
+			// translators: %d is the source template site ID.
+			$message = sprintf(__('Source template site %d not found. Cannot override site.', 'ultimate-multisite'), $from_site_id);
+
+			wu_log_add('site-duplication', new \WP_Error('source_template_site_not_found', $message), LogLevel::ERROR);
+
+			return false;
+		}
+
 		$to_site = wu_get_site($to_site_id);
 
-		if (! $to_site) {
-			wu_log_add('site-duplication', sprintf('Target site %d not found', $to_site_id), LogLevel::ERROR);
+		if ( ! $to_site) {
+			// translators: %d is the destination site ID.
+			$message = sprintf(__('Destination site %d not found. Cannot override site.', 'ultimate-multisite'), $to_site_id);
+
+			wu_log_add('site-duplication', new \WP_Error('destination_site_not_found', $message), LogLevel::ERROR);
+
 			return false;
 		}
 
@@ -231,8 +246,8 @@ class Site_Duplicator {
 
 		self::cleanup_override_context($to_site_id, $to_site_customer, $caller_blog_id);
 
-		// translators: %1$d is the ID of the site template used, and %2$d is the ID of the overriden site.
-		$message = sprintf(__('Attempt to override site %1$d with data from site %2$d successful.', 'ultimate-multisite'), $from_site_id, $duplicate_site_id);
+		// translators: %1$d is the ID of the site template used, and %2$d is the ID of the overridden site.
+		$message = sprintf(__('Attempt to override destination site %2$d with data from source template site %1$d successful.', 'ultimate-multisite'), $from_site_id, $duplicate_site_id);
 
 		wu_log_add('site-duplication', $message);
 
@@ -249,9 +264,9 @@ class Site_Duplicator {
 	 * @since 2.4.0
 	 * @see https://github.com/Ultimate-Multisite/ultimate-multisite/pull/1082
 	 *
-	 * @param int        $to_site_id      Target site blog ID (for cache invalidation).
+	 * @param int          $to_site_id      Target site blog ID (for cache invalidation).
 	 * @param object|false $to_site_customer Customer object or false.
-	 * @param int        $caller_blog_id  Blog ID captured at method entry.
+	 * @param int          $caller_blog_id  Blog ID captured at method entry.
 	 */
 	private static function cleanup_override_context($to_site_id, $to_site_customer, $caller_blog_id) {
 
@@ -543,7 +558,7 @@ class Site_Duplicator {
 	/**
 	 * Rewrite source-site URLs to target-site URLs across all cloned tables.
 	 *
-	 * backfill_postmeta() inserts rows after MUCD_Data::copy_data() has already
+	 * Backfill_postmeta() inserts rows after MUCD_Data::copy_data() has already
 	 * run its source→target URL replacement pass (db_update_data()), so those
 	 * rows contain raw template-site URLs. This method applies the same URL
 	 * substitution to the target's postmeta, posts, options, termmeta, and
@@ -606,7 +621,7 @@ class Site_Duplicator {
 			"{$to_prefix}commentmeta" => 'meta_value',
 		];
 
-		// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+		// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQLPlaceholders.UnfinishedPrepare
 		foreach ($tables as $table => $column) {
 
 			// Skip tables that don't exist (e.g. termmeta on older WP versions).
@@ -622,7 +637,6 @@ class Site_Duplicator {
 			}
 
 			foreach ($replacements as $from => $to) {
-
 				if ($from === $to) {
 					continue;
 				}
@@ -671,7 +685,7 @@ class Site_Duplicator {
 			return;
 		}
 
-		// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+		// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQLPlaceholders.UnfinishedPrepare
 		$wpdb->query(
 			"INSERT INTO {$to_prefix}postmeta (post_id, meta_key, meta_value)
 			SELECT src.post_id, src.meta_key, src.meta_value
@@ -737,7 +751,7 @@ class Site_Duplicator {
 					  SELECT 1 FROM {$to_prefix}postmeta tpm
 					  WHERE tpm.post_id = src.post_id
 						AND tpm.meta_key = src.meta_key
-				  )",
+					  )", // phpcs:ignore WordPress.DB.PreparedSQLPlaceholders.UnfinishedPrepare
 				...$meta_keys
 			)
 		);
@@ -895,7 +909,7 @@ class Site_Duplicator {
 			 */
 			if ( class_exists('\Elementor\Core\Files\CSS\Post') ) {
 				try {
-					( new \Elementor\Core\Files\CSS\Post($kit_id_to) )->update();
+					(new \Elementor\Core\Files\CSS\Post($kit_id_to))->update();
 				} catch ( \Throwable $e ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch
 					// Non-fatal — CSS will be rebuilt on next page load.
 				}

--- a/tests/WP_Ultimo/Helpers/Site_Duplicator_Test.php
+++ b/tests/WP_Ultimo/Helpers/Site_Duplicator_Test.php
@@ -8,6 +8,7 @@
 
 namespace WP_Ultimo\Tests\Helpers;
 
+use Psr\Log\LogLevel;
 use WP_Ultimo\Helpers\Site_Duplicator;
 use WP_Ultimo\Models\Customer;
 use WP_Ultimo\Models\Site;
@@ -47,9 +48,9 @@ class Site_Duplicator_Test extends WP_UnitTestCase {
 		// Create test customer
 		$this->customer = wu_create_customer(
 			[
-				'username'      => 'testuser',
-				'email' => 'test@example.com',
-				'password'      => 'password123',
+				'username' => 'testuser',
+				'email'    => 'test@example.com',
+				'password' => 'password123',
 			]
 		);
 
@@ -174,12 +175,36 @@ class Site_Duplicator_Test extends WP_UnitTestCase {
 		$this->assertTrue(is_wp_error($target_wu_site));
 		$this->assertEquals('Sorry, that site already exists!', $target_wu_site->get_error_message());
 
-		$args = [];
+		$logged_messages = [];
+		$logger          = function ($handle, $message, $log_level) use (&$logged_messages) {
+			if ('site-duplication' === $handle) {
+				$logged_messages[] = [
+					'message' => $message,
+					'level'   => $log_level,
+				];
+			}
+		};
+
+		add_action('wu_log_add', $logger, 10, 3);
+
+		$args = [
+			'copy_files' => false,
+			'keep_users' => false,
+		];
 
 		$result = Site_Duplicator::override_site($this->template_site_id, $target_site_id, $args);
 
-		// Method should return the target site ID or false
-		$this->assertTrue($result === $target_site_id || $result === false);
+		remove_action('wu_log_add', $logger, 10);
+
+		$validation_errors = array_filter(
+			$logged_messages,
+			function ($log) {
+				return LogLevel::ERROR === $log['level'] && false !== strpos($log['message'], 'not found');
+			}
+		);
+
+		$this->assertEmpty($validation_errors, 'Valid source and destination sites should not fail existence validation.');
+		$this->assertNotFalse($result, 'Valid source and destination sites should complete the override.');
 
 		// Clean up
 		wpmu_delete_blog($target_site_id, true);
@@ -227,13 +252,63 @@ class Site_Duplicator_Test extends WP_UnitTestCase {
 	 */
 	public function test_override_invalid_target_site() {
 		$invalid_target_id = 99999;
+		$logged_messages   = [];
+		$logger            = function ($handle, $message, $log_level) use (&$logged_messages) {
+			if ('site-duplication' === $handle) {
+				$logged_messages[] = [
+					'message' => $message,
+					'level'   => $log_level,
+				];
+			}
+		};
+
+		add_action('wu_log_add', $logger, 10, 3);
 
 		$args = [];
 
 		$result = Site_Duplicator::override_site($this->template_site_id, $invalid_target_id, $args);
 
+		remove_action('wu_log_add', $logger, 10);
+
 		// Should handle gracefully
 		$this->assertFalse($result);
+		$this->assertSame(LogLevel::ERROR, $logged_messages[0]['level']);
+		$this->assertStringContainsString('Destination site 99999 not found', $logged_messages[0]['message']);
+	}
+
+	/**
+	 * Test override with invalid source site.
+	 */
+	public function test_override_invalid_source_site() {
+		$invalid_source_id = 99999;
+		$target_site_id    = self::factory()->blog->create(
+			[
+				'domain' => 'invalid-source-target.example.com',
+				'path'   => '/',
+				'title'  => 'Invalid Source Target',
+			]
+		);
+		$logged_messages   = [];
+		$logger            = function ($handle, $message, $log_level) use (&$logged_messages) {
+			if ('site-duplication' === $handle) {
+				$logged_messages[] = [
+					'message' => $message,
+					'level'   => $log_level,
+				];
+			}
+		};
+
+		add_action('wu_log_add', $logger, 10, 3);
+
+		$result = Site_Duplicator::override_site($invalid_source_id, $target_site_id);
+
+		remove_action('wu_log_add', $logger, 10);
+
+		$this->assertFalse($result);
+		$this->assertSame(LogLevel::ERROR, $logged_messages[0]['level']);
+		$this->assertStringContainsString('Source template site 99999 not found', $logged_messages[0]['message']);
+
+		wpmu_delete_blog($target_site_id, true);
 	}
 
 	/**
@@ -396,7 +471,10 @@ class Site_Duplicator_Test extends WP_UnitTestCase {
 			]
 		);
 		add_post_meta($post_id, '_wp_attached_file', '2026/04/test-image.jpg');
-		add_post_meta($post_id, '_wp_attachment_metadata', ['width' => 800, 'height' => 600]);
+		add_post_meta($post_id, '_wp_attachment_metadata', [
+			'width'  => 800,
+			'height' => 600,
+		]);
 		add_post_meta($post_id, '_wp_attachment_image_alt', 'Alt text');
 		restore_current_blog();
 
@@ -437,7 +515,7 @@ class Site_Duplicator_Test extends WP_UnitTestCase {
 		$target_id   = self::factory()->blog->create();
 
 		switch_to_blog($template_id);
-		$post_id = wp_insert_post(
+		$post_id        = wp_insert_post(
 			[
 				'import_id'   => 700,
 				'post_type'   => 'elementor_library',
@@ -486,14 +564,23 @@ class Site_Duplicator_Test extends WP_UnitTestCase {
 
 		$real_settings = [
 			'system_colors' => [
-				['_id' => 'primary', 'color' => '#EAC7C7'],
-				['_id' => 'secondary', 'color' => '#ED6363'],
+				[
+					'_id'   => 'primary',
+					'color' => '#EAC7C7',
+				],
+				[
+					'_id'   => 'secondary',
+					'color' => '#ED6363',
+				],
 			],
 			'custom_colors' => [
-				['_id' => 'brand', 'color' => '#FF0000'],
+				[
+					'_id'   => 'brand',
+					'color' => '#FF0000',
+				],
 			],
 		];
-		$real_data = '[{"id":"kit1","elType":"kit","settings":{}}]';
+		$real_data     = '[{"id":"kit1","elType":"kit","settings":{}}]';
 
 		switch_to_blog($template_id);
 		$kit_id = wp_insert_post(
@@ -509,7 +596,14 @@ class Site_Duplicator_Test extends WP_UnitTestCase {
 		update_post_meta($kit_id, '_elementor_data', $real_data);
 		restore_current_blog();
 
-		$stub_settings = ['system_colors' => [['_id' => 'primary', 'color' => '#6EC1E4']]];
+		$stub_settings = [
+			'system_colors' => [
+				[
+					'_id'   => 'primary',
+					'color' => '#6EC1E4',
+				],
+			],
+		];
 
 		switch_to_blog($target_id);
 		$target_kit_id = wp_insert_post(
@@ -564,7 +658,7 @@ class Site_Duplicator_Test extends WP_UnitTestCase {
 		$method->invoke(null, $site_id, $site_id);
 
 		switch_to_blog($site_id);
-		$values = get_post_meta(800, '_menu_item_type');
+		$values = get_post_meta(800, '_menu_item_type', false);
 		$this->assertCount(1, $values);
 		restore_current_blog();
 
@@ -607,7 +701,7 @@ class Site_Duplicator_Test extends WP_UnitTestCase {
 		$method->invoke(null, $template_id, $target_id);
 
 		switch_to_blog($target_id);
-		$values = get_post_meta(900, '_menu_item_type');
+		$values = get_post_meta(900, '_menu_item_type', false);
 		$this->assertCount(1, $values);
 		$this->assertEquals('post_type', $values[0]);
 		restore_current_blog();


### PR DESCRIPTION
## Summary

Validated source and destination site IDs before override_site() continues, logged clear WP_Error messages for missing sites, and corrected the successful override log wording.

## Files Changed

inc/helpers/class-site-duplicator.php,tests/WP_Ultimo/Helpers/Site_Duplicator_Test.php

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** vendor/bin/phpcs inc/helpers/class-site-duplicator.php tests/WP_Ultimo/Helpers/Site_Duplicator_Test.php; WP_TESTS_DIR=/tmp/wordpress-tests-lib vendor/bin/phpunit --filter 'test_override_invalid_(target|source)_site|test_site_override'

Resolves #1115


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.14.72 plugin for [OpenCode](https://opencode.ai) v1.14.33 with gpt-5.5 spent 5m and 122,296 tokens on this as a headless worker.