### PR TITLE
fix(checkout): guard billing_zip_code v-if against undefined uses_postal_code

### DIFF
--- a/inc/checkout/signup-fields/class-signup-field-billing-address.php
+++ b/inc/checkout/signup-fields/class-signup-field-billing-address.php
@@ -349,11 +349,14 @@ class Signup_Field_Billing_Address extends Base_Signup_Field {
 			 * billing_zip_code adds an extra `uses_postal_code` gate so the
 			 * ZIP field is hidden for countries that don't use postal codes
 			 * (Hong Kong, UAE, Angola, etc. — see Country_Default's list).
+			 * Guard the symbol with `typeof` so older/minified checkout bundles
+			 * that have not registered the Vue data key yet still render the form
+			 * instead of throwing a ReferenceError.
 			 */
 			if ('billing_country' === $field_key) {
 				$field['wrapper_html_attr']['v-if'] = "(order === false || order.should_collect_payment) && !($self_billing_gateways)";
 			} elseif ('billing_zip_code' === $field_key) {
-				$field['wrapper_html_attr']['v-if'] = "(order === false || order.should_collect_payment) && !($self_billing_gateways) && uses_postal_code";
+				$field['wrapper_html_attr']['v-if'] = "(order === false || order.should_collect_payment) && !($self_billing_gateways) && (typeof uses_postal_code === 'undefined' || uses_postal_code)";
 			} elseif ($zip_only) {
 				// Other fields in zip_only mode share the same gateway exclusion.
 				$field['wrapper_html_attr']['v-if'] = "!($self_billing_gateways)";

--- a/tests/WP_Ultimo/Checkout/Signup_Fields/Signup_Field_Billing_Address_Test.php
+++ b/tests/WP_Ultimo/Checkout/Signup_Fields/Signup_Field_Billing_Address_Test.php
@@ -252,6 +252,25 @@ class Signup_Field_Billing_Address_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Regression guard: the ZIP field visibility expression must not throw when
+	 * older/minified checkout assets render before the Vue `uses_postal_code`
+	 * data key is available.
+	 */
+	public function test_zip_visibility_guards_uses_postal_code_symbol(): void {
+		$fields = $this->field->to_fields_array(
+			array(
+				'id'              => 'billing_address',
+				'zip_and_country' => true,
+				'element_classes' => '',
+			)
+		);
+
+		$this->assertArrayHasKey( 'billing_zip_code', $fields );
+		$this->assertArrayHasKey( 'v-if', $fields['billing_zip_code']['wrapper_html_attr'] );
+		$this->assertStringContainsString( "typeof uses_postal_code === 'undefined'", $fields['billing_zip_code']['wrapper_html_attr']['v-if'] );
+	}
+
+	/**
 	 * Test build_select_alternative sets v-if on base_field.
 	 */
 	public function test_build_select_alternative_sets_v_if_on_base_field(): void {


### PR DESCRIPTION
## Summary

The `billing_zip_code` checkout field's Vue `v-if` expression references `uses_postal_code` without a guard. When older or minified checkout bundles render before the Vue data key has been registered, the expression throws a `ReferenceError` and the entire checkout form fails to render.

This change wraps the symbol with `typeof X === 'undefined'` so the form falls back to showing the ZIP field instead of crashing.

## The bug

`inc/checkout/signup-fields/class-signup-field-billing-address.php:355` (before):

```php
$field['wrapper_html_attr']['v-if'] = "(order === false || order.should_collect_payment) && !($self_billing_gateways) && uses_postal_code";
```

If the Vue instance attempts to evaluate this expression before `uses_postal_code` has been registered as a data key, Vue throws `ReferenceError: uses_postal_code is not defined` and the surrounding `<div v-if>` collapses — taking the entire billing block with it on some renderings.

## The fix

```php
$field['wrapper_html_attr']['v-if'] = "(order === false || order.should_collect_payment) && !($self_billing_gateways) && (typeof uses_postal_code === 'undefined' || uses_postal_code)";
```

Defaulting to **visible** when the symbol is undefined is the safe choice:

- The ZIP field still validates and submits correctly.
- The symbol becomes defined on subsequent re-renders (data registration is eventual).
- Countries that genuinely don't use postal codes (Hong Kong, UAE, Angola — see `Country_Default`) hide the field once `uses_postal_code` is defined and falsy, so the previous behaviour is preserved in steady state.

The alternative — defaulting to **hidden** when undefined — would prevent users from filling in the ZIP at all on the first render, which is a worse failure mode than showing a field that may not strictly be required.

## Test

Adds `test_zip_visibility_guards_uses_postal_code_symbol` to `tests/WP_Ultimo/Checkout/Signup_Fields/Signup_Field_Billing_Address_Test.php`:

```php
public function test_zip_visibility_guards_uses_postal_code_symbol(): void {
    $fields = $this->field->to_fields_array(
        array(
            'id'              => 'billing_address',
            'zip_and_country' => true,
            'element_classes' => '',
        )
    );

    $this->assertArrayHasKey( 'billing_zip_code', $fields );
    $this->assertArrayHasKey( 'v-if', $fields['billing_zip_code']['wrapper_html_attr'] );
    $this->assertStringContainsString( "typeof uses_postal_code === 'undefined'", $fields['billing_zip_code']['wrapper_html_attr']['v-if'] );
}
```

This asserts the guard is present in the generated wrapper attribute so future refactors don't quietly drop it.

## Verification

- `vendor/bin/phpcs --standard=.phpcs.xml.dist <both files>` → clean (0 errors, 0 warnings).
- `vendor/bin/phpstan analyse <both files>` → clean (No errors).
- `vendor/bin/phpunit --filter test_zip_visibility_guards_uses_postal_code_symbol …` → `OK (1 test, 3 assertions)`.

## Scope

Pure defensive guard against a JS runtime error. No behaviour change in steady state. No new dependencies, no schema change, no migration.

Files touched:

- `inc/checkout/signup-fields/class-signup-field-billing-address.php` — 1 line changed (the v-if string), 3 lines added (docblock explanation).
- `tests/WP_Ultimo/Checkout/Signup_Fields/Signup_Field_Billing_Address_Test.php` — 1 new test method (19 lines including docblock and arrange/act/assert).

Total: +23 / −1.

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.5 plugin for [OpenCode](https://opencode.ai) v1.15.12 with claude-opus-4-7 spent 1d 13h and 655,199 tokens on this with the user in an interactive session.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# Release Notes

* **Bug Fixes**
  * Enhanced stability of the billing zip code field in checkout by adding protective guards to the visibility logic, ensuring compatibility with older or minified checkout bundles and preventing potential rendering errors.

* **Tests**
  * Added regression test to verify the billing zip code field visibility guard functions correctly across different bundle versions and configurations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Ultimate-Multisite/ultimate-multisite/pull/1318?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->