### PR TITLE
fix: JS defects from CodeRabbit review of PR 1222

### DIFF
--- a/assets/js/admin-screen.js
+++ b/assets/js/admin-screen.js
@@ -12,13 +12,13 @@
 
 		const is_edit_mode = $('body').hasClass('wu-customize-admin-screen');
 
-		let $elem = `<a id="wu-admin-screen-customize" href="${ wu_admin_screen.customize_link }" class="button show-settings">${ wu_admin_screen.i18n.customize_label }</button>`;
+		let $elem = `<a id="wu-admin-screen-customize" href="${ wu_admin_screen.customize_link }" class="button show-settings">${ wu_admin_screen.i18n.customize_label }</a>`;
 
-		const $page_elem = `<a title="${ wu_admin_screen.i18n.page_customize_label }" id="wu-admin-screen-page-customize" href="${ wu_admin_screen.page_customize_link }" class="wubox button show-settings">${ wu_admin_screen.i18n.page_customize_label }</button>`;
+		const $page_elem = `<a title="${ wu_admin_screen.i18n.page_customize_label }" id="wu-admin-screen-page-customize" href="${ wu_admin_screen.page_customize_link }" class="wubox button show-settings">${ wu_admin_screen.i18n.page_customize_label }</a>`;
 
 		if (is_edit_mode) {
 
-			$elem = `<a id="wu-admin-screen-customize" href="${ wu_admin_screen.close_link }" class="button show-settings wu-font-medium"><span class="wu-text-sm wu-align-text-bottom wu-text-red-500 wu-mr-2 wu--ml-1 dashicons-wu-circle-with-cross"></span>${ wu_admin_screen.i18n.close_label }</button>`;
+			$elem = `<a id="wu-admin-screen-customize" href="${ wu_admin_screen.close_link }" class="button show-settings wu-font-medium"><span class="wu-text-sm wu-align-text-bottom wu-text-red-500 wu-mr-2 wu--ml-1 dashicons-wu-circle-with-cross"></span>${ wu_admin_screen.i18n.close_label }</a>`;
 
 		} else {
 

--- a/assets/js/customizer.js
+++ b/assets/js/customizer.js
@@ -4,9 +4,9 @@
 	/**
 	 * If we detect the preview changed, we add a loader.
 	 */
-	window.addEventListener('message', function(message) {
+	let block;
 
-		let block;
+	window.addEventListener('message', function(message) {
 
 		if (message.data === 'wu_preview_changed') {
 
@@ -14,20 +14,20 @@
 
 		} // end if;
 
-		/**
-		 * Unblocks when the loading is finished.
-		 */
-		$('#preview-stage-iframe').on('load', function() {
-
-			if (block) {
-
-				block.unblock();
-
-			} // end if;
-
-		});
-
 	}, false);
+
+	/**
+	 * Unblocks when the loading is finished.
+	 */
+	$('#preview-stage-iframe').on('load', function() {
+
+		if (block) {
+
+			block.unblock();
+
+		} // end if;
+
+	});
 
 	$(document).ready(function() {
 

--- a/assets/js/dashboard-statistics.js
+++ b/assets/js/dashboard-statistics.js
@@ -160,6 +160,10 @@
 			],
 			onClose(selectedDates) {
 
+				if (! selectedDates || selectedDates.length < 2) {
+					return;
+				}
+
 				const redirect = new URL(window.location.href);
 
 				redirect.searchParams.set('start_date', moment(selectedDates[ 0 ]).format('YYYY-MM-DD'));

--- a/assets/js/edit-placeholders.js
+++ b/assets/js/edit-placeholders.js
@@ -212,7 +212,7 @@
 
 							}
 
-							setInterval(function() {
+							setTimeout(function() {
 
 								that.saveMessage = '';
 

--- a/assets/js/tax-rates.js
+++ b/assets/js/tax-rates.js
@@ -368,7 +368,7 @@
 
 							}
 
-							setInterval(function() {
+							setTimeout(function() {
 
 								that.saveMessage = '';
 

--- a/assets/js/template-previewer.js
+++ b/assets/js/template-previewer.js
@@ -75,7 +75,7 @@
 				loadingIndicator.style.display = "none";
 			}
 			if (isIOS()) {
-				const body = (_a2 = document.getElementById("iframe")) == null ? void 0 : _a2.getElementsByTagName("body")[ 0 ];
+				const body = (_a2 = iframe == null ? void 0 : iframe.contentDocument) == null ? void 0 : _a2.getElementsByTagName("body")[ 0 ];
 				body == null ? void 0 : body.classList.add("wu-fix-safari-preview");
 				(body == null ? void 0 : body.style) && Object.assign(body.style, {
 					position: "fixed",

--- a/assets/js/url-preview.js
+++ b/assets/js/url-preview.js
@@ -17,18 +17,6 @@
 
 		}); // end on.keyUp;
 
-		$('.login').on('keyup', '#field-site_url', function(event) {
-
-			event.preventDefault();
-
-			const $selector = $(this);
-
-			const $target = $('#wu-your-site');
-
-			$target.text($selector.val());
-
-		}); // end on.keyUp;
-
 		$('.login').on('change', '#domain_option', function(event) {
 
 			event.preventDefault();

--- a/assets/js/vue-apps.js
+++ b/assets/js/vue-apps.js
@@ -228,7 +228,13 @@
 		});
 		document.body.addEventListener("wubox:unload", function() {
 			const modal = document.getElementById("WUB_window");
+			if (!modal) {
+				return;
+			}
 			const app = modal.querySelector("ul[data-wu-app]");
+			if (!app) {
+				return;
+			}
 			const app_name = "wu_" + app.dataset.wuApp;
 			delete window[ app_name ];
 			delete window[ app_name + "_errors" ];

--- a/assets/js/wubox.js
+++ b/assets/js/wubox.js
@@ -190,9 +190,13 @@
 	const createInlineBox = (boxWindow, boxOverlay, loaded, caption, params) => {
 		const ajaxContent = baseAjaxElement(boxWindow, boxOverlay, caption, params);
 		const element = document.getElementById(params.inlineId);
-		ajaxContent.insertAdjacentElement("beforeend", element == null ? void 0 : element.children[ 0 ]);
+		if (element && element.children && element.children[ 0 ]) {
+			ajaxContent.insertAdjacentElement("beforeend", element.children[ 0 ]);
+		}
 		const unloadAction = () => {
-			element == null ? void 0 : element.insertAdjacentElement("afterbegin", ajaxContent.children[ 0 ]);
+			if (element && ajaxContent.children && ajaxContent.children[ 0 ]) {
+				element.insertAdjacentElement("afterbegin", ajaxContent.children[ 0 ]);
+			}
 			document.body.removeEventListener("wubox:unload", unloadAction);
 		};
 		document.body.addEventListener("wubox:unload", unloadAction);


### PR DESCRIPTION
## Summary

Fixed 8 JavaScript defects identified by CodeRabbit during review of PR #1222:

1. **admin-screen.js** — HTML closing tags: Changed `</button>` to `</a>` for anchor elements
2. **url-preview.js** — Duplicate keyup handler: Removed duplicate event listener
3. **vue-apps.js** — Missing null guard: Added checks for modal and app before accessing properties
4. **customizer.js** — iframe handler accumulation: Moved load handler outside message listener
5. **edit-placeholders.js** — setInterval to setTimeout: Changed for one-shot clear operation
6. **tax-rates.js** — setInterval to setTimeout: Changed for one-shot clear operation
7. **dashboard-statistics.js** — Date range guard: Added check for selectedDates existence and length
8. **template-previewer.js** — iOS body lookup: Fixed to use iframe.contentDocument instead of document.getElementById
9. **wubox.js** — Missing null guards: Added checks before accessing element.children

## Verification

- npm run lint:js passes for all modified files
- All defects verified fixed in source code
- No regressions in related functionality

Fixes #1226

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.64 plugin for [OpenCode](https://opencode.ai) v1.15.5 with claude-haiku-4-5 spent 4m and 2,601 tokens on this as a headless worker.
