### PR TITLE
fix: prevent fatal in get_formatted_date() for null/empty/zero-date values

### DIFF
--- a/inc/functions/date.php
+++ b/inc/functions/date.php
@@ -36,25 +36,35 @@ function wu_validate_date($date, $format = 'Y-m-d H:i:s') {
 }
 
 /**
- * Returns a Carbon object to deal with dates in a more compelling way.
+ * Returns a DateTime object to deal with dates in a more compelling way.
  *
- * Note: this function uses the wu_validate function to check
- * if the string passed is a valid date string. If the string
- * is not valid, now is used.
+ * Note: this function uses the wu_validate_date function to check
+ * if the string passed is a valid date string. If the string is
+ * not valid (including null, empty, or the MySQL zero-date), now
+ * is used as a safe fallback so callers can always chain ->format().
  *
  * @since 2.0.0
  * @see https://carbon.nesbot.com/docs/
  *
- * @param string|false $date Parsable date string.
+ * @param string|false|null $date Parsable date string.
  * @return \DateTime
  */
 function wu_date($date = false) {
 
-	if ( ! wu_validate_date($date)) {
+	if (empty($date) || '0000-00-00 00:00:00' === $date || ! wu_validate_date($date)) {
 		$date = date_i18n('Y-m-d H:i:s');
 	}
 
-	return \DateTime::createFromFormat('Y-m-d H:i:s', $date);
+	$datetime = \DateTime::createFromFormat('Y-m-d H:i:s', $date);
+
+	if (false === $datetime) {
+		// Defensive last-resort fallback: createFromFormat can still fail on
+		// edge-case locale/timezone inputs. Returning a valid DateTime keeps
+		// chained ->format() / ->getTimestamp() calls safe.
+		$datetime = new \DateTime(date_i18n('Y-m-d H:i:s'));
+	}
+
+	return $datetime;
 }
 
 /**

--- a/inc/models/class-base-model.php
+++ b/inc/models/class-base-model.php
@@ -1033,8 +1033,12 @@ abstract class Base_Model implements \JsonSerializable {
 	/**
 	 * Helper method to return formatted dates.
 	 *
-	 * Deals with:
-	 * - dates
+	 * Returns an empty string when the underlying value is null, empty, or
+	 * the MySQL zero-date '0000-00-00 00:00:00'. This protects callers (for
+	 * example the customer dashboard membership widget rendering
+	 * `date_expiration` on a lifetime/null-expiry membership) from a fatal
+	 * "Call to a member function format() on false" when the value can't be
+	 * parsed into a DateTime.
 	 *
 	 * @since 2.0.0
 	 *
@@ -1044,6 +1048,10 @@ abstract class Base_Model implements \JsonSerializable {
 	public function get_formatted_date($key = 'date_created') {
 
 		$value = $this->{"get_{$key}"}();
+
+		if (empty($value) || '0000-00-00 00:00:00' === $value) {
+			return '';
+		}
 
 		if (wu_validate_date($value)) {
 			return date_i18n(get_option('date_format'), wu_date($value)->format('U'));

--- a/tests/WP_Ultimo/Functions/Date_Functions_Test.php
+++ b/tests/WP_Ultimo/Functions/Date_Functions_Test.php
@@ -89,6 +89,48 @@ class Date_Functions_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Regression: wu_date(null) must not crash and must return a usable DateTime.
+	 *
+	 * Before the fix, wu_validate_date(null) returned true, so wu_date()
+	 * skipped its "now" fallback and \DateTime::createFromFormat(null) returned
+	 * false, causing a fatal "Call to a member function format() on false" in
+	 * Base_Model::get_formatted_date() when a membership had no expiration date.
+	 *
+	 * @see \WP_Ultimo\Models\Base_Model::get_formatted_date()
+	 */
+	public function test_wu_date_null_returns_datetime(): void {
+		$date = wu_date(null);
+
+		$this->assertInstanceOf(\DateTime::class, $date);
+		$this->assertIsString($date->format('U'));
+	}
+
+	/**
+	 * Regression: wu_date('') must not crash.
+	 */
+	public function test_wu_date_empty_string_returns_datetime(): void {
+		$date = wu_date('');
+
+		$this->assertInstanceOf(\DateTime::class, $date);
+		$this->assertIsString($date->format('U'));
+	}
+
+	/**
+	 * Regression: wu_date('0000-00-00 00:00:00') (MySQL zero-date) must not
+	 * crash and must fall back to "now" rather than yielding a year-0 date
+	 * that downstream formatters reject.
+	 */
+	public function test_wu_date_zero_date_uses_now(): void {
+		$date = wu_date('0000-00-00 00:00:00');
+
+		$this->assertInstanceOf(\DateTime::class, $date);
+
+		// Year 0 must not leak through; the fallback should land us at "now".
+		$year = (int) $date->format('Y');
+		$this->assertGreaterThan(2000, $year);
+	}
+
+	/**
 	 * Test wu_get_days_ago returns correct value.
 	 */
 	public function test_get_days_ago(): void {

--- a/tests/WP_Ultimo/Models/Base_Model_Test.php
+++ b/tests/WP_Ultimo/Models/Base_Model_Test.php
@@ -504,6 +504,62 @@ class Base_Model_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Regression: get_formatted_date('date_expiration') must not fatal when
+	 * the underlying value is null.
+	 *
+	 * This reproduces the customer-dashboard fatal seen in production on
+	 * lifetime memberships where Membership::is_lifetime() returned false
+	 * (because recurring=true was preserved on the row) and the dashboard
+	 * widget fell through to formatting a null date_expiration, causing
+	 * "Call to a member function format() on false" via wu_date(null).
+	 *
+	 * @see \WP_Ultimo\Models\Membership::is_lifetime()
+	 * @see views/dashboard-widgets/current-membership.php
+	 */
+	public function test_get_formatted_date_returns_empty_string_for_null_value(): void {
+
+		$membership = new Membership(['date_expiration' => null]);
+
+		$this->assertSame('', $membership->get_formatted_date('date_expiration'));
+	}
+
+	/**
+	 * Regression: get_formatted_date must short-circuit for empty string.
+	 */
+	public function test_get_formatted_date_returns_empty_string_for_empty_value(): void {
+
+		$membership = new Membership(['date_expiration' => '']);
+
+		$this->assertSame('', $membership->get_formatted_date('date_expiration'));
+	}
+
+	/**
+	 * Regression: get_formatted_date must short-circuit for MySQL zero-date.
+	 */
+	public function test_get_formatted_date_returns_empty_string_for_zero_date(): void {
+
+		$membership = new Membership(['date_expiration' => '0000-00-00 00:00:00']);
+
+		$this->assertSame('', $membership->get_formatted_date('date_expiration'));
+	}
+
+	/**
+	 * Get_formatted_date must still format a valid date through date_i18n.
+	 */
+	public function test_get_formatted_date_formats_valid_date(): void {
+
+		$membership = new Membership(['date_expiration' => '2030-06-15 10:30:00']);
+
+		$result = $membership->get_formatted_date('date_expiration');
+
+		$this->assertNotSame('', $result);
+		$this->assertIsString($result);
+		// date_i18n applied the WP date_format option, so we expect a non-raw
+		// representation different from the input timestamp string.
+		$this->assertNotSame('2030-06-15 10:30:00', $result);
+	}
+
+	/**
 	 * Tear down test environment.
 	 */
 	public function tearDown(): void {


### PR DESCRIPTION
## Summary

Fixes a fatal error on the customer dashboard membership widget when a
membership has a null / empty / zero `date_expiration` but is still flagged
`recurring = true` (commonly seen after converting a recurring membership
to a lifetime plan):

```
Fatal Error: Uncaught Error: Call to a member function format() on false
in inc/models/class-base-model.php:1049
```

Reported on Ultimate Multisite 2.12.0, PHP 8.3.31, WP 6.9.4. The fatal
blocked several dashboard interactions (template switching, further
membership configuration) even though the site itself stayed up.

## Root cause (three-step chain)

1. **View guard fails open** — `views/dashboard-widgets/current-membership.php:164`
   only hides the "Expires" block when `Membership::is_lifetime()` returns
   `true`. `is_lifetime()` returns `! is_recurring() && empty(date_expiration)`,
   so if `recurring=true` is preserved on the row, the guard misses the case
   and `get_formatted_date('date_expiration')` is called with a null/empty
   value.

2. **`wu_validate_date(null)` returns `true`** — `inc/functions/date.php:21`
   intentionally treats `null` as valid (form-validation contexts in
   `Discount_Code_Edit_Admin_Page` etc. rely on "no date supplied" being
   acceptable).

3. **`wu_date(null)` returns `false`** — `inc/functions/date.php:51` then
   skips its "now" fallback (because `wu_validate_date(null)` returned
   `true`) and calls `\DateTime::createFromFormat('Y-m-d H:i:s', null)`,
   which returns `false`. `Base_Model::get_formatted_date()` then calls
   `->format('U')` on `false` and fatals.

The same latent crash exists in at least:
- `inc/managers/class-site-manager.php:456` (`wu_date($membership->get_date_expiration())->getTimestamp()`)
- `inc/ui/class-current-membership-element.php:316` (`wu_date($pending_swap_order->scheduled_date)->format(...)`)
- `inc/models/class-membership.php:1326` (guarded by `wu_validate_date` — the lying gate)

## Fix (defence in depth, surgical)

### `inc/functions/date.php` — `wu_date()` is now safe for null / empty / zero-date

```php
function wu_date($date = false) {
    if (empty($date) || '0000-00-00 00:00:00' === $date || ! wu_validate_date($date)) {
        $date = date_i18n('Y-m-d H:i:s');
    }

    $datetime = \DateTime::createFromFormat('Y-m-d H:i:s', $date);

    if (false === $datetime) {
        // Defensive last-resort fallback for edge-case locale/timezone inputs.
        $datetime = new \DateTime(date_i18n('Y-m-d H:i:s'));
    }

    return $datetime;
}
```

Chained `->format()` / `->getTimestamp()` calls are now safe across every
caller, not just the one in `get_formatted_date()`.

### `inc/models/class-base-model.php` — `get_formatted_date()` short-circuits empty/zero-date

```php
public function get_formatted_date($key = 'date_created') {
    $value = $this->{"get_{$key}"}();

    if (empty($value) || '0000-00-00 00:00:00' === $value) {
        return '';
    }

    if (wu_validate_date($value)) {
        return date_i18n(get_option('date_format'), wu_date($value)->format('U'));
    }

    return $value;
}
```

This mirrors how the dashboard widget already treats lifetime memberships
(empty Expires field).

## What was deliberately NOT changed

- **`wu_validate_date(null) === true`** is left as-is. Form-validation callers
  (`Discount_Code_Edit_Admin_Page::handle_save` lines 890/894, etc.) depend
  on it meaning "no date supplied is OK in this optional field". Changing it
  would cascade through discount-code save validation.
- **`Membership::is_lifetime()`** itself is left as-is. The
  `recurring=true + date_expiration=null` data state is a separate
  integrity question; widening `is_lifetime()` to `"recurring=false OR
  date_expiration empty"` risks miscategorising paid memberships during
  data races. Worth a follow-up issue.
- **The widget view** is left as-is. Fixing the helper and the model makes
  every caller safe, not just this one render path.

## Tests

Added regression coverage:

- `tests/WP_Ultimo/Functions/Date_Functions_Test.php`
  - `test_wu_date_null_returns_datetime`
  - `test_wu_date_empty_string_returns_datetime`
  - `test_wu_date_zero_date_uses_now`
- `tests/WP_Ultimo/Models/Base_Model_Test.php`
  - `test_get_formatted_date_returns_empty_string_for_null_value`
  - `test_get_formatted_date_returns_empty_string_for_empty_value`
  - `test_get_formatted_date_returns_empty_string_for_zero_date`
  - `test_get_formatted_date_formats_valid_date`

```
vendor/bin/phpunit --filter 'Date_Functions_Test|Base_Model_Test'
OK (80 tests, 132 assertions)
```

PHPCS introduces **0** new errors (5 pre-existing `WordPress.DateTime.RestrictedFunctions.date_date`
errors in `Date_Functions_Test.php` remain). PHPStan introduces **0** new errors
(15 pre-existing errors in `inc/models/class-base-model.php` remain unchanged).

## Verification steps for reviewers

1. Pull this branch on a multisite WP install.
2. Create a customer + membership with `recurring = 1` and clear
   `date_expiration` (`UPDATE wp_wu_memberships SET date_expiration = NULL,
   recurring = 1 WHERE id = <N>;`).
3. Visit the customer "Account" dashboard — previously fatal, now renders
   the widget with an empty "Expires" cell (or omits it if `is_lifetime()`
   returns true).

<!-- aidevops:sig -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved date validation and formatting to gracefully handle null, empty, and invalid date values by falling back to the current localized date/time.
  * Date fields now safely display as empty when values are missing or invalid instead of throwing errors.

* **Tests**
  * Added comprehensive test coverage for date handling edge cases and fallback behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Ultimate-Multisite/ultimate-multisite/pull/1229?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->