### PR TITLE
fix(template-switching): allow current-template description to wrap

### DIFF
--- a/views/ui/template-switching-current.php
+++ b/views/ui/template-switching-current.php
@@ -47,7 +47,28 @@ $has_current_template = $current_template instanceof \WP_Ultimo\Models\Site && $
 				<h3 class="wu-text-lg wu-font-semibold wu-m-0 wu-mb-1 wu-truncate">
 					<?php echo esc_html($current_template->get_title()); ?>
 				</h3>
-				<p class="wu-text-sm wu-text-gray-600 wu-m-0 wu-truncate">
+				<?php
+				/*
+				 * Description wraps to multiple lines when long. We removed
+				 * `wu-truncate` (which was forcing single-line + ellipsis
+				 * via white-space: nowrap; overflow: hidden) so customers
+				 * can read the full description on the current-template
+				 * card. The parent `.wu-flex` row uses `wu-items-center`,
+				 * so the 120px image and "Reset" button stay vertically
+				 * centred against whatever height the wrapped text takes.
+				 *
+				 * `overflow-wrap: anywhere` guards against unbreakable
+				 * strings (long URLs, no-space tokens) blowing out the
+				 * flex column. The compiled framework.css has no
+				 * `wu-break-words`/`wu-words-break` utility, so we use
+				 * the inline style — same pattern as the inline styles
+				 * already used elsewhere in this file.
+				 */
+				?>
+				<p
+					class="wu-text-sm wu-text-gray-600 wu-m-0"
+					style="overflow-wrap: anywhere;"
+				>
 					<?php echo esc_html($current_template->get_description()); ?>
 				</p>
 			</div>


### PR DESCRIPTION
## Summary

- Drop `wu-truncate` from the description `<p>` on the customer-panel template-switching "Current Template" card so long template descriptions wrap onto multiple lines instead of being clipped to a single-line ellipsis.
- Add inline `overflow-wrap: anywhere` so unbreakable strings (long URLs, no-space tokens) cannot overflow the flex column horizontally.
- Title `<h3>` keeps `wu-truncate` — template titles are expected to be short and a single-line title is a stronger visual anchor for the card; only the description needed to wrap.

## Why

Customers on the template-switching page (`/wp-admin/admin.php?page=wu-template-switching`) saw the description of their current template clipped after roughly 80 characters with `…`. The grid cards below already wrapped correctly; only the "Current Template" summary card at the top truncated. Customers could not read past the first line of their template's description without removing the `wu-truncate` class.

## Verification

Tested in the local dev environment with three templates seeded with ~270-character descriptions:

1. Logged in as customer `kpcust1` (site 6, current template = Pink, 267-char description).
2. Navigated to `/wp-admin/admin.php?page=wu-template-switching`.
3. Confirmed the description on the "Current Template" card wraps onto 3 lines, fully visible, with no horizontal overflow.
4. Confirmed the 120px thumbnail (left) and `Reset Current Template` button (right) stay vertically centred against the wrapped text — `wu-items-center` on the parent flex row handles this.
5. Confirmed the grid cards below remain unchanged (they were never affected — descriptions there always wrapped).

PHPCS clean. PHPStan clean.

## Files changed

- `views/ui/template-switching-current.php`

---
<!-- aidevops:sig -->
