### PR TITLE
feat(sso): add wu_sso_url filter

### DIFF
--- a/inc/functions/domain.php
+++ b/inc/functions/domain.php
@@ -132,7 +132,32 @@ function wu_restore_original_url($url, $blog_id) {
  */
 function wu_with_sso($url) {
 
-	return \WP_Ultimo\SSO\SSO::with_sso($url);
+	$sso_url = \WP_Ultimo\SSO\SSO::with_sso($url);
+
+	$user = wp_get_current_user();
+
+	if ( ! $user->exists()) {
+		$user = null;
+	}
+
+	$site_id = 0;
+	$host    = wp_parse_url($url, PHP_URL_HOST);
+
+	if ($host) {
+		$site_id = (int) get_blog_id_from_url($host);
+	}
+
+	/**
+	 * Filter the generated SSO URL.
+	 *
+	 * @since 2.0.0
+	 *
+	 * @param string        $sso_url     The SSO URL.
+	 * @param \WP_User|null $user        The current user, or null when unavailable.
+	 * @param int           $site_id     The target site ID.
+	 * @param string        $redirect_to The redirect URL.
+	 */
+	return apply_filters('wu_sso_url', $sso_url, $user, $site_id, '');
 }
 
 /**

--- a/tests/WP_Ultimo/Functions/Domain_Functions_Test.php
+++ b/tests/WP_Ultimo/Functions/Domain_Functions_Test.php
@@ -108,4 +108,47 @@ class Domain_Functions_Test extends WP_UnitTestCase {
 
 		$this->assertIsString($result);
 	}
+
+	/**
+	 * Test wu_with_sso returns the default SSO URL when no filter is attached.
+	 */
+	public function test_wu_with_sso_returns_default_sso_url(): void {
+
+		$url = home_url('/test-page');
+
+		$this->assertSame(\WP_Ultimo\SSO\SSO::with_sso($url), wu_with_sso($url));
+	}
+
+	/**
+	 * Test wu_with_sso exposes the SSO URL filter with context.
+	 */
+	public function test_wu_with_sso_filters_url_with_context(): void {
+
+		$user_id = self::factory()->user->create();
+		$url     = home_url('/test-page');
+		$host    = wp_parse_url($url, PHP_URL_HOST);
+
+		wp_set_current_user($user_id);
+
+		$filter = function ($sso_url, $user, $site_id, $redirect_to) use ($host) {
+
+			$this->assertInstanceOf(\WP_User::class, $user);
+			$this->assertSame(get_current_user_id(), $user->ID);
+			$this->assertSame((int) get_blog_id_from_url($host), $site_id);
+			$this->assertSame('', $redirect_to);
+
+			return $sso_url . '#test-filter-fired';
+		};
+
+		add_filter(
+			'wu_sso_url',
+			$filter,
+			10,
+			4
+		);
+
+		$this->assertSame(\WP_Ultimo\SSO\SSO::with_sso($url) . '#test-filter-fired', wu_with_sso($url));
+
+		remove_filter('wu_sso_url', $filter, 10);
+	}
 }


### PR DESCRIPTION
## Summary

- Added the `wu_sso_url` filter at the public `wu_with_sso()` helper boundary.
- Passed the filtered URL, current user/null, target site ID parsed from the URL host, and empty redirect context.
- Added domain function tests for default behavior and four-argument filter context.

## Testing

- `vendor/bin/phpcs inc/functions/domain.php tests/WP_Ultimo/Functions/Domain_Functions_Test.php`
- `WP_TESTS_DIR=/home/dave/.aidevops/.agent-workspace/sandbox/tmp/1780010953-479004/wordpress-tests-lib vendor/bin/phpunit --filter Domain_Functions_Test`

Resolves #1310

<!-- aidevops:sig -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Improved Single Sign-On (SSO) functionality to include user and site context information in URL generation.
  * SSO URLs can now be customized through available filter mechanisms.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Ultimate-Multisite/ultimate-multisite/pull/1311?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->