### PR TITLE
fix(domain): skip async enqueue of wu_add_domain/wu_add_subdomain when no listener is hooked

### DIFF
--- a/inc/managers/class-domain-manager.php
+++ b/inc/managers/class-domain-manager.php
@@ -336,7 +336,16 @@ class Domain_Manager extends Base_Manager {
 			'site_id'   => $site->blog_id,
 		];
 
-		wu_enqueue_async_action('wu_add_subdomain', $args, 'domain');
+		/*
+		 * Only enqueue the async action when at least one host-provider integration
+		 * has hooked into wu_add_subdomain. Otherwise Action Scheduler runs the job
+		 * with zero callbacks and logs "no callbacks are registered" on every site
+		 * creation, which is noise — the wu_async_process_domain_stage chain handles
+		 * DNS/SSL progression independently.
+		 */
+		if (has_action('wu_add_subdomain')) {
+			wu_enqueue_async_action('wu_add_subdomain', $args, 'domain');
+		}
 
 		// Create a domain record for the site
 		$this->create_domain_record_for_site($site);
@@ -764,7 +773,16 @@ class Domain_Manager extends Base_Manager {
 				'site_id' => $site_id,
 			];
 
-			wu_enqueue_async_action('wu_add_domain', $args, 'domain');
+			/*
+			 * Only enqueue the async action when at least one host-provider
+			 * integration has hooked into wu_add_domain. Otherwise Action Scheduler
+			 * runs the job with zero callbacks and logs "no callbacks are
+			 * registered" on every domain change — see handle_site_created() for
+			 * the equivalent wu_add_subdomain guard.
+			 */
+			if (has_action('wu_add_domain')) {
+				wu_enqueue_async_action('wu_add_domain', $args, 'domain');
+			}
 
 			/**
 			 * Fires when a custom domain is added to the network.

--- a/tests/WP_Ultimo/Managers/Domain_Manager_Test.php
+++ b/tests/WP_Ultimo/Managers/Domain_Manager_Test.php
@@ -1133,6 +1133,242 @@ class Domain_Manager_Test extends WP_UnitTestCase {
 	}
 
 	// ----------------------------------------------------------------
+	// NEW: wu_add_domain / wu_add_subdomain are skipped when no host
+	// provider integration is listening. Regression for the "no callbacks
+	// are registered" Action Scheduler warning logged on every site
+	// creation when no host integration is enabled.
+	// ----------------------------------------------------------------
+
+	/**
+	 * Test send_domain_to_host does not enqueue wu_add_domain when no listener is hooked.
+	 */
+	public function test_send_domain_to_host_skips_enqueue_without_listener(): void {
+		$unique_domain = 'no-listener-' . uniqid('', true) . '.example.com';
+
+		// Stash any pre-existing listeners so this test can deterministically
+		// assert "nothing got enqueued" — the production guard must skip the
+		// async enqueue when no host-provider integration is listening.
+		$prior_callbacks = $GLOBALS['wp_filter']['wu_add_domain'] ?? null;
+		unset($GLOBALS['wp_filter']['wu_add_domain']);
+
+		try {
+			$domain = wu_create_domain([
+				'blog_id' => $this->get_blog_id(),
+				'domain'  => $unique_domain,
+				'stage'   => Domain_Stage::DONE,
+			]);
+
+			$this->assertNotWPError($domain);
+
+			$this->assertFalse(
+				has_action('wu_add_domain'),
+				'precondition: wu_add_domain must have no listeners'
+			);
+
+			$this->domain_manager->send_domain_to_host(
+				'old-' . $unique_domain,
+				$unique_domain,
+				$domain->get_id()
+			);
+
+			$enqueued_args = [
+				'domain'  => $unique_domain,
+				'site_id' => $domain->get_site_id(),
+			];
+
+			$matching_actions = wu_get_scheduled_actions(
+				[
+					'hook'     => 'wu_add_domain',
+					'status'   => \ActionScheduler_Store::STATUS_PENDING,
+					'args'     => $enqueued_args,
+					'per_page' => 5,
+				],
+				'ids'
+			);
+
+			$this->assertEmpty(
+				$matching_actions,
+				sprintf(
+					'wu_add_domain must not be enqueued for args %s; found action ids: %s',
+					var_export($enqueued_args, true),
+					var_export($matching_actions, true)
+				)
+			);
+		} finally {
+			if (null !== $prior_callbacks) {
+				$GLOBALS['wp_filter']['wu_add_domain'] = $prior_callbacks;
+			}
+		}
+	}
+
+	/**
+	 * Test send_domain_to_host enqueues wu_add_domain when a listener is hooked.
+	 */
+	public function test_send_domain_to_host_enqueues_when_listener_registered(): void {
+		$callback = function () {
+			// no-op listener — its presence is what we are testing
+		};
+
+		$prior_callbacks = $GLOBALS['wp_filter']['wu_add_domain'] ?? null;
+		unset($GLOBALS['wp_filter']['wu_add_domain']);
+
+		try {
+			$domain = wu_create_domain([
+				'blog_id' => $this->get_blog_id(),
+				'domain'  => 'with-listener-host.example.com',
+				'stage'   => Domain_Stage::DONE,
+			]);
+
+			$this->assertNotWPError($domain);
+
+			wu_unschedule_all_actions('wu_add_domain');
+
+			add_action('wu_add_domain', $callback);
+
+			$this->domain_manager->send_domain_to_host(
+				'old-with-listener.example.com',
+				'with-listener-host.example.com',
+				$domain->get_id()
+			);
+
+			$enqueued_args = [
+				'domain'  => 'with-listener-host.example.com',
+				'site_id' => $domain->get_site_id(),
+			];
+
+			$matching_actions = wu_get_scheduled_actions(
+				[
+					'hook'     => 'wu_add_domain',
+					'status'   => \ActionScheduler_Store::STATUS_PENDING,
+					'args'     => $enqueued_args,
+					'per_page' => 5,
+				],
+				'ids'
+			);
+
+			$this->assertNotEmpty(
+				$matching_actions,
+				'wu_add_domain must be enqueued when a host-provider integration is listening.'
+			);
+		} finally {
+			remove_action('wu_add_domain', $callback);
+			if (null !== $prior_callbacks) {
+				$GLOBALS['wp_filter']['wu_add_domain'] = $prior_callbacks;
+			}
+			wu_unschedule_all_actions('wu_add_domain');
+		}
+	}
+
+	/**
+	 * Test handle_site_created does not enqueue wu_add_subdomain when no listener is hooked.
+	 */
+	public function test_handle_site_created_skips_subdomain_enqueue_without_listener(): void {
+		global $current_site;
+
+		$unique_sub = 'no-listener-' . uniqid('', false) . '.' . $current_site->domain;
+
+		$prior_callbacks = $GLOBALS['wp_filter']['wu_add_subdomain'] ?? null;
+		unset($GLOBALS['wp_filter']['wu_add_subdomain']);
+
+		try {
+			$blog_id = $this->create_test_blog([
+				'domain' => $unique_sub,
+			]);
+
+			$site = get_blog_details($blog_id);
+
+			$this->assertFalse(
+				has_action('wu_add_subdomain'),
+				'precondition: wu_add_subdomain must have no listeners'
+			);
+
+			$this->domain_manager->handle_site_created($site);
+
+			$enqueued_args = [
+				'subdomain' => $site->domain,
+				'site_id'   => $site->blog_id,
+			];
+
+			$matching_actions = wu_get_scheduled_actions(
+				[
+					'hook'     => 'wu_add_subdomain',
+					'status'   => \ActionScheduler_Store::STATUS_PENDING,
+					'args'     => $enqueued_args,
+					'per_page' => 5,
+				],
+				'ids'
+			);
+
+			$this->assertEmpty(
+				$matching_actions,
+				sprintf(
+					'wu_add_subdomain must not be enqueued for args %s; found action ids: %s',
+					var_export($enqueued_args, true),
+					var_export($matching_actions, true)
+				)
+			);
+		} finally {
+			if (null !== $prior_callbacks) {
+				$GLOBALS['wp_filter']['wu_add_subdomain'] = $prior_callbacks;
+			}
+		}
+	}
+
+	/**
+	 * Test handle_site_created enqueues wu_add_subdomain when a listener is hooked.
+	 */
+	public function test_handle_site_created_enqueues_subdomain_when_listener_registered(): void {
+		global $current_site;
+
+		$callback = function () {
+			// no-op listener — its presence is what we are testing
+		};
+
+		$prior_callbacks = $GLOBALS['wp_filter']['wu_add_subdomain'] ?? null;
+		unset($GLOBALS['wp_filter']['wu_add_subdomain']);
+
+		try {
+			$blog_id = $this->create_test_blog([
+				'domain' => 'with-listener-sub.' . $current_site->domain,
+			]);
+
+			$site = get_blog_details($blog_id);
+
+			wu_unschedule_all_actions('wu_add_subdomain');
+
+			add_action('wu_add_subdomain', $callback);
+
+			$this->domain_manager->handle_site_created($site);
+
+			$enqueued_args = [
+				'subdomain' => $site->domain,
+				'site_id'   => $site->blog_id,
+			];
+
+			$matching_actions = wu_get_scheduled_actions(
+				[
+					'hook'     => 'wu_add_subdomain',
+					'status'   => \ActionScheduler_Store::STATUS_PENDING,
+					'args'     => $enqueued_args,
+					'per_page' => 5,
+				],
+				'ids'
+			);
+
+			$this->assertNotEmpty(
+				$matching_actions,
+				'wu_add_subdomain must be enqueued when a host-provider integration is listening.'
+			);
+		} finally {
+			remove_action('wu_add_subdomain', $callback);
+			if (null !== $prior_callbacks) {
+				$GLOBALS['wp_filter']['wu_add_subdomain'] = $prior_callbacks;
+			}
+			wu_unschedule_all_actions('wu_add_subdomain');
+		}
+	}
+
+	// ----------------------------------------------------------------
 	// NEW: Domain set_domain normalizes to lowercase
 	// ----------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

`Domain_Manager` unconditionally enqueued the `wu_add_domain` and `wu_add_subdomain` Action Scheduler jobs on every site creation and custom-domain change. Those hooks are extension points consumed only by host‑provider integration modules (Cloudflare, cPanel, Hostinger, RunCloud, Hestia, Plesk, BunnyCDN, etc.) — each one registers its listener inside `register_hooks()` only when the integration is enabled.

In environments where no host integration is active, Action Scheduler ran each enqueued job with zero callbacks and logged `"no callbacks are registered"` on every site/domain operation. This was observed against every site created since 2026‑05‑08 (blogs 70–80) on an install with no host integration enabled.

Site creation and the `wu_async_process_domain_stage` DNS/SSL chain were never affected — domain stage progression has its own dedicated listener (`class-domain-manager.php:155`), which is why `stage=done` still completes.

## Fix

Guard both enqueue sites with `has_action(...)`:

- `inc/managers/class-domain-manager.php:339` (subdomain, inside `handle_site_created`)
- `inc/managers/class-domain-manager.php:776` (domain, inside `send_domain_to_host`)

Host providers register their listeners at plugin init, well before Action Scheduler claims async jobs, so `has_action()` is authoritative at enqueue time. Any enabled integration continues to receive both hooks as before.

## Why not remove the hooks?

They are not vestigial. The `Base_Host_Provider::register_hooks()` method at `inc/integrations/host-providers/class-base-host-provider.php:361,371` plus 17 capability modules under `inc/integrations/providers/*/class-*-domain-mapping.php` all subscribe. Removing the hooks would break every host integration.

## Tests

Four new regression tests in `tests/WP_Ultimo/Managers/Domain_Manager_Test.php`:

- `test_send_domain_to_host_skips_enqueue_without_listener` — asserts no action is queued when nothing is hooked to `wu_add_domain`.
- `test_send_domain_to_host_enqueues_when_listener_registered` — asserts the action is queued with the expected args when a listener exists.
- `test_handle_site_created_skips_subdomain_enqueue_without_listener` — same pair for `wu_add_subdomain`.
- `test_handle_site_created_enqueues_subdomain_when_listener_registered` — same pair for `wu_add_subdomain`.

Each test snapshots `$GLOBALS['wp_filter'][$hook]`, mutates it, asserts the precondition (`has_action(...)`), exercises the manager method, and queries Action Scheduler directly via `wu_get_scheduled_actions()` with status `STATUS_PENDING` and exact args matching. Original listeners are restored in `finally`.

## Verification

```text
vendor/bin/phpunit --filter Domain_Manager_Test --no-coverage
OK (137 tests, 319 assertions)

vendor/bin/phpcs inc/managers/class-domain-manager.php
# clean

vendor/bin/phpstan analyse inc/managers/class-domain-manager.php tests/WP_Ultimo/Managers/Domain_Manager_Test.php
# [OK] No errors
```

## Out of scope

The same `"no callbacks are registered"` warning also appears for `fetch_patterns` (WordPress core block-pattern cache prime) and `wc-admin_process_pending_orders_batch` (WooCommerce Admin order stats backfill). Both are external to this plugin and not addressed here.

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.17.8 plugin for [OpenCode](https://opencode.ai) v1.15.5 with claude-sonnet-4-20250514 spent 3h 34m on this as a headless worker.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented unnecessary background tasks from executing when no integrations are configured to handle domain operations, reducing system overhead and log clutter.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Ultimate-Multisite/ultimate-multisite/pull/1232?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->