### PR TITLE
GH#1132: docs: recover gh signature gate guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -510,7 +510,8 @@ gh pr create --title "fix: describe change" --body-file "$BODY_FILE"
 
 Use the same pattern for `gh issue create`, `gh pr comment`, `gh issue comment`, and review
 writes. The heredoc or script may create the local temporary file, but the `gh` write command
-itself must receive only `--body-file "$BODY_FILE"`. Do not use `--body "$(cat <<'EOF' ... EOF)"`,
+itself must receive only the pre-rendered file path. Keep all dynamic Markdown generation in the
+file creation step, not in the GitHub write command. Do not use `--body "$(cat <<'EOF' ... EOF)"`,
 `--body "$(python3 ... )"`, `<(cat <<'EOF' ... EOF)`, or inline heredoc expansions for GitHub
 writes; they trigger the same `bash:other` signature-gate failure.
 


### PR DESCRIPTION
## Summary

Recovered the closed-unmerged PR #1099 guidance in AGENTS.md and tightened the safe gh --body-file workflow so dynamic Markdown is rendered before GitHub write commands.

## Files Changed

AGENTS.md

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** git diff --check -- AGENTS.md

Resolves #1132


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.14.75 plugin for [OpenCode](https://opencode.ai) v1.14.33 with gpt-5.5 spent 3m and 83,763 tokens on this as a headless worker.