### PR TITLE
feat(checkout-form): warn when required field is missing for products

### DIFF
--- a/inc/admin-pages/class-checkout-form-edit-admin-page.php
+++ b/inc/admin-pages/class-checkout-form-edit-admin-page.php
@@ -1096,9 +1096,172 @@ class Checkout_Form_Edit_Admin_Page extends Edit_Admin_Page {
 		wu_get_template(
 			'base/checkout-forms/steps',
 			[
-				'checkout_form' => $this->get_object()->get_slug(),
+				'checkout_form'                      => $this->get_object()->get_slug(),
+				'price_variation_notice_products'    => $this->get_price_variation_notice_products(),
+				'template_selection_notice_products' => $this->get_template_selection_notice_products(),
 			]
 		);
+	}
+
+	/**
+	 * Returns the names of products that do NOT force a specific site template
+	 * when the checkout form has no template selection field.
+	 *
+	 * Used to render an admin notice in the editor warning that the template
+	 * selection field is required for customers to pick a site template.
+	 *
+	 * @since 2.4.13
+	 * @return array
+	 */
+	protected function get_template_selection_notice_products(): array {
+
+		$form = $this->get_object();
+
+		if ( ! is_a($form, \WP_Ultimo\Models\Checkout_Form::class)) {
+			return [];
+		}
+
+		$template_selection_fields = $form->get_all_fields_by_type('template_selection');
+
+		if ( ! empty($template_selection_fields)) {
+			return [];
+		}
+
+		$product_id_fields = $form->get_all_fields_by_type(['pricing_table', 'products']);
+
+		if (empty($product_id_fields)) {
+			return [];
+		}
+
+		$product_ids = [];
+
+		foreach ($product_id_fields as $field) {
+			$ids_string = '';
+
+			if ('pricing_table' === ($field['type'] ?? '')) {
+				$ids_string = (string) ($field['pricing_table_products'] ?? '');
+			} elseif ('products' === ($field['type'] ?? '')) {
+				$ids_string = (string) ($field['products'] ?? '');
+			}
+
+			if ('' === $ids_string) {
+				continue;
+			}
+
+			foreach (explode(',', $ids_string) as $id) {
+				$id = absint(trim($id));
+
+				if ($id) {
+					$product_ids[ $id ] = $id;
+				}
+			}
+		}
+
+		if (empty($product_ids)) {
+			return [];
+		}
+
+		$names = [];
+
+		foreach ($product_ids as $product_id) {
+			$product = wu_get_product($product_id);
+
+			if ( ! $product) {
+				continue;
+			}
+
+			$limitations = $product->get_limitations();
+
+			if ( ! $limitations || ! isset($limitations->site_templates)) {
+				$names[] = $product->get_name();
+				continue;
+			}
+
+			$mode = $limitations->site_templates->get_mode();
+
+			if (\WP_Ultimo\Limitations\Limit_Site_Templates::MODE_ASSIGN_TEMPLATE !== $mode) {
+				$names[] = $product->get_name();
+			}
+		}
+
+		return $names;
+	}
+
+	/**
+	 * Returns the names of products with price variations that lack a period
+	 * selection field on this checkout form.
+	 *
+	 * Used to render an admin notice in the editor warning that the period
+	 * selection field is required for price variations to be selectable.
+	 *
+	 * @since 2.4.13
+	 * @return array
+	 */
+	protected function get_price_variation_notice_products(): array {
+
+		$form = $this->get_object();
+
+		if ( ! is_a($form, \WP_Ultimo\Models\Checkout_Form::class)) {
+			return [];
+		}
+
+		$period_selection_fields = $form->get_all_fields_by_type('period_selection');
+
+		if ( ! empty($period_selection_fields)) {
+			return [];
+		}
+
+		$product_id_fields = $form->get_all_fields_by_type(['pricing_table', 'products']);
+
+		if (empty($product_id_fields)) {
+			return [];
+		}
+
+		$product_ids = [];
+
+		foreach ($product_id_fields as $field) {
+			$ids_string = '';
+
+			if ('pricing_table' === ($field['type'] ?? '')) {
+				$ids_string = (string) ($field['pricing_table_products'] ?? '');
+			} elseif ('products' === ($field['type'] ?? '')) {
+				$ids_string = (string) ($field['products'] ?? '');
+			}
+
+			if ('' === $ids_string) {
+				continue;
+			}
+
+			foreach (explode(',', $ids_string) as $id) {
+				$id = absint(trim($id));
+
+				if ($id) {
+					$product_ids[ $id ] = $id;
+				}
+			}
+		}
+
+		if (empty($product_ids)) {
+			return [];
+		}
+
+		$names = [];
+
+		foreach ($product_ids as $product_id) {
+			$product = wu_get_product($product_id);
+
+			if ( ! $product) {
+				continue;
+			}
+
+			$variations = $product->get_price_variations();
+
+			if ( ! empty($variations)) {
+				$names[] = $product->get_name();
+			}
+		}
+
+		return $names;
 	}
 
 	/**

--- a/views/base/checkout-forms/steps.php
+++ b/views/base/checkout-forms/steps.php
@@ -9,6 +9,46 @@ defined('ABSPATH') || exit;
 ?>
 <div id="wu-checkout-editor-app">
 
+	<?php if ( ! empty($price_variation_notice_products)) : ?>
+		<div class="wu-py-3 wu-px-4 wu-mb-4 wu-bg-yellow-100 wu-text-yellow-800 wu-border wu-border-solid wu-border-yellow-400 wu-rounded">
+			<strong><?php esc_html_e('Period Selection field missing', 'ultimate-multisite'); ?></strong>
+			<p class="wu-my-1">
+				<?php
+				echo esc_html(
+					sprintf(
+						/* translators: %s: comma-separated list of product names */
+						__('The following products have price variations, but this checkout form has no Period Selection field. Customers will not be able to choose between the variation prices: %s.', 'ultimate-multisite'),
+						implode(', ', $price_variation_notice_products)
+					)
+				);
+				?>
+			</p>
+			<p class="wu-my-1">
+				<?php esc_html_e('Add a Period Selection field to one of the steps to allow customers to switch between the available billing periods.', 'ultimate-multisite'); ?>
+			</p>
+		</div>
+	<?php endif; ?>
+
+	<?php if ( ! empty($template_selection_notice_products)) : ?>
+		<div class="wu-py-3 wu-px-4 wu-mb-4 wu-bg-yellow-100 wu-text-yellow-800 wu-border wu-border-solid wu-border-yellow-400 wu-rounded">
+			<strong><?php esc_html_e('Template Selection field missing', 'ultimate-multisite'); ?></strong>
+			<p class="wu-my-1">
+				<?php
+				echo esc_html(
+					sprintf(
+						/* translators: %s: comma-separated list of product names */
+						__('The following products do not force a specific site template, but this checkout form has no Template Selection field. Customers will not be able to choose a site template: %s.', 'ultimate-multisite'),
+						implode(', ', $template_selection_notice_products)
+					)
+				);
+				?>
+			</p>
+			<p class="wu-my-1">
+				<?php esc_html_e('Add a Template Selection field to one of the steps, or set these products to assign a specific template via their site template limitations.', 'ultimate-multisite'); ?>
+			</p>
+		</div>
+	<?php endif; ?>
+
 	<!-- Add new Step Section -->
 	<div id="wp-ultimo-list-table-add-new-1" class="postbox wu-mb-0" v-cloak>
 


### PR DESCRIPTION
## Summary
- Add admin notice in the checkout form editor when products with **price variations** are configured but no `period_selection` field is on the form.
- Add admin notice when products that don't force a specific site template (`site_templates` limitation mode != `MODE_ASSIGN_TEMPLATE`) are configured but no `template_selection` field is on the form.
- Notices list the offending product names so the admin knows which ones triggered the warning.

## Test plan
- [ ] Create a checkout form with a `pricing_table` field referencing a product that has price variations, and no `period_selection` field → notice appears.
- [ ] Add a `period_selection` field → notice disappears.
- [ ] Create a checkout form with a `products` field referencing a product whose site template limitation mode is not `assign_template`, and no `template_selection` field → notice appears.
- [ ] Add a `template_selection` field, OR set the product's site template mode to `assign_template` → notice disappears.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Checkout editor now displays contextual warning notices when required configuration fields are missing
  * Alerts for missing period selection fields (when products have price variations) and template selection fields
  * Identifies affected products and provides guidance for adding required fields or adjusting settings

<!-- end of auto-generated comment: release notes by coderabbit.ai -->