### PR TITLE
fix(sunrise): ignore duplicate main plugin addon candidates

### DIFF
--- a/inc/class-sunrise.php
+++ b/inc/class-sunrise.php
@@ -240,12 +240,62 @@ class Sunrise {
 			return;
 		}
 
+		$candidates = self::filter_addon_sunrise_candidates($candidates);
+
+		if ( empty( $candidates ) ) {
+			return;
+		}
+
 		sort( $candidates ); // Alphabetical order for determinism.
 
 		foreach ( $candidates as $addon_sunrise ) {
 			// phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.include_include
 			include_once $addon_sunrise;
 		}
+	}
+
+	/**
+	 * Filter addon sunrise candidates to exclude duplicate main plugin copies.
+	 *
+	 * WordPress can leave duplicate upload directories such as
+	 * ultimate-multisite-1-1 in wp-content/plugins. Those directories match the
+	 * addon sunrise glob but are complete copies of the main plugin, so including
+	 * their sunrise.php redeclares functions already loaded from wp-content/sunrise.php.
+	 * Legitimate addons do not ship the main plugin bootstrap file.
+	 *
+	 * @since 2.5.2
+	 *
+	 * @param array $candidates Absolute paths to candidate sunrise.php files.
+	 * @return array
+	 */
+	protected static function filter_addon_sunrise_candidates($candidates) {
+
+		$filtered = [];
+
+		foreach ( $candidates as $candidate ) {
+			if ( self::is_duplicate_main_plugin_sunrise($candidate) ) {
+				continue;
+			}
+
+			$filtered[] = $candidate;
+		}
+
+		return $filtered;
+	}
+
+	/**
+	 * Check if a sunrise candidate belongs to a duplicate main plugin directory.
+	 *
+	 * @since 2.5.2
+	 *
+	 * @param string $candidate Absolute path to a candidate sunrise.php file.
+	 * @return bool
+	 */
+	protected static function is_duplicate_main_plugin_sunrise($candidate) {
+
+		$plugin_dir = dirname($candidate);
+
+		return file_exists($plugin_dir . '/ultimate-multisite.php');
 	}
 
 	/**

--- a/tests/WP_Ultimo/Sunrise_Test.php
+++ b/tests/WP_Ultimo/Sunrise_Test.php
@@ -201,6 +201,78 @@ class Sunrise_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Test addon sunrise filtering excludes duplicate main plugin directories.
+	 */
+	public function test_filter_addon_sunrise_candidates_excludes_duplicate_main_plugin_directories() {
+		$plugins_dir = sys_get_temp_dir() . '/wu-sunrise-test-' . uniqid('', true);
+
+		$duplicate_dir = $plugins_dir . '/ultimate-multisite-1-1';
+		$addon_dir     = $plugins_dir . '/ultimate-multisite-woocommerce';
+
+		wp_mkdir_p($duplicate_dir);
+		wp_mkdir_p($addon_dir);
+
+		$duplicate_sunrise = $duplicate_dir . '/sunrise.php';
+		$addon_sunrise     = $addon_dir . '/sunrise.php';
+
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents -- Test fixture setup.
+		file_put_contents($duplicate_sunrise, '<?php // duplicate main sunrise.');
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents -- Test fixture setup.
+		file_put_contents($duplicate_dir . '/ultimate-multisite.php', '<?php // duplicate main bootstrap.');
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents -- Test fixture setup.
+		file_put_contents($addon_sunrise, '<?php // addon sunrise.');
+
+		$reflection = new \ReflectionClass(Sunrise::class);
+		$method     = $reflection->getMethod('filter_addon_sunrise_candidates');
+
+		// Only call setAccessible() on PHP < 8.1 where it's needed
+		if (PHP_VERSION_ID < 80100) {
+			$method->setAccessible(true);
+		}
+
+		try {
+			$result = $method->invoke(null, [$duplicate_sunrise, $addon_sunrise]);
+
+			$this->assertSame([$addon_sunrise], $result);
+		} finally {
+			$this->remove_test_directory($plugins_dir);
+		}
+	}
+
+	/**
+	 * Remove a temporary test directory recursively.
+	 *
+	 * @param string $dir Directory path.
+	 */
+	private function remove_test_directory($dir) {
+
+		if ( ! is_dir($dir) ) {
+			return;
+		}
+
+		$items = scandir($dir);
+
+		foreach ( $items as $item ) {
+			if ('.' === $item || '..' === $item) {
+				continue;
+			}
+
+			$path = $dir . '/' . $item;
+
+			if ( is_dir($path) ) {
+				$this->remove_test_directory($path);
+				continue;
+			}
+
+			// phpcs:ignore WordPress.WP.AlternativeFunctions.unlink_unlink -- Test fixture cleanup.
+			unlink($path);
+		}
+
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_rmdir -- Test fixture cleanup.
+		rmdir($dir);
+	}
+
+	/**
 	 * Test manage_sunrise_updates method doesn't throw fatal errors.
 	 */
 	public function test_manage_sunrise_updates_no_fatal_errors() {


### PR DESCRIPTION
## Summary

- Filter addon sunrise candidates to skip duplicate main plugin directories that contain `ultimate-multisite.php`.
- Preserve legitimate addon sunrise loading for directories such as `ultimate-multisite-woocommerce`.
- Add a focused `Sunrise_Test` regression for duplicate-main exclusion and addon inclusion.

## Testing

- `vendor/bin/phpcs inc/class-sunrise.php tests/WP_Ultimo/Sunrise_Test.php`
- `WP_TESTS_DIR=/tmp/wordpress-tests-lib vendor/bin/phpunit --filter Sunrise_Test`

Resolves #1333

<!-- MERGE_SUMMARY
summary: Filtered sunrise addon candidates so duplicate main plugin upload folders are not included while legitimate addon sunrise files still load.
testing: vendor/bin/phpcs inc/class-sunrise.php tests/WP_Ultimo/Sunrise_Test.php; WP_TESTS_DIR=/tmp/wordpress-tests-lib vendor/bin/phpunit --filter Sunrise_Test
-->

<!-- aidevops:sig -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved an issue where duplicate addon bootstrap files were being loaded in multisite environments, which could cause conflicts and unexpected behavior. The system now properly identifies and excludes duplicate addon files from initialization.

* **Tests**
  * Added test coverage to validate duplicate addon file exclusion works correctly in multisite configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->