### PR TITLE
fix(setup-wizard): use deterministic /network/ URL on multisite setup success

### DIFF
--- a/inc/admin-pages/class-multisite-setup-admin-page.php
+++ b/inc/admin-pages/class-multisite-setup-admin-page.php
@@ -343,18 +343,6 @@ class Multisite_Setup_Admin_Page extends Wizard_Admin_Page {
 			/*
 			 * Build the network-admin URL deterministically.
 			 *
-			 * We cannot rely on wu_network_admin_url() / network_admin_url()
-			 * here because both fall back to admin_url() when is_multisite()
-			 * returns false — which happens on this success view whenever
-			 * OPcache is still serving a stale wp-config.php that hasn't yet
-			 * picked up the freshly-written MULTISITE constant. In that case
-			 * the button would point at /wp-admin/admin.php?page=wp-ultimo-setup
-			 * (single-site) instead of /wp-admin/network/admin.php?page=wp-ultimo-setup.
-			 *
-			 * site_url() returns the install root regardless of multisite
-			 * state, which is exactly the network's main-site URL on a
-			 * just-enabled multisite, so it is safe to compose the network
-			 * admin path against it directly.
 			 */
 			$continue_url = site_url('wp-admin/network/admin.php?page=wp-ultimo-setup');
 			?>

--- a/inc/admin-pages/class-multisite-setup-admin-page.php
+++ b/inc/admin-pages/class-multisite-setup-admin-page.php
@@ -340,6 +340,23 @@ class Multisite_Setup_Admin_Page extends Wizard_Admin_Page {
 		$result = wu_request('result', ''); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 
 		if ('success' === $result || is_multisite()) :
+			/*
+			 * Build the network-admin URL deterministically.
+			 *
+			 * We cannot rely on wu_network_admin_url() / network_admin_url()
+			 * here because both fall back to admin_url() when is_multisite()
+			 * returns false — which happens on this success view whenever
+			 * OPcache is still serving a stale wp-config.php that hasn't yet
+			 * picked up the freshly-written MULTISITE constant. In that case
+			 * the button would point at /wp-admin/admin.php?page=wp-ultimo-setup
+			 * (single-site) instead of /wp-admin/network/admin.php?page=wp-ultimo-setup.
+			 *
+			 * site_url() returns the install root regardless of multisite
+			 * state, which is exactly the network's main-site URL on a
+			 * just-enabled multisite, so it is safe to compose the network
+			 * admin path against it directly.
+			 */
+			$continue_url = site_url('wp-admin/network/admin.php?page=wp-ultimo-setup');
 			?>
 		<div class="wu-bg-green-100 wu-border wu-border-green-300 wu-rounded-lg wu-p-4 wu-mb-6">
 			<div class="wu-flex">
@@ -358,7 +375,7 @@ class Multisite_Setup_Admin_Page extends Wizard_Admin_Page {
 		</div>
 
 		<div class="wu-flex wu-justify-center">
-			<a href="<?php echo esc_url(wu_network_admin_url('wp-ultimo-setup')); ?>" class="button button-primary button-large">
+			<a href="<?php echo esc_url($continue_url); ?>" class="button button-primary button-large">
 				<?php esc_html_e('Continue to Multisite Ultimate Setup', 'multisite-ultimate'); ?>
 			</a>
 		</div>

--- a/tests/WP_Ultimo/Admin_Pages/Multisite_Setup_Admin_Page_Test.php
+++ b/tests/WP_Ultimo/Admin_Pages/Multisite_Setup_Admin_Page_Test.php
@@ -678,6 +678,39 @@ class Multisite_Setup_Admin_Page_Test extends WP_UnitTestCase {
 		$this->assertStringNotContainsString('wu-bg-blue-700', $output, 'wu-bg-blue-700 is not in framework.css and must not be used');
 	}
 
+	/**
+	 * section_complete() Continue button must point at the /network/ admin URL.
+	 *
+	 * Regression: previously the button used wu_network_admin_url() which falls back
+	 * to admin_url() when is_multisite() returns false (e.g. when OPcache is still
+	 * serving a stale wp-config.php after the install step writes the MULTISITE
+	 * constant). That caused the success-page button to send users to
+	 * /wp-admin/admin.php?page=wp-ultimo-setup (single-site) instead of
+	 * /wp-admin/network/admin.php?page=wp-ultimo-setup. The fix builds the URL
+	 * deterministically with site_url(), so the path must always contain /network/.
+	 */
+	public function test_section_complete_continue_button_points_at_network_admin(): void {
+
+		$_GET['result'] = 'success';
+
+		ob_start();
+		$this->page->section_complete();
+		$output = ob_get_clean();
+
+		unset($_GET['result']);
+
+		$this->assertMatchesRegularExpression(
+			'#href="[^"]*/wp-admin/network/admin\.php\?page=wp-ultimo-setup[^"]*"#',
+			$output,
+			'Continue button must link to the network admin URL, not the single-site admin URL'
+		);
+		$this->assertDoesNotMatchRegularExpression(
+			'#href="[^"]*/wp-admin/admin\.php\?page=wp-ultimo-setup[^"]*"#',
+			$output,
+			'Continue button must NOT link to the single-site admin URL'
+		);
+	}
+
 	// -------------------------------------------------------------------------
 	// display_manual_instructions() — via reflection
 	// -------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Fix the multisite setup wizard success-page button so it always points at the **network** admin URL, not the single-site admin URL.

## The bug

After completing the multisite setup wizard, the **"Continue to Multisite Ultimate Setup"** button on the success page linked to:

```
http://wordpress.local:8080/wp-admin/admin.php?page=wp-ultimo-setup
```

instead of the correct network admin URL:

```
http://wordpress.local:8080/wp-admin/network/admin.php?page=wp-ultimo-setup
```

## Root cause

The button (in `Multisite_Setup_Admin_Page::section_complete()`) used `wu_network_admin_url('wp-ultimo-setup')`, which delegates to WordPress core's `network_admin_url()`. From `wp-includes/link-template.php`:

```php
function network_admin_url( $path = '', $scheme = 'admin' ) {
    if ( ! is_multisite() ) {
        return admin_url( $path, $scheme );   // <-- falls back to single-site
    }
    ...
}
```

On this exact success view, `is_multisite()` returns `false` whenever OPcache is still serving a stale `wp-config.php` that hasn't yet picked up the freshly written `MULTISITE` constant. The file's own docblock at lines 314-321 already documents this stale-OPcache scenario for the redirect path — the same scenario also poisons the button URL.

## The fix

Build the URL deterministically with `site_url('wp-admin/network/admin.php?page=wp-ultimo-setup')`. `site_url()` returns the install root regardless of multisite state, and on a just-enabled multisite the install root is the network main-site URL — so the composed path is correct in every case.

## Files changed

- `inc/admin-pages/class-multisite-setup-admin-page.php` — replace `wu_network_admin_url()` call with deterministic `site_url(...)` plus an explanatory comment.
- `tests/WP_Ultimo/Admin_Pages/Multisite_Setup_Admin_Page_Test.php` — add `test_section_complete_continue_button_points_at_network_admin()` asserting the button URL contains `/network/admin.php` and does **not** contain the single-site form.

## Verification

- `php -l` — no syntax errors.
- `vendor/bin/phpcs` — no new violations introduced (only pre-existing text-domain-mismatch warnings unrelated to this change).
- `vendor/bin/phpstan analyse inc/admin-pages/class-multisite-setup-admin-page.php` — `[OK] No errors`.
- `vendor/bin/phpunit --filter test_section_complete` — `OK (4 tests, 7 assertions)`, including the new regression test.
- `vendor/bin/phpunit --filter Multisite_Setup_Admin_Page_Test` — exit 0 (full class suite still passes).

## How to reproduce (before this fix)

1. Install on a fresh single-site WordPress.
2. Activate Ultimate Multisite.
3. Run the multisite setup wizard to completion.
4. Land on `wp-admin/admin.php?page=wp-ultimo-multisite-setup&step=complete` showing **"Success! WordPress Multisite has been successfully enabled."**
5. Click **"Continue to Multisite Ultimate Setup"**.
6. Observe the URL is the wrong single-site form (`/wp-admin/admin.php?page=wp-ultimo-setup`) instead of the network form (`/wp-admin/network/admin.php?page=wp-ultimo-setup`).

After this fix the button always lands on the `/network/` URL.

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.14.91 plugin for [OpenCode](https://opencode.ai) v1.14.40 with gemma4:e4b spent 15h 12m and 263,673 tokens on this with the user in an interactive session.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed the "Continue to Multisite Ultimate Setup" button to ensure users are correctly redirected to the network admin panel instead of the single-site admin panel when completing the multisite setup process. This prevents navigation errors and allows users to proceed smoothly through the final setup steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->