### PR TITLE
fix: initialize customer DNS management modal

### DIFF
--- a/assets/js/dns-management.js
+++ b/assets/js/dns-management.js
@@ -4,7 +4,7 @@
  *
  * Handles DNS record display and management in the Ultimate Multisite UI.
  *
- * @param $
+ * @param {Function} $ jQuery.
  * @since 2.3.0
  */
 (function($) {
@@ -16,6 +16,71 @@
 	$(document).ready(function() {
 		initDNSManagement();
 	});
+
+	/**
+	 * Get the localized DNS management config.
+	 *
+	 * @return {Object} DNS management config.
+	 */
+	function getConfig() {
+		return window.wu_dns_config || {};
+	}
+
+	/**
+	 * Get a localized string with a fallback.
+	 *
+	 * @param {string} key      The config i18n key.
+	 * @param {string} fallback The fallback string.
+	 * @return {string} Localized string.
+	 */
+	function getString(key, fallback) {
+		const config = getConfig();
+
+		return (config.i18n && config.i18n[ key ]) || fallback;
+	}
+
+	/**
+	 * Get the AJAX endpoint for front-end and admin contexts.
+	 *
+	 * @return {string} AJAX endpoint URL.
+	 */
+	function getAjaxUrl() {
+		const config = getConfig();
+
+		if (config.ajaxurl) {
+			return config.ajaxurl;
+		}
+
+		return typeof ajaxurl !== 'undefined' ? ajaxurl : '';
+	}
+
+	/**
+	 * Add a query argument to a URL.
+	 *
+	 * @param {string} url   Base URL.
+	 * @param {string} key   Query key.
+	 * @param {string} value Query value.
+	 * @return {string} URL with the query argument.
+	 */
+	function addQueryArg(url, key, value) {
+		return url + (url.indexOf('?') > -1 ? '&' : '?') + key + '=' + encodeURIComponent(value);
+	}
+
+	/**
+	 * Show an error message.
+	 *
+	 * @param {string} message The message to show.
+	 */
+	function showError(message) {
+		if (window.wu_ajax_error) {
+			window.wu_ajax_error(message);
+			return;
+		}
+
+		if (window.console && window.console.error) {
+			window.console.error(message);
+		}
+	}
 
 	/**
 	 * Initialize the DNS Management Vue instance.
@@ -85,16 +150,24 @@
 				 */
 				loadRecords() {
 					const self = this;
+					const ajaxUrl = getAjaxUrl();
+					const config = getConfig();
 
 					this.loading = true;
 					this.error = null;
 
+					if (! ajaxUrl || ! config.nonce) {
+						this.loading = false;
+						this.error = getString('missing_config', 'DNS management could not be initialized. Please refresh the page and try again.');
+						return;
+					}
+
 					$.ajax({
-						url: ajaxurl,
+						url: ajaxUrl,
 						method: 'POST',
 						data: {
 							action: 'wu_get_dns_records_for_domain',
-							nonce: wu_dns_config.nonce,
+							nonce: config.nonce,
 							domain: this.domain,
 						},
 						success(response) {
@@ -113,12 +186,12 @@
 									self.error = response.data.message;
 								}
 							} else {
-								self.error = (response.data && response.data.message) || 'Failed to load DNS records.';
+								self.error = (response.data && response.data.message) || getString('failed_load_records', 'Failed to load DNS records.');
 							}
 						},
 						error(xhr, status, errorMsg) {
 							self.loading = false;
-							self.error = 'Network error: ' + errorMsg;
+							self.error = getString('network_error', 'Network error:') + ' ' + errorMsg;
 						},
 					});
 				},
@@ -198,13 +271,13 @@
 				 * @return {string} Edit URL.
 				 */
 				getEditUrl(record) {
-					if (! wu_dns_config.edit_url) {
+					const editUrl = getConfig().edit_url;
+
+					if (! editUrl) {
 						return '#';
 					}
 
-					return wu_dns_config.edit_url +
-						'&record_id=' + encodeURIComponent(record.id) +
-						'&domain_id=' + encodeURIComponent(this.domainId);
+					return addQueryArg(addQueryArg(editUrl, 'record_id', record.id), 'domain_id', this.domainId);
 				},
 
 				/**
@@ -214,13 +287,13 @@
 				 * @return {string} Delete URL.
 				 */
 				getDeleteUrl(record) {
-					if (! wu_dns_config.delete_url) {
+					const deleteUrl = getConfig().delete_url;
+
+					if (! deleteUrl) {
 						return '#';
 					}
 
-					return wu_dns_config.delete_url +
-						'&record_id=' + encodeURIComponent(record.id) +
-						'&domain_id=' + encodeURIComponent(this.domainId);
+					return addQueryArg(addQueryArg(deleteUrl, 'record_id', record.id), 'domain_id', this.domainId);
 				},
 
 				/**
@@ -274,18 +347,26 @@
 						return;
 					}
 
-					if (! confirm('Are you sure you want to delete ' + this.selectedRecords.length + ' selected records?')) {
+					// eslint-disable-next-line no-alert -- Bulk deletion needs a synchronous confirmation before the AJAX request.
+					if (! window.confirm(getString('confirm_delete', 'Are you sure you want to delete the selected DNS records?'))) {
 						return;
 					}
 
 					const self = this;
+					const ajaxUrl = getAjaxUrl();
+					const config = getConfig();
+
+					if (! ajaxUrl || ! config.nonce) {
+						showError(getString('missing_config', 'DNS management could not be initialized. Please refresh the page and try again.'));
+						return;
+					}
 
 					$.ajax({
-						url: ajaxurl,
+						url: ajaxUrl,
 						method: 'POST',
 						data: {
 							action: 'wu_bulk_dns_operations',
-							nonce: wu_dns_config.nonce,
+							nonce: config.nonce,
 							domain: this.domain,
 							operation: 'delete',
 							records: this.selectedRecords,
@@ -295,11 +376,11 @@
 								self.selectedRecords = [];
 								self.loadRecords();
 							} else {
-								alert('Error: ' + ((response.data && response.data.message) || 'Failed to delete records.'));
+								showError((response.data && response.data.message) || getString('failed_delete', 'Failed to delete records.'));
 							}
 						},
 						error() {
-							alert('Network error occurred.');
+							showError(getString('network_failed', 'Network error occurred.'));
 						},
 					});
 				},
@@ -329,6 +410,12 @@
 	 * Reinitialize DNS management when modal content is loaded.
 	 * This handles wubox modal scenarios.
 	 */
+	$(document.body).on('wubox:load', function() {
+		setTimeout(function() {
+			initDNSManagement();
+		}, 100);
+	});
+
 	$(document).on('wubox-load', function() {
 		setTimeout(function() {
 			initDNSManagement();

--- a/inc/managers/class-dns-record-manager.php
+++ b/inc/managers/class-dns-record-manager.php
@@ -205,7 +205,7 @@ class DNS_Record_Manager extends Base_Manager {
 
 			wp_send_json_success(
 				[
-					'records'  => $records,
+					'records'  => $this->normalize_records_for_response($records),
 					'readonly' => true,
 					'message'  => __('DNS management is not available. Records are read-only.', 'ultimate-multisite'),
 				]
@@ -220,7 +220,7 @@ class DNS_Record_Manager extends Base_Manager {
 
 			wp_send_json_success(
 				[
-					'records'  => $fallback_records,
+					'records'  => $this->normalize_records_for_response($fallback_records),
 					'readonly' => true,
 					'message'  => $records->get_error_message(),
 				]
@@ -229,12 +229,56 @@ class DNS_Record_Manager extends Base_Manager {
 
 		wp_send_json_success(
 			[
-				'records'      => array_map(fn($r) => $r instanceof DNS_Record ? $r->to_array() : $r, $records),
+				'records'      => $this->normalize_records_for_response($records),
 				'readonly'     => false,
 				'provider'     => $provider->get_id(),
 				'record_types' => $provider->get_supported_record_types(),
 			]
 		);
+	}
+
+	/**
+	 * Normalize DNS records for the management table response.
+	 *
+	 * Provider records use the DNS_Record shape, while read-only PHPDNS fallback
+	 * records use host/data/ip keys. The front-end table expects name/content/id.
+	 *
+	 * @since 2.3.0
+	 *
+	 * @param array $records DNS records returned by a provider or PHPDNS lookup.
+	 * @return array
+	 */
+	private function normalize_records_for_response(array $records): array {
+
+		$normalized = [];
+
+		foreach ($records as $index => $record) {
+			$record = $record instanceof DNS_Record ? $record->to_array() : (array) $record;
+
+			if (! isset($record['name'])) {
+				$record['name'] = $record['host'] ?? '';
+			}
+
+			if (! isset($record['content'])) {
+				$record['content'] = $record['data'] ?? $record['ip'] ?? '';
+			}
+
+			if (is_array($record['content'])) {
+				$record['content'] = implode(', ', array_map('strval', $record['content']));
+			}
+
+			if (! isset($record['ttl'])) {
+				$record['ttl'] = 0;
+			}
+
+			if (! isset($record['id'])) {
+				$record['id'] = md5((string) wp_json_encode($record) . $index);
+			}
+
+			$normalized[] = $record;
+		}
+
+		return $normalized;
 	}
 
 	/**

--- a/inc/ui/class-domain-mapping-element.php
+++ b/inc/ui/class-domain-mapping-element.php
@@ -237,6 +237,47 @@ class Domain_Mapping_Element extends Base_Element {
 	public function register_scripts() {
 
 		add_wubox();
+
+		wp_register_script(
+			'wu-dns-management',
+			wu_get_asset('dns-management.js', 'js'),
+			['jquery', 'wu-vue', 'wubox'],
+			wu_get_version(),
+			true
+		);
+
+		wp_localize_script(
+			'wu-dns-management',
+			'wu_dns_config',
+			[
+				'ajaxurl'    => admin_url('admin-ajax.php'),
+				'nonce'      => wp_create_nonce('wu_dns_nonce'),
+				'add_url'    => wu_get_form_url('user_add_dns_record'),
+				'edit_url'   => wu_get_form_url('user_edit_dns_record'),
+				'delete_url' => wu_get_form_url('user_delete_dns_record'),
+				'i18n'       => [
+					'failed_load_records' => __('Failed to load DNS records.', 'ultimate-multisite'),
+					'missing_config'      => __('DNS management could not be initialized. Please refresh the page and try again.', 'ultimate-multisite'),
+					'network_error'       => __('Network error:', 'ultimate-multisite'),
+					'confirm_delete'      => __('Are you sure you want to delete the selected DNS records?', 'ultimate-multisite'),
+					'failed_delete'       => __('Failed to delete records.', 'ultimate-multisite'),
+					'network_failed'      => __('Network error occurred.', 'ultimate-multisite'),
+				],
+			]
+		);
+
+		wp_add_inline_script(
+			'wu-dns-management',
+			'window.ajaxurl = window.ajaxurl || ' . wp_json_encode(admin_url('admin-ajax.php')) . ';',
+			'before'
+		);
+
+		wp_add_inline_script(
+			'wu-dns-management',
+			'document.body.addEventListener("wubox:load", function() { document.dispatchEvent(new Event("wubox-load")); });'
+		);
+
+		wp_enqueue_script('wu-dns-management');
 	}
 
 	/**

--- a/tests/WP_Ultimo/Managers/DNS_Record_Manager_Normalization_Test.php
+++ b/tests/WP_Ultimo/Managers/DNS_Record_Manager_Normalization_Test.php
@@ -1,0 +1,54 @@
+<?php
+/**
+ * Tests for DNS record response normalization.
+ *
+ * @package WP_Ultimo\Tests
+ */
+
+namespace WP_Ultimo\Tests\Managers;
+
+use WP_Ultimo\Integrations\Host_Providers\DNS_Record;
+use WP_Ultimo\Managers\DNS_Record_Manager;
+use WP_UnitTestCase;
+
+/**
+ * Test DNS_Record_Manager response normalization.
+ */
+class DNS_Record_Manager_Normalization_Test extends WP_UnitTestCase {
+
+	/**
+	 * Test read-only PHPDNS records are mapped to the front-end table shape.
+	 */
+	public function test_normalize_records_for_response_maps_readonly_dns_records(): void {
+		$manager = DNS_Record_Manager::get_instance();
+		$method  = new \ReflectionMethod($manager, 'normalize_records_for_response');
+		$method->setAccessible(true);
+
+		$records = $method->invoke(
+			$manager,
+			[
+				[
+					'host' => 'www.example.com',
+					'data' => '127.0.0.1',
+					'ttl'  => 300,
+					'type' => 'A',
+				],
+				new DNS_Record(
+					[
+						'id'      => 'txt-1',
+						'type'    => 'TXT',
+						'name'    => '@',
+						'content' => 'v=spf1 -all',
+					]
+				),
+			]
+		);
+
+		$this->assertSame('www.example.com', $records[0]['name']);
+		$this->assertSame('127.0.0.1', $records[0]['content']);
+		$this->assertNotEmpty($records[0]['id']);
+		$this->assertSame('txt-1', $records[1]['id']);
+		$this->assertSame('@', $records[1]['name']);
+		$this->assertSame('v=spf1 -all', $records[1]['content']);
+	}
+}

--- a/tests/WP_Ultimo/UI/Domain_Mapping_Element_Test.php
+++ b/tests/WP_Ultimo/UI/Domain_Mapping_Element_Test.php
@@ -1,0 +1,59 @@
+<?php
+/**
+ * Tests for the domain mapping UI element.
+ *
+ * @package WP_Ultimo\Tests
+ */
+
+namespace WP_Ultimo\UI;
+
+use WP_UnitTestCase;
+
+/**
+ * Test class for Domain_Mapping_Element.
+ */
+class Domain_Mapping_Element_Test extends WP_UnitTestCase {
+
+	/**
+	 * Test DNS management scripts are registered with front-end-safe config in the source.
+	 */
+	public function test_register_scripts_source_registers_dns_management_script_with_frontend_config(): void {
+
+		$source = $this->read_source_file('inc/ui/class-domain-mapping-element.php');
+
+		$this->assertStringContainsString("'wu-dns-management'", $source);
+		$this->assertStringContainsString('wp_localize_script', $source);
+		$this->assertStringContainsString('wp_add_inline_script', $source);
+		$this->assertStringContainsString("'ajaxurl'", $source);
+		$this->assertStringContainsString("admin_url('admin-ajax.php')", $source);
+		$this->assertStringContainsString('wubox:load', $source);
+		$this->assertStringContainsString('wubox-load', $source);
+		$this->assertStringContainsString("wp_enqueue_script('wu-dns-management')", $source);
+	}
+
+	/**
+	 * Test the script hooks into the wubox event emitted after AJAX modal content loads.
+	 */
+	public function test_dns_management_script_listens_for_wubox_load_event(): void {
+
+		$source = $this->read_source_file('assets/js/dns-management.js');
+
+		$this->assertStringContainsString("$(document.body).on('wubox:load'", $source);
+		$this->assertStringContainsString('getAjaxUrl()', $source);
+	}
+
+	/**
+	 * Read a local source file from the plugin under test.
+	 *
+	 * @param string $relative_path Relative source path.
+	 * @return string
+	 */
+	private function read_source_file(string $relative_path): string {
+
+		$source = file_get_contents(WP_ULTIMO_PLUGIN_DIR . '/' . $relative_path); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents -- Local source file fixture.
+
+		$this->assertIsString($source);
+
+		return $source;
+	}
+}


### PR DESCRIPTION
## Summary

- Enqueue and localize the customer DNS management script from `Domain_Mapping_Element::register_scripts()` so `user_manage_dns_records` has config on front-end shortcode pages.
- Listen for the actual `wubox:load` event while preserving the legacy `wubox-load` event path used by the current minified asset.
- Normalize read-only DNS fallback records to the table shape expected by the Vue component (`id`, `name`, `content`, `ttl`).

## Verification

- `vendor/bin/phpcs inc/managers/class-dns-record-manager.php tests/WP_Ultimo/Managers/DNS_Record_Manager_Normalization_Test.php inc/ui/class-domain-mapping-element.php tests/WP_Ultimo/UI/Domain_Mapping_Element_Test.php`
- `vendor/bin/phpunit --no-coverage --filter 'Domain_Mapping_Element_Test|DNS_Record_Manager_Normalization_Test'`
- `node_modules/.bin/eslint --resolve-plugins-relative-to /home/dave/Git/ultimate-multisite /home/dave/Git/ultimate-multisite-user-manage-dns/assets/js/dns-management.js --quiet`
- Browser agent on local WordPress: shortcode page loaded `dns-management.min.js`, opened `user_manage_dns_records` via wubox, Vue mounted, `loadingVisible: false`, and the modal displayed read-only DNS records instead of spinning forever.

---
<!-- aidevops:sig -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved DNS record normalization to ensure consistent display across different DNS providers
  * Enhanced error handling in DNS management with localized error messages
  * Fixed DNS record edit and delete URL generation to properly handle missing configuration values
  * Improved form validation during bulk DNS operations

* **Tests**
  * Added comprehensive test coverage for DNS record normalization and data structure validation
  * Added UI tests for DNS management script registration and event handling

<!-- end of auto-generated comment: release notes by coderabbit.ai -->