### PR TITLE
fix(signup): generic email prefixes create ugly usernames in non-English locales (e.g. contacto@ -> 'contacto')

### DIFF
--- a/inc/functions/customer.php
+++ b/inc/functions/customer.php
@@ -461,15 +461,56 @@ function wu_username_from_email($email, $new_user_args = [], $suffix = '') {
 		$email_username = $email_parts[0];
 
 		$common_emails = [
+			// English.
 			'sales',
 			'hello',
 			'mail',
 			'contact',
 			'info',
+			'support',
+			'admin',
+			'office',
+			'help',
+			'noreply',
+			'no-reply',
+			'team',
+			// Spanish.
+			'ventas',
+			'hola',
+			'correo',
+			'contacto',
+			'soporte',
+			'administracion',
+			'oficina',
+			'ayuda',
+			'equipo',
+			// Portuguese.
+			'vendas',
+			'ola',
+			'contato',
+			'suporte',
+			'ajuda',
+			// French / German / Italian common ones.
+			'bonjour',
+			'kontakt',
+			'vertrieb',
+			'vendite',
 		];
 
-		// Exclude common prefixes.
-		if (in_array($email_username, $common_emails, true)) {
+		/**
+		 * Filter the list of generic mailbox prefixes that should NOT be used as a
+		 * username (e.g. contacto@, info@, ventas@). When the email's local part is
+		 * one of these, the site domain is used instead so the customer does not end
+		 * up with a username like "contacto".
+		 *
+		 * @since 3.7.0
+		 * @param array  $common_emails Generic mailbox prefixes (lowercased).
+		 * @param string $email         The customer email address.
+		 */
+		$common_emails = (array) apply_filters('wu_username_generic_email_prefixes', $common_emails, $email);
+
+		// Exclude common prefixes (case-insensitive: "Contacto", "INFO" also match).
+		if (in_array(strtolower($email_username), array_map('strtolower', $common_emails), true)) {
 
 			// Get the domain part, minus the dot.
 			$email_username = strtok($email_parts[1], '.');


### PR DESCRIPTION
## Problem

When a customer signs up without a first/last name available to the signup flow, `wu_username_from_email()` falls back to the email's local part. There's a blacklist of generic mailbox prefixes that, when matched, uses the site domain instead of the local part — so `info@acme.com` becomes `acme` and not `info`.

The problem: that blacklist is **English-only** (`sales`, `hello`, `mail`, `contact`, `info`).

A non-English customer using a generic mailbox — very common in LATAM/Spain (`contacto@`, `ventas@`, `soporte@`) or Brazil (`contato@`) — slips past the blacklist and ends up with a username (and matching `display_name`) like **`contacto`**. That shows up in the "Password changed" notification, the dashboard greeting, course author, etc. — looks unprofessional.

Real case: a customer registered with `contacto@theirdomain.com` and their account/username became `contacto`.

## Fix

`inc/functions/customer.php` → `wu_username_from_email()`:

- Extend the generic-prefix blacklist with common **ES / PT / FR / DE / IT** mailbox prefixes (`contacto`, `ventas`, `soporte`, `hola`, `contato`, `suporte`, `kontakt`, `admin`, `support`, `office`, `team`, `noreply`, …).
- Make the match **case-insensitive** (`Contacto`, `INFO` also match now).
- Add a `wu_username_generic_email_prefixes` filter so integrators can extend the list without patching core.

```php
$common_emails = (array) apply_filters('wu_username_generic_email_prefixes', $common_emails, $email);
if (in_array(strtolower($email_username), array_map('strtolower', $common_emails), true)) {
    $email_username = strtok($email_parts[1], '.'); // use the domain instead
}
```

## Scope / safety

- **Only** affects the email-fallback path. If a name is provided, nothing changes.
- No DB migration, no change to existing users.
- +43 / −2 lines, `php -l` clean.

## Note (out of scope, for awareness)

The deeper reason the fallback triggers at all is that the default checkout's "user" step often has no first/last name field before the user is created (name comes later in billing), so `wu_username_from_email()` rarely receives a name and almost always hits the email fallback. That's a separate UX/flow consideration; this PR just makes the existing fallback behave well for non-English generic mailboxes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Username generation from email addresses now excludes a more comprehensive list of generic mailbox prefixes, including language variants across English, Spanish, Portuguese, and beyond.
  * Introduced a customization filter to modify the list of excluded email prefixes as needed.
  * Enhanced prefix detection with case-insensitive matching to ensure all variants are properly recognized.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Ultimate-Multisite/ultimate-multisite/pull/1328?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->