### PR TITLE
GH#1196: docs: clarify WooCommerce addon release guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -177,10 +177,12 @@ Use `WP_Error` for validation/operation failures — not exceptions.
   immediately after signup. Inspect the checkout, membership, payment gateway, and
   orphaned-site cleanup paths together before changing watchdog or cancellation logic;
   verify both pending membership cancellation and pending site cleanup.
-- Do not reference an `ultimate-multisite-woocommerce` addon release as v2.0.23; the
-  latest known released version is v2.0.10 unless repository or release evidence says
-  otherwise. Verify addon version claims before adding them to docs, issues, or
-  user-facing troubleshooting notes.
+- Do not reference an `ultimate-multisite-woocommerce` addon release as v2.0.23; that
+  version number has not been released for the WooCommerce addon. The latest known
+  released version is v2.0.10 unless repository or release evidence says otherwise.
+  Verify addon version claims before adding them to docs, issues, or user-facing
+  troubleshooting notes, and do not copy core/plugin version numbers onto addon
+  release references without evidence.
 
 ### Tests
 - Extend `WP_UnitTestCase`. Tests run in a WordPress Multisite environment


### PR DESCRIPTION
## Summary

Clarified the AGENTS.md recurring product context so agents do not cite unreleased ultimate-multisite-woocommerce v2.0.23, treat v2.0.10 as the latest known released addon version unless verified otherwise, and avoid copying core/plugin versions onto addon release references.

## Files Changed

AGENTS.md

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** git diff --check; python3 assertion that AGENTS.md contains the clarified WooCommerce addon release guidance

Resolves #1196


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.38 plugin for [OpenCode](https://opencode.ai) v1.14.48 with gpt-5.5 spent 1m and 90,426 tokens on this with the user in an interactive session.