### PR TITLE
fix(membership): prevent epoch (1970-01-01) corruption of date_expiration on save

### DIFF
--- a/inc/admin-pages/class-customer-edit-admin-page.php
+++ b/inc/admin-pages/class-customer-edit-admin-page.php
@@ -971,7 +971,7 @@ class Customer_Edit_Admin_Page extends Edit_Admin_Page {
 						'placeholder'   => '2020-04-04 12:00:00',
 						'html_attr'     => [
 							'wu-datepicker'   => 'true',
-							'data-format'     => 'Y-m-d H:i:S',
+							'data-format'     => 'Y-m-d H:i:s',
 							'data-allow-time' => 'true',
 						],
 					],

--- a/inc/admin-pages/class-discount-code-edit-admin-page.php
+++ b/inc/admin-pages/class-discount-code-edit-admin-page.php
@@ -167,7 +167,7 @@ class Discount_Code_Edit_Admin_Page extends Edit_Admin_Page {
 						'html_attr'         => [
 							'v-bind:name'     => 'enable_date_start ? "date_start" : ""',
 							'wu-datepicker'   => 'true',
-							'data-format'     => 'Y-m-d H:i:S',
+							'data-format'     => 'Y-m-d H:i:s',
 							'data-allow-time' => 'true',
 						],
 					],
@@ -194,7 +194,7 @@ class Discount_Code_Edit_Admin_Page extends Edit_Admin_Page {
 						'html_attr'         => [
 							'v-bind:name'     => 'enable_date_expiration ? "date_expiration" : ""',
 							'wu-datepicker'   => 'true',
-							'data-format'     => 'Y-m-d H:i:S',
+							'data-format'     => 'Y-m-d H:i:s',
 							'data-allow-time' => 'true',
 						],
 					],

--- a/inc/admin-pages/class-edit-admin-page.php
+++ b/inc/admin-pages/class-edit-admin-page.php
@@ -360,7 +360,7 @@ abstract class Edit_Admin_Page extends Base_Admin_Page {
 			'placeholder'   => '2020-04-04 12:00:00',
 			'html_attr'     => [
 				'wu-datepicker'   => 'true',
-				'data-format'     => 'Y-m-d H:i:S',
+				'data-format'     => 'Y-m-d H:i:s',
 				'data-allow-time' => 'true',
 			],
 		];
@@ -377,7 +377,7 @@ abstract class Edit_Admin_Page extends Base_Admin_Page {
 				'placeholder'   => '2020-04-04 12:00:00',
 				'html_attr'     => [
 					'wu-datepicker'   => 'true',
-					'data-format'     => 'Y-m-d H:i:S',
+					'data-format'     => 'Y-m-d H:i:s',
 					'data-allow-time' => 'true',
 				],
 			];

--- a/inc/admin-pages/class-membership-edit-admin-page.php
+++ b/inc/admin-pages/class-membership-edit-admin-page.php
@@ -908,7 +908,7 @@ class Membership_Edit_Admin_Page extends Edit_Admin_Page {
 				'placeholder'   => '2020-04-04 12:00:00',
 				'html_attr'     => [
 					'wu-datepicker'   => 'true',
-					'data-format'     => 'Y-m-d H:i:S',
+					'data-format'     => 'Y-m-d H:i:s',
 					'data-allow-time' => 'true',
 				],
 			];

--- a/inc/admin-pages/class-membership-list-admin-page.php
+++ b/inc/admin-pages/class-membership-list-admin-page.php
@@ -258,12 +258,43 @@ class Membership_List_Admin_Page extends List_Admin_Page {
 
 		$data['status'] = wu_request('status');
 
-		$date_expiration = gmdate('Y-m-d 23:59:59', strtotime((string) wu_request('date_expiration')));
-
 		$maybe_lifetime = wu_request('lifetime');
 
 		if ($maybe_lifetime) {
 			$date_expiration = null;
+		} else {
+			$raw_date_expiration = trim((string) wu_request('date_expiration', ''));
+
+			if ('' === $raw_date_expiration) {
+				wp_send_json_error(
+					new \WP_Error(
+						'missing-date-expiration',
+						__('Please provide an expiration date or mark the membership as lifetime.', 'ultimate-multisite')
+					)
+				);
+			}
+
+			$expiration_timestamp = strtotime($raw_date_expiration);
+
+			/*
+			 * Guard against invalid/localized date strings. strtotime() returns
+			 * false for unparseable input, which gmdate() then coerces to 0
+			 * (Unix epoch), silently storing 1970-01-01 as the expiration date.
+			 */
+			if (false === $expiration_timestamp) {
+				wp_send_json_error(
+					new \WP_Error(
+						'invalid-date-expiration',
+						sprintf(
+							/* translators: %s: the rejected date string */
+							__('The expiration date "%s" is not a valid date. Please use the format YYYY-MM-DD HH:MM:SS.', 'ultimate-multisite'),
+							$raw_date_expiration
+						)
+					)
+				);
+			}
+
+			$date_expiration = gmdate('Y-m-d 23:59:59', $expiration_timestamp);
 		}
 
 		$data['date_expiration'] = $date_expiration;


### PR DESCRIPTION
## Summary

Customer report: in the membership admin, the expiration date displayed
as **"1월 2, 1970"** (Jan 2, 1970 KST) and could not be changed to a
future date. Root cause: the "Add New Membership" AJAX handler ran
unvalidated input through `strtotime()` and then `gmdate()`, so an
empty, localized or otherwise unparseable string produced `strtotime() →
false`, which `gmdate()` coerced to `0` and wrote `1970-01-01 23:59:59
UTC` to the database. In Asia/Seoul (UTC+9) that renders as Jan 2 1970.

A secondary contributor was a datepicker `data-format` of `Y-m-d H:i:S`
(capital `S` = English ordinal suffix to `DateTime::createFromFormat`),
which is not round-trip compatible with `wu_validate_date()`'s
`Y-m-d H:i:s` format. Standardising both ends prevents future drift.

## Changes

- `inc/admin-pages/class-membership-list-admin-page.php`
  `handle_add_new_membership_modal()` now:
  - requires an expiration date when `lifetime` is not set, returning a
    `missing-date-expiration` `WP_Error` if absent;
  - rejects unparseable strings with an `invalid-date-expiration`
    `WP_Error` and echoes the offending value back to the admin;
  - only calls `gmdate()` once `strtotime()` has produced a non-false
    timestamp, removing the epoch-coercion path.
- `inc/admin-pages/class-membership-edit-admin-page.php`,
  `class-customer-edit-admin-page.php`,
  `class-discount-code-edit-admin-page.php`,
  `class-edit-admin-page.php` — datepicker `data-format` changed from
  `Y-m-d H:i:S` to the MySQL-compatible `Y-m-d H:i:s`.

The membership model setter `set_date_expiration()` is intentionally
left untouched: the existing codebase treats `'0000-00-00 00:00:00'`
and unvalidatable strings as semantic sentinels handled downstream
(`is_lifetime()`, `get_remaining_days_in_cycle()`), and the AJAX-handler
fix above is sufficient to eliminate the root cause.

## Verification

- `vendor/bin/phpstan analyse` on the modified files — **No errors**.
- `vendor/bin/phpcs` on the modified files — only a single pre-existing
  Yoda violation on `inc/models/class-membership.php:2655` (unrelated to
  this PR's hunks).
- `vendor/bin/phpunit --filter Membership_Test` —
  **107 tests, 181 assertions, 1 skipped, 0 failures**.
- `vendor/bin/phpunit --filter Membership_List_Admin_Page_Test` —
  **11 tests, 20 assertions, 0 failures**.
- `vendor/bin/phpunit --filter Discount_Code_Edit_Admin_Page_Test` —
  **86 tests, 116 assertions, 2 skipped, 0 failures**.
- The other affected admin-page test classes
  (`Membership_Edit_Admin_Page_Test`, `Customer_Edit_Admin_Page_Test`,
  `Edit_Admin_Page_Test`) exhibit pre-existing `wp_send_json_error()`
  + `die()` aborts mid-suite that are unchanged from `origin/main`;
  the abort pattern was reproduced on a clean stash of these changes
  and is unrelated to this PR.

## Manual reproduction (before fix)

1. Set WordPress timezone to Asia/Seoul.
2. Go to *Memberships → Add New*, pick a customer + product, leave the
   *Expiration date* empty (or paste a localised string).
3. Save → membership is created with `date_expiration =
   1970-01-01 23:59:59`, listed as "1월 2, 1970" in the admin.

After this fix the same input is rejected with a clear admin notice and
no row is corrupted.

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.50 plugin for [OpenCode](https://opencode.ai) v1.14.50 with claude-sonnet-4-6 spent 10h 41m and 383 tokens on this as a headless worker.
