### PR TITLE
fix: use site-aware wp-cron URL

### DIFF
--- a/inc/ui/class-thank-you-element.php
+++ b/inc/ui/class-thank-you-element.php
@@ -132,7 +132,7 @@ class Thank_You_Element extends Base_Element {
 				'has_pending_site'                => $has_pending_site,
 				'next_queue'                      => wu_get_next_queue_run(),
 				'ajaxurl'                         => admin_url('admin-ajax.php'),
-				'wp_cron_url'                     => admin_url('admin-ajax.php?action=wu_wp_cron'),
+				'wp_cron_url'                     => site_url('wp-cron.php?doing_wp_cron'),
 				'resend_verification_email_nonce' => wp_create_nonce('wu_resend_verification_email_nonce'),
 				'membership_hash'                 => $this->membership ? $this->membership->get_hash() : false,
 				'i18n'                            => [


### PR DESCRIPTION
## Summary
- change the thank-you page cron kick URL from a non-existent `wu_wp_cron` AJAX action to the real `wp-cron.php?doing_wp_cron` endpoint
- use `site_url()` so Bedrock/subdirectory WordPress installs resolve to the core path, e.g. `/wp/wp-cron.php`

## Context
The previous AJAX URL returned WordPress's default admin-ajax `0` response with HTTP 400 because no `wu_wp_cron` action is registered. `home_url()` would still fail in this install because it resolves to the public root, not the WordPress core directory.

## Verification
- `php -l inc/ui/class-thank-you-element.php`
- `vendor/bin/phpcs inc/ui/class-thank-you-element.php`
- `wp --path=site/web/wp --url=https://sdaiagent.com eval 'echo site_url("wp-cron.php?doing_wp_cron") . "\n";'` → `https://sdaiagent.com/wp/wp-cron.php?doing_wp_cron`
- `curl -sk -o /dev/null -w '%{http_code} %{size_download}\n' 'https://sdaiagent.com/wp/wp-cron.php?doing_wp_cron'` → `200 0`

For #1241

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.13 plugin for [OpenCode](https://opencode.ai) v1.15.13 with gpt-5.5


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved background task processing configuration on the thank-you page for better reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->