### PR TITLE
GH#1134: guard checkout editor generated CSS state

### DIFF
--- a/tests/unit/Checkout_Editor_Assets_Test.php
+++ b/tests/unit/Checkout_Editor_Assets_Test.php
@@ -1,0 +1,25 @@
+<?php
+use PHPUnit\Framework\TestCase;
+
+final class Checkout_Editor_Assets_Test extends TestCase {
+
+	public function test_checkout_editor_mobile_styles_stay_in_source_css_only(): void {
+		$source_path = __DIR__ . '/../../assets/css/checkout-editor.css';
+		$min_path    = __DIR__ . '/../../assets/css/checkout-editor.min.css';
+
+		$this->assertFileExists($source_path, 'checkout-editor.css does not exist');
+		$this->assertFileExists($min_path, 'checkout-editor.min.css does not exist');
+
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents -- Reading local fixture assets in a standalone PHPUnit test.
+		$source_contents = file_get_contents($source_path);
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents -- Reading local fixture assets in a standalone PHPUnit test.
+		$min_contents = file_get_contents($min_path);
+
+		$this->assertNotFalse($source_contents);
+		$this->assertNotFalse($min_contents);
+
+		$this->assertStringContainsString('@media screen and (max-width: 782px)', $source_contents, 'Expected mobile checkout editor styles to remain in the source CSS');
+		$this->assertStringNotContainsString('@media screen and (max-width:782px)', $min_contents, 'Generated checkout-editor.min.css should not contain the manually inlined mobile styles from PR #1073');
+		$this->assertStringNotContainsString('flex-direction:column', $min_contents, 'Generated checkout-editor.min.css should remain at its pre-PR #1073 state on feature branches');
+	}
+}


### PR DESCRIPTION
## Summary

- Adds regression coverage that keeps the checkout editor mobile styles in `assets/css/checkout-editor.css` while guarding `assets/css/checkout-editor.min.css` from the manually inlined PR #1073 block on feature branches.
- Confirms the valuable PR #1076 asset change was already recovered and merged via #1077; this PR recovers the missing durable verification for #1134.
- Intentionally omits additional asset edits because `checkout-editor.min.css` is already in the expected pre-PR #1073 state on `main`.

## Verification

- `vendor/bin/phpcs tests/unit/Checkout_Editor_Assets_Test.php`
- `WP_TESTS_DIR=/tmp/wordpress-tests-lib vendor/bin/phpunit --filter Checkout_Editor_Assets_Test`

Resolves #1134
Source PR: #1076
Recovered implementation PR: #1077

<!-- aidevops:sig -->
