### PR TITLE
fix: add iframe document fallback to avoid silently skipping iOS patch

### DIFF
--- a/assets/js/template-previewer.js
+++ b/assets/js/template-previewer.js
@@ -74,8 +74,8 @@
 				loadingIndicator.style.display = "none";
 			}
 			if (isIOS()) {
-				const iframeEl = document.getElementById("iframe");
-				const body = iframeEl && iframeEl.contentDocument ? iframeEl.contentDocument.body : null;
+				const iframe_doc = (iframe == null ? void 0 : iframe.contentDocument) || (iframe == null ? void 0 : iframe.contentWindow == null ? void 0 : iframe.contentWindow.document);
+				const body = iframe_doc ? iframe_doc.body : null;
 				body == null ? void 0 : body.classList.add("wu-fix-safari-preview");
 				(body == null ? void 0 : body.style) && Object.assign(body.style, {
 					position: "fixed",


### PR DESCRIPTION
## Summary

Updated iframe body lookup in template-previewer.js to use contentWindow?.document as fallback, ensuring iOS patch runs reliably on all platforms.

## Changes

- Reuse existing iframe reference instead of re-querying DOM
- Add contentWindow?.document fallback for iOS compatibility  
- Ensures iOS patch runs reliably on all platforms

## Verification

- Verified diff shows correct fallback chain: contentDocument || contentWindow?.document
- Code follows existing patterns in the file

Resolves #1249
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.17.27 plugin for [OpenCode](https://opencode.ai) v1.15.7 with claude-haiku-4-5 spent 39s and 2,218 tokens on this as a headless worker.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced iframe styling compatibility on iOS devices for the template previewer, ensuring more reliable content display.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Ultimate-Multisite/ultimate-multisite/pull/1256?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->