### PR TITLE
fix(checkout): harden step validation scoping

### DIFF
--- a/assets/js/checkout.js
+++ b/assets/js/checkout.js
@@ -617,12 +617,27 @@
 					 * username, password on step 4) from blocking submission of
 					 * earlier steps that do not include those fields.
 					 *
-					 * Falls back to all rules when step_fields is unavailable
-					 * (legacy single-step forms).
+					 * Falls back to the rendered form fields when step_fields is
+					 * unavailable or stale. This keeps multi-step guest checkouts from
+					 * validating account fields that were already submitted on a prior
+					 * step and are no longer present in the DOM.
 					 */
 					const stepFields = (typeof wu_checkout !== 'undefined' && wu_checkout.step_fields) ? wu_checkout.step_fields : null;
 					const currentStep = jQuery('input[name="checkout_step"]').val();
+					const renderedFields = [];
 					let rules = allRules;
+
+					jQuery('#wu_form').serializeArray().forEach(function (field) {
+
+						const fieldName = field.name.replace(/\[\]$/, '');
+
+						if (allRules[ fieldName ] && renderedFields.indexOf(fieldName) === -1) {
+
+							renderedFields.push(fieldName);
+
+						}
+
+					});
 
 					if (stepFields && currentStep && stepFields[ currentStep ]) {
 
@@ -630,13 +645,23 @@
 
 						rules = {};
 
-						allowedFields.forEach(function(fieldId) {
+						allowedFields.forEach(function (fieldId) {
 
 							if (allRules[ fieldId ]) {
 
 								rules[ fieldId ] = allRules[ fieldId ];
 
 							}
+
+						});
+
+					} else if (currentStep && renderedFields.length) {
+
+						rules = {};
+
+						renderedFields.forEach(function (fieldId) {
+
+							rules[ fieldId ] = allRules[ fieldId ];
 
 						});
 

--- a/inc/checkout/class-checkout.php
+++ b/inc/checkout/class-checkout.php
@@ -2324,9 +2324,23 @@ class Checkout {
 		if ($this->checkout_form) {
 			foreach ($this->checkout_form->get_steps_to_show() as $step) {
 				if ( ! empty($step['id']) && ! empty($step['fields'])) {
-					$step_fields[ $step['id'] ] = array_values(
-						array_filter(array_column($step['fields'], 'id'))
-					);
+					$field_ids = [];
+
+					foreach ($step['fields'] as $field) {
+						if ( ! empty($field['id'])) {
+							$field_ids[] = $field['id'];
+						}
+
+						if ('template_selection' === wu_get_isset($field, 'type')) {
+							$field_ids[] = 'template_id';
+						}
+
+						if ('pricing_table' === wu_get_isset($field, 'type')) {
+							$field_ids[] = 'products';
+						}
+					}
+
+					$step_fields[ $step['id'] ] = array_values(array_unique(array_filter($field_ids)));
 				}
 			}
 		}

--- a/tests/unit/Checkout_Step_Fields_Test.php
+++ b/tests/unit/Checkout_Step_Fields_Test.php
@@ -42,9 +42,42 @@ final class Checkout_Step_Fields_Test extends TestCase {
 								'name' => 'E-mail Address',
 								'type' => 'email',
 							],
+							[
+								'id'   => 'account_submit',
+								'name' => 'Next Step',
+								'type' => 'submit_button',
+							],
 						],
 					],
-					// Step 2: payment data only (must NOT leak into step 1).
+					// Step 2: template data only (must NOT re-demand account data).
+					[
+						'id'     => 'site',
+						'name'   => 'Site',
+						'logged' => 'always',
+						'fields' => [
+							[
+								'id'   => 'site_title',
+								'name' => 'Site Title',
+								'type' => 'site_title',
+							],
+							[
+								'id'   => 'site_url',
+								'name' => 'Site URL',
+								'type' => 'site_url',
+							],
+							[
+								'id'   => 'template_selection',
+								'name' => 'Templates',
+								'type' => 'template_selection',
+							],
+							[
+								'id'   => 'site_submit',
+								'name' => 'Next Step',
+								'type' => 'submit_button',
+							],
+						],
+					],
+					// Step 3: payment data only (must NOT leak into step 1).
 					[
 						'id'     => 'payment',
 						'name'   => 'Payment',
@@ -60,6 +93,16 @@ final class Checkout_Step_Fields_Test extends TestCase {
 								'name' => 'Payment',
 								'type' => 'payment',
 							],
+							[
+								'id'   => 'order_summary',
+								'name' => 'Order Summary',
+								'type' => 'order_summary',
+							],
+							[
+								'id'   => 'submit',
+								'name' => 'Submit',
+								'type' => 'submit_button',
+							],
 						],
 					],
 				],
@@ -69,12 +112,12 @@ final class Checkout_Step_Fields_Test extends TestCase {
 		$this->assertNotInstanceOf(
 			\WP_Error::class,
 			$form,
-			'Failed to seed the checkout form fixture: ' . ( is_wp_error($form) ? $form->get_error_message() : '' )
+			'Failed to seed the checkout form fixture: ' . (is_wp_error($form) ? $form->get_error_message() : '')
 		);
 
-		$checkout = new \WP_Ultimo\Checkout\Checkout();
+		$checkout = \WP_Ultimo\Checkout\Checkout::get_instance();
 
-		// Inject the seeded form into the real checkout instance (public prop).
+		// Inject the seeded form into the real checkout singleton (public prop).
 		$checkout->checkout_form = $form;
 
 		$vars = $checkout->get_checkout_variables();
@@ -103,9 +146,11 @@ final class Checkout_Step_Fields_Test extends TestCase {
 		$step_fields = $this->build_step_fields_map();
 
 		$this->assertArrayHasKey('account', $step_fields, 'Step 1 (account) must be present in the step_fields map.');
+		$this->assertArrayHasKey('site', $step_fields, 'The later site/template step must be present in the step_fields map.');
 		$this->assertArrayHasKey('payment', $step_fields, 'The later payment step must be present in the step_fields map.');
 
 		$account_fields = $step_fields['account'];
+		$site_fields    = $step_fields['site'];
 		$payment_fields = $step_fields['payment'];
 
 		// Step 1 owns its own fields.
@@ -115,6 +160,17 @@ final class Checkout_Step_Fields_Test extends TestCase {
 		// The core of the guard: later-step-only fields must NOT be demanded on Step 1.
 		$this->assertNotContains('password', $account_fields, 'Step 1 must NOT require the password field that lives on the payment step.');
 		$this->assertNotContains('payment', $account_fields, 'Step 1 must NOT require the payment/gateway field that lives on the payment step.');
+		$this->assertNotContains('site_title', $account_fields, 'Step 1 must NOT require the site title field that lives on the site step.');
+		$this->assertNotContains('template_id', $account_fields, 'Step 1 must NOT require the template field that lives on the site step.');
+
+		// The issue #1332 guard: after account fields are submitted, the template
+		// step validates its own fields and does not re-demand guest credentials.
+		$this->assertContains('site_title', $site_fields, 'The template step should validate its own site title field.');
+		$this->assertContains('site_url', $site_fields, 'The template step should validate its own site URL field.');
+		$this->assertContains('template_id', $site_fields, 'The template_selection field must expose the template_id validation rule key used by JS.');
+		$this->assertNotContains('email_address', $site_fields, 'The template step must NOT revalidate the prior email field for guest users.');
+		$this->assertNotContains('username', $site_fields, 'The template step must NOT revalidate the prior username field for guest users.');
+		$this->assertNotContains('password', $site_fields, 'The template step must NOT revalidate the prior password field for guest users.');
 
 		// And the later step really does carry the rest (proves a real partition,
 		// not everything collapsed into step 1).
@@ -143,8 +199,8 @@ final class Checkout_Step_Fields_Test extends TestCase {
 
 		$all_field_ids = array_values(array_unique($all_field_ids));
 
-		// All four seeded fields are represented somewhere.
-		foreach (['username', 'email_address', 'password', 'payment'] as $expected) {
+		// All seeded validation targets are represented somewhere.
+		foreach (['username', 'email_address', 'site_title', 'site_url', 'template_id', 'password', 'payment'] as $expected) {
 			$this->assertContains($expected, $all_field_ids, "Field '{$expected}' must appear in some step.");
 		}
 


### PR DESCRIPTION
## Summary

- Hardens checkout client-side validation scoping so stale or missing `wu_checkout.step_fields` falls back to fields rendered on the current form step instead of validating every global rule.
- Adds validation-rule aliases to `step_fields` for checkout field types whose rendered/value key differs from the builder field id (`template_selection` → `template_id`, `pricing_table` → `products`).
- Extends the step-fields regression test with an account → template/site → payment flow to guard against revalidating guest email/username/password on the template step.

## Issue verification

- Verified PR #763 is already included in `v2.12.0` (`git tag --contains a3a6f7c...` returned `v2.12.0`), so the issue body's release-status note was incorrect.
- Browser Agent local reproduction with a guest multi-step checkout reached the later step with `errors: []`; the exact email/username/password client errors were not reproducible on current `v2.12.0` code.
- The same browser run showed the template step still used the raw `template_selection` field id in `step_fields`, while the JS validation rule key is `template_id`; this PR fixes that mismatch and adds a defensive fallback for stale step maps.

## Verification

- `vendor/bin/phpunit --filter Checkout_Step_Fields_Test` — passes (2 tests, 31 assertions; existing PHP 8.4 deprecation notices emitted by dependencies)
- `vendor/bin/phpcs inc/checkout/class-checkout.php tests/unit/Checkout_Step_Fields_Test.php` — passes
- `node_modules/.bin/eslint assets/js/checkout.js --ignore-pattern '*.min.js'` — passes (Browserslist age warning only)
- `git diff --check` — passes

Resolves #1332

---
<!-- aidevops:sig -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced checkout validation to more accurately handle multi-step forms, reducing blocking errors caused by fields previously submitted on earlier steps that are no longer visible on the current step.

* **Tests**
  * Expanded test coverage for multi-step checkout field validation and step-specific field partitioning.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->