### PR TITLE
ci(e2e): clarify Stripe test skip message for fork PRs

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -248,7 +248,18 @@ jobs:
           STRIPE_TEST_SK_KEY: ${{ secrets.STRIPE_TEST_SK_KEY }}
         run: |
           if [ -z "$STRIPE_TEST_SK_KEY" ]; then
-            echo "⏭️  Skipping Stripe tests: STRIPE_TEST_SK_KEY secret not configured"
+            echo "⏭️  Skipping Stripe tests: STRIPE_TEST_SK_KEY not available in this run."
+            echo ""
+            echo "    The repo secrets STRIPE_TEST_PK_KEY and STRIPE_TEST_SK_KEY are configured,"
+            echo "    but GitHub Actions does NOT expose secrets to workflows triggered by"
+            echo "    pull_request events from forked repositories. This is a security feature,"
+            echo "    not a misconfiguration."
+            echo ""
+            echo "    Stripe tests will run automatically when:"
+            echo "      • this branch is merged to main (push event), or"
+            echo "      • the PR is opened from a branch in the upstream Ultimate-Multisite repo."
+            echo ""
+            echo "    To verify locally, run: gh secret list --repo Ultimate-Multisite/ultimate-multisite"
             exit 0
           fi
 


### PR DESCRIPTION
## Summary

Improves the message printed when the E2E workflow skips the Stripe tests, so
the cause is obvious from the run log.

## Why

When a PR is opened from a **forked repository**, GitHub Actions intentionally
does not expose repo secrets (`STRIPE_TEST_PK_KEY`, `STRIPE_TEST_SK_KEY`) to
the workflow run. This is a security feature, not a misconfiguration.

The previous skip message ("STRIPE_TEST_SK_KEY secret not configured") implied
the secret was missing at the repo level, which led to wasted investigation
time — the secret *was* configured (verifiable via `gh secret list`).

## Evidence

Run [`25765984372`](https://github.com/Ultimate-Multisite/ultimate-multisite/actions/runs/25765984372)
(PR from fork `kenedytorcatt/ultimate-multisite`) — Stripe step env block:

```
env:
  STRIPE_TEST_PK_KEY: 
  STRIPE_TEST_SK_KEY: 
```

Run [`25762586860`](https://github.com/Ultimate-Multisite/ultimate-multisite/actions/runs/25762586860)
(push to `main`) — same step:

```
env:
  STRIPE_TEST_SK_KEY: ***
```

Both secrets are present in `gh secret list --repo Ultimate-Multisite/ultimate-multisite`.

## Change

Single workflow file: `.github/workflows/e2e.yml`. The skip message now
explains the fork-PR security behaviour, lists when Stripe tests *will* run
(push to `main`, or PRs from upstream branches), and points to `gh secret list`
for local verification. No logic change — the same `exit 0` path runs when the
key is empty.

## Verification

- YAML syntax validated with `python3 -c "import yaml; yaml.safe_load(...)"`.
- No behavioural change: the gate condition and exit code are unchanged.
- Once merged to `main`, the Stripe step on this push event will run as before
  (secrets exposed), confirming the gate still passes when secrets are available.

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.38 plugin for [OpenCode](https://opencode.ai) v1.14.48 with gpt-5.5 spent 5h 32m and 15,815 tokens on this as a headless worker.
