### PR TITLE
CRITICAL: site cloning copies zero files — broken images on every customer site (MUCD_PRIMARY_SITE_ID undefined)

### DIFF
--- a/inc/duplication/files.php
+++ b/inc/duplication/files.php
@@ -5,6 +5,22 @@
 
 defined('ABSPATH') || exit;
 
+/*
+ * MUCD_Files::copy_files() references MUCD_PRIMARY_SITE_ID at runtime (see
+ * copy_files() below). That constant is otherwise only defined in
+ * inc/helpers/class-site-duplicator.php, which is not guaranteed to have loaded
+ * when copy_files() is invoked through every code path (e.g. async actions or a
+ * direct programmatic call). Under PHP 8.x an undefined constant is a fatal
+ * Error, so copy_files() dies mid-loop and the destination site ends up with an
+ * EMPTY uploads/ directory — every template image on the cloned site 404s.
+ *
+ * Define it here, idempotently, so the constant is always available wherever
+ * this class is loaded. Mirrors the definition in class-site-duplicator.php.
+ */
+if ( ! defined('MUCD_PRIMARY_SITE_ID') ) {
+	define('MUCD_PRIMARY_SITE_ID', function_exists('get_current_network_id') ? (int) get_current_network_id() : 1); // phpcs:ignore
+}
+
 if ( ! class_exists('MUCD_Files') ) {
 
 	/**


### PR DESCRIPTION
## Severity: CRITICAL — breaks every template-based signup under PHP 8.x

Site cloning silently copies **zero files** to the destination. Every customer who signs up from a template gets a site where **all template images 404**. The DB clone succeeds (attachment posts copied), so the site looks fine structurally, but the destination uploads dir is empty.

## Root cause (proven)

`MUCD_Files::copy_files()` (`inc/duplication/files.php` ~L51) references `MUCD_PRIMARY_SITE_ID`, only defined in `inc/helpers/class-site-duplicator.php` (L19-20). When copy_files() runs where that helper has not loaded (async site-publish / direct call), PHP 8.x throws `Undefined constant MUCD_PRIMARY_SITE_ID` and copy_files() dies mid-loop.

## Reproduction (live wildcard-DNS multisite)

- Template 156: 57 files. Customer clone: 181 tables, customer_owned (DB OK) but 0 images on disk.
- debug.log: Undefined constant MUCD_PRIMARY_SITE_ID in .../duplication/files.php line 51
- Direct copy_files(156,356): BEFORE throws + copies ~27/57; AFTER returns true + all 57. Verified on staging.

## Fix

Define MUCD_PRIMARY_SITE_ID idempotently at top of files.php (mirrors class-site-duplicator.php).

## Urgency

Affects every template clone on the async/checkout path. Silent failure — site looks valid, images just 404. Patching with a mu-plugin meanwhile but it belongs in core.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved PHP 8.x compatibility issues with file duplication operations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Ultimate-Multisite/ultimate-multisite/pull/1275?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->