### PR TITLE
perf(checkout): register loopback fast-path on wp_ajax_nopriv so site creation does not always fall back to Action Scheduler

### DIFF
--- a/inc/managers/class-membership-manager.php
+++ b/inc/managers/class-membership-manager.php
@@ -89,9 +89,22 @@ class Membership_Manager extends Base_Manager {
 		add_action('wu_async_membership_swap', [$this, 'async_membership_swap'], 10);
 
 		/*
-		 * Deal with pending sites creation
+		 * Deal with pending sites creation.
+		 *
+		 * `publish_pending_site` is also registered on the nopriv hook
+		 * because the loopback fast-path called by
+		 * Membership::publish_pending_site_async() uses
+		 * wp_remote_request() — which does not forward auth cookies, so
+		 * admin-ajax.php dispatches `wp_ajax_nopriv_wu_publish_pending_site`.
+		 * Without a nopriv listener the dispatch falls through to
+		 * `wp_die('0')` and admin-ajax returns HTTP 400 on every loopback,
+		 * forcing the slower Action Scheduler fallback for every site
+		 * creation. Security on the nopriv path is enforced by the HMAC
+		 * token verified in publish_pending_site(); the admin-modal
+		 * (logged-in) path keeps the nonce check.
 		 */
 		add_action('wp_ajax_wu_publish_pending_site', [$this, 'publish_pending_site']);
+		add_action('wp_ajax_nopriv_wu_publish_pending_site', [$this, 'publish_pending_site']);
 
 		add_action('wp_ajax_wu_check_pending_site_created', [$this, 'check_pending_site_created']);
 

--- a/tests/WP_Ultimo/Managers/Membership_Manager_Test.php
+++ b/tests/WP_Ultimo/Managers/Membership_Manager_Test.php
@@ -1031,6 +1031,43 @@ class Membership_Manager_Test extends \WP_UnitTestCase {
 	}
 
 	/**
+	 * Regression guard for the loopback fast-path 400 perf bug.
+	 *
+	 * Membership::publish_pending_site_async() fires a loopback
+	 * wp_remote_request() against admin-ajax.php to start the site
+	 * publish without waiting for Action Scheduler. That request has no
+	 * auth cookies, so admin-ajax dispatches the *nopriv* action.
+	 *
+	 * If `wp_ajax_nopriv_wu_publish_pending_site` has no listener the
+	 * dispatcher falls through to `wp_die("0")` -> HTTP 400, the
+	 * loopback is logged as "Loopback fast-path returned HTTP 400 -
+	 * falling back to Action Scheduler", and the visible site-creation
+	 * delay balloons from seconds to tens of seconds. (Observed on
+	 * production for every site creation prior to this fix; see the
+	 * production wu-logs/membership-*.log entries.)
+	 *
+	 * Security on the nopriv path is enforced by the HMAC token
+	 * validated inside publish_pending_site() -- the nonce path stays
+	 * available for the logged-in admin modal flow.
+	 *
+	 * @since 2.5.x
+	 */
+	public function test_init_registers_loopback_nopriv_handler_for_publish_pending_site(): void {
+
+		$manager = $this->get_manager_instance();
+
+		$this->assertIsInt(
+			has_action('wp_ajax_wu_publish_pending_site', [$manager, 'publish_pending_site']),
+			'wp_ajax_wu_publish_pending_site must be registered for the logged-in admin modal flow.'
+		);
+
+		$this->assertIsInt(
+			has_action('wp_ajax_nopriv_wu_publish_pending_site', [$manager, 'publish_pending_site']),
+			'wp_ajax_nopriv_wu_publish_pending_site must be registered so the unauthenticated HMAC-gated loopback fast-path from publish_pending_site_async() does not return HTTP 400 and fall back to Action Scheduler.'
+		);
+	}
+
+	/**
 	 * Test that the method bails gracefully when wc_get_order() returns false
 	 * (i.e. the order does not exist).
 	 *


### PR DESCRIPTION
## Summary

The loopback fast-path that
`Membership::publish_pending_site_async()` uses to start
per-membership site creation without waiting for the next Action
Scheduler tick has been broken in production: every call returns
HTTP 400 and falls back to the slow Action Scheduler path.

Root cause: `Membership_Manager::register_hooks()` registered the
publish handler only on `wp_ajax_wu_publish_pending_site` (logged-in
admin modal). The loopback `wp_remote_request()` does not forward
auth cookies, so admin-ajax dispatches the *nopriv* action — which
had no listener — and falls through to `wp_die('0')` → HTTP 400.

## Evidence (production)

Every recent membership log on this production install shows the
same `Loopback fast-path returned HTTP 400 — falling back to Action
Scheduler` message, on four consecutive recent signups:

```text
$ tail wu-logs/membership-{61..64}.log
[2026-05-29 22:41:27] [INFO] Loopback fast-path returned HTTP 400 — falling back to Action Scheduler.
[2026-05-29 22:40:44] [INFO] Loopback fast-path returned HTTP 400 — falling back to Action Scheduler.
[2026-05-29 22:38:23] [INFO] Loopback fast-path returned HTTP 400 — falling back to Action Scheduler.
[2026-05-29 02:05:54] [INFO] Loopback fast-path returned HTTP 400 — falling back to Action Scheduler.
```

Reproduced directly from a WP-CLI eval that builds a valid HMAC
token against `wp_salt('auth')` and posts to the same endpoint
`publish_pending_site_async()` posts to:

```bash
wp eval '
  $mid = 64;
  $exp = time() + 60;
  $tok = hash_hmac("sha256", $mid . "|" . $exp, wp_salt("auth"));
  $r   = wp_remote_request(
    admin_url("admin-ajax.php")
      . "?action=wu_publish_pending_site&membership_id=$mid&wu_token=$tok&wu_expires=$exp",
    ["timeout" => 10, "sslverify" => false]
  );
  echo wp_remote_retrieve_response_code($r) . "\n";
  echo wp_remote_retrieve_body($r);
'
# Before this PR: 400 (body: "0")
# After this PR:  200 (body: {"status":"creating-site"})
```

## Impact

Without the loopback fast-path, site creation waits for the next
Action Scheduler tick. Action Scheduler is driven by wp-cron, which
the thank-you page polls and re-kicks `/wp-cron.php` only every
~3 polls. So in production the visible "Creating your site…"
overlay lasts roughly **5–20 seconds longer than necessary** — every
single signup. (Subsequent steps like the sovereign install or
template duplication add their own time; this PR removes the
needless queueing delay before those steps even start.)

The HMAC fast-path was specifically introduced to skip the cron
delay. It has been silently broken since it landed because the hook
registration assumed admin-ajax would dispatch the logged-in handler
for a loopback request.

## Fix

Register the same `publish_pending_site` handler on
`wp_ajax_nopriv_wu_publish_pending_site` as well. Security on the
nopriv path is enforced by the HMAC token verified inside
`publish_pending_site()` (lines 117–131 of
`inc/managers/class-membership-manager.php`):

```php
if ($wu_token && $wu_expires) {
    $membership_id = wu_request('membership_id');
    $expires       = (int) $wu_expires;

    if ($expires < time()) {
        wp_die('0', 400);
    }

    $expected_token = hash_hmac('sha256', $membership_id . '|' . $expires, wp_salt('auth'));
    if (! hash_equals($expected_token, $wu_token)) {
        wp_die('0', 400);
    }
} else {
    // Fall back to nonce check for admin modal / manual flow.
    check_ajax_referer('wu_publish_pending_site');
    $membership_id = wu_request('membership_id');
}
```

The logged-in admin-modal path still goes through the priv hook +
nonce check, unchanged. The token TTL is 60s and HMAC-bound to
`wp_salt('auth')` and the membership ID, so the nopriv path cannot
be replayed, forged, or used to publish a different membership.

## Regression test

`tests/WP_Ultimo/Managers/Membership_Manager_Test.php` —
`test_init_registers_loopback_nopriv_handler_for_publish_pending_site()`

Asserts that **both** `wp_ajax_wu_publish_pending_site` and
`wp_ajax_nopriv_wu_publish_pending_site` are registered on the
manager after `init()`, matching the existing
`test_init_registers_wc_order_completion_hook()` pattern in this
file.

```text
$ vendor/bin/phpunit \
    --filter test_init_registers_loopback_nopriv_handler \
    tests/WP_Ultimo/Managers/Membership_Manager_Test.php --no-coverage
OK (1 test, 2 assertions)

$ vendor/bin/phpcs inc/managers/class-membership-manager.php
(no new violations introduced)

$ vendor/bin/phpstan analyse inc/managers/class-membership-manager.php --memory-limit=1G
[OK] No errors
```

## Notes for reviewers

- This is a one-line behavioural change plus the regression test —
  the rest of the manager file diff is just an explanatory comment
  block above the hook registrations explaining *why* both hooks
  must be present.
- I considered registering `check_pending_site_created` on nopriv
  too (it's polled from the thank-you page, which may load before
  the signup customer is logged in), but did not include it in this
  PR — that's a separate behavioural question and PR scope is kept
  to the proven 400-on-every-signup fast-path bug. Happy to add it
  in this PR or a follow-up if you'd prefer.


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.5 plugin for [OpenCode](https://opencode.ai) v1.15.12 with claude-opus-4-7 spent 1d 16h and 819,853 tokens on this with the user in an interactive session.
