### PR TITLE
test: cover corrupted credit html fallback

### DIFF
--- a/tests/WP_Ultimo/Credits_Test.php
+++ b/tests/WP_Ultimo/Credits_Test.php
@@ -182,6 +182,31 @@ class Credits_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Test build_credit_html normalizes corrupted custom HTML settings.
+	 */
+	public function test_build_credit_html_normalizes_corrupted_custom_html(): void {
+
+		wu_save_setting('credits_enable', 1);
+		wu_save_setting('credits_type', 'html');
+		wu_save_setting('credits_custom_html', '[object Object]');
+
+		$reflection = new \ReflectionClass($this->credits);
+		$method     = $reflection->getMethod('build_credit_html');
+
+		if (PHP_VERSION_ID < 80100) {
+			$method->setAccessible(true);
+		}
+
+		$result = $method->invoke($this->credits);
+
+		$this->assertStringNotContainsString('[object Object]', $result);
+		$this->assertStringContainsString('Powered by', $result);
+
+		// Clean up.
+		wu_save_setting('credits_enable', 0);
+	}
+
+	/**
 	 * Test build_credit_html with custom network type.
 	 */
 	public function test_build_credit_html_custom_network_type(): void {


### PR DESCRIPTION
## Summary

- Adds regression coverage for corrupted `credits_custom_html` values in runtime credit rendering.
- Verifies `[object Object]` is normalized to the default powered-by credit before output.

## Testing

- `vendor/bin/phpcs tests/WP_Ultimo/Credits_Test.php`
- `WP_TESTS_DIR=/tmp/wordpress-tests-lib vendor/bin/phpunit --filter Credits_Test`

Resolves #1186

<!-- MERGE_SUMMARY: Added regression coverage for runtime normalization of corrupted custom credit HTML settings so footer output cannot render `[object Object]`. -->
<!-- aidevops:sig -->
