### PR TITLE
fix(template-switching): hide inactive/archived/deleted/spam templates from customer grid

### DIFF
--- a/inc/ui/class-template-switching-element.php
+++ b/inc/ui/class-template-switching-element.php
@@ -483,6 +483,34 @@ class Template_Switching_Element extends Base_Element {
 			$sites = array_filter($sites);
 
 			/*
+			 * Hide templates the network admin has marked as unavailable.
+			 *
+			 * `wu_get_site_templates()` (used upstream to seed the candidate
+			 * list) only filters by `wu_type = site_template` — it does not
+			 * exclude templates the network admin has deactivated, archived,
+			 * marked as deleted, or flagged as spam. Without this filter the
+			 * customer-panel switching grid will list templates that the
+			 * admin explicitly took out of circulation, which is what the
+			 * customer reported as "templates that should not be available
+			 * are still listed".
+			 *
+			 * Mirrors the inactive-only filter in
+			 * inc/checkout/signup-fields/class-signup-field-template-selection.php
+			 * (line 349) and extends it to cover archived/deleted/spam.
+			 * Applied here (in the switching element) rather than in
+			 * `wu_get_site_templates()` so we don't change behaviour for
+			 * network-admin pages or any other callers that legitimately
+			 * want every template.
+			 */
+			$sites = array_filter(
+				$sites,
+				static fn($site_template) => $site_template->is_active()
+					&& ! $site_template->is_archived()
+					&& ! $site_template->is_deleted()
+					&& ! $site_template->is_spam()
+			);
+
+			/*
 			 * Hide the current template from the "Available Templates" grid.
 			 * The current template is already shown in the summary card above,
 			 * so listing it again as a "Select" option is redundant and a

--- a/tests/WP_Ultimo/UI/Template_Switching_Element_Test.php
+++ b/tests/WP_Ultimo/UI/Template_Switching_Element_Test.php
@@ -371,4 +371,117 @@ class Template_Switching_Element_Test extends WP_UnitTestCase {
 		);
 	}
 
+	/**
+	 * Templates the network admin has marked unavailable (inactive,
+	 * archived, deleted, or spam) must not appear in the customer-panel
+	 * "Available Templates" grid.
+	 *
+	 * Regression guard for the customer report that "templates that should
+	 * not be available are still listed". `wu_get_site_templates()` only
+	 * filters by `wu_type = site_template`, so without the additional
+	 * filter in Template_Switching_Element::output() any template whose
+	 * availability flags the admin has cleared still ended up rendered.
+	 *
+	 * The assertion looks for `id="wu-site-template-{ID}"` because the
+	 * grid card wrapper uses that exact attribute (see
+	 * views/checkout/templates/template-selection/clean.php). A simple
+	 * presence check on the title would false-positive on the
+	 * current-template card or hidden DOM markers.
+	 */
+	public function test_render_excludes_unavailable_templates_from_grid(): void {
+
+		// Active + available → must render.
+		$active_id = $this->factory()->blog->create();
+		$active    = wu_get_site( $active_id );
+		$active->set_type( 'site_template' );
+		$active->set_active( true );
+		$active->set_archived( false );
+		$active->set_deleted( false );
+		$active->set_spam( false );
+		$active->save();
+
+		// Inactive (network admin disabled) → must NOT render.
+		$inactive_id = $this->factory()->blog->create();
+		$inactive    = wu_get_site( $inactive_id );
+		$inactive->set_type( 'site_template' );
+		$inactive->set_active( false );
+		$inactive->save();
+
+		// Archived → must NOT render.
+		$archived_id = $this->factory()->blog->create();
+		$archived    = wu_get_site( $archived_id );
+		$archived->set_type( 'site_template' );
+		$archived->set_active( true );
+		$archived->set_archived( true );
+		$archived->save();
+
+		// Deleted → must NOT render.
+		$deleted_id = $this->factory()->blog->create();
+		$deleted    = wu_get_site( $deleted_id );
+		$deleted->set_type( 'site_template' );
+		$deleted->set_active( true );
+		$deleted->set_deleted( true );
+		$deleted->save();
+
+		// Spam → must NOT render.
+		$spam_id = $this->factory()->blog->create();
+		$spam    = wu_get_site( $spam_id );
+		$spam->set_type( 'site_template' );
+		$spam->set_active( true );
+		$spam->set_spam( true );
+		$spam->save();
+
+		$html = $this->render_element_with_context();
+
+		/*
+		 * The grid is rendered client-side by Vue from the JSON payload
+		 * embedded in the `<dynamic :template="...">` tag. Server-side
+		 * HTML therefore does not contain `id="wu-site-template-X"` —
+		 * we have to inspect the encoded `sites` array in the dynamic
+		 * tag's attribute. `wp_json_encode()` then `esc_attr()` produce
+		 * `&quot;sites&quot;:[&quot;2&quot;,...]` in the output.
+		 */
+		if ( ! preg_match( '/get_template\\(\'template-selection\\/clean\',\\s*({.*?})\\)/', $html, $matches ) ) {
+			$this->fail( 'Could not find the dynamic-template JSON payload in the rendered output.' );
+		}
+
+		$decoded_attrs = html_entity_decode( $matches[1], ENT_QUOTES );
+		$attrs         = json_decode( $decoded_attrs, true );
+
+		$this->assertIsArray( $attrs, 'Dynamic-template payload must decode to an array. Got: ' . $decoded_attrs );
+		$this->assertArrayHasKey( 'sites', $attrs );
+
+		$sites = array_map( 'intval', $attrs['sites'] );
+
+		$this->assertContains(
+			(int) $active_id,
+			$sites,
+			'Active, non-archived, non-deleted, non-spam template must appear in the grid sites array.'
+		);
+
+		$this->assertNotContains(
+			(int) $inactive_id,
+			$sites,
+			'Inactive template must not appear in the grid sites array.'
+		);
+
+		$this->assertNotContains(
+			(int) $archived_id,
+			$sites,
+			'Archived template must not appear in the grid sites array.'
+		);
+
+		$this->assertNotContains(
+			(int) $deleted_id,
+			$sites,
+			'Deleted template must not appear in the grid sites array.'
+		);
+
+		$this->assertNotContains(
+			(int) $spam_id,
+			$sites,
+			'Spam template must not appear in the grid sites array.'
+		);
+	}
+
 }


### PR DESCRIPTION
## Summary

`wu_get_site_templates()` only filters by `wu_type = site_template`. It does not exclude templates the network admin has flagged as unavailable. The customer-panel template-switching grid was therefore listing every template in the network regardless of those flags, including templates the admin had explicitly taken out of circulation.

Filter `$sites` in `Template_Switching_Element::output()` to keep only templates that satisfy all of:

- `is_active() === true` (mirrors the inactive-only filter the signup field already applies in `inc/checkout/signup-fields/class-signup-field-template-selection.php:349`)
- `is_archived() === false`
- `is_deleted() === false`
- `is_spam() === false`

Applied at the element level (rather than in `wu_get_site_templates()`) so we do not change behaviour for the network-admin template list or any other consumer that legitimately wants to see all templates.

## Why

Customer report: *"some templates that should not be available are still listed"*. After a network admin deactivates, archives, deletes, or spams a template, the template continued to appear in customers''' "Available Templates" grid on the template-switching page, even though it was no longer eligible for assignment.

## Verification

Reproduced and confirmed fix in the local dev environment:

1. As customer `kpcust1` (current template = Pink, customer site 6), navigated to `/wp-admin/admin.php?page=wu-template-switching`.
2. With Template Blue marked inactive (`set_active(false)`), confirmed Blue is removed from the grid.
3. With Template Site marked archived (`set_archived(true)`), confirmed Site is removed from the grid.
4. With both flags cleared, confirmed all three test templates appear (subject to the existing "exclude current template" filter).

Adds a regression test that creates active, inactive, archived, deleted, and spam templates, renders the element, and asserts the `sites` array embedded in the dynamic-template JSON (the grid is rendered client-side by Vue from this payload) contains only the fully-available template.

PHPCS clean (no new violations). PHPStan clean. `Template_Switching_Element_Test` 7/7 (25 assertions); broader `tests/WP_Ultimo/UI/` suite 67/67 (149 assertions).

## Files changed

- `inc/ui/class-template-switching-element.php` — filter unavailable templates from `$sites`.
- `tests/WP_Ultimo/UI/Template_Switching_Element_Test.php` — regression test for the availability filter.

---
<!-- aidevops:sig -->
