### PR TITLE
fix(e2e): stabilize Cypress login on custom login pages

### DIFF
--- a/tests/e2e/cypress/support/commands/login.js
+++ b/tests/e2e/cypress/support/commands/login.js
@@ -56,6 +56,6 @@ Cypress.Commands.add("loginByForm", (username, password) => {
     cy.location("pathname")
       .should("not.contain", "/wp-login.php")
       .and("not.contain", "/login")
-      .and("equal", "/wp-admin/");
+      .and("include", "/wp-admin");
   });
 });

--- a/tests/e2e/cypress/support/commands/login.js
+++ b/tests/e2e/cypress/support/commands/login.js
@@ -42,7 +42,11 @@ Cypress.Commands.add("loginByForm", (username, password) => {
         return;
       }
 
-      cy.get("#rememberme").should("be.visible").and("not.be.checked").click();
+      cy.get("body").then(($body) => {
+        if ($body.find("#rememberme").length) {
+          cy.get("#rememberme").should("be.visible").and("not.be.checked").click();
+        }
+      });
       cy.get("#user_login").should("be.visible").setValue(username);
       cy.get("#user_pass")
         .should("be.visible")


### PR DESCRIPTION
## Summary

Follow-up for #1281 after the original PR merged while Cypress was still running.

- Make `cy.loginByForm()` tolerate custom login pages that omit `#rememberme`.
- Allow successful login redirects to any `/wp-admin` path, including network admin.
- Keeps the password-reset fixture stabilization that already landed with #1281 on `main`.

## Verification

- `node --check tests/e2e/cypress/support/commands/login.js` — passed.
- `php -l tests/e2e/cypress/fixtures/setup-password-reset-subsite.php` — passed.
- `vendor/bin/phpcs tests/e2e/cypress/fixtures/setup-password-reset-subsite.php` — passed.
- `wp eval-file tests/e2e/cypress/fixtures/setup-password-reset-subsite.php` — returned `filter_ran: true`, non-`wp-login.php` rewritten URL, and preserved `wp_lang`.
- `npx cypress run -b chrome --config-file cypress.config.test.js --spec 'tests/e2e/cypress/integration/011-password-reset-subsite-domain.spec.js,tests/e2e/cypress/integration/030-modal-form-error-handling.spec.js'` — local environment blocked because `http://localhost:8889` was not running; CI is authoritative for the wp-env Cypress target.

For #1281

<!-- aidevops:sig -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved login test reliability to handle optional form elements and flexible page path matching.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Ultimate-Multisite/ultimate-multisite/pull/1282?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->