### PR TITLE
fix(tours): honour stripped legacy tour setting keys

### DIFF
--- a/inc/ui/class-tours.php
+++ b/inc/ui/class-tours.php
@@ -91,6 +91,68 @@ class Tours {
 	}
 
 	/**
+	 * Returns legacy user-settings keys that may hold a finished tour flag.
+	 *
+	 * Older tour persistence used WordPress user settings directly. Depending
+	 * on the WordPress version and whether the value travelled through the
+	 * wp-settings-* cookie sanitizer, hyphenated tour IDs may have been stored
+	 * either with underscores or with hyphens stripped entirely. Check both
+	 * shapes so users who already dismissed those tours do not see them again.
+	 *
+	 * @since 2.5.2
+	 *
+	 * @param string $id The tour ID.
+	 * @return array
+	 */
+	protected function get_legacy_setting_keys($id) {
+
+		return array_values(
+			array_unique(
+				[
+					$this->get_setting_key($id),
+					'wu_tour_' . preg_replace('/[^A-Za-z0-9_]/', '', $id),
+				]
+			)
+		);
+	}
+
+	/**
+	 * Whether a legacy user-settings value marks the tour as finished.
+	 *
+	 * @since 2.5.2
+	 *
+	 * @param string $id      The tour ID.
+	 * @param int    $user_id User ID.
+	 * @return bool
+	 */
+	protected function is_legacy_tour_finished($id, $user_id) {
+
+		foreach ($this->get_legacy_setting_keys($id) as $setting_key) {
+			if (get_user_setting($setting_key, false)) {
+				return true;
+			}
+		}
+
+		$stored_settings = get_user_option('user-settings', $user_id);
+
+		if ( ! is_string($stored_settings) || '' === $stored_settings) {
+			return false;
+		}
+
+		$parsed_settings = [];
+
+		parse_str($stored_settings, $parsed_settings);
+
+		foreach ($this->get_legacy_setting_keys($id) as $setting_key) {
+			if ( ! empty($parsed_settings[ $setting_key ])) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	/**
 	 * Whether the tour has been finished for the current user.
 	 *
 	 * Checks user meta first (the authoritative cookie-independent flag) and
@@ -117,7 +179,13 @@ class Tours {
 			return true;
 		}
 
-		return (bool) get_user_setting($this->get_setting_key($id), false);
+		$legacy_finished = $this->is_legacy_tour_finished($id, $user_id);
+
+		if ($legacy_finished) {
+			update_user_meta($user_id, $this->get_meta_key($id), 1);
+		}
+
+		return $legacy_finished;
 	}
 
 	/**

--- a/tests/WP_Ultimo/UI/Tours_Test.php
+++ b/tests/WP_Ultimo/UI/Tours_Test.php
@@ -322,6 +322,41 @@ class Tours_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Test is_tour_finished reads legacy stripped keys from user settings meta.
+	 *
+	 * Regression test for users who dismissed hyphenated tours before the tour ID
+	 * normalisation fix. WordPress could persist keys with hyphens stripped (for
+	 * example, wu_tour_checkoutformlist), while newer code looks for the
+	 * underscore-normalised key (wu_tour_checkout_form_list). The meta fallback
+	 * must recognise the stripped legacy shape and backfill the new user meta flag.
+	 */
+	public function test_is_tour_finished_reads_stripped_legacy_user_settings_meta(): void {
+
+		$instance = $this->get_instance();
+
+		$user_id = self::factory()->user->create(['role' => 'administrator']);
+		wp_set_current_user($user_id);
+
+		$reflection  = new \ReflectionClass($instance);
+		$is_finished = $reflection->getMethod('is_tour_finished');
+		$is_finished->setAccessible(true);
+		$get_meta_key = $reflection->getMethod('get_meta_key');
+		$get_meta_key->setAccessible(true);
+		$get_legacy_keys = $reflection->getMethod('get_legacy_setting_keys');
+		$get_legacy_keys->setAccessible(true);
+
+		$meta_key = $get_meta_key->invoke($instance, 'checkout-form-list');
+
+		update_user_option($user_id, 'user-settings', 'wu_tour_checkoutformlist=1', false);
+
+		$this->assertSame('wu_tour_checkoutformlist=1', get_user_option('user-settings', $user_id));
+		$this->assertContains('wu_tour_checkoutformlist', $get_legacy_keys->invoke($instance, 'checkout-form-list'));
+
+		$this->assertTrue($is_finished->invoke($instance, 'checkout-form-list', $user_id));
+		$this->assertSame('1', get_user_meta($user_id, $meta_key, true));
+	}
+
+	/**
 	 * Test enqueue_scripts uses wp_add_inline_script on 'underscore', not wu-admin.
 	 *
 	 * Regression test for GH#707: wu_tours was localized onto wu-admin which is


### PR DESCRIPTION
## Summary

Fixes remaining admin tours reappearing for users whose dismissed-tour state was saved before the tour ID normalization fix.

Affected URLs observed locally:

- `wp-admin/network/admin.php?page=wp-ultimo-checkout-forms`
- `wp-admin/network/admin.php?page=wp-ultimo`

## Root cause

Prior fixes covered newer persistence paths:

- #1051 normalized hyphenated tour IDs to underscore-based user-setting keys.
- #1268 added cookie-independent `wu_tour_finished_*` user meta for newly dismissed tours.

However, older dismissals can still exist in WordPress `user-settings` with hyphens stripped entirely by the legacy cookie/settings path, for example:

- `wu_tour_checkoutformlist=1`
- `wu_tour_wpultimodashboard=1`

Current code checks the new meta key and the normalized legacy setting key, but not these stripped historical keys. Those users keep seeing tours they already dismissed.

## Fix

- Add legacy key discovery for both normalized and stripped historical key shapes.
- Read persisted WordPress `user-settings` directly with `get_user_option('user-settings', $user_id)` when `get_user_setting()` does not find the normalized key.
- When any legacy key proves the tour was already dismissed, backfill the new `wu_tour_finished_*` meta flag so future reads use the modern source of truth.

## Verification

- `vendor/bin/phpunit --filter test_is_tour_finished_reads_stripped_legacy_user_settings_meta --no-coverage` → passed when mirrored into the dev checkout.
- `vendor/bin/phpunit --filter 'test_is_tour_finished_(reads_user_meta|falls_back_to_legacy_user_setting|reads_stripped_legacy_user_settings_meta)' --no-coverage` → `OK (3 tests, 9 assertions)` when mirrored into the dev checkout.
- `vendor/bin/phpstan analyse inc/ui/class-tours.php` → no errors.
- Pre-commit hook passed for committed production PHP file.
- Browser verification on local WP 7.0-RC2 after simulating stripped legacy state:
  - `wu_tour_checkoutformlist=1&wu_tour_wpultimodashboard=1`
  - checkout forms URL: `window.wu_tours` null, `.shepherd-element` count 0
  - dashboard URL: `window.wu_tours` null, `.shepherd-element` count 0
  - fallback backfilled `wu_tour_finished_checkout_form_list=1` and `wu_tour_finished_wp_ultimo_dashboard=1`

## Notes

The broader `Tours_Test` file still has a pre-existing PHPCS warning for `wp_register_script(..., false, ...)` in an unrelated test path; this PR does not introduce that warning.

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.19.0 plugin for [OpenCode](https://opencode.ai) v1.15.10 with gpt-5.5 spent 5h 33m and 14,327 tokens on this as a headless worker.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced tour completion persistence with improved legacy compatibility to properly recognize and migrate previous completion status from various data formats, ensuring users' tour history is reliably preserved across system updates.

* **Tests**
  * Added regression test to verify tour completion status is correctly recognized from legacy data sources and properly migrated to the current system.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Ultimate-Multisite/ultimate-multisite/pull/1271?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->