### PR TITLE
fix: use yoda condition for tour persistence guard

### DIFF
--- a/inc/ui/class-tours.php
+++ b/inc/ui/class-tours.php
@@ -356,7 +356,7 @@ class Tours {
 					 * fire markTourFinished for completeness (the operation is
 					 * idempotent).
 					 */
-					if ($once && ! $pre_filter_finished && ! $finished) {
+					if (true === $once && false === $pre_filter_finished && false === $finished) {
 						$user_id = get_current_user_id();
 
 						if ($user_id) {


### PR DESCRIPTION
## Summary

- Updated `inc/ui/class-tours.php` to use strict Yoda comparisons in the one-shot tour persistence guard.

## Testing

- `php -l inc/ui/class-tours.php`
- `vendor/bin/phpcs inc/ui/class-tours.php`

Resolves #1287

---
<!-- aidevops:sig -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved type checking for tour completion state tracking to use strict comparisons instead of loose boolean checks.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Ultimate-Multisite/ultimate-multisite/pull/1291?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->