### PR TITLE
fix(membership): guard renew() against a non-advancing expiration on recurring renewals

### DIFF
--- a/inc/models/class-membership.php
+++ b/inc/models/class-membership.php
@@ -2458,6 +2458,51 @@ class Membership extends Base_Model implements Limitable, Billable, Notable {
 			 * @since 2.0.0
 			 */
 			$expiration = apply_filters('wu_membership_renewal_expiration_date', $expiration, $plan, $this->get_id(), $this);
+		} elseif ($this->is_recurring() && ! $this->is_free()) {
+			/*
+			 * Defensive guard against a non-advancing expiration on a recurring
+			 * renewal.
+			 *
+			 * Callers (e.g. payment gateway integrations) may pass an explicit
+			 * $expiration derived from a subscription's "next payment" date. If
+			 * that source date has not been advanced yet at the time renew() is
+			 * called, the passed expiration can be equal to or earlier than the
+			 * membership's current expiration. Accepting it verbatim "renews" the
+			 * membership to an already-due date, so it expires immediately even
+			 * though a payment just succeeded.
+			 *
+			 * When the passed expiration does not move the current expiration
+			 * forward, fall back to the plan-derived expiration so a paid renewal
+			 * always extends access. Non-recurring/free memberships and explicit
+			 * future dates are left untouched.
+			 *
+			 * @since 2.5.1
+			 */
+			$current_expiration = $this->get_date_expiration();
+
+			if ( ! empty($current_expiration) && '0000-00-00 00:00:00' !== $current_expiration) {
+				$passed_ts  = strtotime($expiration);
+				$current_ts = strtotime($current_expiration);
+
+				if ($passed_ts && $current_ts && $passed_ts <= $current_ts) {
+					$fallback = $this->calculate_expiration(! $this->is_recurring());
+
+					if ($fallback && strtotime($fallback) > $current_ts) {
+						wu_log_add(
+							"membership-{$id}",
+							sprintf(
+								'Renewal received a non-advancing expiration (%s <= current %s) for membership #%d; using plan-derived expiration %s instead.',
+								$expiration,
+								$current_expiration,
+								$id,
+								$fallback
+							)
+						);
+
+						$expiration = $fallback;
+					}
+				}
+			}
 		}
 
 		/**


### PR DESCRIPTION
## Problem

On a recurring renewal, a payment gateway integration can call `Membership::renew()` with an explicit `$expiration` derived from the subscription's **next payment** date. That source date is sometimes still stale (not yet advanced) at the moment `renew()` runs, so the passed `$expiration` is **equal to or earlier than** the membership's current expiration.

`renew()` accepts the value verbatim and sets the membership to an already-due date, so it expires **immediately even though the payment just succeeded** — the customer pays and their site is suspended right after.

Real-world cases on our platform: two memberships were suspended right after a successful recurring renewal payment; the membership log showed `New Expiration` set to a past/non-advancing date.

## Fix

Defensive guard inside `renew()`: for a **recurring, non-free** membership, if the passed `$expiration` does not move the current expiration **forward**, fall back to the plan-derived expiration (`calculate_expiration()`) so a paid renewal always extends access.

- Non-recurring and free memberships are untouched.
- Explicit future dates (that *do* advance) are untouched.
- A `wu_log_add()` line records when the fallback kicks in, for traceability.

This is a small, conservative safety net at the core level. The root cause is better fixed in the gateway integration that passes the stale date (separate PR on the WooCommerce add-on), but this guard prevents the worst outcome (immediate suspension after payment) regardless of caller.

## Note

This supersedes a PR I previously opened by mistake against an old WP Ultimo v1 mirror repo; this is the same change targeted at the correct repository.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved membership renewal handling to prevent access interruptions. The system now automatically recalculates expiration dates when explicitly provided dates would not extend membership, ensuring uninterrupted service for recurring memberships.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Ultimate-Multisite/ultimate-multisite/pull/1306?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->