### PR TITLE
fix(tours): persist tour-finished flag in user meta to avoid wp-settings cookie desync

### DIFF
--- a/inc/ui/class-tours.php
+++ b/inc/ui/class-tours.php
@@ -67,6 +67,60 @@ class Tours {
 	}
 
 	/**
+	 * Returns the user meta key used to record a finished tour.
+	 *
+	 * We persist the finished flag in user meta (not just the WordPress
+	 * `wp-settings-*` cookie) because `set_user_setting()` / `wp_set_all_user_settings()`
+	 * only update the user-settings cookie on regular admin page requests via
+	 * `wp_user_settings()` — they do NOT set the cookie during AJAX. When the
+	 * tour dismissal arrives as an AJAX `wu_mark_tour_as_finished` call, the
+	 * browser is never sent a `Set-Cookie` header, so the next page request
+	 * sees a stale or missing `wp-settings-{uid}` cookie and `get_user_setting()`
+	 * returns `false`, re-showing the tour. Storing the flag in user meta gives
+	 * us a cookie-independent source of truth that AJAX writes can persist
+	 * immediately and any subsequent request can read.
+	 *
+	 * @since 2.5.2
+	 *
+	 * @param string $id The tour ID.
+	 * @return string The user meta key.
+	 */
+	protected function get_meta_key($id) {
+
+		return 'wu_tour_finished_' . str_replace('-', '_', $id);
+	}
+
+	/**
+	 * Whether the tour has been finished for the current user.
+	 *
+	 * Checks user meta first (the authoritative cookie-independent flag) and
+	 * falls back to the legacy `get_user_setting()` lookup for users who
+	 * dismissed a tour before the meta-based persistence was introduced.
+	 *
+	 * @since 2.5.2
+	 *
+	 * @param string $id The tour ID.
+	 * @param int    $user_id Optional. Defaults to the current user.
+	 * @return bool
+	 */
+	protected function is_tour_finished($id, $user_id = 0) {
+
+		$user_id = $user_id ? (int) $user_id : get_current_user_id();
+
+		if ( ! $user_id) {
+			return false;
+		}
+
+		$meta_value = get_user_meta($user_id, $this->get_meta_key($id), true);
+
+		if ($meta_value) {
+			return true;
+		}
+
+		return (bool) get_user_setting($this->get_setting_key($id), false);
+	}
+
+	/**
 	 * Mark the tour as finished for a particular user.
 	 *
 	 * @since 2.0.0
@@ -79,6 +133,22 @@ class Tours {
 		$id = wu_request('tour_id');
 
 		if ($id) {
+			$user_id = get_current_user_id();
+
+			if ($user_id) {
+				/*
+				 * Persist the flag in user meta so the next request can read it
+				 * regardless of the wp-settings-* cookie state. AJAX requests do
+				 * not pass through wp_user_settings() (which is what normally
+				 * syncs the cookie from user meta), so writing only to
+				 * set_user_setting() / wp_set_all_user_settings() would leave the
+				 * browser cookie stale and the tour would re-appear on the next
+				 * page load.
+				 */
+				update_user_meta($user_id, $this->get_meta_key($id), 1);
+			}
+
+			// Keep the legacy user-settings write for backward compatibility.
 			set_user_setting($this->get_setting_key($id), true);
 			if (\function_exists('save_user_settings')) {
 				\save_user_settings();
@@ -191,7 +261,7 @@ class Tours {
 					return;
 				}
 
-				$finished = (bool) get_user_setting($this->get_setting_key($id), false);
+				$finished = $this->is_tour_finished($id);
 
 				$finished = apply_filters('wu_tour_finished', $finished, $id, get_current_user_id());
 

--- a/tests/WP_Ultimo/UI/Tours_Test.php
+++ b/tests/WP_Ultimo/UI/Tours_Test.php
@@ -87,7 +87,14 @@ class Tours_Test extends WP_UnitTestCase {
 		$reflection = new \ReflectionClass($instance);
 		$prop       = $reflection->getProperty('tours');
 		$prop->setAccessible(true);
-		$prop->setValue($instance, ['test-tour' => [['id' => 'step1', 'text' => 'Hello']]]);
+		$prop->setValue($instance, [
+			'test-tour' => [
+				[
+					'id'   => 'step1',
+					'text' => 'Hello',
+				],
+			],
+		]);
 
 		$this->assertTrue($instance->has_tours());
 
@@ -209,6 +216,112 @@ class Tours_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Test get_meta_key normalises hyphens to underscores and uses the wu_tour_finished_ prefix.
+	 *
+	 * Regression test: the tour-finished flag is stored in user meta so that
+	 * the AJAX dismissal handler can persist it without depending on the
+	 * wp-settings-* cookie sync (which is skipped during AJAX requests by
+	 * wp_user_settings(), leaving the browser cookie stale and causing the
+	 * tour to re-show on the next page load — observed on the checkout form
+	 * editor page in particular).
+	 */
+	public function test_get_meta_key_uses_wu_tour_finished_prefix(): void {
+
+		$instance = $this->get_instance();
+
+		$reflection = new \ReflectionClass($instance);
+		$method     = $reflection->getMethod('get_meta_key');
+		$method->setAccessible(true);
+
+		$this->assertSame('wu_tour_finished_checkout_form_editor', $method->invoke($instance, 'checkout-form-editor'));
+		$this->assertSame('wu_tour_finished_wp_ultimo_dashboard', $method->invoke($instance, 'wp-ultimo-dashboard'));
+		$this->assertSame('wu_tour_finished_dashboard', $method->invoke($instance, 'dashboard'));
+	}
+
+	/**
+	 * Test is_tour_finished returns true once the user meta flag is set.
+	 *
+	 * Regression test for the checkout-form-editor tour re-showing every
+	 * visit: the AJAX `wu_mark_tour_as_finished` handler writes to user meta,
+	 * so subsequent requests must see the flag without depending on the
+	 * wp-settings-* cookie (which is not updated during AJAX requests).
+	 */
+	public function test_is_tour_finished_reads_user_meta(): void {
+
+		$instance = $this->get_instance();
+
+		$user_id = self::factory()->user->create(['role' => 'administrator']);
+		wp_set_current_user($user_id);
+
+		$reflection  = new \ReflectionClass($instance);
+		$is_finished = $reflection->getMethod('is_tour_finished');
+		$is_finished->setAccessible(true);
+		$get_meta_key = $reflection->getMethod('get_meta_key');
+		$get_meta_key->setAccessible(true);
+
+		// Not finished initially.
+		$this->assertFalse($is_finished->invoke($instance, 'checkout-form-editor'));
+
+		// Mark as finished via the same meta key the AJAX handler writes.
+		update_user_meta($user_id, $get_meta_key->invoke($instance, 'checkout-form-editor'), 1);
+
+		$this->assertTrue($is_finished->invoke($instance, 'checkout-form-editor'));
+
+		// Different tour ID still false.
+		$this->assertFalse($is_finished->invoke($instance, 'dashboard'));
+	}
+
+	/**
+	 * Test is_tour_finished falls back to legacy get_user_setting().
+	 *
+	 * Users who dismissed a tour before this release have their flag stored
+	 * only in the WordPress user-settings cookie (`wp-settings-{uid}`), not in
+	 * the new wu_tour_finished_* meta key. The legacy fallback prevents those
+	 * users from seeing tours they already dismissed.
+	 *
+	 * get_user_setting() reads from $_COOKIE (or its in-memory cache), so the
+	 * test populates $_COOKIE directly to emulate a returning browser whose
+	 * cookie still carries the pre-upgrade dismissal flag.
+	 */
+	public function test_is_tour_finished_falls_back_to_legacy_user_setting(): void {
+
+		$instance = $this->get_instance();
+
+		$user_id = self::factory()->user->create(['role' => 'administrator']);
+		wp_set_current_user($user_id);
+
+		$reflection  = new \ReflectionClass($instance);
+		$is_finished = $reflection->getMethod('is_tour_finished');
+		$is_finished->setAccessible(true);
+		$get_setting = $reflection->getMethod('get_setting_key');
+		$get_setting->setAccessible(true);
+
+		$cookie_name                       = 'wp-settings-' . $user_id;
+		$setting_key                       = $get_setting->invoke($instance, 'legacy-tour');
+		$prior_cookie                      = $_COOKIE[ $cookie_name ] ?? null; // phpcs:ignore WordPress.Security.ValidatedSanitizedInput -- test stash, no user input.
+		$prior_updated_settings            = $GLOBALS['_updated_user_settings'] ?? null;
+		$GLOBALS['_updated_user_settings'] = null;
+		unset($_COOKIE[ $cookie_name ]);
+
+		try {
+			$this->assertFalse($is_finished->invoke($instance, 'legacy-tour'));
+
+			// Simulate the legacy user-settings cookie value that get_user_setting() reads.
+			$_COOKIE[ $cookie_name ]           = $setting_key . '=1';
+			$GLOBALS['_updated_user_settings'] = null;
+
+			$this->assertTrue($is_finished->invoke($instance, 'legacy-tour'));
+		} finally {
+			if (null === $prior_cookie) {
+				unset($_COOKIE[ $cookie_name ]);
+			} else {
+				$_COOKIE[ $cookie_name ] = $prior_cookie;
+			}
+			$GLOBALS['_updated_user_settings'] = $prior_updated_settings;
+		}
+	}
+
+	/**
 	 * Test enqueue_scripts uses wp_add_inline_script on 'underscore', not wu-admin.
 	 *
 	 * Regression test for GH#707: wu_tours was localized onto wu-admin which is
@@ -230,7 +343,14 @@ class Tours_Test extends WP_UnitTestCase {
 		$reflection = new \ReflectionClass($instance);
 		$prop       = $reflection->getProperty('tours');
 		$prop->setAccessible(true);
-		$prop->setValue($instance, ['test-tour' => [['id' => 'step1', 'text' => 'Hello']]]);
+		$prop->setValue($instance, [
+			'test-tour' => [
+				[
+					'id'   => 'step1',
+					'text' => 'Hello',
+				],
+			],
+		]);
 
 		$instance->enqueue_scripts();
 


### PR DESCRIPTION
## Summary

Fixes the Ultimate Multisite tour for the checkout-form editor (and any
other WU tour dismissed via AJAX) re-appearing on every visit.

Reproducible at
`wp-admin/network/admin.php?page=wp-ultimo-edit-checkout-form&id=1&slug=main-form&model=checkout_form`:
complete the tour, click **Save Checkout Form**, revisit the page — the
tour shows again.

## Why this isn't a duplicate of prior tour fixes

Three earlier PRs touched the same area — each fixed an adjacent
failure mode but left the underlying cookie-sync gap intact:

| PR | Fixed | Did **not** fix |
|---|---|---|
| #365 (2021, `a3e62958`) | Introduced once-only tracking via `set_user_setting()` | Cookie-sync gap (didn't exist on WP of the day) |
| #1051 (`06aa90a8`) | Hyphenated tour IDs (e.g. `checkout-form-editor`) silently corrupted the `wp_user-settings` string — added `get_setting_key()` to normalise `-` → `_` | Cookie-sync gap |
| #1161 (`99abf629`, May 2026) | (a) `wu_tours` JS global undefined (script-order race); (b) `$.ajax()` dismissal killed by page navigation — switched to `navigator.sendBeacon()` so the request reliably *reaches the server* | Cookie-sync gap — after the request lands, `set_user_setting()` writes to user-meta, but `wp_user_settings()` short-circuits on AJAX so the browser cookie never updates and `get_user_setting()` still reads stale `$_COOKIE` on the next request |

This PR is the server-side persistence layer: once the dismissal reaches
the server (now reliable thanks to #1161), we must read it back without
depending on a cookie that AJAX cannot set.

## Root cause

`Tours::mark_as_finished()` only wrote the dismissal flag via
`set_user_setting()`, which stores the value in the `wp_user-settings`
user-meta string *and* in the per-user `wp-settings-{uid}` cookie. In
modern WordPress, the cookie is only synced from user meta by
`wp_user_settings()` — and that function short-circuits during AJAX
requests. Because the dismissal is sent through the AJAX action
`wu_mark_tour_as_finished`, no `Set-Cookie` header is ever emitted, so:

1. The browser keeps a stale or missing `wp-settings-{uid}` cookie.
2. On the next page load `get_user_setting()` reads `$_COOKIE` and
   returns `false`.
3. The closure registered in `Tours::create_tour()` re-renders the
   tour.

## Fix

Persist the finished flag in a dedicated user-meta key
`wu_tour_finished_{snake_id}` from the AJAX handler. The closure in
`create_tour()` now calls a new `is_tour_finished()` helper that
reads:

1. `get_user_meta($user_id, 'wu_tour_finished_{snake_id}', true)` —
   the new, cookie-independent source of truth.
2. `get_user_setting()` — legacy fallback so users who dismissed a
   tour before this release are not re-prompted.

The legacy `set_user_setting()` write is retained for backward
compatibility with downstream code that may read the older key.

## Verification

- New unit tests in `tests/WP_Ultimo/UI/Tours_Test.php`:
  - `test_get_meta_key_uses_wu_tour_finished_prefix`
  - `test_is_tour_finished_reads_user_meta`
  - `test_is_tour_finished_falls_back_to_legacy_user_setting`
- Local: `vendor/bin/phpunit --filter Tours_Test` → all new tests pass.
  (The pre-existing failure
  `test_enqueue_scripts_inlines_data_on_underscore_not_wu_admin`
  reproduces on unmodified `main` and is unrelated to this change.)
- `vendor/bin/phpcs inc/ui/class-tours.php` clean; pre-existing
  `NoExplicitVersion` warning on `wp_register_script` (line 339 of the
  test file) is unrelated.
- `vendor/bin/phpstan analyse inc/ui/class-tours.php` clean.
- Browser repro on local WP 7.0-RC2 with admin/admin: with all tour
  state cleared, completed the tour, clicked **Save Checkout Form**,
  revisited the page — `window.wu_tours` is now `undefined`, no
  `.shepherd-element` is rendered, and `wp_usermeta` contains
  `wu_tour_finished_checkout_form_editor = 1`.

## Compatibility

- No breaking changes; legacy `set_user_setting()` write retained.
- New helper methods are `protected`; no public API change.
- Schema unchanged (uses generic `wp_usermeta`).
