### PR TITLE
GH#1121: docs: expand contributor insight guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -173,10 +173,14 @@ Use `WP_Error` for validation/operation failures — not exceptions.
 
 ### Recurring Product Context
 - Signup/payment timeout reports may involve a pre-created pending membership and
-  `pending_site` cleanup. Inspect the checkout, membership, payment gateway, and
-  orphaned-site cleanup paths together before changing watchdog or cancellation logic.
+  `pending_site` cleanup, especially when the payment step times out almost
+  immediately after signup. Inspect the checkout, membership, payment gateway, and
+  orphaned-site cleanup paths together before changing watchdog or cancellation logic;
+  verify both pending membership cancellation and pending site cleanup.
 - Do not reference an `ultimate-multisite-woocommerce` addon release as v2.0.23; the
-  latest known released version is v2.0.10 unless repository evidence says otherwise.
+  latest known released version is v2.0.10 unless repository or release evidence says
+  otherwise. Verify addon version claims before adding them to docs, issues, or
+  user-facing troubleshooting notes.
 
 ### Tests
 - Extend `WP_UnitTestCase`. Tests run in a WordPress Multisite environment


### PR DESCRIPTION
## Summary

Expanded AGENTS.md recurring product context for signup timeout pending_site cleanup and ultimate-multisite-woocommerce addon version verification.

## Files Changed

AGENTS.md

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** git diff --check

Resolves #1121


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.14.73 plugin for [OpenCode](https://opencode.ai) v1.14.33 with gpt-5.5 spent 1m and 44,446 tokens on this as a headless worker.