### PR TITLE
fix: make sovereign tenant checks filterable

### DIFF
--- a/inc/checkout/class-cart.php
+++ b/inc/checkout/class-cart.php
@@ -265,8 +265,9 @@ class Cart implements \JsonSerializable {
 		 * Guard against instantiation in sovereign tenant context.
 		 * Checkout should only run on the main site.
 		 */
-		if (defined('WU_MT_SOVEREIGN_TENANT') && WU_MT_SOVEREIGN_TENANT) {
-			$this->errors = new \WP_Error(
+		if (wu_is_sovereign_tenant()) {
+			$this->attributes = (object) [];
+			$this->errors     = new \WP_Error(
 				'sovereign_checkout_disabled',
 				__('Checkout is disabled in sovereign tenant context.', 'ultimate-multisite')
 			);
@@ -2252,7 +2253,6 @@ class Cart implements \JsonSerializable {
 	 * @return bool
 	 */
 	public function has_trial() {
-
 		/*
 		 * Reactivation carts never get a trial period.
 		 *

--- a/inc/checkout/class-checkout-pages.php
+++ b/inc/checkout/class-checkout-pages.php
@@ -134,7 +134,7 @@ class Checkout_Pages {
 		/*
 		 * In sovereign tenant context, redirect checkout URLs to the main site.
 		 */
-		if (defined('WU_MT_SOVEREIGN_TENANT') && WU_MT_SOVEREIGN_TENANT) {
+		if (wu_is_sovereign_tenant()) {
 			add_filter('post_type_link', [$this, 'redirect_checkout_urls_in_sovereign_context'], 10, 2);
 			add_filter('page_link', [$this, 'redirect_checkout_urls_in_sovereign_context'], 10, 2);
 		}
@@ -597,6 +597,7 @@ class Checkout_Pages {
 	 * @return array
 	 */
 	public function rewrite_new_user_notification_email($email, $user, $blogname) {
+		unset($user, $blogname);
 
 		unset($user, $blogname);
 
@@ -631,6 +632,7 @@ class Checkout_Pages {
 	 * @return array
 	 */
 	public function rewrite_password_notification_email($defaults, $key, $user_login, $user_data) {
+		unset($key, $user_login, $user_data);
 
 		unset($key, $user_login, $user_data);
 
@@ -665,6 +667,7 @@ class Checkout_Pages {
 	 * @return string
 	 */
 	public function rewrite_email_change_content($email_text, $new_user_email) {
+		unset($new_user_email);
 
 		unset($new_user_email);
 

--- a/inc/checkout/class-checkout.php
+++ b/inc/checkout/class-checkout.php
@@ -582,7 +582,7 @@ class Checkout {
 	 */
 	public function maybe_handle_order_submission(): void {
 
-		if (defined('WU_MT_SOVEREIGN_TENANT') && WU_MT_SOVEREIGN_TENANT) {
+		if (wu_is_sovereign_tenant()) {
 			wp_send_json_error(
 				[
 					'code'          => 'sovereign_checkout_disabled',
@@ -1876,7 +1876,7 @@ class Checkout {
 	 */
 	public function create_order(): void {
 
-		if (defined('WU_MT_SOVEREIGN_TENANT') && WU_MT_SOVEREIGN_TENANT) {
+		if (wu_is_sovereign_tenant()) {
 			wp_send_json_error(
 				[
 					'code'          => 'sovereign_checkout_disabled',
@@ -1950,7 +1950,7 @@ class Checkout {
 	 */
 	public function check_user_exists(): void {
 
-		if (defined('WU_MT_SOVEREIGN_TENANT') && WU_MT_SOVEREIGN_TENANT) {
+		if (wu_is_sovereign_tenant()) {
 			wp_send_json_error(
 				[
 					'code'          => 'sovereign_checkout_disabled',
@@ -2015,7 +2015,7 @@ class Checkout {
 	 */
 	public function handle_inline_login(): void {
 
-		if (defined('WU_MT_SOVEREIGN_TENANT') && WU_MT_SOVEREIGN_TENANT) {
+		if (wu_is_sovereign_tenant()) {
 			wp_send_json_error(
 				[
 					'code'          => 'sovereign_checkout_disabled',

--- a/inc/class-wp-ultimo.php
+++ b/inc/class-wp-ultimo.php
@@ -115,7 +115,6 @@ final class WP_Ultimo {
 	 * @return void
 	 */
 	public function init(): void {
-
 		/*
 		 * Ensure wu_dmtable is registered on $wpdb early in the plugin load.
 		 * Domain_Mapping::startup() only runs during the sunrise/mu-plugins phase
@@ -127,7 +126,7 @@ final class WP_Ultimo {
 		global $wpdb;
 
 		if (empty($wpdb->wu_dmtable)) {
-			$wpdb->wu_dmtable        = $wpdb->base_prefix . 'wu_domain_mappings';
+			$wpdb->wu_dmtable         = $wpdb->base_prefix . 'wu_domain_mappings';
 			$wpdb->ms_global_tables[] = 'wu_domain_mappings';
 		}
 
@@ -354,6 +353,7 @@ final class WP_Ultimo {
 		require_once wu_path('inc/functions/reflection.php');
 		require_once wu_path('inc/functions/scheduler.php');
 		require_once wu_path('inc/functions/session.php');
+		require_once wu_path('inc/functions/sovereign.php');
 		require_once wu_path('inc/functions/documentation.php');
 
 		/**

--- a/inc/compat/class-auto-delete-users-compat.php
+++ b/inc/compat/class-auto-delete-users-compat.php
@@ -36,7 +36,7 @@ class Auto_Delete_Users_Compat {
 	 */
 	public function init(): void {
 
-		if ( defined( 'WU_MT_SOVEREIGN_TENANT' ) && WU_MT_SOVEREIGN_TENANT ) {
+		if ( wu_is_sovereign_tenant() ) {
 			return;
 		}
 

--- a/inc/compat/class-edit-users-compat.php
+++ b/inc/compat/class-edit-users-compat.php
@@ -36,7 +36,7 @@ class Edit_Users_Compat {
 	 */
 	public function init(): void {
 
-		if ( defined( 'WU_MT_SOVEREIGN_TENANT' ) && WU_MT_SOVEREIGN_TENANT ) {
+		if ( wu_is_sovereign_tenant() ) {
 			return;
 		}
 

--- a/inc/compat/class-multiple-accounts-compat.php
+++ b/inc/compat/class-multiple-accounts-compat.php
@@ -51,7 +51,7 @@ class Multiple_Accounts_Compat {
 	 */
 	public function init(): void {
 
-		if ( defined( 'WU_MT_SOVEREIGN_TENANT' ) && WU_MT_SOVEREIGN_TENANT ) {
+		if ( wu_is_sovereign_tenant() ) {
 			return;
 		}
 

--- a/inc/functions/sovereign.php
+++ b/inc/functions/sovereign.php
@@ -13,6 +13,27 @@
 defined('ABSPATH') || exit;
 
 /**
+ * Check if the current request is running in a sovereign tenant context.
+ *
+ * Add-ons can use this filter to opt core flows into sovereign-mode behaviour
+ * without core depending on add-on-defined constants.
+ *
+ * @since 2.12.0
+ * @return bool Whether this request is in a sovereign tenant context.
+ */
+function wu_is_sovereign_tenant() {
+
+	/**
+	 * Filters whether the current request is running in a sovereign tenant context.
+	 *
+	 * @since 2.12.0
+	 *
+	 * @param bool $is_sovereign_tenant Whether this request is in a sovereign tenant context.
+	 */
+	return (bool) apply_filters('wu_is_sovereign_tenant', false);
+}
+
+/**
  * Get the main site account URL for sovereign-mode redirects.
  *
  * Returns the account page URL on the main site, with a return_to parameter

--- a/inc/managers/class-gateway-manager.php
+++ b/inc/managers/class-gateway-manager.php
@@ -281,7 +281,7 @@ class Gateway_Manager extends Base_Manager {
 	 */
 	public function process_gateway_confirmations(): void {
 
-		if ( defined( 'WU_MT_SOVEREIGN_TENANT' ) && WU_MT_SOVEREIGN_TENANT ) {
+		if ( wu_is_sovereign_tenant() ) {
 			return;
 		}
 
@@ -619,7 +619,7 @@ class Gateway_Manager extends Base_Manager {
 	 */
 	public function ajax_check_payment_status(): void {
 
-		if ( defined( 'WU_MT_SOVEREIGN_TENANT' ) && WU_MT_SOVEREIGN_TENANT ) {
+		if ( wu_is_sovereign_tenant() ) {
 			return;
 		}
 

--- a/inc/ui/class-account-summary-element.php
+++ b/inc/ui/class-account-summary-element.php
@@ -292,8 +292,8 @@ class Account_Summary_Element extends Base_Element {
 	 */
 	public function output($atts, $content = null) {
 
-		if (defined('WU_MT_SOVEREIGN_TENANT') && WU_MT_SOVEREIGN_TENANT) {
-			echo wu_get_template_contents(
+		if (wu_is_sovereign_tenant()) {
+			echo wu_get_template_contents( // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 				'elements/sovereign-redirect',
 				[
 					'main_site_account_url' => wu_mt_main_site_account_url(),

--- a/inc/ui/class-billing-info-element.php
+++ b/inc/ui/class-billing-info-element.php
@@ -270,8 +270,8 @@ class Billing_Info_Element extends Base_Element {
 	 */
 	public function output($atts, $content = null) {
 
-		if (defined('WU_MT_SOVEREIGN_TENANT') && WU_MT_SOVEREIGN_TENANT) {
-			echo wu_get_template_contents(
+		if (wu_is_sovereign_tenant()) {
+			echo wu_get_template_contents( // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 				'elements/sovereign-redirect',
 				[
 					'main_site_account_url' => wu_mt_main_site_account_url(),

--- a/inc/ui/class-checkout-element.php
+++ b/inc/ui/class-checkout-element.php
@@ -699,7 +699,7 @@ class Checkout_Element extends Base_Element {
 	public function output($atts, $content = null) {
 
 		// In sovereign tenant context, render a link to the main site checkout instead
-		if (defined('WU_MT_SOVEREIGN_TENANT') && WU_MT_SOVEREIGN_TENANT) {
+		if (wu_is_sovereign_tenant()) {
 			$checkout_pages = \WP_Ultimo\Checkout\Checkout_Pages::get_instance();
 			$main_site_url  = $checkout_pages->get_main_site_checkout_url();
 			?>

--- a/inc/ui/class-current-membership-element.php
+++ b/inc/ui/class-current-membership-element.php
@@ -300,8 +300,8 @@ class Current_Membership_Element extends Base_Element {
 	 */
 	public function output($atts, $content = null) {
 
-		if (defined('WU_MT_SOVEREIGN_TENANT') && WU_MT_SOVEREIGN_TENANT) {
-			echo wu_get_template_contents(
+		if (wu_is_sovereign_tenant()) {
+			echo wu_get_template_contents( // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 				'elements/sovereign-redirect',
 				[
 					'main_site_account_url' => wu_mt_main_site_account_url(),

--- a/inc/ui/class-current-site-element.php
+++ b/inc/ui/class-current-site-element.php
@@ -352,8 +352,8 @@ class Current_Site_Element extends Base_Element {
 	 */
 	public function output($atts, $content = null) {
 
-		if (defined('WU_MT_SOVEREIGN_TENANT') && WU_MT_SOVEREIGN_TENANT) {
-			echo wu_get_template_contents(
+		if (wu_is_sovereign_tenant()) {
+			echo wu_get_template_contents( // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 				'elements/sovereign-redirect',
 				[
 					'main_site_account_url' => wu_mt_main_site_account_url(),

--- a/inc/ui/class-domain-mapping-element.php
+++ b/inc/ui/class-domain-mapping-element.php
@@ -1097,8 +1097,8 @@ class Domain_Mapping_Element extends Base_Element {
 	 */
 	public function output($atts, $content = null) {
 
-		if (defined('WU_MT_SOVEREIGN_TENANT') && WU_MT_SOVEREIGN_TENANT) {
-			echo wu_get_template_contents(
+		if (wu_is_sovereign_tenant()) {
+			echo wu_get_template_contents( // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 				'elements/sovereign-redirect',
 				[
 					'main_site_account_url' => wu_mt_main_site_account_url(),

--- a/inc/ui/class-invoices-element.php
+++ b/inc/ui/class-invoices-element.php
@@ -272,8 +272,8 @@ class Invoices_Element extends Base_Element {
 	 */
 	public function output($atts, $content = null) {
 
-		if (defined('WU_MT_SOVEREIGN_TENANT') && WU_MT_SOVEREIGN_TENANT) {
-			echo wu_get_template_contents(
+		if (wu_is_sovereign_tenant()) {
+			echo wu_get_template_contents( // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 				'elements/sovereign-redirect',
 				[
 					'main_site_account_url' => wu_mt_main_site_account_url(),

--- a/inc/ui/class-my-sites-element.php
+++ b/inc/ui/class-my-sites-element.php
@@ -323,8 +323,8 @@ class My_Sites_Element extends Base_Element {
 	 */
 	public function output($atts, $content = null) {
 
-		if (defined('WU_MT_SOVEREIGN_TENANT') && WU_MT_SOVEREIGN_TENANT) {
-			echo wu_get_template_contents(
+		if (wu_is_sovereign_tenant()) {
+			echo wu_get_template_contents( // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 				'elements/sovereign-redirect',
 				[
 					'main_site_account_url' => wu_mt_main_site_account_url(),

--- a/inc/ui/class-template-switching-element.php
+++ b/inc/ui/class-template-switching-element.php
@@ -265,7 +265,7 @@ class Template_Switching_Element extends Base_Element {
 			return;
 		}
 
-		$this->membership = $this->site->get_membership();
+		$this->membership       = $this->site->get_membership();
 		$this->permission_state = $this->membership ? self::STATE_OK : self::STATE_NO_MEMBERSHIP;
 
 		$this->products = [];
@@ -406,8 +406,8 @@ class Template_Switching_Element extends Base_Element {
 			[
 				'redirect_url' => add_query_arg(
 					[
-						'updated'              => 1,
-						'wu_template_action'   => $action_label,
+						'updated'            => 1,
+						'wu_template_action' => $action_label,
 					],
 					$referer
 				),
@@ -430,8 +430,8 @@ class Template_Switching_Element extends Base_Element {
 	 */
 	public function output($atts, $content = null) {
 
-		if (defined('WU_MT_SOVEREIGN_TENANT') && WU_MT_SOVEREIGN_TENANT) {
-			echo wu_get_template_contents(
+		if (wu_is_sovereign_tenant()) {
+			echo wu_get_template_contents( // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 				'elements/sovereign-redirect',
 				[
 					'main_site_account_url' => wu_mt_main_site_account_url(),
@@ -714,6 +714,7 @@ class Template_Switching_Element extends Base_Element {
 			 * (1024px) lines up with the rest of the customer panel content
 			 * areas; wu-mx-auto centres it.
 			 */
+
 			/*
 			 * Scoped CSS adjustments for the switching page only. Each rule
 			 * is scoped to .wu-template-switching-wrap so signup/checkout

--- a/tests/WP_Ultimo/Checkout/Checkout_Test.php
+++ b/tests/WP_Ultimo/Checkout/Checkout_Test.php
@@ -81,6 +81,36 @@ class Checkout_Test extends WP_UnitTestCase {
 		}
 	}
 
+	/**
+	 * Enable the sovereign tenant checkout guards for the current test.
+	 */
+	private function enable_sovereign_tenant_context(): void {
+		add_filter('wu_is_sovereign_tenant', [$this, 'return_true']);
+	}
+
+	/**
+	 * Disable the sovereign tenant checkout guards for the current test.
+	 */
+	private function disable_sovereign_tenant_context(): void {
+		remove_filter('wu_is_sovereign_tenant', [$this, 'return_true']);
+	}
+
+	/**
+	 * Return true for filter callbacks.
+	 */
+	public function return_true(): bool {
+		return true;
+	}
+
+	/**
+	 * Tear down test fixtures.
+	 */
+	protected function tearDown(): void {
+		$this->disable_sovereign_tenant_context();
+
+		parent::tearDown();
+	}
+
 	// -------------------------------------------------------------------------
 	// Singleton
 	// -------------------------------------------------------------------------
@@ -5349,10 +5379,7 @@ class Checkout_Test extends WP_UnitTestCase {
 	 */
 	public function test_create_order_returns_error_in_sovereign_context(): void {
 
-		// Define the sovereign tenant constant
-		if (!defined('WU_MT_SOVEREIGN_TENANT')) {
-			define('WU_MT_SOVEREIGN_TENANT', true);
-		}
+		$this->enable_sovereign_tenant_context();
 
 		$checkout = Checkout::get_instance();
 
@@ -5377,10 +5404,7 @@ class Checkout_Test extends WP_UnitTestCase {
 	 */
 	public function test_maybe_handle_order_submission_returns_error_in_sovereign_context(): void {
 
-		// Define the sovereign tenant constant
-		if (!defined('WU_MT_SOVEREIGN_TENANT')) {
-			define('WU_MT_SOVEREIGN_TENANT', true);
-		}
+		$this->enable_sovereign_tenant_context();
 
 		$checkout = Checkout::get_instance();
 
@@ -5403,10 +5427,7 @@ class Checkout_Test extends WP_UnitTestCase {
 	 */
 	public function test_check_user_exists_returns_error_in_sovereign_context(): void {
 
-		// Define the sovereign tenant constant
-		if (!defined('WU_MT_SOVEREIGN_TENANT')) {
-			define('WU_MT_SOVEREIGN_TENANT', true);
-		}
+		$this->enable_sovereign_tenant_context();
 
 		$checkout = Checkout::get_instance();
 
@@ -5431,10 +5452,7 @@ class Checkout_Test extends WP_UnitTestCase {
 	 */
 	public function test_handle_inline_login_returns_error_in_sovereign_context(): void {
 
-		// Define the sovereign tenant constant
-		if (!defined('WU_MT_SOVEREIGN_TENANT')) {
-			define('WU_MT_SOVEREIGN_TENANT', true);
-		}
+		$this->enable_sovereign_tenant_context();
 
 		$checkout = Checkout::get_instance();
 
@@ -5459,10 +5477,9 @@ class Checkout_Test extends WP_UnitTestCase {
 	 */
 	public function test_cart_constructor_sets_error_in_sovereign_context(): void {
 
-		// Define the sovereign tenant constant
-		if (!defined('WU_MT_SOVEREIGN_TENANT')) {
-			define('WU_MT_SOVEREIGN_TENANT', true);
-		}
+		$this->enable_sovereign_tenant_context();
+
+		$this->assertTrue(\wu_is_sovereign_tenant());
 
 		$cart = new Cart([
 			'products' => [],

--- a/tests/WP_Ultimo/UI/Sovereign_Mode_Elements_Test.php
+++ b/tests/WP_Ultimo/UI/Sovereign_Mode_Elements_Test.php
@@ -20,13 +20,26 @@ class Sovereign_Mode_Elements_Test extends WP_UnitTestCase {
 	protected function setUp(): void {
 		parent::setUp();
 
-		// Define sovereign mode constant if not already defined
-		if ( ! defined('WU_MT_SOVEREIGN_TENANT') ) {
-			define('WU_MT_SOVEREIGN_TENANT', true);
-		}
-
-		// Load the sovereign helper function
+		// Load the sovereign helper function.
 		require_once dirname(__DIR__, 3) . '/inc/functions/sovereign.php';
+
+		add_filter('wu_is_sovereign_tenant', [$this, 'return_true']);
+	}
+
+	/**
+	 * Tear down test fixtures.
+	 */
+	protected function tearDown(): void {
+		remove_filter('wu_is_sovereign_tenant', [$this, 'return_true']);
+
+		parent::tearDown();
+	}
+
+	/**
+	 * Return true for filter callbacks.
+	 */
+	public function return_true(): bool {
+		return true;
 	}
 
 	/**


### PR DESCRIPTION
## Summary

- Add `wu_is_sovereign_tenant()` with the `wu_is_sovereign_tenant` filter so addons can opt core flows into sovereign-tenant behaviour.
- Replace direct `WU_MT_SOVEREIGN_TENANT` checks across checkout, gateway, compat, and UI code with the helper.
- Update sovereign-mode tests to enable the context via the filter instead of defining an addon-owned constant.

## Verification

- Pre-commit hook passed: PHPCS + PHPStan for staged PHP files.
- `vendor/bin/phpunit --filter Sovereign_Mode_Elements_Test --no-coverage`
- `vendor/bin/phpunit --filter test_cart_constructor_sets_error_in_sovereign_context --no-coverage`

Note: one parallel PHPUnit attempt hit the shared WP test DB setup race (`network already exists`); both targeted tests passed when run sequentially.

---
<!-- aidevops:sig -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test suite to reflect refactored tenant detection method

* **Chores**
  * Refactored internal tenant detection across multiple system components to use a unified helper function

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Ultimate-Multisite/ultimate-multisite/pull/1274?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->