### PR TITLE
GH#1276: fix(tours): scope legacy settings lookup to target user

### DIFF
--- a/inc/ui/class-tours.php
+++ b/inc/ui/class-tours.php
@@ -127,9 +127,11 @@ class Tours {
 	 */
 	protected function is_legacy_tour_finished($id, $user_id) {
 
-		foreach ($this->get_legacy_setting_keys($id) as $setting_key) {
-			if (get_user_setting($setting_key, false)) {
-				return true;
+		if (get_current_user_id() === (int) $user_id) {
+			foreach ($this->get_legacy_setting_keys($id) as $setting_key) {
+				if (get_user_setting($setting_key, false)) {
+					return true;
+				}
 			}
 		}
 

--- a/tests/WP_Ultimo/UI/Tours_Test.php
+++ b/tests/WP_Ultimo/UI/Tours_Test.php
@@ -322,6 +322,46 @@ class Tours_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Test is_tour_finished ignores the current user's legacy cookie for other users.
+	 */
+	public function test_is_tour_finished_uses_legacy_settings_for_passed_user(): void {
+
+		$instance = $this->get_instance();
+
+		$current_user_id = self::factory()->user->create(['role' => 'administrator']);
+		$target_user_id  = self::factory()->user->create(['role' => 'administrator']);
+		wp_set_current_user($current_user_id);
+
+		$reflection  = new \ReflectionClass($instance);
+		$is_finished = $reflection->getMethod('is_tour_finished');
+		$is_finished->setAccessible(true);
+		$get_setting = $reflection->getMethod('get_setting_key');
+		$get_setting->setAccessible(true);
+
+		$current_cookie_name               = 'wp-settings-' . $current_user_id;
+		$setting_key                       = $get_setting->invoke($instance, 'legacy-tour');
+		$prior_cookie                      = $_COOKIE[ $current_cookie_name ] ?? null; // phpcs:ignore WordPress.Security.ValidatedSanitizedInput -- test stash, no user input.
+		$prior_updated_settings            = $GLOBALS['_updated_user_settings'] ?? null;
+		$_COOKIE[ $current_cookie_name ]   = $setting_key . '=1';
+		$GLOBALS['_updated_user_settings'] = null;
+
+		try {
+			$this->assertFalse($is_finished->invoke($instance, 'legacy-tour', $target_user_id));
+
+			update_user_option($target_user_id, 'user-settings', $setting_key . '=1', false);
+
+			$this->assertTrue($is_finished->invoke($instance, 'legacy-tour', $target_user_id));
+		} finally {
+			if (null === $prior_cookie) {
+				unset($_COOKIE[ $current_cookie_name ]);
+			} else {
+				$_COOKIE[ $current_cookie_name ] = $prior_cookie;
+			}
+			$GLOBALS['_updated_user_settings'] = $prior_updated_settings;
+		}
+	}
+
+	/**
 	 * Test is_tour_finished reads legacy stripped keys from user settings meta.
 	 *
 	 * Regression test for users who dismissed hyphenated tours before the tour ID
@@ -348,6 +388,7 @@ class Tours_Test extends WP_UnitTestCase {
 		$meta_key = $get_meta_key->invoke($instance, 'checkout-form-list');
 
 		update_user_option($user_id, 'user-settings', 'wu_tour_checkoutformlist=1', false);
+		unset($_COOKIE[ 'wp-settings-' . $user_id ], $GLOBALS['_updated_user_settings'][ $user_id ]);
 
 		$this->assertSame('wu_tour_checkoutformlist=1', get_user_option('user-settings', $user_id));
 		$this->assertContains('wu_tour_checkoutformlist', $get_legacy_keys->invoke($instance, 'checkout-form-list'));
@@ -371,7 +412,7 @@ class Tours_Test extends WP_UnitTestCase {
 
 		// Register 'underscore' if not already registered (test environment may not have it).
 		if ( ! wp_script_is('underscore', 'registered')) {
-			wp_register_script('underscore', false, [], false, false);
+			wp_register_script('underscore', false, [], '1.0.0', false);
 		}
 
 		// Inject a tour so enqueue_scripts() proceeds.


### PR DESCRIPTION
## Summary

Scoped legacy tour cookie checks to the current user only, kept explicit user lookups on stored user-settings, and added regression coverage for passed-user lookups plus stripped-key cache clearing.

## Files Changed

inc/ui/class-tours.php,tests/WP_Ultimo/UI/Tours_Test.php

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** vendor/bin/phpcs inc/ui/class-tours.php tests/WP_Ultimo/UI/Tours_Test.php; WP_TESTS_DIR=/tmp/wordpress-tests-lib vendor/bin/phpunit --filter 'test_is_tour_finished_(uses_legacy_settings_for_passed_user|reads_stripped_legacy_user_settings_meta|falls_back_to_legacy_user_setting)'

Resolves #1276


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.19.4 plugin for [OpenCode](https://opencode.ai) v1.15.10 with gpt-5.5 spent 4m and 64,595 tokens on this as a headless worker.