### PR TITLE
fix(template-switching): tighten sentinel guard to allow sites with no current template to switch

### DIFF
--- a/assets/js/template-switching.js
+++ b/assets/js/template-switching.js
@@ -161,8 +161,12 @@
 					 * initialised" and bail out — the watcher will fire
 					 * again on the next legitimate template change.
 					 */
-					// eslint-disable-next-line eqeqeq
-					if (this.original_template_id == -1 || this.original_template_id <= 0) {
+					// Only -1 is the "not yet bound" sentinel (the data() default).
+					// 0 is a real, valid state meaning "site has no current template"
+					// — the customer must still be able to pick a template from the
+					// grid in that case. Use < 0 to also cover any future negative
+					// sentinel without re-introducing the 0 foot-gun.
+					if (this.original_template_id < 0) {
 
 						return;
 


### PR DESCRIPTION
## Summary

- Fixes a regression introduced in PR #1113 (v2.10.0) that prevented customers from switching templates on sites with no current template (`template_id === 0`).
- Tightened the `original_template_id` sentinel guard in the Vue watcher from `<= 0` to `< 0`, so only the data() sentinel value of `-1` (meaning "v-init not yet run") causes an early return; `0` (a valid state meaning "site has no current template") now passes through correctly and allows `confirm_active` to become `true`.
- The rest of the stack (PHP AJAX handler, `Site_Duplicator::override_site()`, `views/ui/template-switching-current.php`) already handles `original_template_id === 0` correctly — this JS fix is sufficient.

## Files changed

- `assets/js/template-switching.js` — changed `this.original_template_id == -1 || this.original_template_id <= 0` → `this.original_template_id < 0` at the Vue watcher guard. Removed the now-unnecessary `eslint-disable-next-line eqeqeq` suppression. Added an explanatory comment.

## Testing

1. Create a customer site with no template assigned (`template_id` postmeta = `0` — typical when the checkout form has no Template Selection field).
2. Log in as that customer and navigate to Customer Panel → Template Switching.
3. Click **Select** on any template card in the grid.
4. **Before fix:** nothing happened — the confirmation panel never appeared.
5. **After fix:** the confirmation panel appears with the chosen template; clicking Confirm triggers the switch via `wu_switch_template` AJAX → `Site_Duplicator::override_site()`.

Regression check: customers whose sites *do* have a current template still see the confirm panel only after picking a *different* template (the `old_value === undefined` guard at line 137 handles the v-init race independently).

Resolves #1145

<!-- aidevops:sig -->
