### PR TITLE
GH#1237: fix: declare setupfee_off_with_symbol locally to avoid implicit global

### DIFF
--- a/assets/js/coupon-code.js
+++ b/assets/js/coupon-code.js
@@ -167,6 +167,7 @@
 							}
 
 							if (applies_to_setup_fee) {
+								let setupfee_off_with_symbol = '';
 
 								if (setup_fee_discount_type != '"absolute"') {
 									setupfee_off_with_symbol = ''.concat(setup_fee_discount_value, '%');


### PR DESCRIPTION
## Summary

Added let declaration for setupfee_off_with_symbol inside the applies_to_setup_fee block in assets/js/coupon-code.js to prevent implicit global variable creation. This mirrors the existing pattern used for off_with_symbol at line 153.

## Files Changed

assets/js/coupon-code.js

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** Verified with eslint — no new violations introduced. Pre-existing globals (wu_coupon_data, accounting, wpu) and eqeqeq warnings are unchanged.

Resolves #1237


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.17.18 plugin for [OpenCode](https://opencode.ai) v1.15.6 with claude-opus-4-6 spent 1m and 2,593 tokens on this as a headless worker.