### PR TITLE
fix(checkout): trigger fallback when DOM is ready

### DIFF
--- a/inc/ui/class-checkout-element.php
+++ b/inc/ui/class-checkout-element.php
@@ -868,8 +868,7 @@ class Checkout_Element extends Base_Element {
 				if ('loading' === document.readyState) {
 					document.addEventListener('DOMContentLoaded', fallbackLoad);
 				} else {
-					window.addEventListener('scroll', fallbackLoad);
-					window.addEventListener('resize', fallbackLoad);
+					fallbackLoad();
 				}
 			}
 


### PR DESCRIPTION
## Summary

- Trigger deferred checkout fallback immediately when the DOM is already ready.
- Avoid waiting for scroll or resize in late-execution viewport fallback contexts.

## Testing

- `vendor/bin/phpcs inc/ui/class-checkout-element.php`
- Pre-commit hook ran PHPCS and PHPStan on `inc/ui/class-checkout-element.php`

Resolves #1364

<!-- aidevops:sig -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Optimized checkout element fallback loading behavior to initialize immediately when the page is ready, instead of waiting for user scroll or resize events, improving overall page load performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->