### PR TITLE
fix(stripe-checkout): guard null/WP_Error customer in run_preflight

### DIFF
--- a/inc/gateways/class-base-stripe-gateway.php
+++ b/inc/gateways/class-base-stripe-gateway.php
@@ -1544,17 +1544,28 @@ class Base_Stripe_Gateway extends Base_Gateway {
 				$stripe_customer = $this->get_stripe_client()->customers->retrieve($stripe_customer_id);
 
 				/*
-				 * If the customer was deleted, we
-				 * cannot use it again...
+				 * If the customer was deleted, or the response object lacks a
+				 * usable id, we cannot use it again. Fall through to creating
+				 * a fresh Stripe customer below.
 				 */
-				if ( $stripe_customer && (! isset($stripe_customer->deleted) || ! $stripe_customer->deleted)) {
+				if ($stripe_customer && ! empty($stripe_customer->id) && (! isset($stripe_customer->deleted) || ! $stripe_customer->deleted)) {
 					$customer_exists = true;
 				}
-			} catch (\Exception $e) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch
-
-				/**
-				 * Silence is golden.
+			} catch (\Exception $e) {
+				/*
+				 * The stored Stripe customer id could not be retrieved. Common
+				 * causes are a test/live key mismatch, an account swap, or the
+				 * customer being deleted in the Stripe dashboard. Log the cause
+				 * for debugging and self-heal by creating a fresh customer.
 				 */
+				wu_log_add(
+					'stripe',
+					sprintf(
+						'Could not retrieve stored Stripe customer %s — falling back to creating a new one. Reason: %s',
+						$stripe_customer_id,
+						$e->getMessage()
+					)
+				);
 			}
 		}
 
@@ -1597,6 +1608,19 @@ class Base_Stripe_Gateway extends Base_Gateway {
 
 				return new \WP_Error($error_code, $e->getMessage());
 			}
+		}
+
+		/*
+		 * Final defensive check — guarantees the caller receives either a usable
+		 * \Stripe\Customer (with a non-empty id) or a \WP_Error. Without this,
+		 * a malformed retrieve response could leak an object whose ->id is null
+		 * and fatal in downstream typed parameters.
+		 */
+		if (empty($stripe_customer) || empty($stripe_customer->id)) {
+			return new \WP_Error(
+				'wu_stripe_no_customer',
+				__('Could not create or retrieve a Stripe customer record.', 'ultimate-multisite')
+			);
 		}
 
 		return $stripe_customer;

--- a/inc/gateways/class-stripe-checkout-gateway.php
+++ b/inc/gateways/class-stripe-checkout-gateway.php
@@ -219,9 +219,29 @@ class Stripe_Checkout_Gateway extends Base_Stripe_Gateway {
 		$this->setup_api_keys();
 
 		/*
-		 * Creates or retrieves the Stripe Customer
+		 * Creates or retrieves the Stripe Customer.
 		 */
 		$s_customer = $this->get_or_create_customer($this->customer->get_id());
+
+		/*
+		 * Bail early if customer creation/retrieval failed.
+		 *
+		 * get_or_create_customer() is documented to return \Stripe\Customer|\WP_Error,
+		 * but historically the caller dereferenced ->id without checking — which
+		 * fatals on the typed parameter of sync_billing_address_to_stripe() when
+		 * the Stripe API call throws (mismatched test/live keys, deleted customer,
+		 * network failure, etc.). Surface the error to the checkout flow instead.
+		 */
+		if (is_wp_error($s_customer)) {
+			return $s_customer;
+		}
+
+		if (empty($s_customer) || empty($s_customer->id)) {
+			return new \WP_Error(
+				'wu_stripe_checkout_no_customer',
+				__('We could not create or retrieve your Stripe customer record. Please try again, or contact support if the problem persists.', 'ultimate-multisite')
+			);
+		}
 
 		/*
 		 * Update the Stripe customer with the current billing address.
@@ -552,6 +572,14 @@ class Stripe_Checkout_Gateway extends Base_Stripe_Gateway {
 	 * @return void
 	 */
 	protected function sync_billing_address_to_stripe(string $stripe_customer_id): void {
+		/*
+		 * Defensive guard: an empty customer ID would 400 from Stripe and is
+		 * never a valid call. The primary caller (run_preflight) already
+		 * blocks this case, but keep this here for any future caller.
+		 */
+		if (empty($stripe_customer_id)) {
+			return;
+		}
 
 		$billing_address = $this->customer->get_billing_address();
 

--- a/tests/WP_Ultimo/Gateways/Stripe_Checkout_Gateway_Run_Preflight_Test.php
+++ b/tests/WP_Ultimo/Gateways/Stripe_Checkout_Gateway_Run_Preflight_Test.php
@@ -531,6 +531,181 @@ class Stripe_Checkout_Gateway_Run_Preflight_Test extends \WP_UnitTestCase {
 	}
 
 	/**
+	 * Verify that run_preflight() returns a WP_Error (rather than fatalling on
+	 * a null customer id) when get_or_create_customer() fails to retrieve or
+	 * create a Stripe customer.
+	 *
+	 * Regression test for the support report:
+	 *   "Stripe Checkout session is returning null customer; please add
+	 *   customer_creation => always or guard null customer in
+	 *   sync_billing_address_to_stripe()"
+	 *
+	 *   TypeError: Stripe_Checkout_Gateway::sync_billing_address_to_stripe():
+	 *   Argument #1 ($stripe_customer_id) must be of type string, null given
+	 *
+	 * The root cause is that get_or_create_customer() can return WP_Error (or
+	 * an object whose id is null), but run_preflight() previously dereferenced
+	 * ->id without checking.
+	 *
+	 * @return void
+	 */
+	public function test_run_preflight_returns_wp_error_when_customer_creation_fails(): void {
+		$context = $this->build_checkout_context(false, false);
+
+		// Build a Stripe client whose customers service throws on both retrieve
+		// and create — simulating, for example, a key/account mismatch.
+		$failing_client = $this->getMockBuilder(StripeClient::class)
+			->disableOriginalConstructor()
+			->getMock();
+
+		$failing_customers = $this->getMockBuilder(\Stripe\Service\CustomerService::class)
+			->disableOriginalConstructor()
+			->getMock();
+
+		$failing_customers->method('retrieve')->will(
+			$this->throwException(new \Stripe\Exception\InvalidRequestException('No such customer', 404))
+		);
+		$failing_customers->method('create')->will(
+			$this->throwException(new \Stripe\Exception\AuthenticationException('Invalid API key provided', 401))
+		);
+
+		$failing_client->method('__get')->willReturnCallback(
+			function ($property) use ($failing_customers) {
+				if ('customers' === $property) {
+					return $failing_customers;
+				}
+				return null;
+			}
+		);
+
+		$this->gateway->set_stripe_client($failing_client);
+
+		$result = $this->gateway->run_preflight();
+
+		// Must return a WP_Error — never fatal on a null customer id.
+		$this->assertInstanceOf(
+			\WP_Error::class,
+			$result,
+			'run_preflight() must return WP_Error when Stripe customer cannot be created'
+		);
+
+		// Cleanup
+		$context['payment']->delete();
+		$context['membership']->delete();
+		$context['product']->delete();
+	}
+
+	/**
+	 * Verify that get_or_create_customer() self-heals when the stored Stripe
+	 * customer id cannot be retrieved (e.g. test/live key mismatch, account
+	 * swap, customer deleted in dashboard) by creating a fresh customer.
+	 *
+	 * @return void
+	 */
+	public function test_get_or_create_customer_self_heals_on_stale_stored_id(): void {
+		$customer = self::$customer;
+
+		// Pre-seed a stale gateway_customer_id on a membership for this customer.
+		$stale_membership = wu_create_membership(
+			[
+				'customer_id'         => $customer->get_id(),
+				'plan_id'             => 0,
+				'status'              => Membership_Status::PENDING,
+				'recurring'           => false,
+				'gateway'             => 'stripe-checkout',
+				'gateway_customer_id' => 'cus_stale_does_not_exist',
+				'currency'            => 'USD',
+			]
+		);
+
+		// Build a client whose retrieve throws (stale id) but create succeeds.
+		$client = $this->getMockBuilder(StripeClient::class)
+			->disableOriginalConstructor()
+			->getMock();
+
+		$customers_mock = $this->getMockBuilder(\Stripe\Service\CustomerService::class)
+			->disableOriginalConstructor()
+			->getMock();
+
+		$customers_mock->method('retrieve')->will(
+			$this->throwException(new \Stripe\Exception\InvalidRequestException('No such customer: cus_stale_does_not_exist', 404))
+		);
+
+		$fresh_customer = \Stripe\Customer::constructFrom(['id' => 'cus_fresh456']);
+		$customers_mock->method('create')->willReturn($fresh_customer);
+
+		$client->method('__get')->willReturnCallback(
+			function ($property) use ($customers_mock) {
+				if ('customers' === $property) {
+					return $customers_mock;
+				}
+				return null;
+			}
+		);
+
+		$this->gateway->set_stripe_client($client);
+		$this->gateway->set_customer($customer);
+
+		$result = $this->gateway->get_or_create_customer($customer->get_id());
+
+		$this->assertNotInstanceOf(
+			\WP_Error::class,
+			$result,
+			'get_or_create_customer() must self-heal when the stored Stripe id is stale'
+		);
+		$this->assertSame(
+			'cus_fresh456',
+			$result->id,
+			'A fresh Stripe customer id must be returned when the stored one is unretrievable'
+		);
+
+		$stale_membership->delete();
+	}
+
+	/**
+	 * Verify that sync_billing_address_to_stripe() returns early without
+	 * making any API call when given an empty customer id (defensive guard).
+	 *
+	 * @return void
+	 */
+	public function test_sync_billing_address_to_stripe_short_circuits_on_empty_id(): void {
+		$customer = self::$customer;
+		$this->gateway->set_customer($customer);
+
+		// A client whose customers->update would fail the test if called.
+		$client = $this->getMockBuilder(StripeClient::class)
+			->disableOriginalConstructor()
+			->getMock();
+
+		$customers_mock = $this->getMockBuilder(\Stripe\Service\CustomerService::class)
+			->disableOriginalConstructor()
+			->getMock();
+
+		$customers_mock->expects($this->never())->method('update');
+
+		$client->method('__get')->willReturnCallback(
+			function ($property) use ($customers_mock) {
+				if ('customers' === $property) {
+					return $customers_mock;
+				}
+				return null;
+			}
+		);
+
+		$this->gateway->set_stripe_client($client);
+
+		// Reflect to call the protected method directly.
+		$reflection = new \ReflectionClass($this->gateway);
+		$method     = $reflection->getMethod('sync_billing_address_to_stripe');
+		$method->setAccessible(true);
+
+		$method->invoke($this->gateway, '');
+
+		// If the early return works, customers->update was never called.
+		$this->addToAssertionCount(1);
+	}
+
+	/**
 	 * Tear down after all tests.
 	 *
 	 * @return void


### PR DESCRIPTION
## Summary

Fixes a fatal `TypeError` reported via support that crashed Stripe Checkout for some merchants:

```
WP_Ultimo\Gateways\Stripe_Checkout_Gateway::sync_billing_address_to_stripe():
Argument #1 ($stripe_customer_id) must be of type string, null given,
called in .../class-stripe-checkout-gateway.php on line 230
```

## Root cause

`run_preflight()` consumed `$s_customer->id` without checking the documented `\Stripe\Customer|\WP_Error` return contract of `get_or_create_customer()`.

When the stored `gateway_customer_id` belongs to a *different* Stripe account than the currently active API keys (most commonly after a test↔live mode switch, key rotation, or Stripe account swap), the retrieve call throws and is silently swallowed. Execution falls through to `customers->create()`, which can also fail (e.g. authentication error, network failure). `get_or_create_customer()` then returns `WP_Error`, whose magic `__get` returns `null` for `->id`, and PHP fatals on the typed `string` parameter of `sync_billing_address_to_stripe()`.

## Fix

Three layered changes so this failure mode can't recur:

1. **`Stripe_Checkout_Gateway::run_preflight()`** — handles `WP_Error` and empty-id results from `get_or_create_customer()` and surfaces them as a clean checkout error rather than fatalling. The checkout flow already handles `WP_Error` returns from preflight.
2. **`Base_Stripe_Gateway::get_or_create_customer()`** — self-heals: when a stored `cus_*` cannot be retrieved (any reason), the swallowed exception is now logged via `wu_log_add('stripe', …)`, and the function falls through to creating a fresh Stripe customer rather than bubbling an opaque error. A final defensive guard ensures the caller receives either a usable `\Stripe\Customer` or a `WP_Error` — never an object whose `id` is `null`.
3. **`Stripe_Checkout_Gateway::sync_billing_address_to_stripe()`** — adds a defensive `empty()` short-circuit for any future caller that might bypass `run_preflight`.

After this, account/key mismatches will quietly recover on the next checkout attempt, and any genuinely unrecoverable failure produces a `WP_Error` shown to the customer instead of a fatal stack trace.

## Tests

Added three regression tests to `tests/WP_Ultimo/Gateways/Stripe_Checkout_Gateway_Run_Preflight_Test.php`:

- `test_run_preflight_returns_wp_error_when_customer_creation_fails` — both retrieve and create throw; preflight must return `WP_Error`, never fatal.
- `test_get_or_create_customer_self_heals_on_stale_stored_id` — stored `cus_*` is unretrievable but create succeeds; a fresh customer id must be returned.
- `test_sync_billing_address_to_stripe_short_circuits_on_empty_id` — empty input must not produce any API call.

```
$ vendor/bin/phpunit --filter Stripe_Checkout_Gateway_Run_Preflight_Test --no-coverage
OK (6 tests, 34 assertions)

$ vendor/bin/phpunit --filter 'WP_Ultimo\\Gateways\\(Stripe_Gateway_Test|Base_Stripe_Gateway_Test|Stripe_Checkout_Gateway_Run_Preflight_Test|Stripe_Gateway_Process_Checkout_Test)' --no-coverage
OK (148 tests, 296 assertions)
```

PHPCS is clean for the touched lines (the two pre-existing warnings on lines 2918/3295 of `class-base-stripe-gateway.php` are unrelated to this change). PHPStan: no errors.

## Risk

Low. Behavioural changes are all in failure paths:

- The success path is unchanged.
- A previously-fatal request now returns a `WP_Error` to the checkout flow.
- A previously-failing checkout caused by a stale stored `cus_*` now silently self-heals.

## Files changed

- `inc/gateways/class-stripe-checkout-gateway.php`
- `inc/gateways/class-base-stripe-gateway.php`
- `tests/WP_Ultimo/Gateways/Stripe_Checkout_Gateway_Run_Preflight_Test.php`

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.14.75 plugin for [OpenCode](https://opencode.ai) v1.14.33 with claude-sonnet-4-6 spent 1d 21h on this as a headless worker.
