### PR TITLE
fix: use undisclosed-recipients To: header in BCC broadcast (GDPR #1195)

### DIFF
--- a/inc/helpers/class-sender.php
+++ b/inc/helpers/class-sender.php
@@ -123,15 +123,15 @@ class Sender {
 			/*
 			 * Decide which strategy to use, BCC or multiple "to"s.
 			 *
-			 * By default, we use multiple tos, but that can be changed to bcc.
-			 * Depending on the SMTP solution being used, that can make a difference on the number of
-			 * emails sent out.
+			 * Default strategy is BCC. All recipients are placed in the Bcc header so
+			 * no individual address is exposed in the To: field (GDPR/privacy compliance).
+			 * The To: header is set to "undisclosed-recipients:;" per RFC 2822 §3.6.3.
+			 *
+			 * Depending on the SMTP solution being used, BCC vs individual sends can
+			 * make a difference in the number of outbound connections made.
 			 */
 			if (apply_filters('wu_sender_recipients_strategy', 'bcc') === 'bcc') {
-				$main_to = $to[0];
-
-				unset($to[0]);
-
+				// Place every recipient in BCC — do not expose $to[0] in the visible To: header.
 				$bcc_array = array_map(
 					function ($item) {
 
@@ -148,7 +148,8 @@ class Sender {
 
 				$headers[] = "Bcc: $bcc";
 
-				$to = $main_to;
+				// RFC 2822 §3.6.3 — privacy-safe placeholder when all recipients are BCC'd.
+				$to = 'undisclosed-recipients:;';
 			}
 		} else {
 			$to = [


### PR DESCRIPTION
## Summary

- **Bug:** In BCC broadcast strategy, `$to[0]` was set as the visible `To:` header, exposing the first customer's name/email to all other recipients — a GDPR violation.
- **Fix:** All recipients are now placed in `Bcc:`. The `To:` field is set to `undisclosed-recipients:;` per RFC 2822 §3.6.3. No change to the SMTP envelope — all recipients still receive the email.
- **Scope:** Single-line change in the `bcc` strategy branch of `Sender::send_mail()`.

## Change

```
-  $main_to = $to[0];
-  unset($to[0]);
   $bcc_array = array_map(..., $to);   // now includes all recipients
   $headers[] = "Bcc: $bcc";
-  $to = $main_to;
+  $to = 'undisclosed-recipients:;';   // RFC 2822 §3.6.3
```

## Verification

- `wp_mail()` sends one outbound message; SMTP envelope recipients remain unchanged.
- No customer address appears in the `To:` header of the delivered email.
- Filter `wu_sender_recipients_strategy` behaviour is unchanged — returning anything other than `'bcc'` still sends using multiple `To:` addresses.

Resolves #1195

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.50 plugin for [OpenCode](https://opencode.ai) v1.14.50 with claude-sonnet-4-6 spent 6m and 18,904 tokens on this as a headless worker.
