### PR TITLE
fix(e2e): restore manual gateway before checkout spec

### DIFF
--- a/tests/e2e/cypress/integration/010-manual-checkout-flow.spec.js
+++ b/tests/e2e/cypress/integration/010-manual-checkout-flow.spec.js
@@ -10,6 +10,14 @@ describe("Manual Gateway Checkout Flow", () => {
 		path: `manualsite${timestamp}`,
 	};
 
+	before(() => {
+		// The setup wizard/regression specs run before checkout specs in CI and can
+		// rewrite gateway settings. Re-enable manual immediately before this flow.
+		cy.wpCliFile("tests/e2e/cypress/fixtures/setup-gateway.php").then((result) => {
+			expect(result.stdout).to.contain("gateway:manual");
+		});
+	});
+
 	it("Should complete the UM checkout form with manual gateway", {
 		retries: 0,
 	}, () => {


### PR DESCRIPTION
## Summary

- Re-enable the manual gateway immediately before `010-manual-checkout-flow.spec.js` runs.
- This is a follow-up to #1319 / #1317: CI showed the fixture change landed, but the checkout spec still saw the original no-payment symptom after prior setup wizard/regression steps ran.
- The setup wizard can rewrite gateway settings after `000-setup.spec.js`, so the manual checkout spec now restores its own gateway dependency before visiting `/register`.

For #1317

## Testing

- PR #1319 CI before this follow-up: PHP lint, code quality, build, PHP 8.2/8.3/8.4/8.5 passed; Cypress failed with the original `status=done` timeout / `no-payments` symptom.
- `php -l tests/e2e/cypress/fixtures/setup-product.php`
- `vendor/bin/phpcs tests/e2e/cypress/fixtures/setup-product.php`
- Focused local Cypress chrome attempted; local Chrome CDP failed before spec execution.
- Focused local Cypress electron attempted; local worktree wp-env plugin path mismatch prevented hard-coded fixture eval, while CI checkout path is expected to match `ultimate-multisite`.


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.5 plugin for [OpenCode](https://opencode.ai) v1.15.12 with gpt-5.5 spent 35m and 219,201 tokens on this as a headless worker.
