### PR TITLE
fix(checkout): honour is_publishing_stale in publish_pending_site() to unblock stuck pending sites

### DIFF
--- a/inc/models/class-membership.php
+++ b/inc/models/class-membership.php
@@ -2178,7 +2178,41 @@ class Membership extends Base_Model implements Limitable, Billable, Notable {
 		$is_publishing = $pending_site->is_publishing();
 
 		if ($is_publishing) {
-			return true;
+			/*
+			 * If is_publishing has been true for longer than the stale
+			 * timeout (default 5 minutes), the PHP process that set the
+			 * flag is presumed dead (OOM, max_execution_time, fatal,
+			 * server restart). The poller resets the flag in that case,
+			 * but if a competing call (e.g. a duplicate checkout order)
+			 * lands here while the flag is still set we would otherwise
+			 * silently bail and the "Creating your site" overlay would
+			 * hang until the next Action Scheduler retry — which often
+			 * never fires because the duplicate caller never reschedules.
+			 *
+			 * Detect the stale flag here and fall through to the publish
+			 * path so the second caller can finish the job the first
+			 * caller never completed. Site::is_publishing_stale() was
+			 * added in 2.5.3; method_exists() keeps this safe for any
+			 * pre-2.5.3 serialized Site objects deserialized from meta.
+			 *
+			 * @since 2.5.4
+			 */
+			$is_stale = method_exists($pending_site, 'is_publishing_stale')
+				? $pending_site->is_publishing_stale()
+				: false;
+
+			if ( ! $is_stale) {
+				return true;
+			}
+
+			wu_log_add(
+				"membership-{$this->get_id()}",
+				sprintf(
+					// translators: %d: membership ID.
+					__('Detected stale is_publishing flag on pending site for membership %d during publish_pending_site(); the previous publish attempt appears to have been killed before completing. Proceeding with retry.', 'ultimate-multisite'),
+					$this->get_id()
+				)
+			);
 		}
 
 		$pending_site->set_publishing(true);

--- a/tests/WP_Ultimo/Models/Membership_Test.php
+++ b/tests/WP_Ultimo/Models/Membership_Test.php
@@ -1761,4 +1761,168 @@ class Membership_Test extends \WP_UnitTestCase {
 		$this->assertInstanceOf(Membership::class, $captured);
 		$this->assertSame($m->get_id(), $captured->get_id());
 	}
+
+	// ---------------------------------------------------------------
+	// publish_pending_site() — stale is_publishing flag handling
+	//
+	// Regression coverage for the "Creating your site" overlay hang
+	// caused by a duplicate caller bailing on a stuck is_publishing
+	// flag. See inc/models/class-membership.php::publish_pending_site().
+	// ---------------------------------------------------------------
+
+	/**
+	 * Build a persisted membership via the wu_create_* helpers (which
+	 * write through BerlinDB and return a model with a real ID) so that
+	 * update_meta/get_meta operate against a real DB row.
+	 *
+	 * The class-level $this->membership built in setUp() uses raw Model
+	 * constructors with skip_validation; in some environments the save()
+	 * path leaves the in-memory ID at 0, which makes meta calls silently
+	 * no-op (is_meta_available() returns false). Using the helper
+	 * guarantees a real ID.
+	 *
+	 * @return Membership
+	 */
+	private function make_membership_with_pending_meta(): Membership {
+		$user_id = self::factory()->user->create(
+			[
+				'user_email' => 'pending_' . wp_generate_password(6, false) . '@example.com',
+			]
+		);
+
+		$customer = wu_create_customer(
+			[
+				'user_id'         => $user_id,
+				'skip_validation' => true,
+			]
+		);
+
+		$product = wu_create_product(
+			[
+				'name'            => 'Plan ' . wp_generate_password(6, false),
+				'slug'            => 'plan-pending-' . wp_generate_password(6, false),
+				'type'            => 'plan',
+				'amount'          => 9.99,
+				'currency'        => 'USD',
+				'duration'        => 1,
+				'duration_unit'   => 'month',
+				'recurring'       => true,
+				'skip_validation' => true,
+			]
+		);
+
+		$membership = wu_create_membership(
+			[
+				'customer_id'     => $customer->get_id(),
+				'plan_id'         => $product->get_id(),
+				'status'          => 'active',
+				'amount'          => 9.99,
+				'currency'        => 'USD',
+				'skip_validation' => true,
+			]
+		);
+
+		$this->assertNotWPError($membership, 'Helper failed to build a persisted membership for the pending-site fixture.');
+		$this->assertGreaterThan(0, $membership->get_id(), 'Helper produced a membership without an ID — meta will silently no-op.');
+
+		return $membership;
+	}
+
+	/**
+	 * Attach a pending site to the given membership and stamp the
+	 * is_publishing flag and timestamp to simulate a stuck publish.
+	 *
+	 * @param Membership $membership          Persisted membership.
+	 * @param bool       $is_publishing       Initial publishing flag value.
+	 * @param int        $started_seconds_ago Seconds ago the publish was started.
+	 * @return Site
+	 */
+	private function attach_pending_site_with_publishing(Membership $membership, bool $is_publishing, int $started_seconds_ago = 0): Site {
+		$slug = 'pending' . substr((string) (microtime(true) * 1000), -8);
+
+		$pending = $membership->create_pending_site(
+			[
+				'title'         => 'Pending ' . $slug,
+				'path'          => '/' . $slug . '/',
+				'is_publishing' => false,
+			]
+		);
+
+		if ($is_publishing) {
+			$pending->set_publishing(true);
+
+			$reflection = new \ReflectionObject($pending);
+			$prop       = $reflection->getProperty('publishing_started_at');
+			$prop->setAccessible(true);
+			$prop->setValue($pending, time() - $started_seconds_ago);
+		}
+
+		$membership->update_pending_site($pending);
+
+		return $pending;
+	}
+
+	/**
+	 * Fresh is_publishing flag (set seconds ago, not stale) must cause
+	 * publish_pending_site() to bail without touching the pending site.
+	 *
+	 * Guards against accidentally regressing to "always publish" if the
+	 * stale-check is ever rewritten.
+	 */
+	public function test_publish_pending_site_bails_when_flag_is_fresh(): void {
+		$membership = $this->make_membership_with_pending_meta();
+		$pending    = $this->attach_pending_site_with_publishing($membership, true, 60);
+
+		$path = $pending->get_path();
+
+		// Pre-condition: the pending site fixture is actually persisted.
+		$this->assertNotFalse($membership->get_pending_site(), 'Pending site meta should round-trip from BerlinDB.');
+
+		$result = $membership->publish_pending_site();
+
+		$this->assertTrue($result, 'publish_pending_site() should return true to short-circuit duplicate callers.');
+
+		$after = $membership->get_pending_site();
+		$this->assertNotFalse($after, 'Pending site should still exist after fresh-flag short-circuit.');
+		$this->assertTrue((bool) $after->is_publishing(), 'is_publishing should remain true on a fresh-flag short-circuit.');
+
+		global $wpdb;
+		$blog_count = (int) $wpdb->get_var(
+			$wpdb->prepare("SELECT COUNT(*) FROM {$wpdb->blogs} WHERE path = %s", $path)
+		);
+		$this->assertSame(0, $blog_count, 'No blog should be created when the flag is fresh.');
+	}
+
+	/**
+	 * Stale is_publishing flag (started more than 5 minutes ago) must
+	 * cause publish_pending_site() to fall through and complete the
+	 * publish on behalf of the dead caller — the previous behaviour
+	 * was to silently bail, leaving the "Creating your site" overlay
+	 * stuck forever.
+	 *
+	 * This is the core regression test for the BUG 2 fix.
+	 */
+	public function test_publish_pending_site_proceeds_when_flag_is_stale(): void {
+		$membership = $this->make_membership_with_pending_meta();
+		$pending    = $this->attach_pending_site_with_publishing($membership, true, 360);
+
+		// Sanity check: the fixture is in the expected stale state.
+		$this->assertTrue($pending->is_publishing_stale(), 'Pre-condition: pending site must be stale (>300s).');
+		$this->assertNotFalse($membership->get_pending_site(), 'Pre-condition: pending site meta should round-trip.');
+
+		$path = $pending->get_path();
+
+		$result = $membership->publish_pending_site();
+
+		$this->assertTrue($result, 'publish_pending_site() should return true after successful stale recovery.');
+
+		$after = $membership->get_pending_site();
+		$this->assertFalse($after, 'Pending site should have been deleted after successful publish.');
+
+		global $wpdb;
+		$blog_count = (int) $wpdb->get_var(
+			$wpdb->prepare("SELECT COUNT(*) FROM {$wpdb->blogs} WHERE path = %s", $path)
+		);
+		$this->assertSame(1, $blog_count, 'The pending site should have been published to a real blog.');
+	}
 }


### PR DESCRIPTION
## Summary

`publish_pending_site()` in `inc/models/class-membership.php` bailed
silently when `is_publishing=true`, even after the publishing process
that set the flag had died. The result: the "Creating your site"
overlay hung on the customer's screen until the next Action Scheduler
retry — which often never fires, because the duplicate caller never
reschedules.

This change wires `Site::is_publishing_stale()` (added in 2.5.3 to
detect this exact "flag set but the process that set it is dead"
condition, default 5-minute window) into `publish_pending_site()` so
a second caller can finish the job the first caller never completed.
The AJAX poller at `class-membership-manager.php:214` already consumed
`is_publishing_stale()`; this commit closes the symmetry on the
publish path.

A fresh in-flight flag still short-circuits, so the duplicate-call
short-circuit semantics are unchanged for the non-stale case.

## Trigger

A real-world reproduction observed in production logs: a duplicate
$0-trial WooCommerce order arrives ~2.5 minutes after the first order
fails mid-publish (PHP process killed by `max_execution_time` / OOM /
fatal error). Order #1 set `is_publishing=true` and died; order #2's
`publish_pending_site()` call saw the flag and returned without doing
anything. The site stayed at `type=site_template` and the customer's
overlay never completed.

The duplicate-order root cause itself lives in the
`ultimate-multisite-woocommerce` addon; this is the core defence-in-depth
fix so the symptom self-heals after the 5-minute stale window.

## Patch

```php
if ($is_publishing) {
    $is_stale = method_exists($pending_site, 'is_publishing_stale')
        ? $pending_site->is_publishing_stale()
        : false;

    if ( ! $is_stale) {
        return true;
    }

    wu_log_add(/* … stale-recovery log line … */);
}
```

`method_exists()` guards the call so any pre-2.5.3 serialized `Site`
objects deserialized from membership meta still behave like the old
code path. The recovery emits a `wu_log_add()` line on the membership
log so support can correlate stuck-overlay reports.

## Regression coverage

`tests/WP_Ultimo/Models/Membership_Test.php`

- `test_publish_pending_site_bails_when_flag_is_fresh` — a fresh flag
  must still short-circuit (guards against accidentally rewriting the
  check into "always publish").
- `test_publish_pending_site_proceeds_when_flag_is_stale` — a stale
  flag must fall through and actually publish the blog. This is the
  regression guard for the BUG fix; reverting just the inc/ patch and
  re-running this test fails as expected.

Both tests use `wu_create_customer` / `wu_create_product` /
`wu_create_membership` (BerlinDB-persisting helpers); the class-level
`setUp()` uses raw Model constructors which can leave the in-memory ID
at 0 in some environments, silently no-op'ing the meta calls these
tests depend on.

## Verification

- PHPCS on changed inc/ file: clean
- PHPCS on new test block: clean (lines 1764+; pre-existing warnings
  elsewhere in the test file are not touched)
- PHPStan level 0: `[OK] No errors`
- New tests: `OK (2 tests, 14 assertions)`
- Full `Membership_Test` class (118 tests): green
- Deterministic WP-CLI reproduction script confirmed the bug
  pre-patch and confirmed the fix post-patch on the dev install


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of pending site publishing when a publishing operation appears to be running but has stalled. The system now detects stale publishing states and completes the process.

* **Tests**
  * Added test coverage for pending site publishing recovery scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Ultimate-Multisite/ultimate-multisite/pull/1267?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->