### PR TITLE
GH#1289: fix: invalidate skipped cart initialization

### DIFF
--- a/inc/checkout/class-cart.php
+++ b/inc/checkout/class-cart.php
@@ -351,7 +351,15 @@ class Cart implements \JsonSerializable {
 		 */
 		$this->attributes = (object) $args;
 
-		if (apply_filters('wu_cart_skip_initialization', false, $args, $this)) {
+		$skip_initialization = apply_filters('wu_cart_skip_initialization', false, $args, $this);
+
+		if ($skip_initialization) {
+			if ($skip_initialization instanceof \WP_Error) {
+				$this->errors->merge_from($skip_initialization);
+			} elseif ( ! $this->errors->has_errors()) {
+				$this->errors->add('cart_initialization_skipped', __('This checkout is not available.', 'ultimate-multisite'));
+			}
+
 			return;
 		}
 

--- a/tests/WP_Ultimo/Checkout/Checkout_Test.php
+++ b/tests/WP_Ultimo/Checkout/Checkout_Test.php
@@ -90,6 +90,7 @@ class Checkout_Test extends WP_UnitTestCase {
 		remove_filter('wu_checkout_skip_user_exists_check', [$this, 'skip_checkout']);
 		remove_filter('wu_checkout_skip_inline_login', [$this, 'skip_checkout']);
 		remove_filter('wu_cart_skip_initialization', [$this, 'set_cart_error']);
+		remove_filter('wu_cart_skip_initialization', '__return_true');
 
 		parent::tearDown();
 	}
@@ -5482,6 +5483,21 @@ class Checkout_Test extends WP_UnitTestCase {
 
 		$this->assertTrue(is_wp_error($cart->errors));
 		$this->assertEquals('checkout_disabled', $cart->errors->get_error_code());
+	}
+
+	/**
+	 * Test that Cart constructor marks skipped initialization as invalid.
+	 */
+	public function test_cart_constructor_sets_default_error_when_skip_filter_returns_true(): void {
+
+		add_filter('wu_cart_skip_initialization', '__return_true');
+
+		$cart = new Cart([
+			'products' => [],
+		]);
+
+		$this->assertFalse($cart->is_valid());
+		$this->assertEquals('cart_initialization_skipped', $cart->errors->get_error_code());
 	}
 
 	// -------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Mark carts skipped by `wu_cart_skip_initialization` as invalid when the filter does not provide its own error.
- Preserve existing filter-provided errors and merge `WP_Error` filter responses.
- Add regression coverage for the true-return skip path.

## Testing

- `vendor/bin/phpcs inc/checkout/class-cart.php`
- `WP_TESTS_DIR=/tmp/wordpress-tests-lib vendor/bin/phpunit --filter test_cart_constructor_sets_default_error_when_skip_filter_returns_true`

Resolves #1289


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.19.5 plugin for [OpenCode](https://opencode.ai) v1.15.10 with gpt-5.5 spent 5m and 131,290 tokens on this as a headless worker.
