### PR TITLE
fix(cloudways): exclude wildcards from Let's Encrypt SSL request, keep in aliases (#1160)

### DIFF
--- a/inc/integrations/providers/cloudways/class-cloudways-domain-mapping.php
+++ b/inc/integrations/providers/cloudways/class-cloudways-domain-mapping.php
@@ -190,23 +190,27 @@ class Cloudways_Domain_Mapping extends Base_Capability_Module implements Domain_
 	/**
 	 * Returns an array of valid SSL domains.
 	 *
+	 * Wildcard entries (starting with `*.`) are intentionally excluded: the
+	 * Cloudways Let's Encrypt endpoint always sends `wild_card => false`, so a
+	 * wildcard stripped to its apex would either silently receive a non-wildcard
+	 * apex cert or fail DNS validation when the apex does not resolve to the
+	 * Cloudways IP. Wildcards must still appear in the aliases list (handled by
+	 * `sync_domains()` / `get_domains()`), which is unaffected by this method.
+	 *
 	 * @since 2.5.0
 	 * @param array $domains List of domains.
 	 * @return array
 	 */
 	private function get_valid_ssl_domains(array $domains): array {
 
-		$ssl_domains = array_unique(
-			array_map(
-				function ($domain) {
-
-					if (str_starts_with($domain, '*.')) {
-						$domain = str_replace('*.', '', $domain);
-					}
-
-					return $domain;
-				},
-				$domains
+		// Drop wildcard entries entirely — Cloudways' Let's Encrypt endpoint never
+		// issues wildcard certs (wild_card => false), so including the apex of a
+		// wildcard in the SSL list is guaranteed to be wrong. Wildcards remain on
+		// the aliases list (sync_domains()), which is unaffected by this method.
+		$ssl_domains = array_values(
+			array_filter(
+				$domains,
+				static fn($domain) => ! str_starts_with((string) $domain, '*.')
 			)
 		);
 

--- a/inc/integrations/providers/wpengine/class-wpengine-integration.php
+++ b/inc/integrations/providers/wpengine/class-wpengine-integration.php
@@ -51,7 +51,7 @@ class WPEngine_Integration extends Integration {
 	 *
 	 * @return string
 	 */
-	public function get_description() {
+	public function get_description(): string {
 
 		$description = __('WP Engine drives your business forward faster with the first and only WordPress Digital Experience Platform. We offer the best WordPress hosting and developer experience on a proven, reliable architecture that delivers unparalleled speed, scalability, and security for your sites.', 'ultimate-multisite');
 

--- a/tests/WP_Ultimo/Integrations/Providers/Cloudways_Domain_Mapping_Test.php
+++ b/tests/WP_Ultimo/Integrations/Providers/Cloudways_Domain_Mapping_Test.php
@@ -114,4 +114,180 @@ class Cloudways_Domain_Mapping_Test extends WP_UnitTestCase {
 
 		$this->assertNotNull($result);
 	}
+
+	// -------------------------------------------------------------------------
+	// Wildcard / SSL split regression tests (GH#1160)
+	// -------------------------------------------------------------------------
+
+	/**
+	 * Creates a fresh module+integration pair where get_credential is also
+	 * stubbed so we can inject WU_CLOUDWAYS_EXTRA_DOMAINS without touching PHP
+	 * constants or the database.
+	 *
+	 * @param string $extra_domains Comma-separated extra domains to return.
+	 * @return array{0: Cloudways_Domain_Mapping, 1: Cloudways_Integration}
+	 */
+	private function make_module_with_extra_domains(string $extra_domains): array {
+
+		$integration = $this->getMockBuilder(Cloudways_Integration::class)
+			->onlyMethods(['send_cloudways_request', 'get_credential'])
+			->getMock();
+
+		$integration->method('get_credential')
+			->willReturnCallback(
+				static function ($name) use ($extra_domains) {
+					if ('WU_CLOUDWAYS_EXTRA_DOMAINS' === $name) {
+						return $extra_domains;
+					}
+					return '';
+				}
+			);
+
+		$module = new Cloudways_Domain_Mapping();
+		$module->set_integration($integration);
+
+		return [$module, $integration];
+	}
+
+	/**
+	 * A wildcard entry in WU_CLOUDWAYS_EXTRA_DOMAINS MUST appear in the aliases
+	 * payload sent to /app/manage/aliases.
+	 */
+	public function test_wildcard_extra_domain_is_present_in_aliases_payload(): void {
+
+		[$module, $integration] = $this->make_module_with_extra_domains('*.example.com,plain.example.org');
+
+		$captured_aliases = null;
+
+		$integration->expects($this->once())
+			->method('send_cloudways_request')
+			->with(
+				'/app/manage/aliases',
+				$this->callback(
+					static function ($args) use (&$captured_aliases) {
+						$captured_aliases = $args['aliases'] ?? [];
+						return true;
+					}
+				)
+			)
+			->willReturn((object) ['status' => true]);
+
+		$module->on_add_domain('plain.example.org', 1);
+
+		$this->assertContains('*.example.com', $captured_aliases, 'Wildcard should remain in the aliases payload');
+		$this->assertContains('plain.example.org', $captured_aliases, 'Plain extra domain should remain in the aliases payload');
+	}
+
+	/**
+	 * A wildcard entry in WU_CLOUDWAYS_EXTRA_DOMAINS MUST NOT appear in the
+	 * ssl_domains payload sent to /security/lets_encrypt_install.
+	 */
+	public function test_wildcard_extra_domain_is_absent_from_ssl_payload(): void {
+
+		[$module, $integration] = $this->make_module_with_extra_domains('*.example.com');
+
+		add_filter('wu_get_network_public_ip', static function () {
+			return '1.2.3.4';
+		});
+		add_filter(
+			'pre_http_request',
+			static function ($preempt, $args, $url) {
+				if (str_contains($url, 'dns.google')) {
+					return [
+						'headers'       => [],
+						'body'          => '{"Answer":[{"data":"1.2.3.4"}]}',
+						'response'      => [
+							'code'    => 200,
+							'message' => 'OK',
+						],
+						'cookies'       => [],
+						'http_response' => null,
+					];
+				}
+				return $preempt;
+			},
+			10,
+			3
+		);
+
+		$captured_ssl_domains = null;
+
+		$integration->expects($this->once())
+			->method('send_cloudways_request')
+			->with(
+				'/security/lets_encrypt_install',
+				$this->callback(
+					static function ($args) use (&$captured_ssl_domains) {
+						$captured_ssl_domains = $args['ssl_domains'] ?? [];
+						return true;
+					}
+				)
+			)
+			->willReturn((object) ['status' => true]);
+
+		$module->request_ssl();
+
+		$this->assertNotContains('*.example.com', $captured_ssl_domains, 'Wildcard must not appear in the SSL domains payload');
+
+		remove_all_filters('wu_get_network_public_ip');
+		remove_all_filters('pre_http_request');
+	}
+
+	/**
+	 * A plain (non-wildcard) extra domain MUST appear in BOTH the aliases payload
+	 * and the ssl_domains payload.
+	 */
+	public function test_plain_extra_domain_flows_to_both_aliases_and_ssl(): void {
+
+		[$module, $integration] = $this->make_module_with_extra_domains('plain.example.org');
+
+		add_filter('wu_get_network_public_ip', static function () {
+			return '1.2.3.4';
+		});
+		add_filter(
+			'pre_http_request',
+			static function ($preempt, $args, $url) {
+				if (str_contains($url, 'dns.google')) {
+					return [
+						'headers'       => [],
+						'body'          => '{"Answer":[{"data":"1.2.3.4"}]}',
+						'response'      => [
+							'code'    => 200,
+							'message' => 'OK',
+						],
+						'cookies'       => [],
+						'http_response' => null,
+					];
+				}
+				return $preempt;
+			},
+			10,
+			3
+		);
+
+		$aliases_payload     = null;
+		$ssl_domains_payload = null;
+
+		$integration->expects($this->exactly(2))
+			->method('send_cloudways_request')
+			->willReturnCallback(
+				static function ($endpoint, $args) use (&$aliases_payload, &$ssl_domains_payload) {
+					if ('/app/manage/aliases' === $endpoint) {
+						$aliases_payload = $args['aliases'] ?? [];
+					} elseif ('/security/lets_encrypt_install' === $endpoint) {
+						$ssl_domains_payload = $args['ssl_domains'] ?? [];
+					}
+					return (object) ['status' => true];
+				}
+			);
+
+		$module->on_add_domain('plain.example.org', 1);
+		$module->request_ssl();
+
+		$this->assertContains('plain.example.org', $aliases_payload, 'Plain extra domain should be in the aliases payload');
+		$this->assertContains('plain.example.org', $ssl_domains_payload, 'Plain extra domain should be in the ssl_domains payload');
+
+		remove_all_filters('wu_get_network_public_ip');
+		remove_all_filters('pre_http_request');
+	}
 }


### PR DESCRIPTION
## Summary

- `get_valid_ssl_domains()` now **filters out** wildcard entries (`*.x`) entirely instead of stripping the `*.` prefix. Wildcards have no place in a non-wildcard Let's Encrypt request (`wild_card => false` is hard-coded); the stripped apex would either silently receive the wrong cert type or fail DNS validation.
- The aliases path (`sync_domains()` → `/app/manage/aliases`) is **unchanged** — wildcards continue to flow through for Cloudways routing.
- Three PHPUnit regression tests added: (a) wildcard present in aliases payload, (b) wildcard absent from `ssl_domains` payload, (c) plain extra domain flows to both.
- **Bonus fix**: pre-existing PHP 8 declaration incompatibility in `WPEngine_Integration::get_description()` (missing `: string` return type) blocked the entire test suite from booting on PHP 8+.

## Files Changed

- `EDIT: inc/integrations/providers/cloudways/class-cloudways-domain-mapping.php` — `get_valid_ssl_domains()` filter fix
- `EDIT: tests/WP_Ultimo/Integrations/Providers/Cloudways_Domain_Mapping_Test.php` — three regression tests
- `EDIT: inc/integrations/providers/wpengine/class-wpengine-integration.php` — PHP 8 return-type compatibility fix

## Verification

```
vendor/bin/phpcs inc/integrations/providers/cloudways/class-cloudways-domain-mapping.php  ✓
vendor/bin/phpstan analyse inc/integrations/providers/cloudways/class-cloudways-domain-mapping.php  ✓
WP_TESTS_DIR=/tmp/wordpress-tests-lib vendor/bin/phpunit --filter Cloudways_Domain_Mapping_Test --no-coverage
# OK (15 tests, 26 assertions)  ✓
```

Resolves #1160
Ref #1141

---
<!-- aidevops:sig -->
