### PR TITLE
security: use hash_equals for constant-time checksum comparison

### DIFF
--- a/inc/sso/jasny/Server/Server.php
+++ b/inc/sso/jasny/Server/Server.php
@@ -279,7 +279,7 @@ class Server {
 	): void {
 		$expected = $this->generateChecksum($command . (null !== $code ? ":$code" : ''), $brokerId, $token);
 
-		if ($checksum !== $expected) {
+		if ( ! hash_equals($expected, $checksum)) {
 			$this->logger->warning(
 				"Invalid $command checksum",
 				['expected' => $expected, 'received' => $checksum, 'broker' => $brokerId, 'token' => $token]


### PR DESCRIPTION
## Summary

Replaced timing-attack-vulnerable `!==` comparison with `hash_equals()` for constant-time comparison of security-sensitive checksums in SSO Server class.

## Changes

- Modified `inc/sso/jasny/Server/Server.php:282` to use `hash_equals()` instead of `!==` for checksum comparison
- Ensures constant-time comparison to prevent timing side-channel attacks

## Verification

- PHPCS validation: ✅ No violations
- PHPStan analysis: ✅ No errors
- Code logic verified: Both `$expected` and `$checksum` are strings returned from `generateChecksum()`
- `hash_equals()` is the correct constant-time comparison function for security-sensitive values

Resolves #1217

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.61 plugin for [OpenCode](https://opencode.ai) v1.15.4 with claude-haiku-4-5 spent 1m and 3,851 tokens on this as a headless worker.
