### PR TITLE
GH#1206: docs: capture WooCommerce addon release guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -177,6 +177,10 @@ Use `WP_Error` for validation/operation failures — not exceptions.
   immediately after signup. Inspect the checkout, membership, payment gateway, and
   orphaned-site cleanup paths together before changing watchdog or cancellation logic;
   verify both pending membership cancellation and pending site cleanup.
+- Ultimate Multisite WooCommerce addon release references: do not cite or assume
+  `ultimate-multisite-woocommerce` version `v2.0.23`; it was never released. The
+  latest released version for that addon is `v2.0.10` unless verified otherwise from
+  an authoritative release source.
 
 ### Tests
 - Extend `WP_UnitTestCase`. Tests run in a WordPress Multisite environment


### PR DESCRIPTION
## Summary

Added recurring product guidance to AGENTS.md noting that ultimate-multisite-woocommerce v2.0.23 was never released and v2.0.10 is the latest released version unless an authoritative source says otherwise.

## Files Changed

AGENTS.md

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** git diff --check -- AGENTS.md

Resolves #1206


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.38 plugin for [OpenCode](https://opencode.ai) v1.14.48 with gpt-5.5 spent 1m and 80,197 tokens on this with the user in an interactive session.