### PR TITLE
fix(e2e): use API login for modal form error spec

### DIFF
--- a/tests/e2e/cypress/integration/030-modal-form-error-handling.spec.js
+++ b/tests/e2e/cypress/integration/030-modal-form-error-handling.spec.js
@@ -1,13 +1,13 @@
 describe("Modal Form Error Handling", () => {
 	before(() => {
-		cy.loginByForm(
+		cy.loginByApi(
 			Cypress.env("admin").username,
 			Cypress.env("admin").password
 		);
 	});
 
 	beforeEach(() => {
-		cy.loginByForm(
+		cy.loginByApi(
 			Cypress.env("admin").username,
 			Cypress.env("admin").password
 		);


### PR DESCRIPTION
## Summary

Follow-up for #1282 / #1281 after Cypress showed the modal-form spec still depended on UI login fields.

- Switch `030-modal-form-error-handling.spec.js` from UI login to API login.
- Keeps the modal assertions focused on WU AJAX error handling rather than login page markup.

## Verification

- `node --check tests/e2e/cypress/integration/030-modal-form-error-handling.spec.js` — passed.
- `git diff --check` — passed.

For #1282
For #1281

<!-- aidevops:sig -->
