### PR TITLE
fix(sso): return verify: must-redirect from unattached JSONP probe

### DIFF
--- a/inc/sso/class-sso.php
+++ b/inc/sso/class-sso.php
@@ -978,12 +978,29 @@ class SSO {
 		// Attach through redirect if the client isn't attached yet.
 		if ( ! $broker->isAttached()) {
 			/*
-			 * For JSONP requests (initiated by a <script> tag), we must NOT
-			 * redirect — the browser follows 302s transparently for script
-			 * tags, but the final response from the server will be a redirect
-			 * (not JavaScript), so the wu.sso() callback never fires.
-			 * Instead, return a JSONP error so the JS can handle it gracefully
-			 * and set the wu_sso_denied cookie to prevent further attempts.
+			 * For JSONP requests (initiated by a <script> tag) we cannot
+			 * 302 to HTML — the browser follows the redirect transparently
+			 * but the final response is HTML, not JavaScript, so the
+			 * wu.sso() callback never fires.
+			 *
+			 * Previously this branch returned `{code: 0, message: "Broker
+			 * not attached"}`, which sso.js treats as a denial and uses
+			 * to set the `wu_sso_denied` cookie for 5 minutes (see
+			 * window.wu.sso() in assets/js/sso.js, lines 101-117). The
+			 * effect was that the very first subsite front-end page-load
+			 * silently disabled auto-SSO for the next 5 minutes, even
+			 * though the user was in fact logged in on the main site and
+			 * the only reason the broker wasn't attached was that this
+			 * was the JSONP attach probe itself.
+			 *
+			 * Return `verify: must-redirect` instead so the already
+			 * present sso.js branch (assets/js/sso.js, lines 93-95)
+			 * performs a top-level navigation to
+			 * `<broker>/sso?return_url=<original_page>`. That request
+			 * re-enters handle_broker() as a regular page load (not
+			 * JSONP) and falls through to the non-JSONP redirect below,
+			 * which after #1301 reaches the cookie-less server handler
+			 * via `getAttachUrl()` and completes the SSO round-trip.
 			 */
 			if ('jsonp' === $response_type) {
 				header('Content-Type: application/javascript; charset=utf-8');
@@ -992,8 +1009,8 @@ class SSO {
 					'wu.sso(%s, %d);',
 					wp_json_encode(
 						[
-							'code'    => 0,
-							'message' => 'Broker not attached',
+							'code'   => 200,
+							'verify' => 'must-redirect',
 						]
 					),
 					200

--- a/tests/WP_Ultimo/SSO/SSO_Test.php
+++ b/tests/WP_Ultimo/SSO/SSO_Test.php
@@ -747,6 +747,64 @@ class SSO_Test extends \WP_UnitTestCase {
 	}
 
 	/**
+	 * Verify the unattached-broker JSONP payload requests a top-level
+	 * navigation via `verify: must-redirect` rather than the legacy
+	 * `code: 0, message: "Broker not attached"` denial.
+	 *
+	 * The legacy payload tripped sso.js into setting the wu_sso_denied
+	 * cookie for 5 minutes on the very first subsite front-end page-load,
+	 * which silently disabled auto-SSO before it could complete a single
+	 * round-trip. The must-redirect payload makes sso.js navigate the top
+	 * frame to <broker>/sso?return_url=..., which re-enters handle_broker
+	 * as a non-JSONP request and falls through to the redirect branch.
+	 */
+	public function test_handle_broker_source_jsonp_unattached_returns_must_redirect(): void {
+		$source = file_get_contents(
+			dirname(__DIR__, 3) . '/inc/sso/class-sso.php'
+		);
+
+		$unattached_section = '';
+
+		if (preg_match("/isAttached\(\).*?wp_safe_redirect/s", $source, $matches)) {
+			$unattached_section = $matches[0];
+		}
+
+		$this->assertNotEmpty(
+			$unattached_section,
+			'Could not locate the unattached broker section in handle_broker'
+		);
+
+		$this->assertStringContainsString(
+			"'verify' => 'must-redirect'",
+			$unattached_section,
+			'Unattached-broker JSONP response must request a top-level redirect via verify: must-redirect'
+		);
+
+		$this->assertStringNotContainsString(
+			"'message' => 'Broker not attached'",
+			$unattached_section,
+			'Unattached-broker JSONP response must NOT use the legacy denial payload that triggers wu_sso_denied on first hit'
+		);
+	}
+
+	/**
+	 * Verify sso.js still recognises the `must-redirect` verify value
+	 * and performs a top-level navigation. Without this branch the PHP
+	 * fix above would have no effect on the browser side.
+	 */
+	public function test_sso_js_handles_must_redirect_verify(): void {
+		$source = file_get_contents(
+			dirname(__DIR__, 3) . '/assets/js/sso.js'
+		);
+
+		$this->assertStringContainsString(
+			"payload.verify === 'must-redirect'",
+			$source,
+			'sso.js must keep handling the must-redirect verify value with a top-level navigation'
+		);
+	}
+
+	/**
 	 * Verify that the SSO JS does not redirect in incognito mode.
 	 * The incognito redirect caused an infinite loop:
 	 * redirect -> sso_verify=invalid -> redirect -> repeat.


### PR DESCRIPTION
## Summary

Minimal replacement for #1297. Changes a single response payload in `handle_broker()` so the JSONP unattached probe no longer trips `sso.js` into the `wu_sso_denied` denial path on the very first subsite front-end page-load.

## Bug

When a logged-in main-site user visits a subsite front-end page, `sso.js` runs the JSONP `<script src="<broker>/sso?_jsonp=1">` attach probe. On the first hit the broker is unattached (that's the point of the probe), so `handle_broker()` enters the `! $broker->isAttached()` JSONP branch and returns:

```json
{ "code": 0, "message": "Broker not attached" }
```

`sso.js` sees `code !== 200` and falls into the denial path (`window.wu.sso_denied()`), which sets `wu_sso_denied=1` for 5 minutes. After that there is no path that ever surfaces the main-site session to the broker — auto-SSO silently dies before completing a single round-trip, even though the user is in fact logged in on the main site.

## Fix

Return `verify: 'must-redirect'` instead:

```diff
-    'code'    => 0,
-    'message' => 'Broker not attached',
+    'code'   => 200,
+    'verify' => 'must-redirect',
```

`sso.js` already has the matching branch (`assets/js/sso.js:93-95`, present on `main` today):

```js
if (payload.verify === 'must-redirect') {
    window.location.replace(`${ o.server_url }?return_url=${ encodedLocation }`);
}
```

That top-level navigation re-enters `handle_broker()` as a regular page load (not JSONP) and falls through to the non-JSONP redirect via `$broker->getAttachUrl()`. After #1301 that URL (`/sso-grant`) routes correctly to `wu_sso_handle_sso_grant` and completes the cookie-less SSO round-trip.

## Why this is the whole fix now (vs #1297)

PR #1297 was opened against a codebase where two regressions overlapped: the JSONP `code: 0` denial and the broken `/sso-grant` routing. Two follow-up PRs have since merged to `main`:

- **#1301** — `fix: route sso grant attach urls` (normalises `/sso-grant` so `getAttachUrl()` works again)
- **#1302** — `fix(sso): scope redirect loop counter to SSO hops`

With those landed, the only remaining defect from #1297's premise is the JSONP denial payload above. The broader rewrite #1297 proposed (redirecting through `/sso` instead of `/sso-grant`, plus bundled wp-env Cypress fixture changes, sunrise.php glob fallback, and `sso.js` checkout-form skip) is no longer needed for this bug and is intentionally not included here. Closing #1297 in favour of this minimal change.

## Tests

Two source-code regression tests added to `tests/WP_Ultimo/SSO/SSO_Test.php`, matching the style of the existing `test_handle_broker_source_*` assertions:

- `test_handle_broker_source_jsonp_unattached_returns_must_redirect` — asserts the unattached-broker JSONP response now contains `'verify' => 'must-redirect'` and no longer contains `'message' => 'Broker not attached'`.
- `test_sso_js_handles_must_redirect_verify` — asserts `sso.js` still recognises the `must-redirect` verify value.

## Verification

```text
php -l inc/sso/class-sso.php                                                  -> No syntax errors
vendor/bin/phpcs inc/sso/class-sso.php tests/WP_Ultimo/SSO/SSO_Test.php       -> clean
vendor/bin/phpstan analyse --no-progress inc/sso/class-sso.php                -> No errors
WP_TESTS_DIR=/tmp/wordpress-tests-lib vendor/bin/phpunit --filter SSO_Test    -> 74 tests, 111 assertions, 73 pass
```

The one failing test (`test_sso_redirect_loop_counter_ignores_non_sso_requests`) fails identically on unmodified `main` (verified via `git stash` + run), so it is a pre-existing issue unrelated to this PR.

## Out of scope (and explicitly not included)

- `sso.js` `checkout_form` / `/register/` skip from #1297 — separate concern, should be its own PR with its own reproduction.
- wp-env Cypress fixture rework (`setup-sso-test.php`, `setup-checkout-form.php`, `060-sso-cross-domain.spec.js`) — those are CI environment workarounds, not part of this bug.
- `sunrise.php` dynamic plugin-dir `glob()` fallback — also CI environment scoped.

Resolves the actual auto-SSO regression #1297 was trying to address.

<!-- aidevops:sig -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved SSO authentication flow: unattached brokers now seamlessly redirect users to the attachment process instead of showing an error message.

* **Tests**
  * Added validation tests to ensure proper redirect behavior and client-side handling for broker attachment.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Ultimate-Multisite/ultimate-multisite/pull/1309?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->