### PR TITLE
fix(e2e): fall back to API login when login form is unavailable

### DIFF
--- a/tests/e2e/cypress/support/commands/login.js
+++ b/tests/e2e/cypress/support/commands/login.js
@@ -43,15 +43,22 @@ Cypress.Commands.add("loginByForm", (username, password) => {
       }
 
       cy.get("body").then(($body) => {
+        if (!$body.find("#user_login").length) {
+          cy.loginByApi(username, password);
+          cy.visit("/wp-admin/");
+          return;
+        }
+
         if ($body.find("#rememberme").length) {
           cy.get("#rememberme").should("be.visible").and("not.be.checked").click();
         }
+
+        cy.get("#user_login").should("be.visible").setValue(username);
+        cy.get("#user_pass")
+          .should("be.visible")
+          .setValue(password)
+          .type("{enter}");
       });
-      cy.get("#user_login").should("be.visible").setValue(username);
-      cy.get("#user_pass")
-        .should("be.visible")
-        .setValue(password)
-        .type("{enter}");
     });
     cy.location("pathname")
       .should("not.contain", "/wp-login.php")


### PR DESCRIPTION
## Summary

Follow-up for #1283 after checkout Cypress still found custom-login states where `/wp-login.php` did not render `#user_login`.

- Add an API-login fallback inside `cy.loginByForm()` when the login page markup is unavailable.
- Keep existing UI-login behavior when `#user_login` is present.

## Verification

- `node --check tests/e2e/cypress/support/commands/login.js` — passed.
- `git diff --check` — passed.

For #1283
For #1282
For #1281

<!-- aidevops:sig -->
