### PR TITLE
ci: regression guard for 5 known production bugs

### DIFF
--- a/.github/workflows/regression-guard.yml
+++ b/.github/workflows/regression-guard.yml
@@ -1,0 +1,24 @@
+# Ultimate Multisite — regression guard
+#
+# Drop this file into  .github/workflows/regression-guard.yml  in each plugin
+# repo (core / woocommerce / captcha), next to regression-guard.sh at the repo
+# root. It runs on every push and PR and fails the build if any of the guarded
+# bug-fix code paths disappears — so a new feature cannot silently reintroduce
+# one of the 5 documented production regressions.
+#
+# No SSH, no live site, no secrets. Pure grep over the repo source.
+
+name: regression-guard
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  guard:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run regression guard
+        run: bash regression-guard.sh

--- a/REGRESSION-GUARD.md
+++ b/REGRESSION-GUARD.md
@@ -1,0 +1,107 @@
+# Regression guard for Ultimate Multisite — bugs we found, fixes, and a CI guard
+
+Hi David. This is a summary of the production bugs we hit on kursopro.com with the
+three Ultimate Multisite plugins, the root cause of each, the PR that fixes it, and a
+small **CI guard** so a future release does not silently bring any of them back. Each
+bug below comes from a **real customer incident** with logs, not a guess.
+
+**Good news first:** we re-checked your `main` branches and **all five fixes are now
+present upstream.** The guard below passes green on all three repos today. The point of
+the guard is to keep it that way as you add new features.
+
+Everything here is about **your** plugins (core / woocommerce / captcha). We keep a
+one-line local patch alive only until a fix ships in a **tagged release** (a merge to
+`main` is not enough — we install the release zip, which overwrites the file and
+removes our patch). So the moment you cut a release with these, we drop our patches.
+
+---
+
+## The 5 root-cause bugs (all with real cases) — current status in `main`
+
+### 1. Captcha — form submits before the token is ready  → registration blocked
+- **Plugin:** `ultimate-multisite-captcha`
+- **File:** `assets/js/providers/cap-token-resolver.js` → `waitForToken()`
+- **Symptom:** Step 1 of the Vue registration showed *"Captcha verification is taking
+  longer than expected"* and blocked the user. Login also failed with empty token.
+- **Two chained bugs in 1.5.1:** (1) reads `widget.token` with no guard when `widget`
+  is `null` → hard crash on Step 1; (2) invisible mode waits 30s for a `<cap-widget>`
+  that the multi-step Vue form only mounts on the **payment step**, not Step 1.
+- **Fix:** guard `(widget && widget.token)`; with no widget → `resolve()` immediately.
+- **Real cases:** Lis, Ender (login), Eva (checkout).  **PR:** #130 / #134.
+- **Status in `main`:** ✅ present (v1.6.0; prod runs 1.5.3 which already carries it).
+
+### 2. WooCommerce addon — creates a 2nd subscription and cancels the active one
+- **Plugin:** `ultimate-multisite-woocommerce`
+- **File:** `inc/gateways/class-woocommerce-gateway.php` → subscription handling.
+- **Symptom:** on a $0-trial double-order / mid-trial renewal, a 2nd WCS subscription
+  is created and the **real active one is cancelled** → customer gets a false
+  "subscription cancelled" email + DB garbage. The customer never cancelled anything.
+- **Fix:** if the existing subscription is already `active`/`trialing`, cancel the
+  **duplicate**, not the active one.
+- **Real case:** Karoly.  **PR:** #94 / #96.
+- **Status in `main`:** ✅ present (`has_status(['active','trialing'])` guard).
+
+### 3. WooCommerce addon — paid renewal still suspends the site (★ most painful)
+- **Plugin:** `ultimate-multisite-woocommerce` (root) + core (defense)
+- **Symptom:** `on_order_completed` reads `subscription->next_payment` **before** WCS
+  advances it on a renewal → `renew()` gets the OLD date → membership ends up
+  on-hold/trialing with an already-past expiration → the site is suspended **even
+  though the renewal was paid**.
+- **Evidence:** `membership-428.log` → `New Expiration: 2026-05-26` (did not advance).
+- **Fix:** recalculate `next_payment` on renewal before `renew()` (addon), plus a
+  core-side defense so `renew()` rejects an expiration that does not advance.
+- **Real cases:** Elizabeth (MEM #428), Ikena (MEM #466).  **PR:** #99 (addon) + #1306 (core).
+- **Status in `main`:** ✅ both present (addon `calculate_date('next_payment')` on
+  renewal + core "non-advancing expiration" guard from #1306).
+
+### 4. Core — pending site stuck in step 2 / infinite overlay
+- **Plugin:** `ultimate-multisite`
+- **Symptom:** a blind guard `if ($is_publishing) return` left the publishing flag
+  stuck when the $0-trial double-order tripped it → site stuck / overlay never ends.
+- **Fix:** `is_publishing_stale()` so a stale flag does not block publishing
+  (defined in `inc/models/class-site.php`, wired in `class-membership-manager.php`).
+- **PR:** #1267.  **Status in `main`:** ✅ present.
+
+### 5. Core — subdomain callback not registered under wildcard DNS  → half-built site
+- **Plugin:** `ultimate-multisite`
+- **Symptom:** the `wu_add_subdomain` job FAILED ("no calls registered"). Under
+  **wildcard DNS**, with no host-provider hooked, Action Scheduler ran the job with
+  zero callbacks → noise / failed job → site creation could abort half-way (123 of 181
+  tables, missing `wp_<id>_options`/`postmeta`) → site is 200 but broken / unstyled.
+- **Fix:** `handle_site_created()` now guards the enqueue with
+  `if (has_action('wu_add_subdomain'))` — with no provider hooked it simply does not
+  enqueue. (`@since 2.12.1` in `inc/managers/class-domain-manager.php`.)
+- **Real case:** Eva (blog 347).  **Status in `main`:** ✅ present — thanks, this is
+  exactly the guard we needed. We drop our `kp-wu-subdomain-noop-callback` mu-plugin
+  once we install a release that carries it (prod is on 2.12.0).
+
+---
+
+## The CI guard — keep these 5 fixes from regressing
+
+This PR adds two files at the repo root:
+
+- **`regression-guard.sh`** — a portable, repo-only script. No SSH, no live site, no
+  secrets. It greps the source for the fixed code paths above and exits non-zero if any
+  is gone. Auto-detects core/woo/captcha, or pass it explicitly:
+  `bash regression-guard.sh [core|woo|captcha]`.
+- **`.github/workflows/regression-guard.yml`** — runs the script on every push/PR.
+
+Verified today against your `main`: **core PASS (2/2), woo PASS (2/2), captcha PASS
+(2/2).** If a future feature removes one of these paths, the PR turns red with the bug
+name + the customer case behind it, so the regression is caught before it ships.
+
+The grep anchors are intentionally on **stable** signatures (function names,
+`has_action('wu_add_subdomain')`, `has_status(['active','trialing'])`, the null-widget
+guard), not on comments or version strings, so normal refactors won't trip them.
+
+---
+
+## TL;DR for David
+- 5 real production bugs, all with customer cases and logs.
+- **All 5 are already in your `main`** (#94/#96, #99/#1306, #130/#134, #1267, and the
+  `has_action('wu_add_subdomain')` guard you added in 2.12.1). Thank you.
+- Please cut **tagged releases** carrying them — we can only drop our local patches
+  once the fix is in a release zip (we don't install `main`).
+- This PR adds a tiny CI guard (`regression-guard.sh` + a workflow) so no future
+  release silently reintroduces any of them. It passes green on `main` right now.

--- a/regression-guard.sh
+++ b/regression-guard.sh
@@ -1,0 +1,140 @@
+#!/usr/bin/env bash
+# ============================================================================
+#  Ultimate Multisite — REGRESSION GUARD (portable, repo-only)
+#  ----------------------------------------------------------------------------
+#  Run this in CI on every push / PR. It does NOT touch any live site, SSH,
+#  or external service. It only greps the source files of THIS repo to confirm
+#  that the fixes for 5 real production bugs are still present after a change.
+#
+#  If a new feature accidentally removes one of these code paths, the guard
+#  fails and the PR is blocked — so a regression cannot ship silently.
+#
+#  USAGE:
+#    bash regression-guard.sh            # auto-detect which plugin this repo is
+#    bash regression-guard.sh core       # force: core (ultimate-multisite)
+#    bash regression-guard.sh woo        # force: ultimate-multisite-woocommerce
+#    bash regression-guard.sh captcha    # force: ultimate-multisite-captcha
+#
+#  EXIT CODES:  0 = all guarded paths present   1 = a regression was detected
+#
+#  Each check maps to a documented bug (see PARA-DAVID-regression-guard.md).
+#  The grep anchors below were verified against the upstream `main` branch.
+# ============================================================================
+
+set -u
+ROOT="$(cd "$(dirname "$0")" && pwd)"
+RED='\033[0;31m'; GRN='\033[0;32m'; YEL='\033[1;33m'; NC='\033[0m'
+FAIL=0
+PASS=0
+
+ok()   { printf "  ${GRN}PASS${NC}  %s\n" "$1"; PASS=$((PASS+1)); }
+bad()  { printf "  ${RED}FAIL${NC}  %s\n" "$1"; FAIL=$((FAIL+1)); }
+skip() { printf "  ${YEL}SKIP${NC}  %s\n" "$1"; }
+
+# grep helper: returns 0 if pattern found in file (fixed-string), else 1
+has() { # has <file> <fixed-string>
+  [ -f "$ROOT/$1" ] && grep -qF -- "$2" "$ROOT/$1"
+}
+hasE() { # hasE <file> <regex>
+  [ -f "$ROOT/$1" ] && grep -qE -- "$2" "$ROOT/$1"
+}
+
+# ---- auto-detect which plugin this repo is -------------------------------
+detect() {
+  [ -n "${1:-}" ] && { echo "$1"; return; }
+  if   [ -f "$ROOT/inc/managers/class-domain-manager.php" ]; then echo core
+  elif [ -f "$ROOT/inc/gateways/class-woocommerce-gateway.php" ]; then echo woo
+  elif [ -f "$ROOT/assets/js/providers/cap-token-resolver.js" ]; then echo captcha
+  else echo unknown
+  fi
+}
+PLUGIN="$(detect "${1:-}")"
+
+echo "======================================================================"
+echo " Ultimate Multisite — regression guard   (plugin: $PLUGIN)"
+echo "======================================================================"
+
+case "$PLUGIN" in
+
+# =====================================================================  CORE
+core)
+  echo "[BUG 4] pending site stuck / infinite overlay — is_publishing_stale()"
+  if has "inc/models/class-site.php" "function is_publishing_stale" \
+     && hasE "inc/managers/class-membership-manager.php" "is_publishing_stale\(\)"; then
+    ok "is_publishing_stale() defined and wired in the pending-site checker"
+  else
+    bad "is_publishing_stale() missing or not wired -> overlay can hang again (PR #1267)"
+  fi
+
+  echo "[BUG 5] subdomain callback under wildcard DNS — half-built site"
+  # FIX: handle_site_created() must guard the enqueue with has_action('wu_add_subdomain')
+  # so that with no provider hooked the async job is NOT enqueued (no failed job).
+  if hasE "inc/managers/class-domain-manager.php" "has_action\([^)]*wu_add_subdomain"; then
+    ok "has_action('wu_add_subdomain') guard present before enqueue"
+  else
+    bad "NO has_action('wu_add_subdomain') guard -> wildcard DNS aborts site creation (Eva, blog 347)"
+  fi
+  ;;
+
+# ======================================================================  WOO
+woo)
+  GW="inc/gateways/class-woocommerce-gateway.php"
+
+  echo "[BUG 2] creates 2nd subscription & cancels the active one"
+  # FIX: if existing sub is active/trialing, cancel the DUPLICATE, not the active one.
+  if hasE "$GW" "has_status\(\s*\[\s*'active'\s*,\s*'trialing'\s*\]\s*\)"; then
+    ok "active/trialing guard present in subscription handling (cancels the duplicate)"
+  else
+    bad "active/trialing duplicate guard missing -> cancels real active sub (Karoly) (PR #94/#96)"
+  fi
+
+  echo "[BUG 3] paid renewal still suspends the site"
+  # FIX: recalculate next_payment on renewal before renew() so it is in the future.
+  if hasE "$GW" "calculate_date\(\s*'next_payment'\s*\)"; then
+    ok "next_payment recalculation present on renewal path"
+  else
+    bad "next_payment recalculation missing -> paid renewal suspends site (Elizabeth #428, Ikena #466) (PR #99/#1306)"
+  fi
+  ;;
+
+# ==================================================================  CAPTCHA
+captcha)
+  JS="assets/js/providers/cap-token-resolver.js"
+  MIN="assets/js/providers/cap-token-resolver.min.js"
+
+  echo "[BUG 1] form submits before token is ready — registration blocked on Step 1"
+  # FIX #1: guard widget null before reading .token   FIX #2: resolve() with no widget.
+  if hasE "$JS" "widget && widget\.token" && hasE "$JS" "if \(! ?widget\)"; then
+    ok "null-widget guard + immediate-resolve present in cap-token-resolver.js"
+  else
+    bad "captcha resolver guard missing in .js -> Step 1 blocks again (Lis/Ender/Eva) (PR #130/#134)"
+  fi
+
+  # The minified file must carry the same logic (it is what ships/loads).
+  if [ -f "$ROOT/$MIN" ]; then
+    if has "$MIN" "e&&e.token" || has "$MIN" "Captcha verification is taking longer than expected"; then
+      ok "minified resolver carries the guard / resolver string"
+    else
+      bad "cap-token-resolver.min.js does NOT carry the fix -> rebuild the minified asset"
+    fi
+  else
+    skip "no cap-token-resolver.min.js found (nothing to verify)"
+  fi
+  ;;
+
+unknown)
+  echo "  Could not detect which Ultimate Multisite plugin this is."
+  echo "  Run with an explicit target:  bash regression-guard.sh [core|woo|captcha]"
+  exit 2
+  ;;
+esac
+
+echo "----------------------------------------------------------------------"
+if [ "$FAIL" -eq 0 ]; then
+  printf " ${GRN}RESULT: all %d guarded path(s) present — safe.${NC}\n" "$PASS"
+  exit 0
+else
+  printf " ${RED}RESULT: %d regression(s) detected, %d ok — block this change.${NC}\n" "$FAIL" "$PASS"
+  echo " See PARA-DAVID-regression-guard.md for the bug behind each failing check."
+  exit 1
+fi


### PR DESCRIPTION
Hi David — this adds a tiny **CI regression guard** so the fixes for the 5 production bugs we hit on kursopro.com can't silently regress as features are added.

**What's in it**
- `regression-guard.sh` — portable, repo-only (no SSH, no live site, no secrets). Greps the source for the fixed code paths and exits non-zero if any is gone. Auto-detects core/woo/captcha.
- `.github/workflows/regression-guard.yml` — runs it on every push/PR.
- `REGRESSION-GUARD.md` — the 5 bugs, each with a real customer case + the PR that fixed it.

**All 5 fixes are already in your `main`** — the guard passes green today. Its only job is to keep it that way. Anchors are on stable signatures (function names, `has_action('wu_add_subdomain')`, `has_status(['active','trialing'])`, the null-widget guard), not on comments/version strings, so refactors won't trip it.

This repo's checks (core): BUG 4 `is_publishing_stale()` + BUG 5 `wu_add_subdomain` guard — both PASS.

Feel free to adjust the anchors to your liking; the goal is just a cheap safety net. Thanks for the upstream fixes 🙏

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive regression guard documentation outlining protection against known production issues.

* **Chores**
  * Added automated regression detection in CI pipeline to verify previously fixed production issues remain intact.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Ultimate-Multisite/ultimate-multisite/pull/1312?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->