### PR TITLE
fix(stripe): membership upgrade/downgrade fails with 'unknown parameter: coupon'

### DIFF
--- a/inc/gateways/class-base-stripe-gateway.php
+++ b/inc/gateways/class-base-stripe-gateway.php
@@ -1462,21 +1462,38 @@ class Base_Stripe_Gateway extends Base_Gateway {
 			];
 
 			/*
-			 * Use 'discounts' array instead of deprecated 'coupon' parameter.
-			 * The 'coupon' parameter was removed in newer Stripe API versions.
+			 * Use the 'discounts' array instead of the deprecated top-level
+			 * 'coupon' parameter. The 'coupon' parameter was removed from the
+			 * Stripe subscription update endpoint in newer API versions and
+			 * returns: "Received unknown parameter: coupon. Did you mean to
+			 * use `discounts` instead?".
+			 *
+			 * When there is no credit coupon to apply we explicitly clear any
+			 * existing discounts by passing an empty array. This replaces the
+			 * deprecated `subscriptions->deleteDiscount()` call and folds the
+			 * clear into the same update request.
 			 *
 			 * @since 2.0.12
 			 */
 			if ( ! empty($s_coupon)) {
 				$update_data['discounts'] = [['coupon' => $s_coupon]];
+			} elseif ( ! empty($subscription->discount) || ! empty($subscription->discounts)) {
+				$update_data['discounts'] = [];
 			}
 
 			$subscription = $this->get_stripe_client()->subscriptions->update($gateway_subscription_id, $update_data);
-
-			if (empty($s_coupon) && ! empty($subscription->discount)) {
-				$this->get_stripe_client()->subscriptions->deleteDiscount($gateway_subscription_id);
-			}
 		} catch (\Throwable $e) {
+			wu_log_add(
+				'stripe',
+				sprintf(
+					'Error updating Stripe subscription %s during membership update. Sent keys: %s. Message: %s',
+					$gateway_subscription_id,
+					implode(',', array_keys($update_data ?? [])),
+					$e->getMessage()
+				),
+				LogLevel::ERROR
+			);
+
 			return new \WP_Error('wu_stripe_update_error', $e->getMessage());
 		}
 
@@ -1817,6 +1834,14 @@ class Base_Stripe_Gateway extends Base_Gateway {
 		 * Filters the Stripe subscription arguments.
 		 */
 		$sub_args = apply_filters('wu_stripe_create_subscription_args', $sub_args, $this);
+
+		/*
+		 * Defensive: never pass the top-level 'coupon' parameter to the
+		 * Stripe subscriptions->create endpoint. Newer Stripe API versions
+		 * removed it in favour of the 'discounts' array. A legacy filter or
+		 * addon could re-introduce it; strip it before the API call.
+		 */
+		unset($sub_args['coupon']);
 
 		/*
 		 * If we have a `billing_cycle_anchor` AND a `trial_end`, then we need to unset whichever one


### PR DESCRIPTION
## Summary

Fixes the Stripe API error `"Received unknown parameter: coupon. Did you mean to use 'discounts' instead?"` when an admin upgrades or downgrades a membership via the *Add New Product* modal in the network admin.

## What changed

- `process_membership_update()` now clears any existing subscription discount **in the same** `subscriptions->update` call by passing `discounts: []`, instead of issuing a second API call to the deprecated `subscriptions->deleteDiscount()` endpoint. The update is now atomic and uses only modern API methods.
- After `apply_filters('wu_stripe_create_subscription_args', ...)`, the create-subscription path now strips any top-level `coupon` key with `unset($sub_args['coupon'])`. This defends against legacy filters or third-party addons that could re-introduce the deprecated parameter and cause the same Stripe error on initial checkout.
- When `subscriptions->update` throws, the gateway now logs the keys sent to Stripe (without values) so future regressions are diagnosable.

The credit-coupon path (pro-rata discounts on upgrade) is preserved and continues to use the modern `discounts` array with the coupon ID nested inside.

## Verification

- `vendor/bin/phpunit --filter Base_Stripe_Gateway_Test` → 107 tests, 181 assertions, OK.
- `vendor/bin/phpunit --filter Stripe` → 194 tests, exit 0.
- `vendor/bin/phpstan analyse inc/gateways/class-base-stripe-gateway.php` → 0 errors.
- `vendor/bin/phpcs inc/gateways/class-base-stripe-gateway.php` → no new violations (2 pre-existing on lines 2943 and 3320 are outside this diff).

Resolves #1211

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.46 plugin for [OpenCode](https://opencode.ai) v1.14.49 with gpt-5.5 spent 1d 21h and 15,815 tokens on this as a headless worker.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Stripe subscription discount handling to ensure coupons and discounts are properly managed during subscription updates.
  * Enhanced error logging for subscription operations with more detailed troubleshooting information.
  * Added safeguards to prevent deprecated parameters from interfering with subscription creation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Ultimate-Multisite/ultimate-multisite/pull/1212)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->