### PR TITLE
GH#1252: feat: add wu_pre_* filters to 6 model methods

### DIFF
--- a/inc/models/class-customer.php
+++ b/inc/models/class-customer.php
@@ -813,6 +813,12 @@ class Customer extends Base_Model implements Billable, Notable {
 	 */
 	public function get_total_grossed() {
 
+		$pre = apply_filters( 'wu_pre_customer_get_total_grossed', null, $this );
+
+		if ( null !== $pre ) {
+			return $pre;
+		}
+
 		global $wpdb;
 
 		static $sum;

--- a/inc/models/class-domain.php
+++ b/inc/models/class-domain.php
@@ -610,6 +610,12 @@ class Domain extends Base_Model {
 	 */
 	public static function get_by_site($site) {
 
+		$pre = apply_filters( 'wu_pre_domain_get_by_site', null, $site );
+
+		if ( null !== $pre ) {
+			return $pre;
+		}
+
 		global $wpdb;
 
 		// Allow passing a site object in

--- a/inc/models/class-membership.php
+++ b/inc/models/class-membership.php
@@ -2320,6 +2320,12 @@ class Membership extends Base_Model implements Limitable, Billable, Notable {
 	 */
 	public function get_total_grossed() {
 
+		$pre = apply_filters( 'wu_pre_membership_get_total_grossed', null, $this );
+
+		if ( null !== $pre ) {
+			return $pre;
+		}
+
 		global $wpdb;
 
 		static $sum;

--- a/inc/models/class-site.php
+++ b/inc/models/class-site.php
@@ -1158,6 +1158,12 @@ class Site extends Base_Model implements Limitable, Notable {
 			return $this->membership;
 		}
 
+		$pre = apply_filters( 'wu_pre_site_get_membership', null, $this );
+
+		if ( null !== $pre ) {
+			return $pre;
+		}
+
 		global $wpdb;
 
 		$table_name = "{$wpdb->base_prefix}wu_memberships";
@@ -2226,6 +2232,12 @@ class Site extends Base_Model implements Limitable, Notable {
 	 */
 	public static function get_all_by_type($type = 'customer_owned', $query_args = []) {
 
+		$pre = apply_filters( 'wu_pre_site_get_all_by_type', null, $type, $query_args );
+
+		if ( null !== $pre ) {
+			return $pre;
+		}
+
 		global $wpdb;
 
 		if ('pending' === $type) {
@@ -2317,6 +2329,12 @@ class Site extends Base_Model implements Limitable, Notable {
 	 * @return array
 	 */
 	public static function get_all_categories($sites = []) {
+
+		$pre = apply_filters( 'wu_pre_site_get_all_categories', null, $sites );
+
+		if ( null !== $pre ) {
+			return $pre;
+		}
 
 		global $wpdb;
 


### PR DESCRIPTION
## Summary

Added pre-filters to 6 model methods that bypass Base_Model::get_by_id()

## Files Changed

inc/models/class-customer.php,inc/models/class-domain.php,inc/models/class-membership.php,inc/models/class-site.php

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** Existing test suite passes; filters return null by default allowing existing behavior

Resolves #1252


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.17.27 plugin for [OpenCode](https://opencode.ai) v1.15.7 with claude-haiku-4-5 spent 5m and 1,673 tokens on this as a headless worker.