### PR TITLE
feat(settings): clarify Import/Export tab scope and link to Site Export

### DIFF
--- a/inc/class-settings.php
+++ b/inc/class-settings.php
@@ -1781,6 +1781,29 @@ class Settings implements \WP_Ultimo\Interfaces\Singleton {
 			]
 		);
 
+		// Scope notice — clarify that this page is for plugin settings only,
+		// and that site (subsite) export/import lives in a different tool.
+		$site_export_url = is_multisite()
+			? network_admin_url('sites.php?page=wu-site-export')
+			: admin_url('tools.php?page=wu-site-export');
+
+		$this->add_field(
+			'import-export',
+			'scope_notice',
+			[
+				'type'    => 'note',
+				'desc'    => sprintf(
+					'<strong>%s</strong> %s <a href="%s">%s</a>.',
+					esc_html__('Note:', 'ultimate-multisite'),
+					esc_html__('This page is for exporting and importing Ultimate Multisite plugin settings only. To export or import an individual site (subsite) and its content, use the Site Export tool:', 'ultimate-multisite'),
+					esc_url($site_export_url),
+					esc_html__('Go to Site Export', 'ultimate-multisite')
+				),
+				'classes' => 'wu-bg-blue-50 wu-border-l-4 wu-border-blue-500 wu-p-4',
+			],
+			5
+		);
+
 		// Export Settings Header
 		$this->add_field(
 			'import-export',


### PR DESCRIPTION
## Summary

Customers have been confused by the **Settings → Import/Export** tab, mistakenly expecting it to handle per-site (subsite) export/import. That tab only handles the Ultimate Multisite plugin's own settings — site export/import lives in a separate tool.

## Change

Add a top-of-section info notice on **Settings → Import/Export** that:

- States the tab is for **plugin settings only**.
- Links directly to the **Site Export** tool at the install-correct URL:
  - Multisite: `network_admin_url('sites.php?page=wu-site-export')`
  - Single-site: `admin_url('tools.php?page=wu-site-export')`

Reuses the existing blue notice styling (`wu-bg-blue-50 wu-border-l-4 wu-border-blue-500 wu-p-4`) already in this file. All strings are i18n-wrapped under the `ultimate-multisite` text domain and properly escaped.

## Files

- `inc/class-settings.php` — adds a `note`-type field with order `5` so it renders above the existing Export Settings header.

## Verification

- `php -l inc/class-settings.php` → no syntax errors
- `vendor/bin/phpcs inc/class-settings.php` → 0 violations
- Manual: navigate to **Settings → Import/Export**; the blue notice appears at the top of the panel with a working link to the Site Export tool on both single-site and multisite installs.

## Out of scope

No logic, capability, or persistence changes — pure UI/content addition.

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.14.80 plugin for [OpenCode](https://opencode.ai) v1.14.33 with claude-sonnet-4-6 spent 2d 12h on this as a headless worker.
