### PR TITLE
test(e2e): regression guards for #1185 (SSO bootstrap race) and #1169 (subsite password reset)

### DIFF
--- a/tests/e2e/cypress/fixtures/setup-password-reset-subsite.php
+++ b/tests/e2e/cypress/fixtures/setup-password-reset-subsite.php
@@ -1,0 +1,175 @@
+<?php
+/**
+ * Reproduce the subsite password reset URL bug fixed in PR #1169 / issue #1168.
+ *
+ * The bug:
+ *   `replace_reset_password_link()` had an early return on subsites and the
+ *   `retrieve_password_message` filter registration was gated by
+ *   `is_main_site()`. End users who triggered "lost password" on a subsite
+ *   (especially mapped custom domains) received an email pointing to
+ *   `https://main-site.example/wp-login.php` — a domain they don't recognise.
+ *
+ * What this fixture does:
+ *   1. Ensures custom login pages are enabled (the affected setting).
+ *   2. Creates a test subsite at `/pwreset-subsite/` if missing.
+ *   3. Creates a test user owned by that subsite.
+ *   4. Switches to the subsite context and invokes UM's filter directly
+ *      with a synthetic raw message containing a main-site wp-login.php URL.
+ *   5. Extracts the URL from the filtered message and returns its host /
+ *      path / query so the Cypress spec can assert against them.
+ *   6. Also asserts the new `wu_subsite_password_reset_url` filter (added
+ *      by #1169) is reachable — by hooking it transiently and confirming
+ *      it ran.
+ *
+ * Returns JSON consumed by the Cypress spec:
+ *   {
+ *     "site_id":          <int>,
+ *     "subsite_host":     "<host expected to appear in the reset URL>",
+ *     "main_host":        "<main site host>",
+ *     "filter_ran":       true,                  // wu_subsite_password_reset_url
+ *     "rewritten_url":    "<final URL pulled from the message>",
+ *     "rewritten_host":   "<host of the rewritten URL>",
+ *     "rewritten_query":  { action, key, login, wp_lang },
+ *     "raw_url":          "<the URL we asked UM to rewrite>"
+ *   }
+ *
+ * No SMTP is sent. We invoke the filter callback directly so the test is
+ * deterministic and does not depend on Mailpit, cron, or rate limiting.
+ */
+
+global $wpdb, $current_site;
+
+$result = [
+	'site_id'         => null,
+	'subsite_host'    => null,
+	'main_host'       => null,
+	'filter_ran'      => false,
+	'rewritten_url'   => null,
+	'rewritten_host'  => null,
+	'rewritten_query' => null,
+	'raw_url'         => null,
+];
+
+// --------------------------------------------------------------------------
+// 1. Custom login pages must be enabled (the affected feature).
+// --------------------------------------------------------------------------
+if (function_exists('wu_save_setting')) {
+	wu_save_setting('enable_custom_login_page', true);
+}
+
+// --------------------------------------------------------------------------
+// 2. Create or reuse the test subsite.
+// --------------------------------------------------------------------------
+$network_domain = $current_site->domain;
+$result['main_host'] = $network_domain;
+
+$existing = get_blog_id_from_url($network_domain, '/pwreset-subsite/');
+
+if ($existing) {
+	$site_id = (int) $existing;
+} else {
+	$site_id = wpmu_create_blog(
+		$network_domain,
+		'/pwreset-subsite/',
+		'PW Reset Subsite',
+		get_current_user_id()
+	);
+
+	if (is_wp_error($site_id)) {
+		echo wp_json_encode([
+			'error' => 'Subsite create failed: ' . $site_id->get_error_message(),
+		]);
+		exit(1);
+	}
+}
+
+$result['site_id'] = (int) $site_id;
+
+// --------------------------------------------------------------------------
+// 3. Create or reuse a test user attached to the subsite.
+// --------------------------------------------------------------------------
+$login = 'pwresetuser';
+$user  = get_user_by('login', $login);
+
+if (! $user) {
+	$user_id = wpmu_create_user($login, wp_generate_password(20), 'pwresetuser@example.test');
+	if (! $user_id) {
+		echo wp_json_encode(['error' => 'User create failed', 'site_id' => $site_id]);
+		exit(1);
+	}
+	$user = get_user_by('id', $user_id);
+}
+
+add_user_to_blog($site_id, $user->ID, 'subscriber');
+
+// --------------------------------------------------------------------------
+// 4. Switch context to the subsite and invoke the UM filter directly.
+//    `replace_reset_password_link()` is registered on `retrieve_password_message`
+//    in Checkout_Pages::__construct(). We reach it via apply_filters().
+// --------------------------------------------------------------------------
+switch_to_blog($site_id);
+
+// `home_url('/')` after switch_to_blog is the subsite's own URL.
+// We extract just the host portion so we can compare it later.
+$subsite_home = home_url('/');
+$subsite_host = wp_parse_url($subsite_home, PHP_URL_HOST);
+$result['subsite_host'] = $subsite_host;
+
+// Hook the new filter introduced by PR #1169 so we can prove it ran.
+$filter_marker = function ($url, $key, $user_login, $user_data) use (&$result) {
+	$result['filter_ran'] = true;
+
+	return $url;
+};
+
+add_filter('wu_subsite_password_reset_url', $filter_marker, 10, 4);
+
+// Build a synthetic raw message that mimics what core's retrieve_password()
+// would produce on a subsite BEFORE the UM filter runs: a URL pointing at
+// the main network site's wp-login.php.
+$key      = 'fixturetestkey1234567890';
+$raw_url  = network_site_url(
+	"wp-login.php?action=rp&key={$key}&login=" . rawurlencode($login),
+	'login'
+);
+
+$result['raw_url'] = $raw_url;
+
+$raw_message = "Someone has requested a password reset for the following account:\n\n"
+	. "Site Name: PW Reset Subsite\n\nUsername: {$login}\n\n"
+	. "If this was a mistake, ignore this email and nothing will happen.\n\n"
+	. "To reset your password, visit the following address:\n\n{$raw_url}";
+
+// Apply the UM filter chain.
+$filtered = apply_filters(
+	'retrieve_password_message',
+	$raw_message,
+	$key,
+	$login,
+	$user
+);
+
+remove_filter('wu_subsite_password_reset_url', $filter_marker, 10);
+
+restore_current_blog();
+
+// --------------------------------------------------------------------------
+// 5. Extract the URL line from the filtered message.
+// --------------------------------------------------------------------------
+if (preg_match('#https?://\S+#', $filtered, $m)) {
+	$rewritten = $m[0];
+	$result['rewritten_url']  = $rewritten;
+	$result['rewritten_host'] = wp_parse_url($rewritten, PHP_URL_HOST);
+
+	$query_str = (string) wp_parse_url($rewritten, PHP_URL_QUERY);
+	parse_str($query_str, $parsed_q);
+
+	$result['rewritten_query'] = [
+		'action'  => $parsed_q['action']  ?? null,
+		'key'     => $parsed_q['key']     ?? null,
+		'login'   => $parsed_q['login']   ?? null,
+		'wp_lang' => $parsed_q['wp_lang'] ?? null,
+	];
+}
+
+echo wp_json_encode($result);

--- a/tests/e2e/cypress/fixtures/setup-sso-bootstrap-race.php
+++ b/tests/e2e/cypress/fixtures/setup-sso-bootstrap-race.php
@@ -1,0 +1,99 @@
+<?php
+/**
+ * Reproduce the SSO bootstrap race fixed in PR #1185.
+ *
+ * The bug:
+ *   `convert_bearer_into_auth_cookies()` runs on `init`, but on some multisite
+ *   bootstraps the `$GLOBALS['current_blog']` object exists with an empty
+ *   `registered` property. `calculate_secret_from_date('')` then threw
+ *   `SSO_Exception` and the response became a 500 / blank page (most visible
+ *   when admin UI is loaded inside an iframe via SSO).
+ *
+ * The fix (PR #1185, merged in 2.11.1) added two guards:
+ *   1. `convert_bearer_into_auth_cookies()`: early return when `$current_blog`
+ *      is missing or its `registered` property is empty.
+ *   2. `calculate_secret_from_date($date)`: when `$date` is empty, fall back
+ *      to the main site's registered date (or '2024-01-01 00:00:00') instead
+ *      of throwing.
+ *
+ * This fixture verifies both guards still work, in a way that survives
+ * future refactors of the SSO bootstrap chain.
+ *
+ * Outputs JSON consumed by the Cypress spec:
+ *   {
+ *     "main_secret":    "<hash from a populated main-site registered date>",
+ *     "empty_secret_1": "<hash from calculate_secret_from_date('')>",
+ *     "empty_secret_2": "<same call again — must equal empty_secret_1>",
+ *     "bearer_threw":   false,                  // guard 1 must not throw
+ *     "secret_threw":   false                   // guard 2 must not throw
+ *   }
+ */
+
+if (! class_exists('\\WP_Ultimo\\SSO\\SSO')) {
+	echo wp_json_encode(['error' => 'WP_Ultimo SSO class not loaded']);
+	exit(1);
+}
+
+$result = [
+	'main_secret'    => null,
+	'empty_secret_1' => null,
+	'empty_secret_2' => null,
+	'bearer_threw'   => false,
+	'secret_threw'   => false,
+];
+
+// Grab the SSO singleton (uses the Singleton trait, see inc/sso/class-sso.php:40).
+try {
+	$sso = \WP_Ultimo\SSO\SSO::get_instance();
+} catch (\Throwable $e) {
+	echo wp_json_encode(['error' => 'Cannot get SSO instance: ' . $e->getMessage()]);
+	exit(1);
+}
+
+// -----------------------------------------------------------------------
+// Guard 2: calculate_secret_from_date() must never throw on empty input.
+// It must return a deterministic hash (same call -> same hash).
+// -----------------------------------------------------------------------
+try {
+	$main = function_exists('get_main_site_id') ? get_site(get_main_site_id()) : get_site(1);
+	$result['main_secret'] = $sso->calculate_secret_from_date($main->registered);
+} catch (\Throwable $e) {
+	$result['main_secret'] = 'THREW:' . $e->getMessage();
+}
+
+try {
+	$result['empty_secret_1'] = $sso->calculate_secret_from_date('');
+} catch (\Throwable $e) {
+	$result['secret_threw']  = true;
+	$result['empty_secret_1'] = 'THREW:' . $e->getMessage();
+}
+
+try {
+	$result['empty_secret_2'] = $sso->calculate_secret_from_date('');
+} catch (\Throwable $e) {
+	$result['secret_threw']   = true;
+	$result['empty_secret_2'] = 'THREW:' . $e->getMessage();
+}
+
+// -----------------------------------------------------------------------
+// Guard 1: convert_bearer_into_auth_cookies() must early-return (no throw)
+// when $current_blog->registered is empty.
+// -----------------------------------------------------------------------
+global $current_blog;
+$saved_registered = $current_blog->registered ?? null;
+
+try {
+	if (is_object($current_blog)) {
+		$current_blog->registered = '';
+	}
+	$sso->convert_bearer_into_auth_cookies();
+} catch (\Throwable $e) {
+	$result['bearer_threw'] = true;
+	$result['bearer_error'] = $e->getMessage();
+} finally {
+	if (is_object($current_blog) && $saved_registered !== null) {
+		$current_blog->registered = $saved_registered;
+	}
+}
+
+echo wp_json_encode($result);

--- a/tests/e2e/cypress/integration/011-password-reset-subsite-domain.spec.js
+++ b/tests/e2e/cypress/integration/011-password-reset-subsite-domain.spec.js
@@ -1,0 +1,113 @@
+/**
+ * Password Reset Subsite Domain — regression guard for PR #1169 / issue #1168
+ *
+ * Bug recap:
+ *   `replace_reset_password_link()` in `inc/checkout/class-checkout-pages.php`
+ *   had two issues:
+ *     1. `add_filter('retrieve_password_message', ...)` was registered inside
+ *        an `if (is_main_site())` block, so the filter never ran on subsites.
+ *     2. The function itself bailed out early with
+ *        `if (! is_main_site()) return $message;`.
+ *
+ *   Combined, every subsite's password-reset email pointed to
+ *   `https://<main-site>/wp-login.php?action=rp&...` — confusing end users
+ *   who registered on a mapped custom domain (they didn't recognise the host
+ *   and treated the email as phishing).
+ *
+ * Fix (merged in 2.10.2, present in 2.11.x):
+ *   - Filter registration moved out of the `is_main_site()` gate.
+ *   - `replace_reset_password_link()` rewrites the URL to `home_url('/')` of
+ *     the current subsite, preserving the `action / key / login / wp_lang`
+ *     query args so existing handlers (WooCommerce my-account, BuddyPress,
+ *     custom themes, default wp-login fallback) can pick the request up.
+ *   - New filter `wu_subsite_password_reset_url` lets integrations override
+ *     the destination URL without re-implementing the rewrite.
+ *
+ * What this spec verifies (so the fix can't silently regress):
+ *   - On a subsite, the rewritten URL's host is the SUBSITE host, NOT the
+ *     main site's host.
+ *   - The reset query args (action=rp, key, login, wp_lang) are preserved
+ *     so handlers downstream still get the data they need.
+ *   - The new `wu_subsite_password_reset_url` filter is reachable.
+ *
+ * Driven from PHP via a WP-CLI fixture — we apply the filter chain directly
+ * with a synthetic raw message. No SMTP / Mailpit / cron dependency.
+ */
+describe("Password Reset on Subsite Stays on Subsite Domain (PR #1169 regression guard)", () => {
+  let fixtureData;
+
+  before(() => {
+    cy.wpCliFile("tests/e2e/cypress/fixtures/setup-password-reset-subsite.php", {
+      failOnNonZeroExit: false,
+    }).then((result) => {
+      const output = result.stdout.trim();
+      cy.log(`Password reset fixture output: ${output}`);
+
+      try {
+        fixtureData = JSON.parse(output);
+      } catch (e) {
+        throw new Error(
+          `Fixture did not return JSON. Raw output:\n${output}`
+        );
+      }
+
+      expect(fixtureData, "fixture produced an error").to.not.have.property("error");
+      expect(fixtureData.site_id, "no site_id").to.be.a("number");
+      expect(fixtureData.rewritten_url, "no rewritten_url").to.be.a("string");
+    });
+  });
+
+  it("Should rewrite the reset URL to the subsite host (not the main-site host)", () => {
+    const subsite = fixtureData.subsite_host;
+    const main    = fixtureData.main_host;
+    const host    = fixtureData.rewritten_host;
+    const rawUrl  = fixtureData.raw_url || "";
+
+    // Sanity: confirm the raw input we asked UM to rewrite did point at
+    // the main site (otherwise the test wouldn't actually exercise the fix).
+    expect(rawUrl, "raw URL did not point at main host — fixture is misconfigured")
+      .to.include(main);
+
+    // Core assertion: the host of the rewritten URL must be the subsite host.
+    // We allow `subsite === main` as a degenerate case for environments where
+    // wp-env has not been given a separate subsite domain (path-based subsite
+    // on the same host — still passes because the URL is at least no longer
+    // pointed at wp-login.php on a different host).
+    if (subsite && subsite !== main) {
+      expect(host, "rewritten URL host should be the subsite host")
+        .to.equal(subsite);
+    } else {
+      // Path-based subsite scenario: the URL should at least not be the
+      // raw main-site wp-login.php URL we fed in.
+      expect(fixtureData.rewritten_url).to.not.equal(rawUrl);
+    }
+
+    // It must never silently fall back to wp-login.php on a host different
+    // from the subsite host — that's the symptom of the regression.
+    expect(fixtureData.rewritten_url, "URL still points at /wp-login.php")
+      .to.not.match(/\/wp-login\.php(\?|$)/);
+  });
+
+  it("Should preserve the reset query args needed by downstream handlers", () => {
+    const q = fixtureData.rewritten_query || {};
+
+    // action / key / login / wp_lang are what WooCommerce, BuddyPress, and
+    // default wp-login fallback look for. Losing any of them silently breaks
+    // the reset flow on subsites.
+    expect(q.action, "missing action=rp").to.equal("rp");
+    expect(q.key, "missing key").to.be.a("string").and.to.have.length.greaterThan(0);
+    expect(q.login, "missing login").to.be.a("string").and.to.have.length.greaterThan(0);
+    expect(q.wp_lang, "missing wp_lang").to.be.a("string");
+  });
+
+  it("Should expose the wu_subsite_password_reset_url filter for integrations", () => {
+    // PR #1169 introduced this filter so integrations can override the
+    // destination URL (e.g. point at the WooCommerce reset-password endpoint)
+    // without re-implementing the rewrite. The fixture hooks the filter
+    // transiently and toggles `filter_ran` when it fires.
+    expect(
+      fixtureData.filter_ran,
+      "wu_subsite_password_reset_url did not run — fix may be regressing"
+    ).to.equal(true);
+  });
+});

--- a/tests/e2e/cypress/integration/066-sso-bootstrap-race.spec.js
+++ b/tests/e2e/cypress/integration/066-sso-bootstrap-race.spec.js
@@ -1,0 +1,93 @@
+/**
+ * SSO Bootstrap Race — regression guard for PR #1185
+ *
+ * Bug recap:
+ *   The SSO callback `convert_bearer_into_auth_cookies()` is attached to `init`.
+ *   On some multisite bootstraps the `$GLOBALS['current_blog']` object exists
+ *   but its `registered` property is still an empty string (mapped-domain
+ *   subsites right after a cache flush, iframe'd admin requests, hosts that
+ *   warm object caches between `sunrise.php` and `ms-settings.php`).
+ *
+ *   `get_broker()` then called `calculate_secret_from_date('')`, which threw
+ *   `SSO_Exception`. The user-visible symptom was admin pages loaded through
+ *   an iframe via SSO rendering blank, masked by full-page cache on healthy
+ *   requests but reappearing on every cache invalidation. Reproduced
+ *   reliably on a 300+ subsite production network (kursopro.com).
+ *
+ * Fix (merged in 2.11.1):
+ *   Two defensive guards in `inc/sso/class-sso.php`:
+ *     1. `convert_bearer_into_auth_cookies()` early-returns when
+ *        `$current_blog` is missing or its `registered` property is empty.
+ *     2. `calculate_secret_from_date($date)` falls back to the main site's
+ *        registered date (or '2024-01-01 00:00:00') when `$date` is empty,
+ *        instead of throwing.
+ *
+ * What this spec verifies (so the fix can't silently regress):
+ *   - `calculate_secret_from_date('')` does NOT throw and returns a real hash.
+ *   - Two consecutive calls with the same empty input return the SAME hash
+ *     (deterministic fallback — important so SSO state stays consistent
+ *     across requests during a bootstrap window).
+ *   - `convert_bearer_into_auth_cookies()` does NOT throw when called with
+ *     an emptied `$current_blog->registered`.
+ *
+ * Driven entirely from PHP via a WP-CLI fixture; no browser interaction
+ * is required because the race is at the PHP layer, not in the UI.
+ */
+describe("SSO Bootstrap Race (PR #1185 regression guard)", () => {
+  it("Should not throw and should return a deterministic hash when bootstrap data is incomplete", () => {
+    cy.wpCliFile("tests/e2e/cypress/fixtures/setup-sso-bootstrap-race.php", {
+      failOnNonZeroExit: false,
+    }).then((result) => {
+      const output = result.stdout.trim();
+      cy.log(`Bootstrap race fixture output: ${output}`);
+
+      // The fixture must always emit valid JSON, even on internal errors.
+      let data;
+      try {
+        data = JSON.parse(output);
+      } catch (e) {
+        throw new Error(
+          `Fixture did not return JSON. Raw output:\n${output}`
+        );
+      }
+
+      // Bootstrap sanity: SSO class must be loadable in the test environment.
+      expect(data, "fixture produced an error").to.not.have.property("error");
+
+      // Guard 2: calculate_secret_from_date('') must not throw.
+      expect(data.secret_threw, "calculate_secret_from_date('') threw").to.equal(false);
+
+      // It must return a real hash (32-char hex, like wp_hash output length).
+      expect(data.empty_secret_1, "empty_secret_1 is not a string").to.be.a("string");
+      expect(data.empty_secret_1, "empty_secret_1 looks like a throw marker")
+        .to.not.match(/^THREW:/);
+      expect(data.empty_secret_1.length, "empty_secret_1 is too short to be a hash")
+        .to.be.greaterThan(16);
+
+      // Determinism: same empty input -> same hash on a repeat call.
+      // If the fallback ever switched to a non-deterministic source
+      // (e.g. current time), SSO would break in production whenever a
+      // subsite hits the empty-`registered` window between requests.
+      expect(
+        data.empty_secret_1,
+        "empty_secret_1 and empty_secret_2 must be equal (deterministic fallback)"
+      ).to.equal(data.empty_secret_2);
+
+      // The main-site path is the established baseline. The empty-input
+      // fallback should normally match it (both resolve to the main site's
+      // registered date), but we don't hard-assert equality because a future
+      // fallback constant ('2024-01-01 00:00:00') would diverge while still
+      // being correct. We assert it at least produced a hash.
+      expect(data.main_secret, "main_secret is not a string").to.be.a("string");
+      expect(data.main_secret, "main_secret looks like a throw marker")
+        .to.not.match(/^THREW:/);
+
+      // Guard 1: convert_bearer_into_auth_cookies() with empty registered
+      // must not throw SSO_Exception (it should early-return).
+      expect(
+        data.bearer_threw,
+        `convert_bearer_into_auth_cookies() threw: ${data.bearer_error || ""}`
+      ).to.equal(false);
+    });
+  });
+});


### PR DESCRIPTION
## Why this PR exists

A senior contributor on our side recently shipped two fixes that affected ~300+ subsites in our production network (kursopro.com), and we'd like to make sure they can't silently regress in a future refactor:

- **PR #1185** — `inc/sso/class-sso.php` early-return + deterministic-secret fallback (merged 2.11.1).
- **PR #1169** — `inc/checkout/class-checkout-pages.php` subsite password reset URL rewrite (merged 2.10.2).

This PR adds two Cypress specs + matching WP-CLI fixtures that lock in the behaviour of those fixes. They sit alongside your existing `060-sso-cross-domain.spec.js`, `065-sso-redirect-loop.spec.js`, and `050-password-strength-enforcement.spec.js` and follow the same patterns (`cy.wpCliFile`, JSON output from fixture, `cy.loginByApi`, baseUrl `localhost:8889`).

## What each spec verifies

### `066-sso-bootstrap-race.spec.js` — guards #1185

- `calculate_secret_from_date('')` does **not** throw and returns a real hash.
- Two consecutive calls with empty input return the **same** hash (deterministic fallback — important so SSO state stays consistent across requests during the empty-\`registered\` window).
- `convert_bearer_into_auth_cookies()` does **not** throw when \`\$current_blog\` exists with an empty \`registered\` property.

Driven entirely from PHP via `setup-sso-bootstrap-race.php`. The race is at the PHP layer (between `sunrise.php` and `ms-settings.php`), so no browser interaction is required.

### `011-password-reset-subsite-domain.spec.js` — guards #1169

- The URL produced by the `retrieve_password_message` filter on a subsite uses the **subsite** host — not the main-site \`/wp-login.php\` host (the symptom of the original bug that confused `zuletadia` on `yariglam.cl`).
- The reset query args \`action=rp / key / login / wp_lang\` are preserved so WooCommerce my-account, BuddyPress, custom themes, and the default wp-login fallback can still complete the reset.
- The new `wu_subsite_password_reset_url` filter is reachable for integration overrides.

Driven via `setup-password-reset-subsite.php` which creates a test subsite, switches into it, and applies the filter chain directly with a synthetic raw message — no SMTP / Mailpit / cron dependency.

## How they fit your existing suite

| File | Type | Notes |
|---|---|---|
| `tests/e2e/cypress/integration/066-sso-bootstrap-race.spec.js` | new | Numbered after your `060/065` SSO specs |
| `tests/e2e/cypress/integration/011-password-reset-subsite-domain.spec.js` | new | Numbered next to the `010-manual-checkout-flow.spec.js` group |
| `tests/e2e/cypress/fixtures/setup-sso-bootstrap-race.php` | new | Same pattern as your `setup-sso-test.php` |
| `tests/e2e/cypress/fixtures/setup-password-reset-subsite.php` | new | Same pattern as your `setup-sso-test.php` |

Both specs are deterministic, single-process, and avoid any heavy setup (no Stripe, no PayPal, no Mailpit).

## Honest note — please validate in your CI before merging

I authored these on Windows without Docker locally, so **I was not able to run `npm run cy:run:test` against your `wp-env` setup**. I verified:

- PHP `-l` syntax check on both fixtures.
- `node --check` syntax check on both specs.
- That the SSO class is a singleton (`\WP_Ultimo\SSO\SSO::get_instance()`) by reading `inc/sso/class-sso.php`.
- That `replace_reset_password_link()` and the `wu_subsite_password_reset_url` filter live where the PR diffs say they do.
- That fixture conventions match your `setup-sso-test.php` (JSON output, `wp_json_encode`, container path via `cy.wpCliFile`).

If anything fails in your CI I'm happy to iterate — feel free to push directly to the branch or comment with the failure output.

## Production context

Bug context behind each spec, in case it helps reviewing the assertions:

- **#1185 SSO bootstrap race**: surfaced as blank admin panels inside iframes on mapped-domain subsites after a cache invalidation. Masked by full-page cache on healthy requests, reappeared every time the cache was cold. Affected 300+ subsites until 2.11.1.
- **#1169 password reset on subsites**: a customer of a subsite owner (mapped `.cl` TLD) requested a password reset and received an email pointing at the **main network**'s `wp-login.php`. She didn't recognise the domain, treated the email as phishing, and complained to the subsite owner that the site had been hacked. Reproduced on 8/8 subsites in our staging network before patch.

Thanks David — and thank you for shipping both fixes so quickly. These specs are our way of helping keep them locked in.