### PR TITLE
GH#1303: handle template fixture save failures

### DIFF
--- a/tests/e2e/cypress/fixtures/setup-templates-and-customer.php
+++ b/tests/e2e/cypress/fixtures/setup-templates-and-customer.php
@@ -74,7 +74,16 @@ foreach ( [$template_one_id, $template_two_id] as $template_blog_id ) {
 	$template_site->set_archived( false );
 	$template_site->set_deleted( false );
 	$template_site->set_spam( false );
-	$template_site->save();
+	$template_saved = $template_site->save();
+
+	if ( is_wp_error( $template_saved ) || false === $template_saved ) {
+		echo wp_json_encode( [
+			'error'   => 'template_save_failed',
+			'blog_id' => $template_blog_id,
+			'detail'  => is_wp_error( $template_saved ) ? $template_saved->get_error_message() : 'save returned false',
+		] );
+		return;
+	}
 }
 
 // --- Customer ----------------------------------------------------------


### PR DESCRIPTION
## Summary

- Checks the template site `save()` result in the E2E setup fixture.
- Fails fast with a clear JSON error containing the template blog id and save failure detail.
- Keeps the fixture's existing JSON error response pattern.

## Testing

- `php -l tests/e2e/cypress/fixtures/setup-templates-and-customer.php`
- `vendor/bin/phpcs tests/e2e/cypress/fixtures/setup-templates-and-customer.php`

Resolves #1303


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.4 plugin for [OpenCode](https://opencode.ai) v1.15.11 with gpt-5.5 spent 2m and 53,475 tokens on this as a headless worker.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced error handling in template setup test fixture with explicit failure detection and reporting for template save operations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Ultimate-Multisite/ultimate-multisite/pull/1304?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->