### PR TITLE
GH#1207: docs: clarify OpenCode Bash description metadata

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -472,7 +472,9 @@ Most `bash:other` errors in this codebase fall into one of these categories:
 **Missing Bash tool metadata in OpenCode** — OpenCode requires every Bash tool call to include
 a short `description` field. If a command fails before execution with a schema error like
 `Missing key at ["description"]`, do not change the shell command itself. Retry the same command
-with a concise description, for example: `description="Lists tracked admin asset files"`.
+with a concise description, for example: `description="Lists tracked admin asset files"`. This
+is tool-call metadata, not a shell argument; keep the original command intact and add the
+description alongside it in the Bash tool payload.
 
 **Tool not installed** — run the prerequisite checks above before any lint, test, or analysis command.
 


### PR DESCRIPTION
## Summary

Clarified the AGENTS.md bash:other recovery guidance so workers know the missing OpenCode description field is tool-call metadata, not a shell argument, and should retry the unchanged command with a payload description.

## Files Changed

AGENTS.md

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** git diff --check -- AGENTS.md

Resolves #1207


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.38 plugin for [OpenCode](https://opencode.ai) v1.14.48 with gpt-5.5 spent 1m and 47,475 tokens on this with the user in an interactive session.