### PR TITLE
fix: resolve checkout PHPCS violations

### DIFF
--- a/inc/checkout/class-checkout.php
+++ b/inc/checkout/class-checkout.php
@@ -1217,23 +1217,27 @@ class Checkout {
 					'email'              => wp_get_current_user()->user_email,
 					'email_verification' => 'verified',
 				];
-			} elseif (isset($customer_data['email']) && ($existing_wp_user = get_user_by('email', $customer_data['email']))) {
-				/*
-				 * A WP user already exists with this email.
-				 *
-				 * Only block checkout when a customer record also exists for
-				 * that user — the email is genuinely in use. If no customer
-				 * exists yet, the previous checkout attempt created the WP
-				 * user but failed before saving the customer (partial /
-				 * orphaned state). Allow the retry to proceed by passing the
-				 * existing user's ID to wu_create_customer(), which will skip
-				 * WP user creation and link the new customer to it instead.
-				 */
-				if (wu_get_customer_by_user_id($existing_wp_user->ID)) {
-					return new \WP_Error('email_exists', __('The email address you entered is already in use.', 'ultimate-multisite'));
-				}
+			} else {
+				$existing_wp_user = isset($customer_data['email']) ? get_user_by('email', $customer_data['email']) : false;
 
-				$customer_data['user_id'] = $existing_wp_user->ID;
+				if ($existing_wp_user) {
+					/*
+					 * A WP user already exists with this email.
+					 *
+					 * Only block checkout when a customer record also exists for
+					 * that user — the email is genuinely in use. If no customer
+					 * exists yet, the previous checkout attempt created the WP
+					 * user but failed before saving the customer (partial /
+					 * orphaned state). Allow the retry to proceed by passing the
+					 * existing user's ID to wu_create_customer(), which will skip
+					 * WP user creation and link the new customer to it instead.
+					 */
+					if (wu_get_customer_by_user_id($existing_wp_user->ID)) {
+						return new \WP_Error('email_exists', __('The email address you entered is already in use.', 'ultimate-multisite'));
+					}
+
+					$customer_data['user_id'] = $existing_wp_user->ID;
+				}
 			}
 
 			/*
@@ -2647,6 +2651,7 @@ class Checkout {
 		 *
 		 * First, let's set upm the general rules:
 		 */
+
 		/*
 		 * When the password field is set to auto-generate, the customer does
 		 * not submit a password value, so we must not require it.


### PR DESCRIPTION
## Summary

Fixes two pre-existing PHPCS violations in `inc/checkout/class-checkout.php`:

- Moves the `get_user_by()` assignment out of an `elseif` condition so the condition no longer performs assignment inline.
- Adds the required blank line before the adjacent block comment in `validation_rules()`.

## Scope

This is intentionally narrow: one PHP file, no behaviour change intended.

## Verification

- `vendor/bin/phpcs inc/checkout/class-checkout.php`
- `vendor/bin/phpstan analyse inc/checkout/class-checkout.php --no-progress`
- Pre-commit hook passed on the staged file.

## Context

This unblocks future checkout edits from being blocked by unrelated pre-existing PHPCS errors in `class-checkout.php`.

<!-- aidevops:sig -->
