### PR TITLE
fix(site): propagate WP_Error from wp_delete_site() to prevent silent redirect on failure

### DIFF
--- a/inc/models/class-site.php
+++ b/inc/models/class-site.php
@@ -1766,7 +1766,7 @@ class Site extends Base_Model implements Limitable, Notable {
 		}
 
 		/**
-		 * Fires after an object is stored into the database.
+		 * Fires before the site is deleted.
 		 *
 		 * @since 2.0.0
 		 *
@@ -1775,15 +1775,29 @@ class Site extends Base_Model implements Limitable, Notable {
 		do_action("wu_{$this->model}_pre_delete", $this); // @phpstan-ignore-line
 
 		try {
-			$result = (bool) wp_delete_site($this->get_id());
+			$wp_result = wp_delete_site($this->get_id());
 		} catch (\Throwable $e) {
-			$result = false;
-
 			wu_log_add('fatal-error', $e->getMessage(), LogLevel::ERROR);
+
+			return false;
 		}
 
+		/*
+		 * wp_delete_site() returns a WP_Error on failure (e.g. trying to
+		 * delete the main site). The old code cast the return to (bool),
+		 * which made WP_Error truthy — so callers received `true` even when
+		 * the deletion had not taken place. Return the WP_Error directly so
+		 * that handle_model_delete_form() can surface the error in the modal
+		 * instead of silently redirecting the user to a blank/white page.
+		 */
+		if (is_wp_error($wp_result)) {
+			return $wp_result;
+		}
+
+		$result = true;
+
 		/**
-		 * Fires after an object is stored into the database.
+		 * Fires after the site is deleted.
 		 *
 		 * @since 2.0.0
 		 *

--- a/tests/WP_Ultimo/Models/Site_Test.php
+++ b/tests/WP_Ultimo/Models/Site_Test.php
@@ -824,6 +824,41 @@ class Site_Test extends \WP_UnitTestCase {
 	}
 
 	/**
+	 * Regression test for t532: Site::delete() must propagate WP_Error from
+	 * wp_delete_site() instead of silently treating it as success.
+	 *
+	 * The old code used `(bool) wp_delete_site()`: any WP_Error (e.g. when the
+	 * underlying blog no longer exists) was truthy, so `handle_model_delete_form()`
+	 * received `true`, sent a JSON success, and the JS redirected the user —
+	 * producing a white page because the site was never actually removed.
+	 *
+	 * We verify this by asking Site::delete() to remove a blog whose underlying
+	 * WordPress site has already been deleted, so wp_delete_site() returns WP_Error.
+	 */
+	public function test_delete_propagates_wp_error_from_wp_delete_site(): void {
+		// Create and immediately delete a real blog so its ID is now invalid.
+		$blog_id = $this->factory()->blog->create();
+		if (is_wp_error($blog_id)) {
+			$this->markTestSkipped('Could not create a blog for this test.');
+		}
+
+		wp_delete_site($blog_id); // removes the blog from wp_blogs
+
+		// Build a Site model pointing at the now-deleted blog_id.
+		// wu_get_site() would return false here since the row is gone, so
+		// we construct it directly with just the id filled in.
+		$site = new Site(['blog_id' => $blog_id]);
+
+		$result = $site->delete();
+
+		$this->assertInstanceOf(
+			\WP_Error::class,
+			$result,
+			'Site::delete() must propagate the WP_Error returned by wp_delete_site() instead of coercing it to true.'
+		);
+	}
+
+	/**
 	 * Test get_type returns main for the main site.
 	 */
 	public function test_get_type_main_site(): void {


### PR DESCRIPTION
## Summary

- `Site::delete()` was casting `wp_delete_site()` return to `(bool)`, making any `WP_Error` truthy — callers received `true` even when deletion failed
- `handle_model_delete_form()` then sent JSON success, wubox JS redirected the user, and the resulting page appeared blank/white because the site was never actually removed
- Fix: return the `WP_Error` directly so the delete modal surfaces the real failure instead of silently redirecting

## Changes

**`inc/models/class-site.php`** — `Site::delete()` now stores the raw `wp_delete_site()` return, checks `is_wp_error()` on it, and propagates any `WP_Error` to the caller. On success it still returns `true`; on exception it still returns `false`.

**`tests/WP_Ultimo/Models/Site_Test.php`** — adds `test_delete_propagates_wp_error_from_wp_delete_site` which creates a blog, pre-deletes it from WordPress, then calls `Site::delete()` and asserts the returned `WP_Error` is not coerced to `true`.

## Testing

```bash
vendor/bin/phpunit --filter "Site_Test::test_delete_unsaved_site|Site_Test::test_delete_propagates_wp_error_from_wp_delete_site"
```

Both tests pass. All pre-existing Site_Test / Site_Manager_Test failures are unrelated to this change.

Resolves t532

---
<!-- aidevops:sig -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced site deletion with improved error handling and logging for failed deletion scenarios.

* **Tests**
  * Added test coverage for site deletion error propagation when an underlying blog has been previously removed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->