### PR TITLE
feat(membership): guard auto_renew against missing gateway renewal credential

### DIFF
--- a/inc/models/class-membership.php
+++ b/inc/models/class-membership.php
@@ -9,6 +9,7 @@
 
 namespace WP_Ultimo\Models;
 
+use Psr\Log\LogLevel;
 use WP_Ultimo\Checkout\Cart;
 use WP_Ultimo\Database\Memberships\Membership_Status;
 use WP_Ultimo\Models\Interfaces\Billable;
@@ -1435,6 +1436,100 @@ class Membership extends Base_Model implements Limitable, Billable, Notable {
 	}
 
 	/**
+	 * Verify the active gateway has a usable renewal credential before this
+	 * membership is persisted with `auto_renew=1`.
+	 *
+	 * Runs only when the membership claims to auto-renew (recurring + auto_renew
+	 * + a real paid gateway). Gateway integrations answer via the
+	 * `wu_membership_has_renewal_credential` filter:
+	 *
+	 *  - `true`  → credential verified; persist unchanged.
+	 *  - `false` → no credential / known-broken signature; the membership is
+	 *              still saved but `auto_renew` is forced off and a meta flag is
+	 *              recorded so admin/support can recover the buyer before the
+	 *              renewal cron fires (otherwise renewal would silently fail
+	 *              weeks later and cancel the membership with a thin audit trail).
+	 *  - `null`  → no opinion (default); behaviour unchanged.
+	 *
+	 * Free / manual / empty-gateway memberships and non-recurring memberships
+	 * skip the check entirely.
+	 *
+	 * @since 2.5.2
+	 * @return void
+	 */
+	protected function maybe_downgrade_auto_renew_without_credential() {
+
+		if ( ! $this->should_auto_renew() || ! $this->is_recurring()) {
+			return;
+		}
+
+		$gateway = (string) $this->get_gateway();
+
+		if ('' === $gateway || 'free' === $gateway || 'manual' === $gateway) {
+			return;
+		}
+
+		/*
+		 * Already flagged on a prior save — keep auto_renew off but don't re-log
+		 * or fire the event again. Admin/buyer recovery flow clears the meta
+		 * explicitly when re-authorization succeeds.
+		 */
+		if ($this->get_meta('wu_renewal_credential_missing')) {
+			$this->set_auto_renew(false);
+
+			return;
+		}
+
+		/**
+		 * Filters whether the active gateway has a usable renewal credential
+		 * stored for this membership.
+		 *
+		 * Gateways should add a listener that returns `true` when they have
+		 * persisted a renewable token / subscription id / billing agreement,
+		 * and `false` when the checkout completed but the recurring credential
+		 * was NOT saved (e.g. PPCP intent=CAPTURE on a recurring cart with no
+		 * vault reference). Leave the default `null` to opt out.
+		 *
+		 * @since 2.5.2
+		 *
+		 * @param bool|null                    $verified   `true`, `false`, or `null` (unknown).
+		 * @param \WP_Ultimo\Models\Membership $membership The membership being saved.
+		 */
+		$verified = apply_filters('wu_membership_has_renewal_credential', null, $this);
+
+		if (false !== $verified) {
+			return;
+		}
+
+		$id                      = $this->get_id();
+		$gateway_subscription_id = (string) $this->get_gateway_subscription_id();
+
+		wu_log_add(
+			"membership-{$id}",
+			sprintf(
+				'Membership #%1$d: gateway "%2$s" reported no renewal credential at save time (gateway_subscription_id=%3$s). Forcing auto_renew=0; admin notification queued so the buyer can re-authorize before the renewal cron fires.',
+				$id,
+				$gateway,
+				'' !== $gateway_subscription_id ? $gateway_subscription_id : '(empty)'
+			),
+			LogLevel::WARNING
+		);
+
+		$this->set_auto_renew(false);
+		$this->update_meta('wu_renewal_credential_missing', gmdate('Y-m-d H:i:s'));
+
+		/**
+		 * Fires when a membership save was about to claim auto-renewal but the
+		 * gateway integration could not confirm a renewal credential.
+		 *
+		 * @since 2.5.2
+		 *
+		 * @param \WP_Ultimo\Models\Membership $membership The membership.
+		 */
+		do_action('wu_membership_renewal_credential_missing', $this);
+	}
+
+	/**
 	 * Get the discount code applied if exist.
 	 *
 	 * @since 2.0.20
@@ -2762,6 +2857,8 @@ class Membership extends Base_Model implements Limitable, Billable, Notable {
 				}
 			}
 		}
+
+		$this->maybe_downgrade_auto_renew_without_credential();
 
 		return parent::save();
 	}

--- a/tests/WP_Ultimo/Models/Membership_Test.php
+++ b/tests/WP_Ultimo/Models/Membership_Test.php
@@ -1523,4 +1523,242 @@ class Membership_Test extends \WP_UnitTestCase {
 		$address = $this->membership->get_default_billing_address();
 		$this->assertInstanceOf(\WP_Ultimo\Objects\Billing_Address::class, $address);
 	}
+
+	// ---------------------------------------------------------------
+	// Renewal credential guard
+	// ---------------------------------------------------------------
+
+	/**
+	 * Create a freshly-saved recurring auto-renewing membership on a paid
+	 * gateway — the state space where the guard is supposed to engage.
+	 *
+	 * Uses wu_create_membership so we get a real persisted row (with a real
+	 * ID) the guard can attach meta to.
+	 *
+	 * @return Membership
+	 */
+	protected function make_recurring_paid_membership(string $gateway = 'woocommerce', string $sub_id = 'wc-sub-1'): Membership {
+		$user_id = self::factory()->user->create([
+			'user_login' => 'guard_' . wp_generate_password(6, false),
+			'user_email' => 'guard_' . wp_generate_password(6, false) . '@example.test',
+		]);
+
+		$customer = new Customer([
+			'user_id'            => $user_id,
+			'email_verification' => 'none',
+			'type'               => 'customer',
+		]);
+		$customer->set_skip_validation(true);
+		$customer->save();
+
+		$product = new Product([
+			'name'          => 'Guard Plan',
+			'slug'          => 'guard-plan-' . wp_generate_password(6, false),
+			'pricing_type'  => 'paid',
+			'amount'        => 29.99,
+			'currency'      => 'USD',
+			'duration'      => 1,
+			'duration_unit' => 'month',
+			'type'          => 'plan',
+			'recurring'     => true,
+			'active'        => true,
+		]);
+		$product->set_skip_validation(true);
+		$product->save();
+
+		$membership = wu_create_membership([
+			'customer_id'             => $customer->get_id(),
+			'user_id'                 => $user_id,
+			'plan_id'                 => $product->get_id(),
+			'status'                  => Membership_Status::ACTIVE,
+			'amount'                  => 29.99,
+			'initial_amount'          => 29.99,
+			'duration'                => 1,
+			'duration_unit'           => 'month',
+			'recurring'               => true,
+			'auto_renew'              => true,
+			'currency'                => 'USD',
+			'gateway'                 => $gateway,
+			'gateway_subscription_id' => $sub_id,
+			'skip_validation'         => true,
+			'date_expiration'         => gmdate('Y-m-d H:i:s', strtotime('+30 days')),
+		]);
+
+		if (is_wp_error($membership)) {
+			$this->fail('Failed to create membership: ' . $membership->get_error_message());
+		}
+
+		// wu_create_membership runs save() once already. Drop any flag the
+		// initial save may have introduced so each test starts clean.
+		$membership->delete_meta('wu_renewal_credential_missing');
+		$membership->set_auto_renew(true);
+
+		return $membership;
+	}
+
+	/**
+	 * No filter listener → guard treats verification as "unknown", auto_renew preserved.
+	 */
+	public function test_save_preserves_auto_renew_when_no_filter_listener(): void {
+		$m = $this->make_recurring_paid_membership();
+
+		$m->save();
+
+		$this->assertTrue($m->should_auto_renew(), 'auto_renew should remain on when no gateway expresses an opinion');
+		$this->assertEmpty($m->get_meta('wu_renewal_credential_missing'), 'no flag should be set without a false verdict');
+	}
+
+	/**
+	 * Filter returns true (credential verified) → auto_renew preserved, no flag.
+	 */
+	public function test_save_preserves_auto_renew_when_filter_returns_true(): void {
+		$m = $this->make_recurring_paid_membership();
+
+		add_filter('wu_membership_has_renewal_credential', '__return_true', 10, 2);
+
+		try {
+			$m->save();
+		} finally {
+			remove_filter('wu_membership_has_renewal_credential', '__return_true', 10);
+		}
+
+		$this->assertTrue($m->should_auto_renew());
+		$this->assertEmpty($m->get_meta('wu_renewal_credential_missing'));
+	}
+
+	/**
+	 * Filter returns false → auto_renew is forced off, meta flag is set,
+	 * and the dedicated action fires exactly once.
+	 */
+	public function test_save_downgrades_auto_renew_when_filter_returns_false(): void {
+		$m = $this->make_recurring_paid_membership();
+
+		add_filter('wu_membership_has_renewal_credential', '__return_false', 10, 2);
+
+		$event_count    = 0;
+		$received_arg   = null;
+		$event_listener = function ($membership) use (&$event_count, &$received_arg) {
+			++$event_count;
+			$received_arg = $membership;
+		};
+		add_action('wu_membership_renewal_credential_missing', $event_listener, 10, 1);
+
+		try {
+			$m->save();
+		} finally {
+			remove_filter('wu_membership_has_renewal_credential', '__return_false', 10);
+			remove_action('wu_membership_renewal_credential_missing', $event_listener, 10);
+		}
+
+		$this->assertFalse($m->should_auto_renew(), 'auto_renew should be forced off');
+
+		$flag = $m->get_meta('wu_renewal_credential_missing');
+		$this->assertNotEmpty($flag, 'meta flag should record the timestamp of the downgrade');
+		$this->assertSame(1, preg_match('/^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}$/', $flag), 'flag should be a MySQL datetime');
+		$this->assertSame(1, $event_count, 'event should fire exactly once for a fresh downgrade');
+		$this->assertSame($m->get_id(), $received_arg->get_id());
+	}
+
+	/**
+	 * Once the flag is set, subsequent saves must keep auto_renew off without
+	 * re-logging or re-firing the event, even if the filter is no longer wired.
+	 */
+	public function test_save_keeps_auto_renew_off_when_flag_already_set(): void {
+		$m = $this->make_recurring_paid_membership();
+		$m->update_meta('wu_renewal_credential_missing', '2026-01-01 00:00:00');
+
+		// Re-enable auto_renew at the model level (simulating an admin toggle)
+		// and confirm the guard still drops it because the flag is set.
+		$m->set_auto_renew(true);
+
+		$event_count    = 0;
+		$event_listener = function () use (&$event_count) {
+			++$event_count;
+		};
+		add_action('wu_membership_renewal_credential_missing', $event_listener, 10, 1);
+
+		try {
+			$m->save();
+		} finally {
+			remove_action('wu_membership_renewal_credential_missing', $event_listener, 10);
+		}
+
+		$this->assertFalse($m->should_auto_renew());
+		$this->assertSame(0, $event_count, 'event should not re-fire when the flag is already set');
+		$this->assertSame('2026-01-01 00:00:00', $m->get_meta('wu_renewal_credential_missing'), 'existing flag should be preserved as-is');
+	}
+
+	/**
+	 * Non-recurring memberships skip the guard entirely.
+	 */
+	public function test_save_skips_guard_for_non_recurring(): void {
+		$m = $this->make_recurring_paid_membership();
+		$m->set_recurring(false);
+
+		add_filter('wu_membership_has_renewal_credential', '__return_false', 10, 2);
+
+		try {
+			$m->save();
+		} finally {
+			remove_filter('wu_membership_has_renewal_credential', '__return_false', 10);
+		}
+
+		// auto_renew stays whatever the model holds — the guard didn't intervene.
+		$this->assertTrue($m->should_auto_renew());
+		$this->assertEmpty($m->get_meta('wu_renewal_credential_missing'));
+	}
+
+	/**
+	 * Free / manual / empty gateway memberships skip the guard.
+	 *
+	 * @dataProvider provider_exempt_gateways
+	 */
+	public function test_save_skips_guard_for_exempt_gateways(string $gateway): void {
+		$m = $this->make_recurring_paid_membership($gateway, '');
+
+		add_filter('wu_membership_has_renewal_credential', '__return_false', 10, 2);
+
+		try {
+			$m->save();
+		} finally {
+			remove_filter('wu_membership_has_renewal_credential', '__return_false', 10);
+		}
+
+		$this->assertTrue($m->should_auto_renew(), "guard should not downgrade for gateway '$gateway'");
+		$this->assertEmpty($m->get_meta('wu_renewal_credential_missing'));
+	}
+
+	/**
+	 * @return array<string, array{0: string}>
+	 */
+	public function provider_exempt_gateways(): array {
+		return [
+			'empty gateway'  => [''],
+			'free gateway'   => ['free'],
+			'manual gateway' => ['manual'],
+		];
+	}
+
+	/**
+	 * The filter receives the membership instance as the second argument.
+	 */
+	public function test_filter_receives_membership_argument(): void {
+		$m = $this->make_recurring_paid_membership();
+
+		$captured = null;
+		$listener = function ($verified, $membership) use (&$captured) {
+			$captured = $membership;
+			return $verified;
+		};
+		add_filter('wu_membership_has_renewal_credential', $listener, 10, 2);
+
+		try {
+			$m->save();
+		} finally {
+			remove_filter('wu_membership_has_renewal_credential', $listener, 10);
+		}
+
+		$this->assertInstanceOf(Membership::class, $captured);
+		$this->assertSame($m->get_id(), $captured->get_id());
+	}
 }


### PR DESCRIPTION
## Summary

Adds a defensive guard so a recurring auto-renewing membership cannot be marked
`auto_renew=1` when the underlying gateway has no renewable credential on file.

## Why

End-to-end reproduction on 2026-05-19 with PayPal Payments for WooCommerce
(PPCP) 4.0.4 + WooCommerce Subscriptions 7.7.0 + Ultimate Multisite WooCommerce
2.0.12 produced a checkout that looked completely successful:

- WC order **completed**
- WC subscription **active**
- UM membership **active**, `auto_renew=1`, gateway=`woocommerce`

…but on the PayPal side the order was captured with `intent=CAPTURE` (one-shot
sale). The WC subscription has **no** `_ppcp_*` / `_paypal_subscription_id` /
`_ppcp_billing_agreement_id` / vault meta. A month later, the WC subscription
renewal has nothing to charge -> fails -> UM membership cascade-cancels with no
recoverable trace for the customer or admin.

This PR introduces a hookable contract so gateways and addons can declare
"this membership has no renewable artifact on my side", and the model degrades
gracefully **before** the silent cancellation cascade has a chance to fire.

## How

A new `wu_membership_has_renewal_credential` filter (default `null` = unknown)
runs at the end of `Membership::save()` whenever the membership is recurring,
auto-renewing, and on a paid gateway (i.e. not `''`/`free`/`manual`).

If a listener returns explicit `false`, the model:

- forces `auto_renew` off,
- writes a `wu_renewal_credential_missing` meta timestamp,
- logs WARNING to `membership-{id}`,
- fires `wu_membership_renewal_credential_missing` exactly once (idempotent on re-save).

Default behaviour is unchanged: gateways that do not register an opinion let
auto_renew stand. Free / manual / empty gateway memberships are skipped.

The companion verifier for PPCP one-shot recurring purchases lives in
`ultimate-multisite-woocommerce` (separate PR).

## Verification

- `vendor/bin/phpunit --filter '/Membership_Test::test_(save_(preserves|downgrades|keeps|skips)|filter_receives)/'` -- **9 tests, 22 assertions, OK**.
- `vendor/bin/phpcs inc/models/class-membership.php tests/WP_Ultimo/Models/Membership_Test.php` -- no new violations introduced (pre-existing Yoda + doc-comment violations remain unchanged on both files; present on `main`).
- `vendor/bin/phpstan analyse inc/models/class-membership.php tests/WP_Ultimo/Models/Membership_Test.php` -- no errors.

## Test coverage

| Case | Expected |
| --- | --- |
| No filter listener | `auto_renew` preserved, no flag |
| Filter returns `true` | `auto_renew` preserved, no flag |
| Filter returns `false` | `auto_renew=false`, flag set, action fires once |
| Re-save with flag already set | `auto_renew` stays off, action does NOT re-fire |
| Non-recurring membership | Guard skipped |
| Empty / free / manual gateway | Guard skipped |
| Filter signature | Listener receives `(?bool $verified, Membership $m)` |

## Files

- `inc/models/class-membership.php` -- `maybe_downgrade_auto_renew_without_credential()` + `use Psr\Log\LogLevel;` + save() integration.
- `tests/WP_Ultimo/Models/Membership_Test.php` -- 8 new test methods (1 with a 3-row data provider).

## Out of scope

- The PPCP-specific verifier (lives in the WooCommerce addon).
- Fixing PPCP itself to request `intent=SUBSCRIPTION` for recurring carts (PPCP-side bug, follow-up issue).

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.68 plugin for [OpenCode](https://opencode.ai) v1.15.5 with claude-sonnet-4-6 spent 57m and 106 tokens on this as a headless worker.
