### PR TITLE
GH#1187: test: cover UI Field class name regression

### DIFF
--- a/tests/WP_Ultimo/UI/Field_Test.php
+++ b/tests/WP_Ultimo/UI/Field_Test.php
@@ -15,6 +15,16 @@ use WP_UnitTestCase;
 class Field_Test extends WP_UnitTestCase {
 
 	/**
+	 * Test class keeps the expected name for autoloaded consumers.
+	 */
+	public function test_class_uses_expected_name(): void {
+		$field = new Field('test_field', []);
+
+		$this->assertInstanceOf(Field::class, $field);
+		$this->assertSame(Field::class, get_class($field));
+	}
+
+	/**
 	 * Test constructor creates field with attributes.
 	 */
 	public function test_constructor(): void {


### PR DESCRIPTION
## Summary

Verified the reported class declaration issue is already fixed as WP_Ultimo\UI\Field and added a focused regression test that asserts instantiated fields keep the expected class name used by autoloaded consumers.

## Files Changed

tests/WP_Ultimo/UI/Field_Test.php

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** WP_TESTS_DIR=/tmp/wordpress-tests-lib vendor/bin/phpunit --filter 'WP_Ultimo\\UI\\Field_Test'; vendor/bin/phpcs -n tests/WP_Ultimo/UI/Field_Test.php

Resolves #1187


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.34 plugin for [OpenCode](https://opencode.ai) v1.14.48 with gpt-5.5 spent 3m and 50,920 tokens on this with the user in an interactive session.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test coverage to verify correct class instantiation and naming validation for the Field component.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Ultimate-Multisite/ultimate-multisite/pull/1188)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->