### PR TITLE
fix: restore settings invoice sidebar width

### DIFF
--- a/views/base/settings.php
+++ b/views/base/settings.php
@@ -277,7 +277,7 @@ defined('ABSPATH') || exit;
 
 		</div>
 
-		<div class="sm:wu-col-span-8 sm:wu-col-start-5 lg:wu-col-span-4 lg:wu-col-start-9 metabox-holder wu-min-w-0">
+		<div class="sm:wu-col-span-8 sm:wu-col-start-5 lg:wu-col-span-3 lg:wu-col-start-10 metabox-holder wu-min-w-0">
 
 		<?php
 		/**


### PR DESCRIPTION
## Summary

- Restore the settings page side-panel grid width so the Invoices box appears as a narrow right sidebar on large screens.
- Use generated framework utilities available in `assets/css/framework.css` instead of missing `lg:wu-col-span-4` / `lg:wu-col-start-9` classes.

## Verification

- `php -l views/base/settings.php`
- `vendor/bin/phpcs views/base/settings.php`
- Browser check on `wp-admin/network/admin.php?page=wp-ultimo-settings&tab=payment-gateways`

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.19.0 plugin for [OpenCode](https://opencode.ai) v1.15.10 with gpt-5.5 spent 6h and 14,327 tokens on this as a headless worker.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Adjusted the settings page layout for improved display on larger screens.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Ultimate-Multisite/ultimate-multisite/pull/1272?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->