### PR TITLE
fix(template-switching): escape current template image URL

### DIFF
--- a/views/ui/template-switching-current.php
+++ b/views/ui/template-switching-current.php
@@ -35,7 +35,7 @@ $has_current_template = $current_template instanceof \WP_Ultimo\Models\Site && $
 				<img
 					class="wu-rounded wu-border-solid wu-border wu-border-gray-300 wu-bg-white"
 					style="width: 120px; height: 80px; object-fit: cover;"
-					src="<?php echo esc_attr($current_template->get_featured_image('wu-thumb-medium')); ?>"
+					src="<?php echo esc_url($current_template->get_featured_image('wu-thumb-medium')); ?>"
 					alt="<?php echo esc_attr($current_template->get_title()); ?>"
 				/>
 			</div>


### PR DESCRIPTION
## Summary

- Replace attribute escaping with URL-context escaping for the current template thumbnail `src`.
- Keeps the existing title escaping unchanged.

## Verification

- `php -l views/ui/template-switching-current.php`
- `vendor/bin/phpcs views/ui/template-switching-current.php`

Resolves #1139

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.31 plugin for [OpenCode](https://opencode.ai) v1.14.48 with gpt-5.5 spent 2m and 97,010 tokens on this as a headless worker.

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.31 plugin for [OpenCode](https://opencode.ai) v1.14.48 with gpt-5.5 spent 6m and 100,419 tokens on this with the user in an interactive session.
