### PR TITLE
fix(membership): invalidate pending site meta cache

### DIFF
--- a/inc/models/class-membership.php
+++ b/inc/models/class-membership.php
@@ -2293,12 +2293,21 @@ class Membership extends Base_Model implements Limitable, Billable, Notable {
 	/**
 	 * Removes a pending site of a membership.
 	 *
+	 * Explicitly clears the membership meta cache after the delete attempt so
+	 * cross-process pending-site pollers cannot keep reading a stale
+	 * `pending_site` value from persistent object cache when the meta row was
+	 * already removed by another worker.
+	 *
 	 * @since 2.0.0
 	 * @return bool
 	 */
 	public function delete_pending_site() {
 
-		return $this->delete_meta('pending_site');
+		$result = $this->delete_meta(self::META_PENDING_SITE);
+
+		wp_cache_delete($this->get_id(), 'wu_membership_meta');
+
+		return $result;
 	}
 
 	/**

--- a/tests/WP_Ultimo/Models/Membership_Test.php
+++ b/tests/WP_Ultimo/Models/Membership_Test.php
@@ -1238,6 +1238,30 @@ class Membership_Test extends \WP_UnitTestCase {
 		$this->assertIsBool($result);
 	}
 
+	/**
+	 * Test delete_pending_site clears stale membership meta cache entries.
+	 */
+	public function test_delete_pending_site_invalidates_meta_cache(): void {
+		$membership = $this->make_membership_with_pending_meta();
+		$pending    = $membership->create_pending_site(
+			[
+				'title' => 'Pending Cache Test',
+				'path'  => '/pending-cache-test/',
+			]
+		);
+
+		get_metadata('wu_membership', $membership->get_id());
+
+		$this->assertNotFalse(wp_cache_get($membership->get_id(), 'wu_membership_meta'), 'Pre-condition: membership meta cache should be warmed.');
+
+		$this->assertTrue($membership->delete_pending_site(), 'First delete should remove the pending_site row.');
+
+		wp_cache_set($membership->get_id(), ['pending_site' => [$pending]], 'wu_membership_meta');
+
+		$this->assertFalse($membership->delete_pending_site(), 'Second delete should report no deleted row.');
+		$this->assertFalse(wp_cache_get($membership->get_id(), 'wu_membership_meta'), 'delete_pending_site() must clear stale membership meta cache even when no row is deleted.');
+	}
+
 	// ---------------------------------------------------------------
 	// to_search_results Tests
 	// ---------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Explicitly clears the `wu_membership_meta` cache group in `Membership::delete_pending_site()` after every pending-site delete attempt.
- Preserves the `delete_meta()` boolean return value while covering cross-process persistent-cache staleness when a row is already gone.
- Adds a regression test that warms membership meta, deletes the row, simulates a stale cache repopulation, and verifies a second delete still clears the cache.

## Production context

This addresses the Docket Cache-style cross-process failure mode described in #1307: the async publish worker removes `pending_site`, but the frontend poller can keep reading a stale `wu_membership_meta` entry and remain stuck on "Creating your site…" until a manual cache flush.

## Verification

- `php -l inc/models/class-membership.php && php -l tests/WP_Ultimo/Models/Membership_Test.php`
- `vendor/bin/phpcs inc/models/class-membership.php`
- `vendor/bin/phpstan analyse inc/models/class-membership.php`
- `WP_TESTS_DIR=/tmp/wordpress-tests-lib vendor/bin/phpunit --filter test_delete_pending_site_invalidates_meta_cache`
- `WP_TESTS_DIR=/tmp/wordpress-tests-lib vendor/bin/phpunit --filter Membership_Test`

Resolves #1307


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.4 plugin for [OpenCode](https://opencode.ai) v1.15.11 with gpt-5.5 spent 5m and 123,625 tokens on this as a headless worker.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Improved data reliability in membership operations by ensuring cached data is properly cleared when deleting pending site records, preventing stale information from persisting across concurrent operations.

## Tests
* Added test to verify proper cache invalidation during pending site deletion.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Ultimate-Multisite/ultimate-multisite/pull/1308?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->