### PR TITLE
fix(sso): scope redirect loop counter to SSO hops

### DIFF
--- a/inc/sso/class-sso.php
+++ b/inc/sso/class-sso.php
@@ -438,7 +438,7 @@ class SSO {
 		$threshold = (int) apply_filters('wu_sso_redirect_loop_threshold', 3);
 		$window    = (int) apply_filters('wu_sso_redirect_loop_window', 120);
 
-		if ($threshold < 1 || $window < 1) {
+		if ($threshold < 1 || $window < 1 || ! $this->is_sso_loop_request()) {
 			return false;
 		}
 
@@ -464,6 +464,34 @@ class SSO {
 		$_COOKIE['wu_sso_redirect_attempts'] = $value;
 
 		return $count >= $threshold;
+	}
+
+	/**
+	 * Check if the current request looks like an SSO loop hop.
+	 *
+	 * Plain logged-out visits to protected URLs can call auth_redirect()
+	 * repeatedly without ever entering the SSO flow. Only requests carrying an
+	 * SSO fingerprint should consume the redirect-loop budget.
+	 *
+	 * @since 2.0.11
+	 * @return bool True when the request carries an SSO fingerprint.
+	 */
+	private function is_sso_loop_request(): bool {
+
+		if ($this->input('wu_sso_token') || 'login' === $this->input('sso') || $this->input('return_url') || $this->input('_jsonp')) {
+			return true;
+		}
+
+		$referer = wp_get_referer();
+
+		if ( ! $referer) {
+			return false;
+		}
+
+		$referer_path = (string) wp_parse_url($referer, PHP_URL_PATH);
+		$sso_path     = '/' . ltrim($this->get_url_path(), '/');
+
+		return 0 === strpos($referer_path, $sso_path);
 	}
 
 	/**

--- a/tests/WP_Ultimo/SSO/SSO_Test.php
+++ b/tests/WP_Ultimo/SSO/SSO_Test.php
@@ -45,10 +45,13 @@ class SSO_Test extends \WP_UnitTestCase {
 		unset($_REQUEST['broker']);
 		unset($_REQUEST['sso_verify']);
 		unset($_REQUEST['wu_sso_token']);
+		unset($_REQUEST['sso']);
 		unset($_REQUEST['return_url']);
 		unset($_REQUEST['redirect_to']);
+		unset($_REQUEST['_jsonp']);
 		unset($_COOKIE['wu_sso_denied']);
 		unset($_COOKIE['wu_sso_redirect_attempts']);
+		unset($_SERVER['HTTP_REFERER']);
 
 		remove_all_filters('wu_sso_redirect_loop_threshold');
 		remove_all_filters('wu_sso_redirect_loop_window');
@@ -253,6 +256,8 @@ class SSO_Test extends \WP_UnitTestCase {
 	public function test_sso_redirect_loop_counter_skips_at_threshold(): void {
 		$sso = SSO::get_instance();
 
+		$_REQUEST['sso'] = 'login';
+
 		add_filter(
 			'wu_sso_redirect_loop_threshold',
 			function () {
@@ -276,6 +281,8 @@ class SSO_Test extends \WP_UnitTestCase {
 	public function test_sso_redirect_loop_counter_resets_after_window(): void {
 		$sso = SSO::get_instance();
 
+		$_REQUEST['sso'] = 'login';
+
 		add_filter(
 			'wu_sso_redirect_loop_threshold',
 			function () {
@@ -291,6 +298,34 @@ class SSO_Test extends \WP_UnitTestCase {
 		);
 
 		$_COOKIE['wu_sso_redirect_attempts'] = '1:' . (time() - 120);
+
+		$method = new \ReflectionMethod($sso, 'should_skip_redirect_due_to_loop');
+		$method->setAccessible(true);
+
+		$this->assertFalse($method->invoke($sso));
+		$this->assertSame(1, $this->get_sso_redirect_attempt_count());
+	}
+
+	/**
+	 * Test plain protected URL visits do not consume the SSO loop budget.
+	 */
+	public function test_sso_redirect_loop_counter_ignores_non_sso_requests(): void {
+		$sso = SSO::get_instance();
+
+		$method = new \ReflectionMethod($sso, 'should_skip_redirect_due_to_loop');
+		$method->setAccessible(true);
+
+		$this->assertFalse($method->invoke($sso));
+		$this->assertSame(0, $this->get_sso_redirect_attempt_count());
+	}
+
+	/**
+	 * Test SSO referers consume the redirect-loop budget.
+	 */
+	public function test_sso_redirect_loop_counter_counts_sso_referer(): void {
+		$sso = SSO::get_instance();
+
+		$_SERVER['HTTP_REFERER'] = home_url('/sso');
 
 		$method = new \ReflectionMethod($sso, 'should_skip_redirect_due_to_loop');
 		$method->setAccessible(true);


### PR DESCRIPTION
## Summary

- Scoped the SSO redirect-loop counter to requests with an SSO fingerprint.
- Preserved loop protection for SSO query parameters and main-site `/sso` referers.
- Added coverage proving plain logged-out protected URL visits do not consume the redirect budget.

## Testing

- `WP_TESTS_DIR=/tmp/wordpress-tests-lib vendor/bin/phpunit --filter SSO_Test`
- `vendor/bin/phpcs inc/sso/class-sso.php tests/WP_Ultimo/SSO/SSO_Test.php` (passes with existing test warnings for `file_get_contents()`)

MERGE_SUMMARY: Scoped `should_skip_redirect_due_to_loop()` so only SSO-fingerprinted requests consume the `wu_sso_redirect_attempts` budget, with PHPUnit coverage for non-SSO requests and SSO referers.

Resolves #1299

<!-- aidevops:sig -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Single Sign-On (SSO) redirect-loop detection to accurately identify actual SSO authentication attempts, reducing false positives that previously blocked legitimate SSO sessions.

* **Tests**
  * Added test coverage for redirect-loop counter behavior with SSO and non-SSO request scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Ultimate-Multisite/ultimate-multisite/pull/1302?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->