### PR TITLE
fix: clarify compatibility mode copy

### DIFF
--- a/inc/checkout/class-checkout-pages.php
+++ b/inc/checkout/class-checkout-pages.php
@@ -216,8 +216,8 @@ class Checkout_Pages {
 
 	<div class="misc-pub-section misc-pub-section-last" style="margin-top: 12px; margin-bottom: 6px; display: flex; align-items: center;">
 		<label for="wu-compat-mode">
-				<span style="display: block; font-weight: 600; margin-bottom: 3px;"><?php esc_html_e('Ultimate Multisite Compatibility Mode', 'ultimate-multisite'); ?></span>
-				<small style="display: block; line-height: 1.8em;"><?php esc_html_e('Toggle this option on if Ultimate Multisite elements are not loading correctly or at all.', 'ultimate-multisite'); ?></small>
+				<span style="display: block; font-weight: 600; margin-bottom: 3px;"><?php esc_html_e('Force loading Ultimate Multisite frontend assets', 'ultimate-multisite'); ?></span>
+				<small style="display: block; line-height: 1.8em;"><?php esc_html_e('If Ultimate Multisite elements are not loading correctly on this page enable this option to always inject the javascripts and css assets on this page.', 'ultimate-multisite'); ?></small>
 		</label>
 		<div style="margin-left: 6px;">
 			<input id="wu-compat-mode" type="checkbox" value="1" <?php checked($value, true, true); ?> name="_wu_force_elements_loading" />
@@ -461,7 +461,6 @@ class Checkout_Pages {
 		$switched_locale = switch_to_locale($locale);
 
 		if (is_main_site()) {
-
 			/*
 			 * On the main site, point the reset URL at the custom login
 			 * page so users land on the network's branded login screen.
@@ -478,7 +477,6 @@ class Checkout_Pages {
 
 			$new_url = set_url_scheme($new_url, null);
 		} else {
-
 			/*
 			 * On a subsite, rewrite the URL so the reset flow stays on the
 			 * subsite's own domain. The default wp-login.php URL points to
@@ -522,7 +520,7 @@ class Checkout_Pages {
 			 * @param string  $new_url    The default subsite reset URL.
 			 * @param string  $key        The reset key.
 			 * @param string  $user_login The user login.
-			 * @param WP_User $user_data  The user data.
+			 * @param array   $user_data  The user data.
 			 */
 			$new_url = apply_filters('wu_subsite_password_reset_url', $new_url, $key, $user_login, $user_data);
 
@@ -600,6 +598,8 @@ class Checkout_Pages {
 	 */
 	public function rewrite_new_user_notification_email($email, $user, $blogname) {
 
+		unset($user, $blogname);
+
 		if (empty($email['message']) || ! is_array($email)) {
 			return $email;
 		}
@@ -632,6 +632,8 @@ class Checkout_Pages {
 	 */
 	public function rewrite_password_notification_email($defaults, $key, $user_login, $user_data) {
 
+		unset($key, $user_login, $user_data);
+
 		if (empty($defaults['message']) || ! is_array($defaults)) {
 			return $defaults;
 		}
@@ -663,6 +665,8 @@ class Checkout_Pages {
 	 * @return string
 	 */
 	public function rewrite_email_change_content($email_text, $new_user_email) {
+
+		unset($new_user_email);
 
 		if (empty($email_text) || ! is_string($email_text)) {
 			return $email_text;

--- a/lang/ultimate-multisite.pot
+++ b/lang/ultimate-multisite.pot
@@ -7908,11 +7908,11 @@ msgid "Signup Credit for %s"
 msgstr ""
 
 #: inc/checkout/class-checkout-pages.php:167
-msgid "Ultimate Multisite Compatibility Mode"
+msgid "Force loading Ultimate Multisite frontend assets"
 msgstr ""
 
 #: inc/checkout/class-checkout-pages.php:168
-msgid "Toggle this option on if Ultimate Multisite elements are not loading correctly or at all."
+msgid "If Ultimate Multisite elements are not loading correctly on this page enable this option to always inject the javascripts and css assets on this page."
 msgstr ""
 
 #: inc/checkout/class-checkout-pages.php:292

--- a/tests/WP_Ultimo/Checkout/Checkout_Pages_Test.php
+++ b/tests/WP_Ultimo/Checkout/Checkout_Pages_Test.php
@@ -909,7 +909,11 @@ class Checkout_Pages_Test extends \WP_UnitTestCase {
 		$this->assertIsString($output);
 		$this->assertStringContainsString('wu-compat-mode', $output);
 		$this->assertStringContainsString('_wu_force_elements_loading', $output);
-		$this->assertStringContainsString('Compatibility Mode', $output);
+		$this->assertStringContainsString('Force loading Ultimate Multisite frontend assets', $output);
+		$this->assertStringContainsString(
+			'If Ultimate Multisite elements are not loading correctly on this page enable this option to always inject the javascripts and css assets on this page.',
+			$output
+		);
 	}
 
 	/**


### PR DESCRIPTION
## Summary
- Rename the editor option from "Ultimate Multisite Compatibility Mode" to "Force loading Ultimate Multisite frontend assets".
- Update the help text to explain that enabling the option injects Ultimate Multisite JavaScript/CSS assets on that page.
- Update the render test and POT strings for the new copy.
- Fix same-file PHPCS/PHPStan hook failures surfaced by the pre-commit check.

## Verification
- `vendor/bin/phpunit --filter Checkout_Pages_Test::test_render_compat_mode_setting_outputs_html`
- Pre-commit hook: PHPCS + PHPStan passed.

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.19.0 plugin for [OpenCode](https://opencode.ai) v1.15.10 with gpt-5.5 spent 6h 19m and 14,327 tokens on this as a headless worker.
