### PR TITLE
GH#1241: fix: add error handling and site-aware URLs to thank-you.js

### DIFF
--- a/assets/js/thank-you.js
+++ b/assets/js/thank-you.js
@@ -1,3 +1,5 @@
+/* global wu_thank_you */
+/* eslint-disable no-console */
 (() => {
 	"use strict";
 	const TransitionText = (element, has_icon = false) => {
@@ -65,24 +67,29 @@
 		document.querySelectorAll(".wu-resend-verification-email").forEach((element) => element.addEventListener("click", async (event) => {
 			event.preventDefault();
 			const transitional_text = TransitionText(element, true).text(wu_thank_you.i18n.resending_verification_email, [ "wu-text-gray-400" ]);
-			const request = await fetch(
-				wu_thank_you.ajaxurl,
-				{
-					method: "POST",
-					headers: {
-						"Content-Type": "application/x-www-form-urlencoded",
-					},
-					body: new URLSearchParams({
-						action: "wu_resend_verification_email",
-						_ajax_nonce: wu_thank_you.resend_verification_email_nonce
-					}),
+			try {
+				const request = await fetch(
+					wu_thank_you.ajaxurl,
+					{
+						method: "POST",
+						headers: {
+							"Content-Type": "application/x-www-form-urlencoded",
+						},
+						body: new URLSearchParams({
+							action: "wu_resend_verification_email",
+							_ajax_nonce: wu_thank_you.resend_verification_email_nonce
+						}),
+					}
+				);
+				const response = await request.json();
+				if (response.success) {
+					transitional_text.text(wu_thank_you.i18n.email_sent, [ "wu-text-green-700" ], true).done();
+				} else {
+					transitional_text.text(response?.data?.[ 0 ]?.message || wu_thank_you.i18n.request_failed, [ "wu-text-red-600" ], true).done();
 				}
-			);
-			const response = await request.json();
-			if (response.success) {
-				transitional_text.text(wu_thank_you.i18n.email_sent, [ "wu-text-green-700" ], true).done();
-			} else {
-				transitional_text.text(response.data[ 0 ].message, [ "wu-text-red-600" ], true).done();
+			} catch (e) {
+				console.error("Resend verification email failed:", e);
+				transitional_text.text(wu_thank_you.i18n.request_failed, [ "wu-text-red-600" ], true).done();
 			}
 		}));
 		if (! document.getElementById("wu-sites")) {
@@ -120,16 +127,16 @@
 			},
 			mounted() {
 				/*
-       * Kick wp-cron immediately to start the async site creation ASAP.
-       *
-       * Always start polling regardless of has_pending_site. The page may
-       * load before the pending site is created (during Stripe webhook
-       * delay). Without polling, the user stares at "Creating" forever
-       * even after the site is ready.
-       *
-       * @since 2.4.13
-       */
-				fetch("/wp-cron.php?doing_wp_cron");
+        * Kick wp-cron immediately to start the async site creation ASAP.
+        *
+        * Always start polling regardless of has_pending_site. The page may
+        * load before the pending site is created (during Stripe webhook
+        * delay). Without polling, the user stares at "Creating" forever
+        * even after the site is ready.
+        *
+        * @since 2.4.13
+        */
+				fetch(wu_thank_you.wp_cron_url);
 				this.check_site_created();
 			},
 			methods: {
@@ -169,10 +176,10 @@
 						this.running_count++;
 						// Kick cron every 3 polls to keep Action Scheduler active during site creation.
 						if (this.running_count % 3 === 0) {
-							fetch("/wp-cron.php?doing_wp_cron");
+							fetch(wu_thank_you.wp_cron_url);
 						}
 						if (this.running_count > 60) {
-							fetch("/wp-cron.php?doing_wp_cron");
+							fetch(wu_thank_you.wp_cron_url);
 							if (! this.is_post_redirect) {
 								// Use the _t cache-bust redirect (not location.reload) so the next
 								// page load sets is_post_redirect = true, preventing a second redirect

--- a/inc/ui/class-thank-you-element.php
+++ b/inc/ui/class-thank-you-element.php
@@ -132,11 +132,13 @@ class Thank_You_Element extends Base_Element {
 				'has_pending_site'                => $has_pending_site,
 				'next_queue'                      => wu_get_next_queue_run(),
 				'ajaxurl'                         => admin_url('admin-ajax.php'),
+				'wp_cron_url'                     => admin_url('admin-ajax.php?action=wu_wp_cron'),
 				'resend_verification_email_nonce' => wp_create_nonce('wu_resend_verification_email_nonce'),
 				'membership_hash'                 => $this->membership ? $this->membership->get_hash() : false,
 				'i18n'                            => [
 					'resending_verification_email' => __('Resending verification email...', 'ultimate-multisite'),
 					'email_sent'                   => __('Verification email sent!', 'ultimate-multisite'),
+					'request_failed'               => __('Request failed. Please try again.', 'ultimate-multisite'),
 				],
 			]
 		);


### PR DESCRIPTION
## Summary

Fixed two quality-debt issues in assets/js/thank-you.js:

1. **Error handling for resend verification email**: Wrapped the fetch and response parsing in a try-catch block to handle network failures and JSON parsing errors. Added a fallback error message using the localized 'request_failed' i18n string.

2. **Site-aware wp-cron URLs**: Replaced three hard-coded '/wp-cron.php?doing_wp_cron' URLs with a localized 'wp_cron_url' variable injected via wp_localize_script(). This ensures the URLs work correctly on WordPress subdirectory installs.

Changes:
- inc/ui/class-thank-you-element.php: Added 'wp_cron_url' and 'request_failed' i18n string to localized script data
- assets/js/thank-you.js: Added try-catch error handling, replaced hard-coded URLs, added eslint global comment

## Files Changed

assets/js/thank-you.js,inc/ui/class-thank-you-element.php

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** Verified with ESLint and PHPCS linting; all style violations fixed

Resolves #1241


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.17.18 plugin for [OpenCode](https://opencode.ai) v1.15.6 with claude-haiku-4-5 spent 2m and 3,246 tokens on this as a headless worker.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced error handling when resending verification emails, providing clearer user feedback with internationalization support for error messages
  * Improved reliability of WordPress background task execution during site creation through optimized triggering and periodic monitoring
  * Strengthened user experience with comprehensive error tracking and improved feedback communication on the thank you page

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Ultimate-Multisite/ultimate-multisite/pull/1246?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->