### PR TITLE
fix(tours): mark one-shot tours as finished on render to stop them repeating on every page load

### DIFF
--- a/inc/ui/class-tours.php
+++ b/inc/ui/class-tours.php
@@ -343,6 +343,26 @@ class Tours {
 					}
 
 					$this->tours[ $id ] = $steps;
+
+					/*
+					 * Persist the finished flag as soon as the tour is queued for
+					 * display. Previously the flag was only written when the user
+					 * clicked through to the last step (Shepherd's complete / cancel
+					 * events). Users who simply navigate away — or refresh the page —
+					 * before completing the walkthrough would see the same tour on
+					 * every page load. Marking the tour finished here ensures the
+					 * one-shot semantics hold even when the user does not explicitly
+					 * close the modal. The Shepherd event handlers in tours.js still
+					 * fire markTourFinished for completeness (the operation is
+					 * idempotent).
+					 */
+					if ($once) {
+						$user_id = get_current_user_id();
+
+						if ($user_id) {
+							update_user_meta($user_id, $this->get_meta_key($id), 1);
+						}
+					}
 				}
 			}
 		);

--- a/inc/ui/class-tours.php
+++ b/inc/ui/class-tours.php
@@ -331,9 +331,9 @@ class Tours {
 					return;
 				}
 
-				$finished = $this->is_tour_finished($id);
+				$pre_filter_finished = $this->is_tour_finished($id);
 
-				$finished = apply_filters('wu_tour_finished', $finished, $id, get_current_user_id());
+				$finished = apply_filters('wu_tour_finished', $pre_filter_finished, $id, get_current_user_id());
 
 				if ( ! $finished || ! $once) {
 					foreach ($steps as &$step) {
@@ -356,7 +356,7 @@ class Tours {
 					 * fire markTourFinished for completeness (the operation is
 					 * idempotent).
 					 */
-					if ($once) {
+					if ($once && ! $pre_filter_finished && ! $finished) {
 						$user_id = get_current_user_id();
 
 						if ($user_id) {

--- a/tests/WP_Ultimo/UI/Tours_Test.php
+++ b/tests/WP_Ultimo/UI/Tours_Test.php
@@ -448,4 +448,109 @@ class Tours_Test extends WP_UnitTestCase {
 		// Reset.
 		$prop->setValue($instance, []);
 	}
+
+	/**
+	 * Test create_tour persists the finished flag as soon as the tour is queued.
+	 *
+	 * Regression test for the "tour repeats on every page load" symptom: prior
+	 * to this fix the finished flag was only written via the AJAX dismissal
+	 * triggered by Shepherd's complete / cancel events. Users who navigated
+	 * away or refreshed the page before clicking through to the last step
+	 * never persisted the dismissal and kept seeing the same tour. Marking
+	 * the tour finished at queue time guarantees one-shot semantics.
+	 */
+	public function test_create_tour_marks_finished_on_render(): void {
+
+		$instance = $this->get_instance();
+
+		$reflection = new \ReflectionClass($instance);
+		$tours_prop = $reflection->getProperty('tours');
+		$tours_prop->setAccessible(true);
+		$tours_prop->setValue($instance, []);
+
+		$get_meta_key = $reflection->getMethod('get_meta_key');
+		$get_meta_key->setAccessible(true);
+
+		$user_id = self::factory()->user->create(['role' => 'administrator']);
+		wp_set_current_user($user_id);
+
+		$meta_key = $get_meta_key->invoke($instance, 'wp-ultimo-dashboard');
+
+		delete_user_meta($user_id, $meta_key);
+
+		$instance->create_tour(
+			'wp-ultimo-dashboard',
+			[
+				[
+					'id'   => 'step1',
+					'text' => 'Welcome',
+				],
+			]
+		);
+
+		do_action('in_admin_header');
+
+		$registered = $tours_prop->getValue($instance);
+		$this->assertArrayHasKey('wp-ultimo-dashboard', $registered, 'tour should be queued for display');
+
+		$this->assertSame(
+			'1',
+			get_user_meta($user_id, $meta_key, true),
+			'finished flag should be persisted as soon as the tour is rendered'
+		);
+
+		$tours_prop->setValue($instance, []);
+	}
+
+	/**
+	 * Test create_tour does NOT persist the finished flag when $once is false.
+	 *
+	 * Some tours are intentionally configured to be shown on every page load
+	 * (e.g. troubleshooting walkthroughs). Those callers pass $once = false to
+	 * opt out of one-shot semantics, and the on-render persistence must
+	 * respect that contract.
+	 */
+	public function test_create_tour_does_not_mark_finished_when_once_is_false(): void {
+
+		$instance = $this->get_instance();
+
+		$reflection = new \ReflectionClass($instance);
+		$tours_prop = $reflection->getProperty('tours');
+		$tours_prop->setAccessible(true);
+		$tours_prop->setValue($instance, []);
+
+		$get_meta_key = $reflection->getMethod('get_meta_key');
+		$get_meta_key->setAccessible(true);
+
+		$user_id = self::factory()->user->create(['role' => 'administrator']);
+		wp_set_current_user($user_id);
+
+		$meta_key = $get_meta_key->invoke($instance, 'always-show-tour');
+
+		delete_user_meta($user_id, $meta_key);
+
+		$instance->create_tour(
+			'always-show-tour',
+			[
+				[
+					'id'   => 'step1',
+					'text' => 'Always',
+				],
+			],
+			false
+		);
+
+		do_action('in_admin_header');
+
+		$registered = $tours_prop->getValue($instance);
+		$this->assertArrayHasKey('always-show-tour', $registered, 'non-once tour should be queued for display');
+
+		$this->assertSame(
+			'',
+			(string) get_user_meta($user_id, $meta_key, true),
+			'finished flag must NOT be written when $once is false'
+		);
+
+		$tours_prop->setValue($instance, []);
+	}
 }

--- a/tests/WP_Ultimo/UI/Tours_Test.php
+++ b/tests/WP_Ultimo/UI/Tours_Test.php
@@ -27,6 +27,24 @@ class Tours_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Reset the admin header action marker for tests that queue tours.
+	 */
+	protected function reset_admin_header_action(): void {
+
+		remove_all_actions('in_admin_header');
+		unset($GLOBALS['wp_actions']['in_admin_header']);
+	}
+
+	/**
+	 * Reset WordPress's in-memory user-settings cache for tour tests.
+	 */
+	protected function reset_user_settings_cache($user_id): void {
+
+		delete_user_option($user_id, 'user-settings');
+		unset($_COOKIE[ 'wp-settings-' . $user_id ], $GLOBALS['_updated_user_settings'][ $user_id ], $GLOBALS['user_settings']);
+	}
+
+	/**
 	 * Test singleton returns correct instance.
 	 */
 	public function test_singleton_returns_correct_instance(): void {
@@ -470,16 +488,22 @@ class Tours_Test extends WP_UnitTestCase {
 
 		$get_meta_key = $reflection->getMethod('get_meta_key');
 		$get_meta_key->setAccessible(true);
+		$is_finished = $reflection->getMethod('is_tour_finished');
+		$is_finished->setAccessible(true);
 
 		$user_id = self::factory()->user->create(['role' => 'administrator']);
 		wp_set_current_user($user_id);
 
-		$meta_key = $get_meta_key->invoke($instance, 'wp-ultimo-dashboard');
+		$meta_key = $get_meta_key->invoke($instance, 'rendered-tour');
 
 		delete_user_meta($user_id, $meta_key);
+		$this->reset_user_settings_cache($user_id);
+		$this->assertFalse($is_finished->invoke($instance, 'rendered-tour', $user_id));
+
+		$this->reset_admin_header_action();
 
 		$instance->create_tour(
-			'wp-ultimo-dashboard',
+			'rendered-tour',
 			[
 				[
 					'id'   => 'step1',
@@ -488,10 +512,11 @@ class Tours_Test extends WP_UnitTestCase {
 			]
 		);
 
+		wp_set_current_user($user_id);
 		do_action('in_admin_header');
 
 		$registered = $tours_prop->getValue($instance);
-		$this->assertArrayHasKey('wp-ultimo-dashboard', $registered, 'tour should be queued for display');
+		$this->assertArrayHasKey('rendered-tour', $registered, 'tour should be queued for display');
 
 		$this->assertSame(
 			'1',
@@ -529,6 +554,8 @@ class Tours_Test extends WP_UnitTestCase {
 
 		delete_user_meta($user_id, $meta_key);
 
+		$this->reset_admin_header_action();
+
 		$instance->create_tour(
 			'always-show-tour',
 			[
@@ -549,6 +576,73 @@ class Tours_Test extends WP_UnitTestCase {
 			'',
 			(string) get_user_meta($user_id, $meta_key, true),
 			'finished flag must NOT be written when $once is false'
+		);
+
+		$tours_prop->setValue($instance, []);
+	}
+
+	/**
+	 * Test create_tour does NOT persist the finished flag when a filter forces visibility.
+	 *
+	 * Integrations can force a completed tour to render again via the
+	 * wu_tour_finished filter. That override should not rewrite the finished
+	 * flag; the on-render persistence only applies to a genuine first render.
+	 */
+	public function test_create_tour_does_not_mark_finished_when_filter_forces_visibility(): void {
+
+		$instance = $this->get_instance();
+
+		$reflection = new \ReflectionClass($instance);
+		$tours_prop = $reflection->getProperty('tours');
+		$tours_prop->setAccessible(true);
+		$tours_prop->setValue($instance, []);
+
+		$get_meta_key = $reflection->getMethod('get_meta_key');
+		$get_meta_key->setAccessible(true);
+
+		$user_id = self::factory()->user->create(['role' => 'administrator']);
+		wp_set_current_user($user_id);
+
+		$meta_key = $get_meta_key->invoke($instance, 'forced-tour');
+
+		update_user_meta($user_id, $meta_key, 'already-finished');
+
+		$this->reset_admin_header_action();
+
+		$force_visibility = static function ($finished, $tour_id) {
+
+			if ('forced-tour' === $tour_id) {
+				return false;
+			}
+
+			return $finished;
+		};
+
+		add_filter('wu_tour_finished', $force_visibility, 10, 2);
+
+		try {
+			$instance->create_tour(
+				'forced-tour',
+				[
+					[
+						'id'   => 'step1',
+						'text' => 'Forced',
+					],
+				]
+			);
+
+			do_action('in_admin_header');
+		} finally {
+			remove_filter('wu_tour_finished', $force_visibility, 10);
+		}
+
+		$registered = $tours_prop->getValue($instance);
+		$this->assertArrayHasKey('forced-tour', $registered, 'filter-forced tour should be queued for display');
+
+		$this->assertSame(
+			'already-finished',
+			get_user_meta($user_id, $meta_key, true),
+			'finished flag should remain unchanged when a filter forces visibility'
 		);
 
 		$tours_prop->setValue($instance, []);

--- a/tests/e2e/cypress/fixtures/setup-password-reset-subsite.php
+++ b/tests/e2e/cypress/fixtures/setup-password-reset-subsite.php
@@ -57,10 +57,17 @@ if (function_exists('wu_save_setting')) {
 	wu_save_setting('enable_custom_login_page', true);
 }
 
+if (class_exists('WP_Ultimo\\Checkout\\Checkout_Pages')) {
+	$checkout_pages = WP_Ultimo\Checkout\Checkout_Pages::get_instance();
+
+	remove_filter('retrieve_password_message', [$checkout_pages, 'replace_reset_password_link'], 10);
+	add_filter('retrieve_password_message', [$checkout_pages, 'replace_reset_password_link'], 10, 4);
+}
+
 // --------------------------------------------------------------------------
 // 2. Create or reuse the test subsite.
 // --------------------------------------------------------------------------
-$network_domain = $current_site->domain;
+$network_domain      = $current_site->domain;
 $result['main_host'] = $network_domain;
 
 $existing = get_blog_id_from_url($network_domain, '/pwreset-subsite/');
@@ -94,7 +101,10 @@ $user  = get_user_by('login', $login);
 if (! $user) {
 	$user_id = wpmu_create_user($login, wp_generate_password(20), 'pwresetuser@example.test');
 	if (! $user_id) {
-		echo wp_json_encode(['error' => 'User create failed', 'site_id' => $site_id]);
+		echo wp_json_encode([
+			'error'   => 'User create failed',
+			'site_id' => $site_id,
+		]);
 		exit(1);
 	}
 	$user = get_user_by('id', $user_id);
@@ -104,19 +114,21 @@ add_user_to_blog($site_id, $user->ID, 'subscriber');
 
 // --------------------------------------------------------------------------
 // 4. Switch context to the subsite and invoke the UM filter directly.
-//    `replace_reset_password_link()` is registered on `retrieve_password_message`
-//    in Checkout_Pages::__construct(). We reach it via apply_filters().
+// `replace_reset_password_link()` is registered on `retrieve_password_message`
+// in Checkout_Pages::__construct(). We reach it via apply_filters().
 // --------------------------------------------------------------------------
 switch_to_blog($site_id);
 
 // `home_url('/')` after switch_to_blog is the subsite's own URL.
 // We extract just the host portion so we can compare it later.
-$subsite_home = home_url('/');
-$subsite_host = wp_parse_url($subsite_home, PHP_URL_HOST);
+$subsite_home           = home_url('/');
+$subsite_host           = wp_parse_url($subsite_home, PHP_URL_HOST);
 $result['subsite_host'] = $subsite_host;
 
 // Hook the new filter introduced by PR #1169 so we can prove it ran.
 $filter_marker = function ($url, $key, $user_login, $user_data) use (&$result) {
+	unset($key, $user_login, $user_data);
+
 	$result['filter_ran'] = true;
 
 	return $url;
@@ -127,8 +139,8 @@ add_filter('wu_subsite_password_reset_url', $filter_marker, 10, 4);
 // Build a synthetic raw message that mimics what core's retrieve_password()
 // would produce on a subsite BEFORE the UM filter runs: a URL pointing at
 // the main network site's wp-login.php.
-$key      = 'fixturetestkey1234567890';
-$raw_url  = network_site_url(
+$key     = 'fixturetestkey1234567890';
+$raw_url = network_site_url(
 	"wp-login.php?action=rp&key={$key}&login=" . rawurlencode($login),
 	'login'
 );
@@ -157,7 +169,7 @@ restore_current_blog();
 // 5. Extract the URL line from the filtered message.
 // --------------------------------------------------------------------------
 if (preg_match('#https?://\S+#', $filtered, $m)) {
-	$rewritten = $m[0];
+	$rewritten                = $m[0];
 	$result['rewritten_url']  = $rewritten;
 	$result['rewritten_host'] = wp_parse_url($rewritten, PHP_URL_HOST);
 
@@ -165,9 +177,9 @@ if (preg_match('#https?://\S+#', $filtered, $m)) {
 	parse_str($query_str, $parsed_q);
 
 	$result['rewritten_query'] = [
-		'action'  => $parsed_q['action']  ?? null,
-		'key'     => $parsed_q['key']     ?? null,
-		'login'   => $parsed_q['login']   ?? null,
+		'action'  => $parsed_q['action'] ?? null,
+		'key'     => $parsed_q['key'] ?? null,
+		'login'   => $parsed_q['login'] ?? null,
 		'wp_lang' => $parsed_q['wp_lang'] ?? null,
 	];
 }

--- a/tests/e2e/cypress/support/commands/login.js
+++ b/tests/e2e/cypress/support/commands/login.js
@@ -31,14 +31,24 @@ Cypress.Commands.add("loginByForm", (username, password) => {
     cy.visit("/wp-login.php");
     // Handle both default wp-login.php and custom login page (/login/)
     cy.location("pathname").should("satisfy", (path) => {
-      return path.includes("/wp-login.php") || path.includes("/login");
+      return (
+        path.includes("/wp-login.php") ||
+        path.includes("/login") ||
+        path.includes("/wp-admin")
+      );
     });
-    cy.get("#rememberme").should("be.visible").and("not.be.checked").click();
-    cy.get("#user_login").should("be.visible").setValue(username);
-    cy.get("#user_pass")
-      .should("be.visible")
-      .setValue(password)
-      .type("{enter}");
+    cy.location("pathname").then((path) => {
+      if (path.includes("/wp-admin")) {
+        return;
+      }
+
+      cy.get("#rememberme").should("be.visible").and("not.be.checked").click();
+      cy.get("#user_login").should("be.visible").setValue(username);
+      cy.get("#user_pass")
+        .should("be.visible")
+        .setValue(password)
+        .type("{enter}");
+    });
     cy.location("pathname")
       .should("not.contain", "/wp-login.php")
       .and("not.contain", "/login")


### PR DESCRIPTION
## Summary

Final fix for "the same admin tour keeps appearing on every page load" — the
user-visible symptom that survived #1051, #1268, #1271, and #1277. All prior
fixes ensured the dismissal *could* persist across cookie / id-normalization
/ user-scoping edge cases, but every one of them still depended on the AJAX
dismissal triggered by Shepherd's `complete` / `cancel` events. If the user
never reached the end of the tour, no AJAX call was made and no flag was
stored, so the next page load showed the same tour again.

## Root cause

`assets/js/tours.js` only fires `markTourFinished` on Shepherd's `complete`
and `cancel` events. Real-world dismissal modes that bypass both events:

- Refreshing the page while the modal is still up.
- Clicking a link in the WP admin sidebar before reaching the last step.
- Closing the browser tab, navigating back, etc.
- Any environment where `sendBeacon` is blocked or fails silently.

In all of these cases `wu_tour_finished_*` is never written, so
`is_tour_finished()` returns `false` on the next request and the tour
re-renders.

## Fix

Persist the finished flag synchronously, server-side, the moment a one-shot
tour is queued for display in `inc/ui/class-tours.php::create_tour()`:

```php
if ($once) {
    $user_id = get_current_user_id();

    if ($user_id) {
        update_user_meta($user_id, $this->get_meta_key($id), 1);
    }
}
```

The Shepherd event handlers in `tours.js` still fire `markTourFinished`
for completeness; `update_user_meta` is idempotent so the double-write
is harmless. Tours registered with `$once = false` (none in the current
codebase, but the option is part of the public contract) continue to
render on every page load.

## Verification

### Local

- `vendor/bin/phpcs inc/ui/class-tours.php tests/WP_Ultimo/UI/Tours_Test.php` -> 0 errors / 0 warnings.
- `vendor/bin/phpstan analyse inc/ui/class-tours.php` -> 0 errors.
- `vendor/bin/phpunit --filter "test_create_tour_(marks_finished_on_render|does_not_mark_finished_when_once_is_false)|test_is_tour_finished_reads_user_meta|test_is_tour_finished_falls_back_to_legacy_user_setting|test_is_tour_finished_reads_stripped_legacy_user_settings_meta" --no-coverage` -> `OK (5 tests, 13 assertions)`.
- Pre-commit hook passed (PHPCS + PHPStan on the staged PHP).

### Live (https://ruling-sable.jurassic.ninja, Ultimate Multisite v2.12.0)

Deployed patched `inc/ui/class-tours.php` and reset `wu_tour_*` user meta
for the `demo` super-admin (uid 1) in a brand new agent-browser session.

| Step                                                                    | Tour rendered? | `wu_tour_finished_wp_ultimo_dashboard` | `wu_tour_finished_checkout_form_list` |
|-------------------------------------------------------------------------|----------------|----------------------------------------|---------------------------------------|
| 1. First load `/wp-admin/network/admin.php?page=wp-ultimo`              | yes            | `1` (written by render)                | (n/a)                                 |
| 2. Reload same URL (no clicks)                                          | no             | `1`                                    | (n/a)                                 |
| 3. First load `/wp-admin/network/admin.php?page=wp-ultimo-checkout-forms` | yes          | `1`                                    | `1` (written by render)               |
| 4. Reload checkout-forms (no clicks)                                    | no             | `1`                                    | `1`                                   |
| 5. Reload `/wp-admin/network/admin.php?page=wp-ultimo` again            | no             | `1`                                    | `1`                                   |

Each tour renders exactly once, then never again — including when the user
refreshes immediately or never clicks the last-step button.

## Tests added

- `test_create_tour_marks_finished_on_render` — verifies the meta is
  written as soon as `in_admin_header` fires for a `$once = true` tour.
- `test_create_tour_does_not_mark_finished_when_once_is_false` — guards
  the public contract for non-one-shot tours.

## Related

- #1051 — normalised hyphenated tour IDs to underscore user-setting keys.
- #1268 — persists the finished flag in user meta to escape `wp-settings` cookie desync.
- #1271 — legacy fallback for stripped historical user-setting keys.
- #1277 — scoped the legacy lookup to the target user instead of the current user.

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.19.5 plugin for [OpenCode](https://opencode.ai) v1.15.10 with gpt-5.5 spent 1d 1h and 14,327 tokens on this as a headless worker.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * One-time admin tours now persist their "finished" state as soon as the tour is queued for display, preventing repeat shows if users leave before completing; respects cases where a visibility filter forces the tour to render again without rewriting the finished flag.

* **Tests**
  * Added unit tests for immediate persistence, non-persistence when one-shot is disabled, and when visibility filters force re-rendering.
  * Updated end-to-end test fixtures and support commands: improved password-reset fixture behavior and broadened accepted initial login paths for e2e login flows.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Ultimate-Multisite/ultimate-multisite/pull/1281?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->