### PR TITLE
GH#1150 follow-up: preserve default network CLI site selection

### DIFF
--- a/inc/site-exporter/class-site-exporter.php
+++ b/inc/site-exporter/class-site-exporter.php
@@ -89,13 +89,41 @@ final class Site_Exporter {
 			$this->load_dependencies();
 		}
 
-		add_action('wu_export_site', [$this, 'handle_site_export'], 10, 3);
+		add_action(
+			'wu_export_site',
+			function (int $site_id, array $options = [], string $hash = ''): void {
 
-		add_action('wu_export_network', [$this, 'handle_network_export'], 10, 3);
+				$this->handle_site_export($site_id, $options, $hash);
+			},
+			10,
+			3
+		);
 
-		add_action('wu_import_site', [$this, 'handle_site_import']);
+		add_action(
+			'wu_export_network',
+			function (array $included_blog_ids, int $main_site_blog_id, array $options = [], string $hash = ''): void {
 
-		add_action('wu_import_network', [$this, 'handle_network_import'], 10, 3);
+				$this->handle_network_export($included_blog_ids, $main_site_blog_id, $options, $hash);
+			},
+			10,
+			4
+		);
+
+		add_action(
+			'wu_import_site',
+			function (): void {
+
+				$this->handle_site_import();
+			}
+		);
+
+		add_action(
+			'wu_import_network',
+			function (): void {
+
+				$this->handle_network_import();
+			}
+		);
 
 		add_filter('wu_site_exporter_files_to_zip', [$this, 'maybe_exclude_wp_ultimo_plugins']);
 
@@ -121,7 +149,7 @@ final class Site_Exporter {
 
 		// Network export (GH#1149)
 		add_filter('wu_site_bulk_actions', [$this, 'add_bulk_network_export_action']);
-		add_action('wu_handle_bulk_action_form_network_export', [$this, 'handle_bulk_network_export'], 10, 3);
+		add_action('wu_handle_bulk_action_form_network_export', [$this, 'handle_bulk_network_export'], 10, 2);
 
 		if (defined('WP_CLI') && WP_CLI) {
 			\WP_CLI::add_command('wp-ultimo import-network', [$this, 'wp_cli_import_network']);


### PR DESCRIPTION
## Summary

- Preserve the network import CLI default of importing all manifest-included sites when `--sites` is omitted.
- Follow-up to the merged network import implementation.

## Testing

- `vendor/bin/phpcs inc/site-exporter/class-network-importer.php inc/site-exporter/class-site-exporter.php inc/functions/importer.php tests/WP_Ultimo/Site_Exporter/Network_Importer_Test.php`
- `php -l` on changed PHP files
- `vendor/bin/phpunit --filter Network_Importer_Test` blocked locally by database credentials (`mysqli` access denied for root@localhost) after installing the expected WP test suite path.

Ref #1150

MERGE_SUMMARY: Follow-up ensures omitted `--sites` in the WP-CLI network import wrapper imports all manifest-included sites rather than passing an empty selected list.

---
<!-- aidevops:sig -->
