### PR TITLE
test: add sso fixture entry guard

### DIFF
--- a/tests/e2e/cypress/fixtures/setup-sso-test.php
+++ b/tests/e2e/cypress/fixtures/setup-sso-test.php
@@ -1,4 +1,6 @@
 <?php
+defined('ABSPATH') || exit;
+
 /**
  * Set up the SSO e2e test environment.
  *


### PR DESCRIPTION
## Summary

- Added the standard `defined('ABSPATH') || exit;` entry guard to the SSO Cypress setup fixture.
- Ensures direct execution exits before the fixture mutates domain mapping settings or database records.

## Testing

- `php -l tests/e2e/cypress/fixtures/setup-sso-test.php`

Resolves #1359

<!-- MERGE_SUMMARY
summary: Added the standard ABSPATH guard to the SSO Cypress setup fixture so direct execution exits before mutating WordPress state.
testing: php -l tests/e2e/cypress/fixtures/setup-sso-test.php
-->

<!-- aidevops:sig -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test fixture initialization with added safeguards to prevent unauthorized direct access to test configuration scripts, enhancing test stability and integrity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->