### PR TITLE
fix(checkout): remove redundant 'Log in to renew' notice on email field

### DIFF
--- a/inc/checkout/signup-fields/class-signup-field-email.php
+++ b/inc/checkout/signup-fields/class-signup-field-email.php
@@ -211,18 +211,6 @@ class Signup_Field_Email extends Base_Signup_Field {
 				];
 			}
 		} else {
-			if ($attributes['display_notices']) {
-				$checkout_fields['login_note'] = [
-					'type'              => 'note',
-					'title'             => __('Existing customer?', 'ultimate-multisite'),
-					'desc'              => [$this, 'render_existing_customer_message'],
-					'wrapper_classes'   => wu_get_isset($attributes, 'wrapper_element_classes', ''),
-					'wrapper_html_attr' => [
-						'style' => $this->calculate_style_attr(),
-					],
-				];
-			}
-
 			$checkout_fields['email_address'] = [
 				'type'              => 'text',
 				'id'                => 'email_address',
@@ -272,32 +260,6 @@ class Signup_Field_Email extends Base_Signup_Field {
 		}
 
 		return $checkout_fields;
-	}
-
-	/**
-	 * Renders the login message for users that are not logged in.
-	 *
-	 * @since 2.0.0
-	 * @return string
-	 */
-	public function render_existing_customer_message() {
-
-		$login_url = wp_login_url(add_query_arg('logged', '1'));
-
-		ob_start(); ?>
-
-		<div class="wu-p-4 wu-bg-yellow-200">
-
-			<?php
-			// translators: %s is the login URL.
-			printf(wp_kses_post(__('<a href="%s">Log in</a> to renew or change an existing membership.', 'ultimate-multisite')), esc_attr($login_url));
-
-			?>
-
-		</div>
-
-		<?php
-		return ob_get_clean();
 	}
 
 	/**


### PR DESCRIPTION
## Summary

- Remove the "Log in to renew or change an existing membership." notice
  rendered above the checkout email field for logged-out visitors.
- The notice is redundant: the email signup field already includes the
  inline-login feature (`enable_inline_login`, default on) which detects
  an existing email address and surfaces a login prompt in-context.

## Changes

- `inc/checkout/signup-fields/class-signup-field-email.php`
  - Drop the "Existing customer?" `login_note` registration in
    `to_fields_array()` for the logged-out branch.
  - Delete the now-unused `render_existing_customer_message()` helper.

The "Not you?" notice for logged-in users is unchanged. The
`display_notices` builder toggle continues to control that notice.

## Verification

- `php -l inc/checkout/signup-fields/class-signup-field-email.php` — no
  syntax errors.
- `vendor/bin/phpcs inc/checkout/signup-fields/class-signup-field-email.php`
  — clean.
- `vendor/bin/phpstan analyse inc/checkout/signup-fields/class-signup-field-email.php`
  — no errors.
- `vendor/bin/phpunit --filter Signup_Field_Email_Test` — 9 tests, 12
  assertions, all pass.
- `vendor/bin/phpunit --filter Signup_Fields_Manager_Test` — 8 tests, all
  pass.
- `vendor/bin/phpunit --filter Checkout_Test` — 216 tests pass (1
  pre-existing skip).
- Two pre-existing failures in `Base_Signup_Field_Test::test_get_value_uses_request_when_from_request_is_set`
  and `Signup_Field_Site_Url_Test::test_to_fields_array_with_domain_selection`
  reproduce on `main` and are unrelated to this change.
- `rg "Log in.*to renew|renew or change an existing|render_existing_customer_message" inc/ views/ assets/`
  — no matches.

The string still appears in `lang/ultimate-multisite.pot` line 7838; the
POT file is regenerated by `npm run makepot` at release time and does
not need a feature-branch update.

---
<!-- aidevops:sig -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Email field messaging in the checkout signup process has been updated for logged-in users. The message displayed alongside the email field has been changed to a "Not you?" prompt, replacing the previous account-related message for improved account-switching experience during checkout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->