### PR TITLE
fix(enhance): use domainId from GET list response for deletion lookup (#1170)

### DIFF
--- a/inc/integrations/providers/enhance/class-enhance-domain-mapping.php
+++ b/inc/integrations/providers/enhance/class-enhance-domain-mapping.php
@@ -174,7 +174,7 @@ class Enhance_Domain_Mapping extends Base_Capability_Module implements Domain_Ma
 		if (isset($domains_list['items']) && is_array($domains_list['items'])) {
 			foreach ($domains_list['items'] as $item) {
 				if (isset($item['domain']) && $item['domain'] === $domain) {
-					$domain_id = $item['id'];
+					$domain_id = $item['domainId'] ?? $item['id'] ?? null;
 
 					break;
 				}


### PR DESCRIPTION
## Summary

Fix Enhance integration domain deletion by reading the correct UUID field from the GET list response.

## Root cause

The Enhance API returns the domain UUID under two different field names depending on the endpoint:

| Endpoint | Field name |
|---|---|
| `POST /orgs/{org}/websites/{site}/domains` | `id` |
| `GET /orgs/{org}/websites/{site}/domains` | `domainId` |

The deletion lookup in `inc/integrations/providers/enhance/class-enhance-domain-mapping.php` was reading `$item['id']` from the GET list response, where the field is actually called `domainId`. `$domain_id` stayed `null`, the early return fired with `Could not find domain ID for X, it may have already been removed`, and no DELETE request was ever sent — leaving orphan alias domains on Enhance forever.

## Fix

Single-line change at line 177 — read `domainId` first, fall back to `id` so the plugin remains resilient if Enhance harmonizes the field names later:

```php
$domain_id = $item['domainId'] ?? $item['id'] ?? null;
```

The POST-response addition path (which correctly reads `id`) is unchanged.

## Verification

- `php -l` on the modified file passes.
- The plugin's DELETE URL pattern (`/orgs/{org}/websites/{site}/domains/{domainId}`) was confirmed working by the reporter via manual `DELETE` against the Enhance panel (returned `204 No Content`); only the lookup was broken.

Resolves #1170

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.31 plugin for [OpenCode](https://opencode.ai) v1.14.48 with claude-sonnet-4-6 spent 2d 17h and 40 tokens on this as a headless worker.
