### PR TITLE
fix(i18n): defer translations until init to silence WP 6.7 textdomain notice

### DIFF
--- a/inc/apis/trait-wp-cli.php
+++ b/inc/apis/trait-wp-cli.php
@@ -56,12 +56,38 @@ trait WP_CLI {
 	}
 
 	/**
-	 * Registers the routes. Should be called by the entity
-	 * to actually enable the REST API.
+	 * Schedules WP-CLI command registration.
+	 *
+	 * Called synchronously from each manager's `init()` method. The actual
+	 * command registration — which calls `__()` for translatable shortdescs —
+	 * is deferred to the `init` action so WordPress 6.7+ does not emit a
+	 * `_load_textdomain_just_in_time` `_doing_it_wrong` notice. WP-CLI
+	 * registers commands during its own bootstrap phase before `init` fires;
+	 * hooking the registration to `init` priority 0 keeps the commands
+	 * available for every WP-CLI invocation while satisfying WP 6.7's
+	 * "translate after init" rule.
 	 *
 	 * @since 2.0.0
 	 */
 	public function enable_wp_cli(): void {
+
+		if ( ! defined('WP_CLI')) {
+			return;
+		}
+
+		add_action('init', [$this, 'register_wp_cli_commands'], 0);
+	}
+
+	/**
+	 * Registers the WP-CLI commands for this entity.
+	 *
+	 * Hooked to `init` priority 0 by `enable_wp_cli()` so translations are
+	 * loaded before any `__()` call runs (see `enable_wp_cli()` docblock).
+	 *
+	 * @since 2.10.2
+	 * @return void
+	 */
+	public function register_wp_cli_commands(): void {
 
 		if ( ! defined('WP_CLI')) {
 			return;

--- a/inc/integrations/providers/wpengine/class-wpengine-integration.php
+++ b/inc/integrations/providers/wpengine/class-wpengine-integration.php
@@ -26,21 +26,36 @@ class WPEngine_Integration extends Integration {
 	/**
 	 * Constructor.
 	 *
+	 * Note: Translation calls (`__()`, `_e()`, etc.) are intentionally absent
+	 * from this constructor because integration providers are instantiated on
+	 * `plugins_loaded` priority 9 by the Integration_Registry — before the
+	 * WordPress `init` action fires. WordPress 6.7+ emits a `_doing_it_wrong`
+	 * notice for any translation triggered before `init`. The translatable
+	 * description is returned lazily by `get_description()` so it only runs
+	 * when the wizard or admin UI requests it (always after `init`).
+	 *
 	 * @since 2.5.0
 	 */
 	public function __construct() {
 
 		parent::__construct('wpengine', 'WP Engine');
 
-		$description = __('WP Engine drives your business forward faster with the first and only WordPress Digital Experience Platform. We offer the best WordPress hosting and developer experience on a proven, reliable architecture that delivers unparalleled speed, scalability, and security for your sites.', 'ultimate-multisite');
-
-		$description .= '<br><br><b>' . __('We recommend to enter in contact with WP Engine support to ask for a Wildcard domain if you are using a subdomain install.', 'ultimate-multisite') . '</b>';
-
-		$this->set_description($description);
 		$this->set_logo(function_exists('wu_get_asset') ? wu_get_asset('wpengine.svg', 'img/hosts') : '');
 		$this->set_tutorial_link('https://ultimatemultisite.com/docs/user-guide/host-integrations/wp-engine');
 		$this->set_constants([['WPE_API', 'WPE_APIKEY']]);
 		$this->set_supports(['no-instructions', 'no-config']);
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function get_description(): string {
+
+		$description = __('WP Engine drives your business forward faster with the first and only WordPress Digital Experience Platform. We offer the best WordPress hosting and developer experience on a proven, reliable architecture that delivers unparalleled speed, scalability, and security for your sites.', 'ultimate-multisite');
+
+		$description .= '<br><br><b>' . __('We recommend to enter in contact with WP Engine support to ask for a Wildcard domain if you are using a subdomain install.', 'ultimate-multisite') . '</b>';
+
+		return $description;
 	}
 
 	/**


### PR DESCRIPTION
## Summary

Fix the WordPress 6.7+ `_load_textdomain_just_in_time` _doing_it_wrong_ notice for the `ultimate-multisite` text domain by deferring two paths that translated strings before the `init` action fires.

## Symptom

```
PHP Notice: Function _load_textdomain_just_in_time was called incorrectly.
Translation loading for the ultimate-multisite domain was triggered too early.
This is usually an indicator for some code in the plugin or theme running too early.
Translations should be loaded at the init action or later.
(This message was added in version 6.7.0.)
```

## Root cause (reproduced)

Instrumented WordPress's `gettext` filter to log any `__()` call made before `did_action('init')`. On `origin/main` two distinct call sites trigger early translations on every request:

1. **`WPEngine_Integration::__construct()`** at `inc/integrations/providers/wpengine/class-wpengine-integration.php:35,37`. `Integration_Registry::fire_registration_hooks()` is hooked to `plugins_loaded` priority 9, which instantiates 17 provider classes — only WPEngine sets its description with inline `__()` instead of overriding `get_description()` (the lazy pattern used by the other 16 providers).

2. **`WP_CLI` trait `enable_wp_cli()`** at `inc/apis/trait-wp-cli.php:79,95,100,130-150,178,193,212,221,237`. Every Manager's `init()` synchronously calls `enable_wp_cli()` during plugin bootstrap, which calls `__()` while registering WP-CLI command shortdescs. WP-CLI's own bootstrap loads WordPress before `init` fires, so the textdomain just-in-time loader trips the WP 6.7 notice on every WP-CLI run.

Trace excerpt (reproduced locally on WP 7.x dev install):

```
EARLY TRANSLATION: "WP Engine drives your business forward faster..."
  did_plugins_loaded=1 did_init=0 current_action=gettext
  # 4 inc/integrations/providers/wpengine/class-wpengine-integration.php:35 __
  # 5 inc/integrations/class-integration-registry.php:133 WPEngine_Integration->__construct
  # 6 inc/integrations/class-integration-registry.php:100 register_core_integrations
  # 7 wp-includes/class-wp-hook.php:341 Integration_Registry->fire_registration_hooks (plugins_loaded:9)

EARLY TRANSLATION: "Manages %ss."
  # 4 inc/apis/trait-wp-cli.php:95 __
  # 5 inc/managers/class-event-manager.php:76 Event_Manager->enable_wp_cli
  # 6 inc/traits/trait-singleton.php:36 Event_Manager->init
  # 7 inc/class-wp-ultimo.php:921 Event_Manager::get_instance
  # 8 inc/class-wp-ultimo.php:245 WP_Ultimo->load_managers
```

## Changes

### `inc/integrations/providers/wpengine/class-wpengine-integration.php`

- Removed the `__()` calls from the constructor.
- Added a `get_description()` override that runs the translations on demand. This matches the pattern already used by Closte, Cloudways, RunCloud, cPanel, ServerPilot, GridPane, Cloudflare, Hestia, Enhance, Plesk, Rocket, WPMUDEV, BunnyNet, LaravelForge, Amazon SES, and CyberPanel — WPEngine was the odd one out.

### `inc/apis/trait-wp-cli.php`

- `enable_wp_cli()` keeps its public signature so every existing Manager continues to call it from `init()` unchanged.
- The body now schedules a single `add_action('init', [$this, 'register_wp_cli_commands'], 0)`.
- A new `register_wp_cli_commands()` method holds the original registration logic (the `__()` calls move into it). It runs on `init` priority 0, before WP-CLI dispatches commands, so `wp wu …` continues to work without any other code change.

## Verification

- Repro probe (gettext filter mu-plugin, logs every translation before `init`):
  - **Before**: 6+ early-translation events per request — WPEngine description (×2 on every page load) and 6 WP-CLI shortdescs per Manager × N managers.
  - **After**: 0 events on the same probe.
- `wp wu` lists all sub-commands (customer, membership, payment, product, registered_domain, site, webhook).
- `wp wu customer list --format=count` runs cleanly.
- `vendor/bin/phpcs inc/integrations/providers/wpengine/class-wpengine-integration.php inc/apis/trait-wp-cli.php` → clean.
- `vendor/bin/phpstan analyse inc/integrations/providers/wpengine/class-wpengine-integration.php inc/apis/trait-wp-cli.php` → no errors.
- `vendor/bin/phpunit --filter 'Integration_Registry_Test|Provider_Integration_Test|Event_Manager_Test'` → 127 tests, 1 unrelated pre-existing failure (`amazon-ses missing domain-mapping capability`, also fails on `origin/main`).

## Notes

- No public API changed. `enable_wp_cli()` signature is preserved; the only behavioural difference is that command registration now happens on `init` priority 0 rather than synchronously during the Manager's `init()` method.
- `register_wp_cli_commands()` is `public` because the trait may be used by classes that compose it differently; the method is referenced only via the `add_action` callback.

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.12 plugin for [OpenCode](https://opencode.ai) v1.14.41 with claude-sonnet-4-6 spent 13h 24m and 40 tokens on this as a headless worker.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized WP-CLI command registration for improved performance.
  * Enhanced WPEngine integration initialization efficiency with deferred description loading.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Ultimate-Multisite/ultimate-multisite/pull/1166)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->