### PR TITLE
fix(wpengine): remove public description return type

### DIFF
--- a/inc/integrations/providers/wpengine/class-wpengine-integration.php
+++ b/inc/integrations/providers/wpengine/class-wpengine-integration.php
@@ -48,8 +48,10 @@ class WPEngine_Integration extends Integration {
 
 	/**
 	 * {@inheritdoc}
+	 *
+	 * @return string
 	 */
-	public function get_description(): string {
+	public function get_description() {
 
 		$description = __('WP Engine drives your business forward faster with the first and only WordPress Digital Experience Platform. We offer the best WordPress hosting and developer experience on a proven, reliable architecture that delivers unparalleled speed, scalability, and security for your sites.', 'ultimate-multisite');
 


### PR DESCRIPTION
## Summary

- Remove the public `: string` return type from `WPEngine_Integration::get_description()` to preserve addon override compatibility.
- Add an explicit PHPDoc return tag in place of the signature return type.

## Verification

- `php -l inc/integrations/providers/wpengine/class-wpengine-integration.php`
- `vendor/bin/phpcs inc/integrations/providers/wpengine/class-wpengine-integration.php`

Resolves #1171

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.31 plugin for [OpenCode](https://opencode.ai) v1.14.48 with gpt-5.5 spent 1m and 45,031 tokens on this as a headless worker.
