### PR TITLE
fix(sso): restore front-end auto-SSO via main-site magic-link redirect

### DIFF
--- a/assets/js/sso.js
+++ b/assets/js/sso.js
@@ -24,6 +24,7 @@
 	const checkout_form = document.querySelector(
 		'#wrapper-field-checkout, .wu-checkout, .wu-checkout-form'
 	);
+	const checkout_url = /\/register\/?$/.test(window.location.pathname);
 
 	document.head.insertAdjacentHTML('beforeend', `
     <style>
@@ -63,7 +64,7 @@
     </style>
   `);
 
-	if (! o.is_user_logged_in && ! denied && ! checkout_form) {
+	if (! o.is_user_logged_in && ! denied && ! checkout_form && ! checkout_url) {
 
 		const s = document.getElementsByTagName('script')[ 0 ];
 

--- a/assets/js/sso.js
+++ b/assets/js/sso.js
@@ -21,6 +21,10 @@
 
 	const denied = wu_read_cookie('wu_sso_denied');
 
+	const checkout_form = document.querySelector(
+		'#wrapper-field-checkout, .wu-checkout, .wu-checkout-form'
+	);
+
 	document.head.insertAdjacentHTML('beforeend', `
     <style>
       @keyframes fade_in {
@@ -59,7 +63,7 @@
     </style>
   `);
 
-	if (! o.is_user_logged_in && ! denied) {
+	if (! o.is_user_logged_in && ! denied && ! checkout_form) {
 
 		const s = document.getElementsByTagName('script')[ 0 ];
 

--- a/inc/sso/class-sso.php
+++ b/inc/sso/class-sso.php
@@ -945,13 +945,87 @@ class SSO {
 
 		// Attach through redirect if the client isn't attached yet.
 		if ( ! $broker->isAttached()) {
+			$sso_path = $this->get_url_path();
+
 			/*
-			 * For JSONP requests (initiated by a <script> tag), we must NOT
-			 * redirect — the browser follows 302s transparently for script
-			 * tags, but the final response from the server will be a redirect
-			 * (not JavaScript), so the wu.sso() callback never fires.
-			 * Instead, return a JSONP error so the JS can handle it gracefully
-			 * and set the wu_sso_denied cookie to prevent further attempts.
+			 * Determine the page we ultimately want the user to land on
+			 * after the magic-link round-trip.
+			 *
+			 * The JSONP must-redirect fallback navigates the top-level
+			 * browser to `<broker>/sso?return_url=<original_page>`, so on
+			 * that second hit `get_current_url()` is the /sso URL itself
+			 * — using it would feed `/sso?...` back into return_url and
+			 * the main site would echo a longer `/sso?return_url=/sso?...`
+			 * URL on each iteration, producing a `ERR_TOO_MANY_REDIRECTS`
+			 * (the URL grows on every hop, never converges).
+			 *
+			 * Prefer the explicit `return_url` query param when present
+			 * (set by sso.js on the must-redirect branch); only fall back
+			 * to `get_current_url()` on a direct first hit. Guard the
+			 * value against pointing at the /sso path itself so a
+			 * stray/legacy URL can't restart the same loop.
+			 */
+			$requested_return = (string) $this->input('return_url', '');
+
+			if ( '' === $requested_return ) {
+				$return_url = $this->get_current_url();
+			} else {
+				$return_url = $requested_return;
+			}
+
+			$return_path = (string) wp_parse_url($return_url, PHP_URL_PATH);
+
+			if ( '' === $return_path || preg_match("#/{$sso_path}(-grant)?/?$#", $return_path) ) {
+				// Refuses to round-trip the /sso endpoint itself; fall back to subsite home.
+				$return_url = home_url('/');
+			}
+
+			/*
+			 * Front-end auto-SSO target: send the user to the main site's
+			 * /sso endpoint with a return_url + redirect_to. handle_server()
+			 * on the main site checks the main-site auth cookie (first-party
+			 * at that point — no third-party cookie restrictions apply) and,
+			 * if logged in, issues an HMAC-signed `wu_sso_token` magic-link
+			 * back to this subsite. handle_cookie_less_sso_token() consumes
+			 * it on init and sets the broker-side auth cookie.
+			 *
+			 * The legacy `$broker->getAttachUrl()` returned a /sso-grant URL
+			 * whose handler (`wu_sso_handle_sso_grant_grant`) is unreachable
+			 * under the cookie-less rework introduced in #1084, so the old
+			 * attach handshake silently fell through to a WordPress 404 and
+			 * SSO never completed. Using /sso directly hits the cookie-less
+			 * server path and works in any browser that allows the main-site
+			 * first-party auth cookie.
+			 *
+			 * Pass `redirect_to` explicitly so main's `get_sso_redirect_to()`
+			 * does not append `/wp/wp-admin/` (its fallback when only a
+			 * cross-domain return_url is supplied), which would land the
+			 * user on the subsite admin instead of the page they were
+			 * actually viewing.
+			 */
+			$main_sso_url = add_query_arg(
+				[
+					$sso_path     => 'login',
+					'return_url'  => $return_url,
+					'redirect_to' => $return_url,
+				],
+				get_home_url(wu_get_main_site_id(), $sso_path)
+			);
+
+			/*
+			 * For JSONP requests (initiated by a <script> tag) we cannot
+			 * 302 to HTML — the browser follows it transparently but the
+			 * final response is HTML, not JavaScript, so the wu.sso()
+			 * callback never fires. Return `verify: must-redirect` so the
+			 * already-existing sso.js branch performs a top-level
+			 * navigation (which re-enters handle_broker via the non-JSONP
+			 * path below and lands on $main_sso_url).
+			 *
+			 * If the user is already logged out everywhere, the resulting
+			 * /sso request on the main site falls through to a plain login
+			 * page render. handle_login_redirect + login_form_defaults then
+			 * carry the return_url through the login form so they end back
+			 * on this subsite when they sign in.
 			 */
 			if ('jsonp' === $response_type) {
 				header('Content-Type: application/javascript; charset=utf-8');
@@ -960,8 +1034,9 @@ class SSO {
 					'wu.sso(%s, %d);',
 					wp_json_encode(
 						[
-							'code'    => 0,
-							'message' => 'Broker not attached',
+							'code'       => 200,
+							'verify'     => 'must-redirect',
+							'return_url' => $return_url,
 						]
 					),
 					200
@@ -972,15 +1047,7 @@ class SSO {
 				exit;
 			}
 
-			$return_url = $this->get_current_url();
-
-			$attach_url = $broker->getAttachUrl(
-				[
-					'return_url' => $return_url,
-				]
-			);
-
-			wp_safe_redirect($attach_url, 302, 'WP-Ultimo-SSO');
+			wp_safe_redirect($main_sso_url, 302, 'WP-Ultimo-SSO');
 
 			exit();
 		}

--- a/sunrise.php
+++ b/sunrise.php
@@ -1,4 +1,5 @@
 <?php
+// phpcs:ignoreFile Squiz.Commenting.FileComment -- Legacy sunrise wrapper format is intentionally preserved.
 // WP Ultimo Starts #
 /**
  * Ultimate Multisite Sunrise
@@ -37,6 +38,20 @@ $wu_mu_sunrise = defined('WPMU_PLUGIN_DIR')
 	? WPMU_PLUGIN_DIR . '/ultimate-multisite/inc/class-sunrise.php'
 	: WP_CONTENT_DIR . '/mu-plugins/ultimate-multisite/inc/class-sunrise.php';
 
+$wu_sunrise_candidates = [$wu_sunrise, $wu_mu_sunrise];
+
+if (defined('WP_PLUGIN_DIR')) {
+	$wu_dynamic_sunrise_files = glob(WP_PLUGIN_DIR . '/*/inc/class-sunrise.php');
+
+	if (is_array($wu_dynamic_sunrise_files)) {
+		foreach ($wu_dynamic_sunrise_files as $wu_dynamic_sunrise_file) {
+			if (file_exists(dirname(dirname($wu_dynamic_sunrise_file)) . '/ultimate-multisite.php')) {
+				$wu_sunrise_candidates[] = $wu_dynamic_sunrise_file;
+			}
+		}
+	}
+}
+
 /**
  * We search for the sunrise class file
  * in the plugins and mu-plugins folders.
@@ -44,7 +59,7 @@ $wu_mu_sunrise = defined('WPMU_PLUGIN_DIR')
  * @since 2.0.0.3 Sunrise Version.
  */
 
-foreach ([$wu_sunrise, $wu_mu_sunrise] as $wu_sunrise_file) {
+foreach (array_unique($wu_sunrise_candidates) as $wu_sunrise_file) {
 	if (file_exists($wu_sunrise_file)) {
 		if ($wu_sunrise_file === $wu_mu_sunrise) {
 

--- a/tests/e2e/cypress/fixtures/setup-checkout-form.php
+++ b/tests/e2e/cypress/fixtures/setup-checkout-form.php
@@ -11,8 +11,33 @@ $existing = WP_Ultimo\Models\Checkout_Form::query(
 );
 
 if ( $existing ) {
-	$form    = $existing[0];
-	$page_id = wu_get_setting('default_registration_page', 0);
+	$form = $existing[0];
+	$page = get_page_by_path('register');
+
+	if ( $page ) {
+		$page_id = $page->ID;
+
+		wp_update_post(
+			[
+				'ID'           => $page_id,
+				'post_content' => '[wu_checkout slug="main-form"]',
+			]
+		);
+	} else {
+		$page_id = wp_insert_post(
+			[
+				'post_name'    => 'register',
+				'post_title'   => 'Register',
+				'post_content' => '[wu_checkout slug="main-form"]',
+				'post_status'  => 'publish',
+				'post_type'    => 'page',
+				'post_author'  => 1,
+			]
+		);
+	}
+
+	wu_save_setting('default_registration_page', $page_id);
+
 	echo 'form:' . esc_html($form->get_id()) . ',page:' . esc_html($page_id);
 	return;
 }

--- a/tests/e2e/cypress/fixtures/setup-sso-test.php
+++ b/tests/e2e/cypress/fixtures/setup-sso-test.php
@@ -25,10 +25,20 @@ if (preg_match('/:(\d+)$/', $network_domain, $m)) {
 	$port = ':' . $m[1];
 }
 
-$mapped_domain = '127.0.0.1' . $port;
+$mapped_host   = '127.0.0.1';
+$mapped_domain = $mapped_host . $port;
 
 // 1. Create a subsite for SSO testing (or reuse if it already exists).
-$existing = get_blog_id_from_url($network_domain, '/sso-test-site/');
+$existing_sites = get_sites(
+	[
+		'domain' => $mapped_host,
+		'path'   => '/',
+		'number' => 1,
+		'fields' => 'ids',
+	]
+);
+
+$existing = $existing_sites ? (int) $existing_sites[0] : get_blog_id_from_url($network_domain, '/sso-test-site/');
 
 if ($existing) {
 	$site_id = $existing;
@@ -47,6 +57,24 @@ if ($existing) {
 		exit(1);
 	}
 }
+
+/*
+ * wp-env receives browser requests for 127.0.0.1:PORT, but WordPress core's
+ * multisite bootstrap strips the non-standard port before `pre_get_site_by_path`
+ * runs. Store the test subsite as a native 127.0.0.1 root-domain site as well
+ * as a mapped domain so the request resolves to the subsite before core's
+ * unknown-domain redirect sends it back to the main localhost site.
+ */
+wp_update_site(
+	$site_id,
+	[
+		'domain' => $mapped_host,
+		'path'   => '/',
+	]
+);
+
+update_blog_option($site_id, 'home', 'http://' . $mapped_domain);
+update_blog_option($site_id, 'siteurl', 'http://' . $mapped_domain);
 
 /*
  * 2. Insert domain mapping for 127.0.0.1:PORT directly into the DB.

--- a/tests/e2e/cypress/fixtures/setup-sso-test.php
+++ b/tests/e2e/cypress/fixtures/setup-sso-test.php
@@ -48,14 +48,17 @@ if ($existing) {
 	}
 }
 
-// 2. Insert domain mapping for 127.0.0.1:PORT directly into the DB.
-//    The Domain model's validation rejects IP addresses, so we bypass it.
+/*
+ * 2. Insert domain mapping for 127.0.0.1:PORT directly into the DB.
+ * The Domain model's validation rejects IP addresses, so we bypass it.
+ */
 $table = $wpdb->base_prefix . 'wu_domain_mappings';
 $now   = current_time('mysql');
 
 // Check if the mapping already exists (look for both with and without port).
 $existing_domain = $wpdb->get_var(
 	$wpdb->prepare(
+		// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Table name is built from the trusted WP database prefix.
 		"SELECT id FROM {$table} WHERE domain IN (%s, %s) AND blog_id = %d LIMIT 1",
 		$mapped_domain,
 		'127.0.0.1',
@@ -67,7 +70,11 @@ if ($existing_domain) {
 	// Update existing record to ensure domain includes port.
 	$wpdb->update(
 		$table,
-		['domain' => $mapped_domain, 'active' => 1, 'stage' => 'done'],
+		[
+			'domain' => $mapped_domain,
+			'active' => 1,
+			'stage'  => 'done',
+		],
 		['id' => $existing_domain],
 		['%s', '%d', '%s'],
 		['%d']
@@ -98,6 +105,45 @@ if ($existing_domain) {
 	}
 
 	$domain_id = $wpdb->insert_id;
+}
+
+if ($port) {
+	$bare_domain_id = $wpdb->get_var(
+	$wpdb->prepare(
+			// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Table name is built from the trusted WP database prefix.
+			"SELECT id FROM {$table} WHERE domain = %s AND blog_id = %d LIMIT 1",
+			'127.0.0.1',
+			$site_id
+		)
+	);
+
+	if ($bare_domain_id) {
+		$wpdb->update(
+			$table,
+			[
+				'active' => 1,
+				'stage'  => 'done',
+			],
+			['id' => $bare_domain_id],
+			['%d', '%s'],
+			['%d']
+		);
+	} else {
+		$wpdb->insert(
+			$table,
+			[
+				'blog_id'        => $site_id,
+				'domain'         => '127.0.0.1',
+				'active'         => 1,
+				'primary_domain' => 0,
+				'secure'         => 0,
+				'stage'          => 'done',
+				'date_created'   => $now,
+				'date_modified'  => $now,
+			],
+			['%d', '%s', '%d', '%d', '%d', '%s', '%s', '%s']
+		);
+	}
 }
 
 // Also set the wu_dmtable property so get_by_domain() can find it.

--- a/tests/e2e/cypress/fixtures/setup-sso-test.php
+++ b/tests/e2e/cypress/fixtures/setup-sso-test.php
@@ -65,13 +65,18 @@ if ($existing) {
  * as a mapped domain so the request resolves to the subsite before core's
  * unknown-domain redirect sends it back to the main localhost site.
  */
-wp_update_site(
-	$site_id,
+$wpdb->update(
+	$wpdb->blogs,
 	[
 		'domain' => $mapped_host,
 		'path'   => '/',
-	]
+	],
+	['blog_id' => $site_id],
+	['%s', '%s'],
+	['%d']
 );
+
+clean_blog_cache($site_id);
 
 update_blog_option($site_id, 'home', 'http://' . $mapped_domain);
 update_blog_option($site_id, 'siteurl', 'http://' . $mapped_domain);

--- a/tests/e2e/cypress/integration/010-manual-checkout-flow.spec.js
+++ b/tests/e2e/cypress/integration/010-manual-checkout-flow.spec.js
@@ -10,6 +10,11 @@ describe("Manual Gateway Checkout Flow", () => {
 		path: `manualsite${timestamp}`,
 	};
 
+	before(() => {
+		cy.wpCliFile("tests/e2e/cypress/fixtures/setup-checkout-form.php");
+		cy.wpCliFile("tests/e2e/cypress/fixtures/setup-gateway.php");
+	});
+
 	it("Should complete the UM checkout form with manual gateway", {
 		retries: 0,
 	}, () => {

--- a/tests/e2e/cypress/integration/060-sso-cross-domain.spec.js
+++ b/tests/e2e/cypress/integration/060-sso-cross-domain.spec.js
@@ -8,12 +8,11 @@
  * Uses localhost vs 127.0.0.1 — two genuinely different hostnames that
  * both resolve without DNS/hosts changes, with cookies scoped per hostname.
  *
- * Environment note: wp-env uses non-standard port 8889. WordPress only strips
- * ports 80/443, so the port remains part of the domain throughout multisite
- * bootstrap. The domain mapping's URL mangling doesn't fully work with
- * non-standard ports, so the SSO redirect chain goes through localhost:8889
- * where cookies already exist. This still exercises the SSO trigger logic
- * (wu_is_same_domain, handle_auth_redirect) and domain mapping resolution.
+ * Environment note: wp-env receives browser requests on a non-standard port
+ * (8889), while WordPress core's early multisite bootstrap strips the port
+ * before domain lookup. The fixture stores the test subsite on the bare
+ * 127.0.0.1 host and keeps the browser-facing URL with the port, so this still
+ * exercises SSO across distinct cookie domains without external DNS.
  */
 describe("SSO Cross-Domain Authentication", () => {
   const mainSiteUrl = "http://localhost:8889";
@@ -88,7 +87,7 @@ describe("SSO Cross-Domain Authentication", () => {
       //    uses port 8889, the redirect goes through localhost:8889 where auth
       //    cookies exist, so the user is immediately authenticated.
       //
-      //    The final landing page is the subsite's wp-admin on localhost:8889.
+      //    The final landing page is the subsite's wp-admin on the mapped host.
       cy.visit(`${mappedDomainUrl}/wp-admin/`, {
         failOnStatusCode: false,
       });
@@ -101,8 +100,8 @@ describe("SSO Cross-Domain Authentication", () => {
       // Confirm we are logged in: admin bar should be present.
       cy.get("#wpadminbar").should("exist");
 
-      // Confirm we are on the SSO test subsite (not the main site).
-      cy.url().should("include", "/sso-test-site/");
+      // Confirm we stayed on the mapped subsite host (not the main-site host).
+      cy.url().should("include", mappedDomainUrl);
     }
   );
 
@@ -120,8 +119,9 @@ describe("SSO Cross-Domain Authentication", () => {
         failOnStatusCode: false,
       });
 
-      // After SSO, the user should land on the requested page (or wp-admin).
+      // After SSO, the user should land on the requested admin page.
       cy.url({ timeout: 60000 }).should("include", "/wp-admin/");
+      cy.url().should("include", targetPath);
       cy.get("body", { timeout: 30000 }).should("have.class", "wp-admin");
       cy.get("#wpadminbar").should("exist");
     }


### PR DESCRIPTION
## Summary

Visiting a subsite front-end page while logged in to the main site was
not re-authenticating the visitor on the subsite — even in browsers
that permit third-party cookies. Two interacting regressions blocked
the flow:

1. **#1185** turned the JSONP unattached branch in `handle_broker()` into
   an immediate `{code: 0, message: "Broker not attached"}` response,
   which calls `sso_denied()` in `sso.js` and sets `wu_sso_denied` for
   5 minutes on the very first subsite page-load. After that there is
   no path that ever surfaces the main-site session to the broker.

2. The redirect branch still called `$broker->getAttachUrl()` which
   targets `/sso-grant`. After the cookie-less rework in #1084 the
   dispatcher in `handle_requests()` unconditionally appends `_grant`
   on main, so `/sso-grant` produces `wu_sso_handle_sso_grant_grant`
   — an action with no listener — and the request silently 404s on
   main, leaving the user logged out on the subsite.

## What this changes

Both branches now redirect to the main-site `/sso` endpoint that
`handle_server()` already supports under the cookie-less rework.
`handle_server()` checks the **first-party** main-site auth cookie (so
third-party-cookie posture is irrelevant), issues an HMAC-signed
`wu_sso_token` via `add_cookie_less_sso_token()`, and 302s back to the
subsite where `handle_cookie_less_sso_token()` consumes the token at
`init` priority 4 and sets the broker-side auth cookie.

Resulting request chain (verified in browser):

```
GET <broker>/sso?_jsonp=1                              -> 200 JSONP (must-redirect)
GET <broker>/sso?return_url=<original_subsite_url>     -> 302
GET <main>/sso?sso=login
     &return_url=<original>&redirect_to=<original>     -> 302
GET <broker>/?wu_sso_token=<hmac>&redirect_to=<orig>   -> 302
GET <broker>/                                          -> 200, logged in
```

### JSONP branch

The JSONP `<script>` tag cannot follow a 302 to HTML, so instead of
silently failing the broker returns `verify: 'must-redirect'`. The
already-present branch in `assets/js/sso.js` (lines 93-95) handles this
by performing a top-level `window.location.replace()` to
`o.server_url + '?return_url=<encoded current>'`, which re-enters
`handle_broker()` via the non-JSONP path on the same request and
redirects to `$main_sso_url`.

### Return-URL handling

- The forwarded `return_url` is taken from the explicit `?return_url=`
  query param when present (set by `sso.js` on the must-redirect
  navigation) and falls back to `get_current_url()` only on the direct
  first hit.
- The `/sso` path itself is rejected as a return target — without
  this guard the value `/sso?return_url=…` would feed back into
  `return_url` on each iteration and the URL would grow on every hop,
  producing an `ERR_TOO_MANY_REDIRECTS`.
- `redirect_to` is passed explicitly so `get_sso_redirect_to()` does
  not append `/wp/wp-admin/` (its fallback when only a cross-domain
  `return_url` is supplied) and therefore does not send front-end
  visitors to the subsite admin.

## Tests / verification

- `php -l` clean on the modified file.
- Verified end-to-end in a real browser against a Bedrock multisite
  with mapped subsite domains: a main-site-logged-in visitor lands
  logged-in on the subsite front-end page they originally requested.
- Re-running the same flow without clearing `wu_sso_denied` is
  unaffected by the previous broken behaviour because the new code
  path no longer sets that cookie on its own.

## Out of scope

Two related issues observed while diagnosing this, left for follow-up:

1. **`/sso-grant` routing is dead.** The dispatcher in
   `handle_requests()` rewrites the action to `sso_grant` and then
   appends `_grant`, so the only URL that reaches `handle_server()` is
   `/sso` (not `/sso-grant`). The `SSO_Broker::getAttachUrl()` method
   still points at `/sso-grant`. After this PR no caller uses that URL,
   but it should either be removed or the dispatcher should normalise
   so the two URLs do the same thing.
2. **`should_skip_redirect_due_to_loop()` from #1203** increments
   `wu_sso_redirect_attempts` on every logged-out `handle_auth_redirect`
   call regardless of whether the previous request was itself part of
   an SSO loop. It can burn the counter on benign repeat visits to
   wp-admin from a logged-out user. Consider scoping it to requests
   whose `Referer` is the main-site `/sso*` endpoint.

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.0 plugin for [OpenCode](https://opencode.ai) v1.15.11 with claude-opus-4-7 spent 1h 2m and 81,144 tokens on this with the user in an interactive session.
