### PR TITLE
fix(checkout): address deferred checkout review feedback

### DIFF
--- a/inc/ui/class-checkout-element.php
+++ b/inc/ui/class-checkout-element.php
@@ -534,9 +534,14 @@ class Checkout_Element extends Base_Element {
 		$headers = apply_filters('wu_checkout_nocache_headers', $headers, $atts, $this);
 
 		foreach ($headers as $name => $value) {
+			$name  = trim(str_replace(["\r", "\n"], '', (string) $name));
 			$value = str_replace(["\r", "\n"], '', (string) $value);
 
-			header(sprintf('%s: %s', sanitize_key($name), $value), true);
+			if ('' === $name || ! preg_match('/^[A-Za-z0-9-]+$/', $name)) {
+				continue;
+			}
+
+			header(sprintf('%s: %s', $name, $value), true);
 		}
 	}
 
@@ -848,6 +853,26 @@ class Checkout_Element extends Base_Element {
 				request.send(parts.join('&'));
 			}
 
+			function cleanupFallbackLoad() {
+				document.removeEventListener('DOMContentLoaded', fallbackLoad);
+				window.removeEventListener('scroll', fallbackLoad);
+				window.removeEventListener('resize', fallbackLoad);
+			}
+
+			function fallbackLoad() {
+				cleanupFallbackLoad();
+				loadCheckout();
+			}
+
+			function scheduleFallbackLoad() {
+				if ('loading' === document.readyState) {
+					document.addEventListener('DOMContentLoaded', fallbackLoad);
+				} else {
+					window.addEventListener('scroll', fallbackLoad);
+					window.addEventListener('resize', fallbackLoad);
+				}
+			}
+
 			if (button) {
 				button.addEventListener('click', function(event) {
 					event.preventDefault();
@@ -870,6 +895,8 @@ class Checkout_Element extends Base_Element {
 						loadCheckout();
 					}
 				}).observe(root);
+			} else if ('viewport' === trigger) {
+				scheduleFallbackLoad();
 			}
 		})();
 		</script>

--- a/tests/WP_Ultimo/UI/Checkout_Element_Test.php
+++ b/tests/WP_Ultimo/UI/Checkout_Element_Test.php
@@ -85,6 +85,8 @@ class Checkout_Element_Test extends WP_UnitTestCase {
 	 * Test live checkout output path contains explicit no-cache safeguards.
 	 */
 	public function test_source_contains_live_checkout_cache_safeguards(): void {
+		// Source-token assertions intentionally guard cache-safety hooks/headers that
+		// are otherwise hard to observe reliably in PHPUnit.
 		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
 		$source = file_get_contents(dirname(__DIR__, 3) . '/inc/ui/class-checkout-element.php');
 


### PR DESCRIPTION
## Summary

- Preserve configured checkout no-cache header casing while stripping CR/LF and rejecting invalid header names.
- Add a viewport deferred-checkout fallback for browsers without `IntersectionObserver`, loading once on DOM readiness or first scroll/resize and removing listeners.
- Document the source-token cache safeguard test assertions.

## Testing

- `vendor/bin/phpcs inc/ui/class-checkout-element.php tests/WP_Ultimo/UI/Checkout_Element_Test.php`
- `WP_TESTS_DIR=/tmp/wordpress-tests-lib vendor/bin/phpunit --filter Checkout_Element_Test`

Resolves #1360

MERGE_SUMMARY: Preserved checkout cache-control header casing safely, added an IntersectionObserver-free deferred checkout viewport fallback, and documented source-token cache-safety test guardrails. Verified with PHPCS on modified files and the targeted Checkout_Element_Test PHPUnit filter.

---
<!-- aidevops:sig -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Strengthened checkout header security with stricter validation to prevent cache bypass vulnerabilities
  * Improved checkout deferred loading behavior for viewport-based triggers
* **Tests**
  * Enhanced test documentation for checkout cache safeguards

<!-- end of auto-generated comment: release notes by coderabbit.ai -->