### PR TITLE
fix: recover template switching bug fix from PR #1108 (GH#1154)

### DIFF
--- a/inc/models/class-checkout-form.php
+++ b/inc/models/class-checkout-form.php
@@ -1032,9 +1032,7 @@ class Checkout_Form extends Base_Model {
 
 				$old_template_list = is_array($old_template_list) ? $old_template_list : [];
 
-				$template_list = array_flip($old_template_list);
-
-				$template_list = ! empty($template_list) ? $template_list : $templates;
+				$template_list = ! empty($old_template_list) ? $old_template_list : $templates;
 
 				$step['fields'] = [
 					'template_selection' => [


### PR DESCRIPTION
## Summary

Recovered the valuable code fix from closed-unmerged PR #1108.

The bug was in the `Checkout_Form::convert_steps_to_v2` method where `array_flip` was being used incorrectly on the template list, causing the template switching element to not work properly when templates were configured.

Fixed by removing the `array_flip` call and using the original template list directly when it's not empty.

## Changes

- `inc/models/class-checkout-form.php`: Removed incorrect `array_flip` call and simplified the template list logic.

## Verification

- Ran `vendor/bin/phpunit --filter Template_Switching_Element_Test` → **OK (7 tests, 25 assertions)**
- Ran `vendor/bin/phpunit --filter test_is_customer_allowed` → **OK (6 tests, 6 assertions)**

## Links

- Issue: #1154
- Source PR: #1108

---
<!-- aidevops:sig -->
