### PR TITLE
fix: route sso grant attach urls

### DIFF
--- a/inc/sso/class-sso.php
+++ b/inc/sso/class-sso.php
@@ -488,6 +488,8 @@ class SSO {
 
 		$return_type = wp_is_jsonp_request() ? 'jsonp' : 'redirect';
 
+		$action = (string) preg_replace('/-grant\/?$/', '', $action);
+
 		$action = str_replace($this->get_url_path(), 'sso', $action);
 
 		$action = trim(wu_replace_dashes($action), '/');
@@ -654,6 +656,7 @@ class SSO {
 		// HMAC-signed token.
 		$hmac = hash_hmac('sha256', $payload, wp_salt('auth'));
 
+		// phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_encode -- Encodes an HMAC-signed SSO token for URL transport.
 		return rtrim(strtr(base64_encode($hmac . '::' . $payload), '+/', '-_'), '=');
 	}
 
@@ -775,6 +778,7 @@ class SSO {
 			$token .= str_repeat('=', 4 - $padding);
 		}
 
+		// phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_decode -- Decodes the URL-safe HMAC-signed SSO token generated above.
 		$decoded = base64_decode($token, true);
 
 		if ( ! $decoded || false === strpos($decoded, '::') ) {

--- a/tests/WP_Ultimo/SSO/SSO_Test.php
+++ b/tests/WP_Ultimo/SSO/SSO_Test.php
@@ -745,6 +745,21 @@ class SSO_Test extends \WP_UnitTestCase {
 		$this->assertTrue(true);
 	}
 
+	/**
+	 * Test handle_requests normalizes sso-grant URLs before dispatching.
+	 */
+	public function test_handle_requests_source_normalizes_sso_grant_to_server_action(): void {
+		$source = file_get_contents(
+			dirname(__DIR__, 3) . '/inc/sso/class-sso.php'
+		);
+
+		$this->assertStringContainsString(
+			"preg_replace('/-grant\\/?$/', '', \$action)",
+			$source,
+			'handle_requests() must normalize sso-grant requests to the sso server action'
+		);
+	}
+
 	// ------------------------------------------------------------------
 	// Session handler
 	// ------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Normalize `/sso-grant` SSO actions before dispatch so `SSO_Broker::getAttachUrl()` reaches the existing main-site `wu_sso_handle_sso_grant` server handler.
- Add focused regression coverage asserting the grant suffix normalization remains in `handle_requests()`.
- Add PHPCS justifications for existing SSO token base64 encode/decode calls so the touched source file passes staged checks.

## Testing

- `vendor/bin/phpcs inc/sso/class-sso.php`
- `vendor/bin/phpstan analyse --no-progress --error-format=table inc/sso/class-sso.php`
- `WP_TESTS_DIR=/tmp/wordpress-tests-lib vendor/bin/phpunit --filter SSO_Test`
- `WP_TESTS_DIR=/tmp/wordpress-tests-lib vendor/bin/phpunit --filter test_handle_requests_source_normalizes_sso_grant_to_server_action`

Resolves #1298

<!-- aidevops:sig -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Single Sign-On (SSO) request handling by normalizing incoming action parameters for consistent routing between grant and broker configurations.
  * Enhanced documentation for SSO token encoding and decoding processes.

* **Tests**
  * Added unit test to verify SSO request normalization behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Ultimate-Multisite/ultimate-multisite/pull/1301?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->