### PR TITLE
fix: harden Divi cache cleanup

### DIFF
--- a/inc/compat/class-general-compat.php
+++ b/inc/compat/class-general-compat.php
@@ -465,17 +465,35 @@ class General_Compat {
 		);
 
 		foreach ($iterator as $file) {
-			$path = $file->getRealPath();
+			$path            = $file->getPathname();
+			$normalized_path = untrailingslashit(wp_normalize_path($path));
 
-			if (false === $path) {
+			if ($real_cache_dir !== $normalized_path && 0 !== strpos(trailingslashit($normalized_path), trailingslashit($real_cache_dir))) {
+				continue;
+			}
+
+			if ($file->isLink()) {
+				wp_delete_file($path);
+				continue;
+			}
+
+			$real_path = $file->getRealPath();
+
+			if (false === $real_path) {
+				continue;
+			}
+
+			$real_path = untrailingslashit(wp_normalize_path($real_path));
+
+			if ($real_cache_dir !== $real_path && 0 !== strpos(trailingslashit($real_path), trailingslashit($real_cache_dir))) {
 				continue;
 			}
 
 			if ($file->isDir()) {
 				// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_rmdir, WordPress.PHP.NoSilencedErrors.Discouraged -- Removes an empty generated cache directory after deleting its contents.
-				@rmdir($path);
+				@rmdir($real_path);
 			} else {
-				wp_delete_file($path);
+				wp_delete_file($real_path);
 			}
 		}
 

--- a/tests/WP_Ultimo/General_Compat_Test.php
+++ b/tests/WP_Ultimo/General_Compat_Test.php
@@ -6,9 +6,10 @@
  * @subpackage Tests
  */
 
-namespace WP_Ultimo\Tests;
+namespace WP_Ultimo\Compat;
 
-use WP_Ultimo\Compat\General_Compat;
+defined('ABSPATH') || exit;
+
 use WP_UnitTestCase;
 
 /**
@@ -79,6 +80,47 @@ class General_Compat_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Test Divi et-cache symlinks do not delete files outside the cache tree.
+	 */
+	public function test_clear_divi_static_css_cache_does_not_follow_symlinks(): void {
+
+		if ( ! is_multisite()) {
+			$this->markTestSkipped('Divi cache purge tests require multisite');
+		}
+
+		if ( ! function_exists('symlink')) {
+			$this->markTestSkipped('Symlink support is not available');
+		}
+
+		$blog_id       = self::factory()->blog->create();
+		$other_blog_id = self::factory()->blog->create();
+		$network_id    = (int) get_current_network_id();
+		$cache_root    = trailingslashit(WP_CONTENT_DIR) . 'et-cache';
+		$cache_dir     = trailingslashit($cache_root) . $network_id . '/' . $blog_id;
+		$other_dir     = trailingslashit($cache_root) . $network_id . '/' . $other_blog_id;
+		$outside_file  = $other_dir . '/external-target.css';
+		$symlink       = $cache_dir . '/external-target.css';
+
+		$this->cache_dirs = [$cache_dir, $other_dir];
+
+		wp_mkdir_p($cache_dir);
+		wp_mkdir_p($other_dir);
+
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents -- Test fixture setup.
+		file_put_contents($outside_file, 'external divi css');
+
+		// phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged, WordPress.WP.AlternativeFunctions.symlink_symlink -- Test fixture setup requires a symlink.
+		if ( ! @symlink($outside_file, $symlink)) {
+			$this->markTestSkipped('Symlink fixture could not be created');
+		}
+
+		General_Compat::get_instance()->clear_divi_static_css_cache(['site_id' => $blog_id]);
+
+		$this->assertFileExists($outside_file);
+		$this->assertDirectoryDoesNotExist($cache_dir);
+	}
+
+	/**
 	 * Recursively remove a test directory.
 	 *
 	 * @param string $dir Directory path.
@@ -96,7 +138,7 @@ class General_Compat_Test extends WP_UnitTestCase {
 		);
 
 		foreach ($iterator as $file) {
-			$path = $file->getRealPath();
+			$path = $file->isLink() ? $file->getPathname() : $file->getRealPath();
 
 			if (false === $path) {
 				continue;


### PR DESCRIPTION
## Summary

- Harden Divi static CSS cache purging so symlink entries are removed as links instead of deleting resolved targets outside the cache tree.
- Re-check each cache entry against the cloned-site cache directory before deletion.
- Add the General_Compat test guard/namespace cleanup and regression coverage for symlink targets.

## Testing

- `vendor/bin/phpcs inc/compat/class-general-compat.php tests/WP_Ultimo/General_Compat_Test.php`
- `WP_TESTS_DIR=/tmp/wordpress-tests-lib vendor/bin/phpunit --filter General_Compat_Test`

Resolves #1367

<!-- aidevops:sig -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened Divi static CSS cache cleanup with additional security checks to prevent deletion of files outside the cache directory and properly handle symbolic links without following their targets.

* **Tests**
  * Added test coverage to verify the cache cleanup functionality correctly handles and doesn't follow symbolic links, ensuring external files remain protected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->