### PR TITLE
fix: guard against empty path in Broker.getRequestUrl()

### DIFF
--- a/inc/sso/jasny/Broker/Broker.php
+++ b/inc/sso/jasny/Broker/Broker.php
@@ -288,6 +288,10 @@ class Broker {
 	protected function getRequestUrl(string $path, $params = ''): string {
 		$query = is_array($params) ? http_build_query($params) : $params;
 
+		if ('' === $path) {
+			throw new \InvalidArgumentException('Request path cannot be empty');
+		}
+
 		$base = '/' === $path[0]
 			? preg_replace('~^(\w+://[^/]+).*~', '$1', $this->url)
 			: preg_replace('~/[^/]*$~', '', $this->url);


### PR DESCRIPTION
## Summary

Added explicit empty path check before accessing `$path[0]` to prevent undefined offset error when `request()` is called with an empty path.

## Changes

- Added validation in `getRequestUrl()` method to throw `InvalidArgumentException` with clear message when path is empty
- Prevents undefined offset error on `$path[0]` access

## Testing

- PHPCS validation passed, no style violations
- Code follows WordPress coding standards

Resolves #1216

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.61 plugin for [OpenCode](https://opencode.ai) v1.15.4 with claude-haiku-4-5 spent 59s and 3,484 tokens on this as a headless worker.
