### PR TITLE
GH#1238: fix: prevent repeated iframe load handler accumulation

### DIFF
--- a/assets/js/customizer.js
+++ b/assets/js/customizer.js
@@ -19,7 +19,7 @@
 	/**
 	 * Unblocks when the loading is finished.
 	 */
-	$('#preview-stage-iframe').on('load', function() {
+	$('#preview-stage-iframe').off('load').one('load', function() {
 
 		if (block) {
 


### PR DESCRIPTION
## Summary

Applied CodeRabbit review feedback to prevent handler accumulation on iframe load events by using .off('load').one('load') pattern instead of .on('load')

## Files Changed

assets/js/customizer.js

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** Verified with ESLint — customizer.js passes without errors

Resolves #1238


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.17.14 plugin for [OpenCode](https://opencode.ai) v1.15.6 with claude-haiku-4-5 spent 1m and 2,427 tokens on this as a headless worker.