### PR TITLE
Security: enforce object ownership in customer-panel AJAX handlers

### DIFF
--- a/inc/ui/class-billing-info-element.php
+++ b/inc/ui/class-billing-info-element.php
@@ -389,6 +389,10 @@ class Billing_Info_Element extends Base_Element {
 			wp_send_json_error($error);
 		}
 
+		if ( ! $membership->is_customer_allowed()) {
+			wp_send_json_error(new \WP_Error('no-permissions', __('You do not have permissions to perform this action.', 'ultimate-multisite')));
+		}
+
 		$billing_address = $membership->get_billing_address();
 
 		$billing_address->load_attributes_from_post();

--- a/inc/ui/class-current-site-element.php
+++ b/inc/ui/class-current-site-element.php
@@ -493,6 +493,10 @@ class Current_Site_Element extends Base_Element {
 			wp_send_json_error($error);
 		}
 
+		if ( ! $site->is_customer_allowed()) {
+			wp_send_json_error(new \WP_Error('no-permissions', __('You do not have permissions to perform this action.', 'ultimate-multisite')));
+		}
+
 		$new_title = wu_request('site_title');
 
 		if ( ! $new_title) {

--- a/inc/ui/class-domain-mapping-element.php
+++ b/inc/ui/class-domain-mapping-element.php
@@ -580,6 +580,30 @@ class Domain_Mapping_Element extends Base_Element {
 	}
 
 	/**
+	 * Checks whether the current user is allowed to manage a given domain.
+	 *
+	 * The customer-panel domain modals are registered with the 'exist'
+	 * capability (any logged-in user) and reference the target by a
+	 * client-supplied, forgeable id/hash. Authorization must therefore be
+	 * enforced per-object: the user must either be a network admin or the
+	 * owner of the site the domain is mapped to.
+	 *
+	 * @since 2.13.2
+	 * @param \WP_Ultimo\Models\Domain $domain The domain being acted upon.
+	 * @return bool
+	 */
+	protected function current_user_can_manage_domain($domain): bool {
+
+		if (current_user_can('manage_network')) {
+			return true;
+		}
+
+		$site = $domain ? $domain->get_site() : false;
+
+		return (bool) ($site && $site->is_customer_allowed());
+	}
+
+	/**
 	 * Handles deletion of the selected domain
 	 *
 	 * @since 2.0.0
@@ -598,6 +622,10 @@ class Domain_Mapping_Element extends Base_Element {
 		$current_site = wu_request('current_site');
 
 		$get_domain = Domain::get_by_id(wu_request('domain_id'));
+
+		if ( ! $get_domain || ! $this->current_user_can_manage_domain($get_domain)) {
+			wp_send_json_error(new \WP_Error('no-permissions', __('You do not have permissions to perform this action.', 'ultimate-multisite')));
+		}
 
 		$domain = new Domain($get_domain);
 
@@ -684,6 +712,10 @@ class Domain_Mapping_Element extends Base_Element {
 		$domain_id = wu_request('domain_id');
 
 		$domain = wu_get_domain($domain_id);
+
+		if ( ! $domain || ! $this->current_user_can_manage_domain($domain)) {
+			wp_send_json_error(new \WP_Error('no-permissions', __('You do not have permissions to perform this action.', 'ultimate-multisite')));
+		}
 
 		if ($domain) {
 			$domain->set_primary_domain(true);


### PR DESCRIPTION
## Summary

Several customer-panel modal handlers (registered as `wu_form` actions with the
`exist` capability, i.e. available to any logged-in user) acted on an object
referenced by a client-supplied id/hash **without verifying the caller owns it**.
Sibling handlers in the same files already enforce ownership
(`handle_user_add_new_domain_modal`, the DNS-record handlers via
`customer_can_manage_dns`), so this restores a consistent check.

Because the object identifiers are not secret, any authenticated user (including
a subscriber on any sub-site) could reach another tenant's objects — a
cross-tenant (IDOR / broken access control) issue.

## Changes

Adds the project's existing `Site::is_customer_allowed()` /
`Membership::is_customer_allowed()` ownership guard to:

- `Domain_Mapping_Element::handle_user_delete_domain_modal` (delete a domain)
- `Domain_Mapping_Element::handle_user_make_domain_primary_modal`
- `Current_Site_Element::handle_edit_site` (rename a site)
- `Billing_Info_Element::handle_update_billing_address`

Network admins (`manage_network`) are unaffected — `is_customer_allowed()`
returns `true` for them.

## Compatibility

No behavior change for legitimate users acting on their own objects; the guard
only rejects cross-tenant requests. No DB or API changes.

---
Part of a small series of focused security hardening PRs. Full technical detail
is available privately to the maintainers on request (coordinated disclosure).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Strengthened authorization checks when updating billing address information, preventing unauthorized billing changes.
  * Enhanced permission verification for site editing operations to ensure only allowed customers can proceed.
  * Implemented stricter authorization controls for domain management actions, blocking primary/deletion updates when access is not permitted.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->