### PR TITLE
test(e2e): restore manual checkout flow

### DIFF
--- a/tests/e2e/cypress/fixtures/setup-product.php
+++ b/tests/e2e/cypress/fixtures/setup-product.php
@@ -8,6 +8,8 @@ $product->set_slug('test-plan');
 $product->set_amount(29.99);
 $product->set_duration(1);
 $product->set_duration_unit('month');
+$product->set_recurring(false);
+$product->set_pricing_type('paid');
 $product->set_type('plan');
 $product->set_active(true);
 $product->save();

--- a/tests/e2e/cypress/integration/010-manual-checkout-flow.spec.js
+++ b/tests/e2e/cypress/integration/010-manual-checkout-flow.spec.js
@@ -26,7 +26,7 @@ describe("Manual Gateway Checkout Flow", () => {
 		cy.get('#wrapper-field-pricing_table label[id^="wu-product-"]', {
 			timeout: 15000,
 		})
-			.first()
+			.contains("Test Plan")
 			.click();
 
 		cy.wait(3000);


### PR DESCRIPTION
## Summary

- Make the shared e2e `Test Plan` fixture explicitly one-time and paid so the manual gateway is available.
- Pin the manual checkout spec to `Test Plan` by label instead of selecting the first rendered plan.

Resolves #1317

## Testing

- `php -l tests/e2e/cypress/fixtures/setup-product.php`
- `vendor/bin/phpcs tests/e2e/cypress/fixtures/setup-product.php`
- `npx cypress run --config-file cypress.config.test.js --spec "tests/e2e/cypress/integration/010-manual-checkout-flow.spec.js" --browser chrome` — local Chrome failed to open CDP before executing the spec (`ECONNREFUSED 127.0.0.1`).
- `npx cypress run --config-file cypress.config.test.js --spec "tests/e2e/cypress/integration/010-manual-checkout-flow.spec.js" --browser electron` — local wp-env worktree plugin path mismatch prevented hard-coded fixture eval; CI checkout path should be `ultimate-multisite`.
- `npm run lint:js` — fails on pre-existing `assets/js` lint violations outside this change.


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.5 plugin for [OpenCode](https://opencode.ai) v1.15.12 with gpt-5.5 spent 20m and 125,541 tokens on this as a headless worker.
