### PR TITLE
fix(current): guard get_query_var when $wp_query is null (template-switching 500)

### DIFF
--- a/inc/class-current.php
+++ b/inc/class-current.php
@@ -239,6 +239,33 @@ class Current implements \WP_Ultimo\Interfaces\Singleton {
 			return;
 		}
 
+		/*
+		 * `get_query_var()` reads from the global `$wp_query`, which
+		 * WordPress only populates during `parse_query` (just before
+		 * `wp` fires). The lazy-load entry path added in PR #1118 can
+		 * call `load_currents()` from `Site::is_customer_allowed()` /
+		 * `Membership::is_customer_allowed()` while still on
+		 * `plugins_loaded` — for example when the wu-ajax pipeline
+		 * (`Light_Ajax::process_light_ajax`) dispatches
+		 * `wu_ajax_wu_switch_template` at `plugins_loaded` priority 20
+		 * and the handler reads `is_customer_allowed()`. At that point
+		 * `$wp_query` is still null and `get_query_var()` fatals with
+		 * `Call to a member function get() on null` on PHP 8+, which
+		 * crashes the AJAX handler with a 500 — surfacing in the
+		 * customer-panel template-switching UI as a generic
+		 * "A network error occurred. Please check your connection and
+		 * try again." banner.
+		 *
+		 * Skip the pretty-URL hash overrides when we know the query
+		 * cannot have been parsed yet. The wu-ajax pipeline is a flat
+		 * `?wu-ajax=1` POST with no rewrite-driven `site_hash` /
+		 * `membership_hash` query vars, so there is nothing to lose
+		 * by skipping them here. Frontend pretty-URL requests still
+		 * hit `load_currents()` via the `wp` action where `$wp_query`
+		 * is populated and these reads succeed normally.
+		 */
+		$query_vars_ready = did_action('parse_query') && isset($GLOBALS['wp_query']) && $GLOBALS['wp_query'] instanceof \WP_Query;
+
 		$site = false;
 
 		/**
@@ -250,7 +277,9 @@ class Current implements \WP_Ultimo\Interfaces\Singleton {
 			 */
 			$site_url_param = self::param_key('site');
 
-			$site_hash = wu_request($site_url_param, get_query_var('site_hash'));
+			$site_hash_default = $query_vars_ready ? get_query_var('site_hash') : '';
+
+			$site_hash = wu_request($site_url_param, $site_hash_default);
 
 			$site_from_url = wu_get_site_by_hash($site_hash);
 
@@ -296,7 +325,9 @@ class Current implements \WP_Ultimo\Interfaces\Singleton {
 		 */
 		$membership_url_param = self::param_key('membership');
 
-		$membership_hash = wu_request($membership_url_param, get_query_var('membership_hash'));
+		$membership_hash_default = $query_vars_ready ? get_query_var('membership_hash') : '';
+
+		$membership_hash = wu_request($membership_url_param, $membership_hash_default);
 
 		if ($membership_hash) {
 			$this->membership_set_via_request = true;

--- a/tests/WP_Ultimo/Current_Test.php
+++ b/tests/WP_Ultimo/Current_Test.php
@@ -199,6 +199,62 @@ class Current_Test extends \WP_UnitTestCase {
 	}
 
 	/**
+	 * Regression test for the wu-ajax `plugins_loaded` fatal.
+	 *
+	 * The light-ajax pipeline (`Light_Ajax::process_light_ajax`) dispatches
+	 * `wu_ajax_*` handlers at `plugins_loaded` priority 20. The handler for
+	 * `wu_switch_template` calls `Site::is_customer_allowed()`, which (after
+	 * the lazy-load entry from PR #1118) calls `Current::load_currents()`
+	 * before the `wp` action has fired. At that point the global
+	 * `$wp_query` is null, and any `get_query_var()` call inside
+	 * `load_currents()` throws `Call to a member function get() on null`
+	 * on PHP 8+ — surfacing in the customer-panel template-switching UI as
+	 * a generic "A network error occurred" banner because the AJAX call
+	 * died with a 500 instead of returning JSON.
+	 *
+	 * This test temporarily nulls `$GLOBALS['wp_query']` to simulate the
+	 * early-call condition, then asserts `load_currents()` runs to
+	 * completion without fataling. The hash-override branches must be
+	 * skipped via the `$query_vars_ready` guard so the lazy-load can
+	 * still populate the customer/membership fields.
+	 */
+	public function test_load_currents_survives_when_wp_query_is_null(): void {
+
+		set_current_screen('front');
+
+		$user_id = $this->factory()->user->create(['role' => 'subscriber']);
+
+		wu_create_customer(
+			[
+				'user_id'       => $user_id,
+				'email_address' => 'current-no-wp-query@example.com',
+			]
+		);
+
+		wp_set_current_user($user_id);
+
+		$this->current->set_site(null);
+		$this->current->set_customer(null);
+		$this->current->set_membership(null);
+		$this->set_loaded_state(false);
+
+		// Save and null out the global wp_query to simulate the
+		// plugins_loaded entry path where it has not yet been set up.
+		$saved_wp_query      = $GLOBALS['wp_query'] ?? null;
+		$GLOBALS['wp_query'] = null;
+
+		try {
+			$this->current->load_currents();
+
+			// Sanity assertion — if get_query_var() had been called we
+			// would have fataled before reaching this line.
+			$this->assertTrue(true, 'load_currents survived a null $wp_query.');
+		} finally {
+			$GLOBALS['wp_query'] = $saved_wp_query;
+		}
+	}
+
+	/**
 	 * Test param_key returns expected defaults.
 	 */
 	public function test_param_key_returns_defaults(): void {


### PR DESCRIPTION
## Summary

Fix a PHP 8+ fatal in `Current::load_currents()` that surfaces in production
as **"A network error occurred. Please check your connection and try again."**
on the customer-panel **Switch Template** page (and any other wu-ajax
endpoint that reads `is_customer_allowed()`).

## Root cause

PR #1118 added a lazy-load entry from `Current::get_customer()` /
`get_membership()` so callers that arrive before the `init`/`wp` cache
warm-up still get a populated value. That fix is correct in spirit but
exposes a latent hazard inside `load_currents()` itself: both pretty-URL
hash overrides call `get_query_var()`.

`get_query_var()` is `$wp_query->get($var, $default)`. The wu-ajax
pipeline (`Light_Ajax::process_light_ajax`) dispatches `wu_ajax_*`
handlers at `plugins_loaded` priority 20 — long before WordPress reaches
`parse_query`. At that point `$wp_query` is `null`, and PHP 8+ fatals
with `Call to a member function get() on null`. The AJAX handler dies
with HTTP 500 and no JSON body, so the JS error callback shows the
generic network-error banner.

Backtrace from a real customer (production):

```
#0 wp-includes/query.php:29  — get_query_var('site_hash')
#1 inc/class-current.php:253 — load_currents()
#2 inc/class-current.php:377 — get_customer()
#3 inc/models/class-site.php:1075 — Site->is_customer_allowed()
#4 inc/ui/class-template-switching-element.php:320 — switch_template()
...
#7 inc/class-light-ajax.php:160 — do_action('wu_ajax_wu_switch_template')
#11 wp-settings.php:593 — do_action('plugins_loaded')
```

## Fix

Compute `$query_vars_ready = did_action('parse_query') && $GLOBALS['wp_query'] instanceof WP_Query`
once at the top of `load_currents()`. When false, substitute an empty
string for both `get_query_var()` calls. `wu_request()` still picks up
`$_REQUEST` overrides if present, and the wu-ajax pipeline carries no
rewrite-driven `site_hash` / `membership_hash` anyway (it is a flat
`?wu-ajax=1` POST), so nothing functional is lost. Once WP reaches `wp`
and re-runs `load_currents()`, the guard is true and the original
behaviour is preserved verbatim.

## Test plan

- New regression test `test_load_currents_survives_when_wp_query_is_null`
  nulls `$GLOBALS['wp_query']` and asserts `load_currents()` runs to
  completion. Verified by reverting the fix and confirming the test
  reproduces the production fatal exactly:
  > `Error: Call to a member function get() on null at class-current.php:253`
- Full `Current_Test` suite: **11 tests, 16 assertions, all pass**.
- PHPCS: clean.
- PHPStan: clean.
- Other test failures in the suite are pre-existing and unrelated
  (verified by running the same scope on `origin/main`).

## Files changed

- `inc/class-current.php` — guard both `get_query_var()` calls.
- `tests/WP_Ultimo/Current_Test.php` — regression test.

Resolves the customer-reported 500 / "A network error occurred" banner
on the customer-panel template-switching page reported after #1118
landed.

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.14.75 plugin for [OpenCode](https://opencode.ai) v1.14.33 with claude-sonnet-4-6 spent 1d 23h on this as a headless worker.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed potential errors that could occur during specific WordPress initialization scenarios, improving system stability.

* **Performance**
  * Optimized object loading to prevent unnecessary reprocessing in administrative and background request contexts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->