### PR TITLE
GH#1345: fix: handle delete modal failures

### DIFF
--- a/inc/managers/class-form-manager.php
+++ b/inc/managers/class-form-manager.php
@@ -125,6 +125,8 @@ class Form_Manager extends Base_Manager {
 
 		call_user_func($form['render']);
 
+		printf('<input type="hidden" name="form" value="%s">', esc_attr($form['id']));
+
 		echo '<input type="hidden" name="action" value="wu_form_handler">';
 
 		wp_nonce_field('wu_form_' . $form['id']);
@@ -492,6 +494,15 @@ class Form_Manager extends Base_Manager {
 
 			if (is_wp_error($saved)) {
 				wp_send_json_error($saved);
+			}
+
+			if ( ! $saved) {
+				wp_send_json_error(
+					new \WP_Error(
+						'delete-failed',
+						__('The item could not be deleted.', 'ultimate-multisite')
+					)
+				);
 			}
 
 			do_action("wu_after_delete_{$model}_modal", $object);

--- a/tests/WP_Ultimo/Managers/Form_Manager_Test.php
+++ b/tests/WP_Ultimo/Managers/Form_Manager_Test.php
@@ -583,6 +583,48 @@ class Form_Manager_Test extends \WP_UnitTestCase {
 		$this->assertStringContainsString('customers', $response['data']['redirect_url']);
 	}
 
+	/**
+	 * Test handle_model_delete_form returns an error when the model delete fails.
+	 */
+	public function test_handle_model_delete_form_errors_when_delete_returns_false(): void {
+
+		$manager = $this->get_manager_instance();
+
+		$filter = function () {
+			return new class() {
+				public function get_id() {
+
+					return 123;
+				}
+
+				public function delete() {
+
+					return false;
+				}
+			};
+		};
+
+		add_filter('wu_delete_form_get_object_customer', $filter);
+
+		$_REQUEST['model']   = 'customer';
+		$_REQUEST['id']      = '123';
+		$_REQUEST['confirm'] = '1';
+		unset($_REQUEST['meta_key']);
+
+		$result = $this->call_in_ajax_context([$manager, 'handle_model_delete_form']);
+
+		remove_filter('wu_delete_form_get_object_customer', $filter);
+		unset($_REQUEST['model'], $_REQUEST['id'], $_REQUEST['confirm']);
+
+		$this->assertTrue($result['exception'], 'Should terminate via wp_die()');
+
+		$response = json_decode($result['output'], true);
+
+		$this->assertIsArray($response);
+		$this->assertFalse($response['success']);
+		$this->assertSame('delete-failed', $response['data'][0]['code']);
+	}
+
 	// =========================================================================
 	// render_model_delete_form
 	// =========================================================================


### PR DESCRIPTION
## Summary

Added the submitted form id as a POST field for delete modals and return a JSON error when model deletion returns false instead of treating it as success.

## Files Changed

inc/managers/class-form-manager.php,tests/WP_Ultimo/Managers/Form_Manager_Test.php

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** WP_TESTS_DIR=/tmp/wordpress-tests-lib vendor/bin/phpunit --filter Form_Manager_Test; vendor/bin/phpcs inc/managers/class-form-manager.php

Resolves #1345


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.11 plugin for [OpenCode](https://opencode.ai) v1.15.13 with gpt-5.5 spent 7m and 178,797 tokens on this as a headless worker.