### PR TITLE
ci(e2e): gate PayPal tests on both sandbox secrets

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -450,8 +450,8 @@ jobs:
           PAYPAL_SANDBOX_CLIENT_ID: ${{ secrets.PAYPAL_SANDBOX_CLIENT_ID }}
           PAYPAL_SANDBOX_CLIENT_SECRET: ${{ secrets.PAYPAL_SANDBOX_CLIENT_SECRET }}
         run: |
-          if [ -z "$PAYPAL_SANDBOX_CLIENT_SECRET" ]; then
-            echo "⏭️  Skipping PayPal tests: PAYPAL_SANDBOX_CLIENT_SECRET not available in this run."
+          if [ -z "$PAYPAL_SANDBOX_CLIENT_ID" ] || [ -z "$PAYPAL_SANDBOX_CLIENT_SECRET" ]; then
+            echo "⏭️  Skipping PayPal tests: PAYPAL_SANDBOX_CLIENT_ID or PAYPAL_SANDBOX_CLIENT_SECRET not available in this run."
             echo ""
             echo "    The repo secrets PAYPAL_SANDBOX_CLIENT_ID and PAYPAL_SANDBOX_CLIENT_SECRET"
             echo "    must be configured for these tests to run. GitHub Actions does NOT expose"


### PR DESCRIPTION
## Summary
- Gate PayPal E2E tests on both `PAYPAL_SANDBOX_CLIENT_ID` and `PAYPAL_SANDBOX_CLIENT_SECRET`.
- Update the skip message so it references either missing required PayPal sandbox secret.

## Testing
- `python3` assertion verified the workflow contains the combined ID/secret gate and updated message.
- `actionlint .github/workflows/e2e.yml` skipped because `actionlint` is not installed locally.
- Pre-commit checks passed during commit.

Resolves #1288

<!-- aidevops:sig -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced PayPal integration testing by improving credential validation in the test pipeline to ensure all required credentials are present before test execution.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Ultimate-Multisite/ultimate-multisite/pull/1290?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->