### PR TITLE
GH#1235: fix: guard scrollIntoView against missing elements

### DIFF
--- a/assets/js/checkout-forms-editor.js
+++ b/assets/js/checkout-forms-editor.js
@@ -196,23 +196,25 @@
 
 					});
 
-				},
-				scroll_to(element_id) {
+			},
+			scroll_to(element_id) {
 
-					this.$nextTick(function() {
+				this.$nextTick(function() {
 
-						setTimeout(() => {
+					setTimeout(() => {
 
-							const element = document.getElementById(element_id);
+						const element = document.getElementById(element_id);
 
+						if (element) {
 							element.scrollIntoView({ behavior: 'smooth', block: 'center', inline: 'nearest' });
+						}
 
-						}, 500);
+					}, 500);
 
-					});
+				});
 
-				},
-				find_step(step_name) {
+			},
+			find_step(step_name) {
 
 					return _.findWhere(this.steps, {
 						id: step_name,


### PR DESCRIPTION
## Summary

Added null-check guard for document.getElementById() result before calling scrollIntoView() in the scroll_to method. This prevents TypeError when an element with the given ID is not found.

## Files Changed

assets/js/checkout-forms-editor.js

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** Verified the fix matches the suggested code from PR #1222 review feedback. The guard ensures scrollIntoView is only called when the element exists.

Resolves #1235


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.17.14 plugin for [OpenCode](https://opencode.ai) v1.15.6 with claude-haiku-4-5 spent 59s and 2,348 tokens on this as a headless worker.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where the editor could crash when attempting to scroll to missing or unavailable elements. The component now safely handles cases where target elements don't exist on the page.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Ultimate-Multisite/ultimate-multisite/pull/1243?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->