### PR TITLE
GH#1253: feat: disable compat shims in sovereign tenants

### DIFF
--- a/inc/compat/class-auto-delete-users-compat.php
+++ b/inc/compat/class-auto-delete-users-compat.php
@@ -35,6 +35,11 @@ class Auto_Delete_Users_Compat {
 	 * @since 2.4.5
 	 */
 	public function init(): void {
+
+		if ( defined( 'WU_MT_SOVEREIGN_TENANT' ) && WU_MT_SOVEREIGN_TENANT ) {
+			return;
+		}
+
 		// Add the settings to enable or disable this feature.
 		add_action('wu_settings_login', [$this, 'add_settings'], 10);
 

--- a/inc/compat/class-edit-users-compat.php
+++ b/inc/compat/class-edit-users-compat.php
@@ -35,6 +35,11 @@ class Edit_Users_Compat {
 	 * @since 2.4.4
 	 */
 	public function init(): void {
+
+		if ( defined( 'WU_MT_SOVEREIGN_TENANT' ) && WU_MT_SOVEREIGN_TENANT ) {
+			return;
+		}
+
 		// Add the settings to enable or disable this feature.
 		add_action('wu_settings_login', [$this, 'add_settings'], 10);
 

--- a/inc/compat/class-multiple-accounts-compat.php
+++ b/inc/compat/class-multiple-accounts-compat.php
@@ -51,6 +51,10 @@ class Multiple_Accounts_Compat {
 	 */
 	public function init(): void {
 
+		if ( defined( 'WU_MT_SOVEREIGN_TENANT' ) && WU_MT_SOVEREIGN_TENANT ) {
+			return;
+		}
+
 		// Add the settings to enable or disable this feature.
 		add_action('wu_settings_login', [$this, 'add_settings'], 10);
 


### PR DESCRIPTION
## Summary

Added early-return guards to three compat shims (Auto_Delete_Users, Multiple_Accounts, Edit_Users) to prevent them from registering hooks when WU_MT_SOVEREIGN_TENANT is defined. Non-sovereign installs see zero behavioural change.

## Files Changed

inc/compat/class-auto-delete-users-compat.php,inc/compat/class-edit-users-compat.php,inc/compat/class-multiple-accounts-compat.php

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** PHPCS linting passed on all three modified files. Code follows the reference pattern from issue #1250.

Resolves #1253


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.17.27 plugin for [OpenCode](https://opencode.ai) v1.15.7 with claude-haiku-4-5 spent 2m and 1,728 tokens on this as a headless worker.