### PR TITLE
GH#1344: fix: resolve product delete modal capability

### DIFF
--- a/inc/managers/class-form-manager.php
+++ b/inc/managers/class-form-manager.php
@@ -176,10 +176,11 @@ class Form_Manager extends Base_Manager {
 	 */
 	public function security_checks() {
 		/*
-		 * We only want ajax requests.
+		 * We only want ajax requests, but return a clear message instead of a raw
+		 * `0` so direct modal URLs fail clearly.
 		 */
 		if ((empty($_SERVER['HTTP_X_REQUESTED_WITH']) || strtolower(sanitize_key(wp_unslash($_SERVER['HTTP_X_REQUESTED_WITH']))) !== 'xmlhttprequest')) {
-			wp_die(0);
+			wp_die(esc_html__('Invalid form request.', 'ultimate-multisite'));
 		}
 
 		$form = $this->get_form(wu_request('form'));
@@ -188,9 +189,58 @@ class Form_Manager extends Base_Manager {
 			$this->display_form_unavailable();
 		}
 
-		if ( ! current_user_can($form['capability'])) {
-			$this->display_form_unavailable();
+		$capability = $this->get_form_capability($form);
+
+		if ( ! $capability || ! current_user_can($capability)) {
+			$this->display_form_unavailable(new \WP_Error('permission-denied', __('You do not have permission to access this form.', 'ultimate-multisite')));
 		}
+	}
+
+	/**
+	 * Returns the capability required to access a registered form.
+	 *
+	 * Form capabilities can be static strings or callables that resolve against
+	 * the current request. The dynamic path is used by shared action forms such
+	 * as the delete modal, whose model is only known when the modal URL is opened.
+	 *
+	 * @since 2.4.5
+	 *
+	 * @param array $form Registered form attributes.
+	 * @return string
+	 */
+	public function get_form_capability($form) {
+
+		$capability = wu_get_isset($form, 'capability', 'manage_network');
+
+		if (is_callable($capability)) {
+			$capability = call_user_func($capability, $form);
+		}
+
+		return (string) $capability;
+	}
+
+	/**
+	 * Returns the current model delete capability for the shared delete modal.
+	 *
+	 * @since 2.4.5
+	 *
+	 * @return string
+	 */
+	public function get_model_delete_capability() {
+
+		$model = wu_request('model');
+
+		if ( ! $model) {
+			return 'manage_network';
+		}
+
+		if (str_contains((string) $model, '_meta_')) {
+			$elements = explode('_meta_', (string) $model);
+
+			$model = $elements[0];
+		}
+
+		return "wu_delete_{$model}s";
 	}
 
 	/**
@@ -297,14 +347,12 @@ class Form_Manager extends Base_Manager {
 	 */
 	public function register_action_forms(): void {
 
-		$model = wu_request('model');
-
 		wu_register_form(
 			'delete_modal',
 			[
 				'render'     => [$this, 'render_model_delete_form'],
 				'handler'    => [$this, 'handle_model_delete_form'],
-				'capability' => "wu_delete_{$model}s",
+				'capability' => [$this, 'get_model_delete_capability'],
 			]
 		);
 

--- a/tests/WP_Ultimo/Managers/Form_Manager_Test.php
+++ b/tests/WP_Ultimo/Managers/Form_Manager_Test.php
@@ -203,6 +203,23 @@ class Form_Manager_Test extends \WP_UnitTestCase {
 	}
 
 	/**
+	 * Test get_form_capability resolves callable capabilities.
+	 */
+	public function test_get_form_capability_resolves_callable(): void {
+
+		$manager = $this->get_manager_instance();
+
+		$form = [
+			'id'         => 'callable_capability_form_xyz',
+			'capability' => function () {
+				return 'read';
+			},
+		];
+
+		$this->assertSame('read', $manager->get_form_capability($form));
+	}
+
+	/**
 	 * Test register_form stores custom render and handler callables.
 	 */
 	public function test_register_form_stores_render_and_handler(): void {
@@ -405,6 +422,41 @@ class Form_Manager_Test extends \WP_UnitTestCase {
 		$this->assertIsArray($form);
 		$this->assertIsCallable($form['render']);
 		$this->assertIsCallable($form['handler']);
+	}
+
+	/**
+	 * Test register_action_forms delete_modal uses a request-time capability.
+	 */
+	public function test_register_action_forms_delete_modal_has_dynamic_capability(): void {
+
+		$manager = $this->get_manager_instance();
+
+		$manager->register_action_forms();
+
+		$form = $manager->get_form('delete_modal');
+
+		$this->assertIsArray($form);
+		$this->assertIsCallable($form['capability']);
+
+		$_REQUEST['model'] = 'product';
+
+		$this->assertSame('wu_delete_products', $manager->get_form_capability($form));
+
+		unset($_REQUEST['model']);
+	}
+
+	/**
+	 * Test get_model_delete_capability handles metadata delete modal models.
+	 */
+	public function test_get_model_delete_capability_handles_meta_model(): void {
+
+		$manager = $this->get_manager_instance();
+
+		$_REQUEST['model'] = 'membership_meta_pending_site';
+
+		$this->assertSame('wu_delete_memberships', $manager->get_model_delete_capability());
+
+		unset($_REQUEST['model']);
 	}
 
 	/**
@@ -1048,10 +1100,11 @@ class Form_Manager_Test extends \WP_UnitTestCase {
 	// =========================================================================
 
 	/**
-	 * Test security_checks calls wp_die(0) when request is not an AJAX request.
+	 * Test security_checks calls wp_die() when request is not an AJAX request.
 	 *
 	 * security_checks() checks $_SERVER['HTTP_X_REQUESTED_WITH'] for the value
-	 * 'xmlhttprequest'. When absent (or wrong), it calls wp_die(0).
+	 * 'xmlhttprequest'. When absent (or wrong), it calls wp_die() with a clear
+	 * message instead of returning a raw 0.
 	 *
 	 * wp_die() in non-AJAX context uses wp_die_handler (not wp_die_ajax_handler).
 	 * We install a wp_die_handler filter that throws WPDieException so PHPUnit
@@ -1072,17 +1125,17 @@ class Form_Manager_Test extends \WP_UnitTestCase {
 
 		add_filter('wp_die_handler', $die_handler, 1);
 
-		$exception_caught = false;
+		$exception_message = '';
 
 		try {
 			$manager->security_checks();
 		} catch (\WPDieException $e) {
-			$exception_caught = true;
+			$exception_message = $e->getMessage();
 		}
 
 		remove_filter('wp_die_handler', $die_handler, 1);
 
-		$this->assertTrue($exception_caught, 'security_checks() should call wp_die() for non-AJAX requests');
+		$this->assertSame('Invalid form request.', $exception_message, 'security_checks() should return a clear message for non-AJAX requests');
 	}
 
 	/**


### PR DESCRIPTION
## Summary

Registered the shared delete modal with a request-time model delete capability so product edit delete links authorize against wu_delete_products instead of a capability captured during early form registration. Direct non-AJAX modal URL opens now return a clear invalid-request message instead of raw 0. Added Form_Manager tests for callable capability resolution and model/meta-model delete capabilities.

## Files Changed

inc/managers/class-form-manager.php,tests/WP_Ultimo/Managers/Form_Manager_Test.php

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** WP_TESTS_DIR=/tmp/wordpress-tests-lib vendor/bin/phpunit --filter Form_Manager_Test; vendor/bin/phpcs inc/managers/class-form-manager.php

Resolves #1344


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.11 plugin for [OpenCode](https://opencode.ai) v1.15.13 with gpt-5.5 spent 6m and 129,061 tokens on this as a headless worker.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error messaging when accessing restricted forms, providing users with clearer, translated feedback messages.
  * Strengthened form permission validation through enhanced capability checking and more consistent access control enforcement across the application.

* **Tests**
  * Added comprehensive test coverage for form capability resolution, permission verification, and dynamic capability handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->