### PR TITLE
GH#1255: feat: disable tenant-side gateway manager in sovereign mode

### DIFF
--- a/inc/managers/class-gateway-manager.php
+++ b/inc/managers/class-gateway-manager.php
@@ -280,6 +280,11 @@ class Gateway_Manager extends Base_Manager {
 	 * @return void
 	 */
 	public function process_gateway_confirmations(): void {
+
+		if ( defined( 'WU_MT_SOVEREIGN_TENANT' ) && WU_MT_SOVEREIGN_TENANT ) {
+			return;
+		}
+
 		/*
 		 * First we check for the confirmation parameter.
 		 */
@@ -613,6 +618,10 @@ class Gateway_Manager extends Base_Manager {
 	 * @return void
 	 */
 	public function ajax_check_payment_status(): void {
+
+		if ( defined( 'WU_MT_SOVEREIGN_TENANT' ) && WU_MT_SOVEREIGN_TENANT ) {
+			return;
+		}
 
 		check_ajax_referer('wu_payment_status_poll', 'nonce');
 


### PR DESCRIPTION
## Summary

Added early-return guards to process_gateway_confirmations() and ajax_check_payment_status() methods when WU_MT_SOVEREIGN_TENANT is defined. This prevents gateway confirmation processing and payment status polling on tenant sites in sovereign mode, as checkout and payment handling occur on the main site.

## Files Changed

inc/managers/class-gateway-manager.php

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** PHPCS validation passed. Verified both guards are in place and maybe_process_webhooks() retains its is_main_site() gate.

Resolves #1255


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.17.27 plugin for [OpenCode](https://opencode.ai) v1.15.7 with claude-haiku-4-5 spent 1m and 1,573 tokens on this as a headless worker.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes

* Payment gateway confirmation and payment status polling operations have been updated to skip processing in certain deployment configurations. The system now bypasses these functions when operating in specific operational modes. This affects how the system communicates with payment gateways and changes the API call patterns.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Ultimate-Multisite/ultimate-multisite/pull/1257?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->