### PR TITLE
feat: ADR-001 Phase 3-A7 — Sovereign-mode disable for remaining customer-facing UI elements

### DIFF
--- a/inc/functions/sovereign.php
+++ b/inc/functions/sovereign.php
@@ -1,0 +1,31 @@
+<?php
+/**
+ * Sovereign Mode Helper Functions
+ *
+ * Functions for handling sovereign-mode tenant redirects.
+ *
+ * @package WP_Ultimo
+ * @subpackage Functions/Sovereign
+ * @since 2.2.0
+ */
+
+// Exit if accessed directly
+defined('ABSPATH') || exit;
+
+/**
+ * Get the main site account URL for sovereign-mode redirects.
+ *
+ * Returns the account page URL on the main site, with a return_to parameter
+ * pointing back to the current site's admin.
+ *
+ * @since 2.2.0
+ * @return string The main site account URL.
+ */
+function wu_mt_main_site_account_url() {
+	$main_site_blog_id = get_main_site_id();
+
+	return get_admin_url(
+		$main_site_blog_id,
+		'admin.php?page=account&return_to=' . rawurlencode(home_url('/wp-admin/'))
+	);
+}

--- a/inc/ui/class-account-summary-element.php
+++ b/inc/ui/class-account-summary-element.php
@@ -292,6 +292,17 @@ class Account_Summary_Element extends Base_Element {
 	 */
 	public function output($atts, $content = null) {
 
+		if (defined('WU_MT_SOVEREIGN_TENANT') && WU_MT_SOVEREIGN_TENANT) {
+			echo wu_get_template_contents(
+				'elements/sovereign-redirect',
+				[
+					'main_site_account_url' => wu_mt_main_site_account_url(),
+					'element_label'         => __('Your account', 'ultimate-multisite'),
+				]
+			);
+			return;
+		}
+
 		$this->ensure_setup();
 
 		// Return empty if no site available (e.g., during SEO processing)

--- a/inc/ui/class-billing-info-element.php
+++ b/inc/ui/class-billing-info-element.php
@@ -270,6 +270,17 @@ class Billing_Info_Element extends Base_Element {
 	 */
 	public function output($atts, $content = null) {
 
+		if (defined('WU_MT_SOVEREIGN_TENANT') && WU_MT_SOVEREIGN_TENANT) {
+			echo wu_get_template_contents(
+				'elements/sovereign-redirect',
+				[
+					'main_site_account_url' => wu_mt_main_site_account_url(),
+					'element_label'         => __('Billing information', 'ultimate-multisite'),
+				]
+			);
+			return;
+		}
+
 		$this->ensure_setup();
 
 		// Return empty if no membership available (e.g., during SEO processing)

--- a/inc/ui/class-current-membership-element.php
+++ b/inc/ui/class-current-membership-element.php
@@ -300,6 +300,17 @@ class Current_Membership_Element extends Base_Element {
 	 */
 	public function output($atts, $content = null) {
 
+		if (defined('WU_MT_SOVEREIGN_TENANT') && WU_MT_SOVEREIGN_TENANT) {
+			echo wu_get_template_contents(
+				'elements/sovereign-redirect',
+				[
+					'main_site_account_url' => wu_mt_main_site_account_url(),
+					'element_label'         => __('Subscription', 'ultimate-multisite'),
+				]
+			);
+			return;
+		}
+
 		$atts['membership'] = $this->membership;
 		$atts['plan']       = $this->plan;
 		$atts['element']    = $this;

--- a/inc/ui/class-current-site-element.php
+++ b/inc/ui/class-current-site-element.php
@@ -352,6 +352,17 @@ class Current_Site_Element extends Base_Element {
 	 */
 	public function output($atts, $content = null) {
 
+		if (defined('WU_MT_SOVEREIGN_TENANT') && WU_MT_SOVEREIGN_TENANT) {
+			echo wu_get_template_contents(
+				'elements/sovereign-redirect',
+				[
+					'main_site_account_url' => wu_mt_main_site_account_url(),
+					'element_label'         => __('Site actions', 'ultimate-multisite'),
+				]
+			);
+			return;
+		}
+
 		$this->ensure_setup();
 
 		// Return empty if no site available (e.g., during SEO processing)

--- a/inc/ui/class-domain-mapping-element.php
+++ b/inc/ui/class-domain-mapping-element.php
@@ -1097,6 +1097,17 @@ class Domain_Mapping_Element extends Base_Element {
 	 */
 	public function output($atts, $content = null) {
 
+		if (defined('WU_MT_SOVEREIGN_TENANT') && WU_MT_SOVEREIGN_TENANT) {
+			echo wu_get_template_contents(
+				'elements/sovereign-redirect',
+				[
+					'main_site_account_url' => wu_mt_main_site_account_url(),
+					'element_label'         => __('Domain mapping', 'ultimate-multisite'),
+				]
+			);
+			return;
+		}
+
 		$current_site = $this->site;
 
 		$all_domains = wu_get_domains(

--- a/inc/ui/class-invoices-element.php
+++ b/inc/ui/class-invoices-element.php
@@ -272,6 +272,17 @@ class Invoices_Element extends Base_Element {
 	 */
 	public function output($atts, $content = null) {
 
+		if (defined('WU_MT_SOVEREIGN_TENANT') && WU_MT_SOVEREIGN_TENANT) {
+			echo wu_get_template_contents(
+				'elements/sovereign-redirect',
+				[
+					'main_site_account_url' => wu_mt_main_site_account_url(),
+					'element_label'         => __('Invoices', 'ultimate-multisite'),
+				]
+			);
+			return;
+		}
+
 		$this->ensure_setup();
 
 		// Return empty if no membership available (e.g., during SEO processing)

--- a/inc/ui/class-my-sites-element.php
+++ b/inc/ui/class-my-sites-element.php
@@ -323,6 +323,17 @@ class My_Sites_Element extends Base_Element {
 	 */
 	public function output($atts, $content = null) {
 
+		if (defined('WU_MT_SOVEREIGN_TENANT') && WU_MT_SOVEREIGN_TENANT) {
+			echo wu_get_template_contents(
+				'elements/sovereign-redirect',
+				[
+					'main_site_account_url' => wu_mt_main_site_account_url(),
+					'element_label'         => __('My sites', 'ultimate-multisite'),
+				]
+			);
+			return;
+		}
+
 		$atts['customer'] = $this->customer;
 
 		$atts['sites'] = $this->get_sites(wu_get_isset($atts, 'site_show'));

--- a/inc/ui/class-template-switching-element.php
+++ b/inc/ui/class-template-switching-element.php
@@ -430,6 +430,17 @@ class Template_Switching_Element extends Base_Element {
 	 */
 	public function output($atts, $content = null) {
 
+		if (defined('WU_MT_SOVEREIGN_TENANT') && WU_MT_SOVEREIGN_TENANT) {
+			echo wu_get_template_contents(
+				'elements/sovereign-redirect',
+				[
+					'main_site_account_url' => wu_mt_main_site_account_url(),
+					'element_label'         => __('Template switching', 'ultimate-multisite'),
+				]
+			);
+			return;
+		}
+
 		if ( ! $this->site || self::STATE_NOT_ALLOWED === $this->permission_state) {
 			$this->render_not_allowed_notice();
 

--- a/tests/WP_Ultimo/UI/Sovereign_Mode_Elements_Test.php
+++ b/tests/WP_Ultimo/UI/Sovereign_Mode_Elements_Test.php
@@ -1,0 +1,179 @@
+<?php
+/**
+ * Tests for sovereign-mode UI elements.
+ *
+ * @package WP_Ultimo\Tests
+ */
+
+namespace WP_Ultimo\UI;
+
+use WP_UnitTestCase;
+
+/**
+ * Test class for sovereign-mode element short-circuits.
+ */
+class Sovereign_Mode_Elements_Test extends WP_UnitTestCase {
+
+	/**
+	 * Set up test fixtures.
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+
+		// Define sovereign mode constant if not already defined
+		if ( ! defined('WU_MT_SOVEREIGN_TENANT') ) {
+			define('WU_MT_SOVEREIGN_TENANT', true);
+		}
+
+		// Load the sovereign helper function
+		require_once dirname(__DIR__, 3) . '/inc/functions/sovereign.php';
+	}
+
+	/**
+	 * Test Account_Summary_Element outputs redirect in sovereign mode.
+	 */
+	public function test_account_summary_element_sovereign_mode(): void {
+		$element = Account_Summary_Element::get_instance();
+
+		ob_start();
+		$element->output([]);
+		$output = ob_get_clean();
+
+		$this->assertStringContainsString('wu-sovereign-redirect', $output);
+		$this->assertStringContainsString('manage on main site', $output);
+		$this->assertStringContainsString('Your account', $output);
+	}
+
+	/**
+	 * Test Billing_Info_Element outputs redirect in sovereign mode.
+	 */
+	public function test_billing_info_element_sovereign_mode(): void {
+		$element = Billing_Info_Element::get_instance();
+
+		ob_start();
+		$element->output([]);
+		$output = ob_get_clean();
+
+		$this->assertStringContainsString('wu-sovereign-redirect', $output);
+		$this->assertStringContainsString('manage on main site', $output);
+		$this->assertStringContainsString('Billing information', $output);
+	}
+
+	/**
+	 * Test Invoices_Element outputs redirect in sovereign mode.
+	 */
+	public function test_invoices_element_sovereign_mode(): void {
+		$element = Invoices_Element::get_instance();
+
+		ob_start();
+		$element->output([]);
+		$output = ob_get_clean();
+
+		$this->assertStringContainsString('wu-sovereign-redirect', $output);
+		$this->assertStringContainsString('manage on main site', $output);
+		$this->assertStringContainsString('Invoices', $output);
+	}
+
+	/**
+	 * Test My_Sites_Element outputs redirect in sovereign mode.
+	 */
+	public function test_my_sites_element_sovereign_mode(): void {
+		$element = My_Sites_Element::get_instance();
+
+		ob_start();
+		$element->output([]);
+		$output = ob_get_clean();
+
+		$this->assertStringContainsString('wu-sovereign-redirect', $output);
+		$this->assertStringContainsString('manage on main site', $output);
+		$this->assertStringContainsString('My sites', $output);
+	}
+
+	/**
+	 * Test Current_Membership_Element outputs redirect in sovereign mode.
+	 */
+	public function test_current_membership_element_sovereign_mode(): void {
+		$element = Current_Membership_Element::get_instance();
+
+		ob_start();
+		$element->output([]);
+		$output = ob_get_clean();
+
+		$this->assertStringContainsString('wu-sovereign-redirect', $output);
+		$this->assertStringContainsString('manage on main site', $output);
+		$this->assertStringContainsString('Subscription', $output);
+	}
+
+	/**
+	 * Test Current_Site_Element outputs redirect in sovereign mode.
+	 */
+	public function test_current_site_element_sovereign_mode(): void {
+		$element = Current_Site_Element::get_instance();
+
+		ob_start();
+		$element->output([]);
+		$output = ob_get_clean();
+
+		$this->assertStringContainsString('wu-sovereign-redirect', $output);
+		$this->assertStringContainsString('manage on main site', $output);
+		$this->assertStringContainsString('Site actions', $output);
+	}
+
+	/**
+	 * Test Template_Switching_Element outputs redirect in sovereign mode.
+	 */
+	public function test_template_switching_element_sovereign_mode(): void {
+		$element = Template_Switching_Element::get_instance();
+
+		ob_start();
+		$element->output([]);
+		$output = ob_get_clean();
+
+		$this->assertStringContainsString('wu-sovereign-redirect', $output);
+		$this->assertStringContainsString('manage on main site', $output);
+		$this->assertStringContainsString('Template switching', $output);
+	}
+
+	/**
+	 * Test Domain_Mapping_Element outputs redirect in sovereign mode.
+	 */
+	public function test_domain_mapping_element_sovereign_mode(): void {
+		$element = Domain_Mapping_Element::get_instance();
+
+		ob_start();
+		$element->output([]);
+		$output = ob_get_clean();
+
+		$this->assertStringContainsString('wu-sovereign-redirect', $output);
+		$this->assertStringContainsString('manage on main site', $output);
+		$this->assertStringContainsString('Domain mapping', $output);
+	}
+
+	/**
+	 * Test redirect output contains button element.
+	 */
+	public function test_redirect_output_contains_button(): void {
+		$element = Account_Summary_Element::get_instance();
+
+		ob_start();
+		$element->output([]);
+		$output = ob_get_clean();
+
+		$this->assertStringContainsString('<a class="button button-primary"', $output);
+		$this->assertStringContainsString('href=', $output);
+	}
+
+	/**
+	 * Test redirect output contains main site URL.
+	 */
+	public function test_redirect_output_contains_main_site_url(): void {
+		$element = Account_Summary_Element::get_instance();
+
+		ob_start();
+		$element->output([]);
+		$output = ob_get_clean();
+
+		$this->assertStringContainsString('admin.php?page=account', $output);
+		$this->assertStringContainsString('return_to=', $output);
+	}
+}

--- a/views/elements/sovereign-redirect.php
+++ b/views/elements/sovereign-redirect.php
@@ -1,0 +1,17 @@
+<?php
+/**
+ * Sovereign Mode Redirect Element
+ *
+ * Displays a redirect link to the main site for sovereign-mode tenants.
+ *
+ * @since 2.2.0
+ */
+
+defined('ABSPATH') || exit;
+
+?>
+<div class="wu-sovereign-redirect">
+	<a class="button button-primary" href="<?php echo esc_url($main_site_account_url); ?>">
+		<?php echo esc_html($element_label); ?> → <?php esc_html_e('manage on main site', 'ultimate-multisite'); ?>
+	</a>
+</div>


### PR DESCRIPTION
## Summary

Extends the sovereign-mode disable pattern (established in #1257, #1258, #1261) to the remaining 8 customer-facing UI elements. When WU_MT_SOVEREIGN_TENANT is defined, each element renders a single 'Manage on main site' link instead of its normal output.

## Changes

- Add sovereign helper function wu_mt_main_site_account_url() in inc/functions/sovereign.php
- Add sovereign-redirect template in views/elements/sovereign-redirect.php
- Add sovereign-mode short-circuit to output() method in 8 UI elements
- Add comprehensive unit tests for sovereign-mode functionality (10 tests, all passing)

## Testing

- All 10 new unit tests pass
- Existing test suite passes (no regressions)
- PHPCS compliance verified
- Follows established pattern from #1257, #1258, #1261

## Resolves

- #1263
- Ultimate-Multisite/ultimate-multisite-multi-tenancy#86
- Ultimate-Multisite/ultimate-multisite-multi-tenancy#87
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.17.28 plugin for [OpenCode](https://opencode.ai) v1.15.7 with claude-haiku-4-5 spent 7m and 4,665 tokens on this as a headless worker.
