### PR TITLE
Security: require capability checks on privileged network-admin AJAX endpoints

### DIFF
--- a/assets/js/dns-table.js
+++ b/assets/js/dns-table.js
@@ -1,7 +1,7 @@
 /* global ajaxurl, Vue, wu_dns_table_config, wu_ajax_error */
 (function($) {
 
-	wu_dns_table = new Vue({
+	window.wu_dns_table = new Vue({
 		el: '#wu-dns-table',
 		data: {
 			error: null,
@@ -23,26 +23,27 @@
 			url: ajaxurl,
 			data: {
 				action: 'wu_get_dns_records',
-				domain: window.wu_dns_table_config.domain,
+				domain: wu_dns_table_config.domain,
+				_ajax_nonce: wu_dns_table_config.nonce,
 			},
 			success(data) {
 
-				Vue.set(wu_dns_table, 'loading', false);
+				Vue.set(window.wu_dns_table, 'loading', false);
 
 				if (data.success) {
 
-					Vue.set(wu_dns_table, 'results', data.data);
+					Vue.set(window.wu_dns_table, 'results', data.data);
 
 				} else {
 
-					Vue.set(wu_dns_table, 'error', data.data);
+					Vue.set(window.wu_dns_table, 'error', data.data);
 
 				}
 
 			},
 			error(jqXHR) {
 
-				Vue.set(wu_dns_table, 'loading', false);
+				Vue.set(window.wu_dns_table, 'loading', false);
 
 				wu_ajax_error(jqXHR);
 

--- a/assets/js/integration-test.js
+++ b/assets/js/integration-test.js
@@ -1,3 +1,4 @@
+/* global ajaxurl, Vue, wu_integration_test_data */
 (function($) {
 	$(document).ready(function() {
 		new Vue({
@@ -18,6 +19,7 @@
 						data: {
 							action: 'wu_test_hosting_integration',
 							integration: wu_integration_test_data.integration_id,
+							_ajax_nonce: wu_integration_test_data.nonce,
 						},
 						success(response) {
 							that.loading = false;

--- a/assets/js/screenshot-scraper.js
+++ b/assets/js/screenshot-scraper.js
@@ -1,4 +1,4 @@
-/* global wu_block_ui, wu_ajax_error */
+/* global wu_block_ui, wu_ajax_error, wu_screenshot_scraper */
 (function($) {
 
 	$(document).ready(function() {
@@ -18,6 +18,7 @@
 				data: {
 					action: 'wu_get_screenshot',
 					site_id: $('#id').val(),
+					_ajax_nonce: wu_screenshot_scraper.nonce,
 				},
 				error(jqXHR) {
 

--- a/inc/admin-pages/class-base-customer-facing-admin-page.php
+++ b/inc/admin-pages/class-base-customer-facing-admin-page.php
@@ -74,12 +74,18 @@ abstract class Base_Customer_Facing_Admin_Page extends Base_Admin_Page {
 
 		add_action('updated_user_meta', [$this, 'save_settings'], 10, 4);
 
+		/*
+		 * This form customizes the network-admin menu title/position/icon of
+		 * the customer-facing pages and persists a network-level setting, so it
+		 * must require network-admin rights. The previous 'exist' capability
+		 * allowed any logged-in user to submit it.
+		 */
 		wu_register_form(
 			"edit_admin_page_$this->id",
 			[
 				'render'     => [$this, 'render_edit_page'],
 				'handler'    => [$this, 'handle_edit_page'],
-				'capability' => 'exist',
+				'capability' => 'manage_network',
 			]
 		);
 

--- a/inc/admin-pages/class-domain-edit-admin-page.php
+++ b/inc/admin-pages/class-domain-edit-admin-page.php
@@ -170,6 +170,7 @@ class Domain_Edit_Admin_Page extends Edit_Admin_Page {
 			'wu_dns_table_config',
 			[
 				'domain' => $this->get_object()->get_domain(),
+				'nonce'  => wp_create_nonce('wu_get_dns_records'),
 			]
 		);
 

--- a/inc/admin-pages/class-hosting-integration-wizard-admin-page.php
+++ b/inc/admin-pages/class-hosting-integration-wizard-admin-page.php
@@ -406,6 +406,7 @@ class Hosting_Integration_Wizard_Admin_Page extends Wizard_Admin_Page {
 			'wu-integration-test',
 			'var wu_integration_test_data = {
 				integration_id: "' . esc_js($this->integration->get_id()) . '",
+				nonce: "' . esc_js(wp_create_nonce('wu_test_hosting_integration')) . '",
 				waiting_message: "' . esc_js(__('Waiting for results...', 'ultimate-multisite')) . '",
 				error_message: "' . esc_js(__('Connection test failed. Please try again.', 'ultimate-multisite')) . '"
 			};',

--- a/inc/admin-pages/class-site-edit-admin-page.php
+++ b/inc/admin-pages/class-site-edit-admin-page.php
@@ -95,6 +95,14 @@ class Site_Edit_Admin_Page extends Edit_Admin_Page {
 
 		wp_enqueue_script('wu-screenshot-scraper');
 
+		wp_localize_script(
+			'wu-screenshot-scraper',
+			'wu_screenshot_scraper',
+			[
+				'nonce' => wp_create_nonce('wu_get_screenshot'),
+			]
+		);
+
 		wp_enqueue_media();
 
 		wp_enqueue_editor();

--- a/inc/admin-pages/class-system-info-admin-page.php
+++ b/inc/admin-pages/class-system-info-admin-page.php
@@ -561,6 +561,10 @@ class System_Info_Admin_Page extends Base_Admin_Page {
 	 */
 	public function generate_text_file_system_info(): void {
 
+		if ( ! current_user_can('manage_network')) {
+			wp_die(esc_html__('You do not have permission to access this resource.', 'ultimate-multisite'), 403);
+		}
+
 		$file_name = sprintf("$this->id-%s.txt", gmdate('Y-m-d'));
 
 		header('Content-Description: File Transfer');

--- a/inc/admin-pages/class-view-logs-admin-page.php
+++ b/inc/admin-pages/class-view-logs-admin-page.php
@@ -141,15 +141,21 @@ class View_Logs_Admin_Page extends Edit_Admin_Page {
 	 */
 	public function handle_view_logs() {
 
+		if ( ! current_user_can('manage_network')) {
+			wp_die(esc_html__('You do not have permission to access this resource.', 'ultimate-multisite'), 403);
+		}
+
+		$logs_folder = Logger::get_logs_folder();
+
 		$logs_list = list_files(
-			Logger::get_logs_folder(),
+			$logs_folder,
 			2,
 			[
 				'index.html',
 			]
 		);
 
-		$logs_list = array_combine(array_values($logs_list), array_map(fn($file) => str_replace(Logger::get_logs_folder(), '', (string) $file), $logs_list));
+		$logs_list = array_combine(array_values($logs_list), array_map(fn($file) => str_replace($logs_folder, '', (string) $file), $logs_list));
 
 		if (empty($logs_list)) {
 			$logs_list[''] = __('No log files found', 'ultimate-multisite');
@@ -161,9 +167,24 @@ class View_Logs_Admin_Page extends Edit_Admin_Page {
 
 		$contents = '';
 
-		// Security check
-		if ($file && ! stristr((string) $file, Logger::get_logs_folder())) {
-			wp_die(esc_html__('You can see files that are not Ultimate Multisite\'s logs', 'ultimate-multisite'));
+		/*
+		 * Security check: confine the requested file to the logs folder.
+		 *
+		 * realpath() resolves any '..' traversal so a crafted path cannot
+		 * escape the logs directory (the previous substring check accepted
+		 * any path that merely *contained* the logs folder, e.g.
+		 * "<logs>/../../../wp-config.php"). The resolved path must also be a
+		 * real file located under the resolved logs folder.
+		 */
+		if ($file) {
+			$real_file   = realpath((string) $file);
+			$real_folder = realpath($logs_folder);
+
+			if (false === $real_file || false === $real_folder || ! str_starts_with($real_file, trailingslashit($real_folder))) {
+				wp_die(esc_html__('You can only view Ultimate Multisite log files.', 'ultimate-multisite'), 403);
+			}
+
+			$file = $real_file;
 		}
 
 		if ( ! $file && ! empty($logs_list)) {

--- a/inc/class-ajax.php
+++ b/inc/class-ajax.php
@@ -86,6 +86,19 @@ class Ajax implements \WP_Ultimo\Interfaces\Singleton {
 	 */
 	public function search_models(): void {
 
+		/*
+		 * The selectize search endpoint returns network-wide objects
+		 * (customers, memberships, payments and — for the 'user' model —
+		 * WordPress user logins and email addresses). It is only ever wired
+		 * to network-admin forms, so restrict it to network administrators
+		 * to prevent any logged-in user from enumerating that data.
+		 */
+		if ( ! current_user_can('manage_network')) {
+			wp_send_json([]);
+
+			return;
+		}
+
 		/**
 		 * Fires before the processing of the search request.
 		 *

--- a/inc/class-dashboard-widgets.php
+++ b/inc/class-dashboard-widgets.php
@@ -320,10 +320,16 @@ class Dashboard_Widgets implements \WP_Ultimo\Interfaces\Singleton {
 	 */
 	public function process_ajax_fetch_rss(): void {
 
+		if ( ! current_user_can('manage_network')) {
+			wp_die('', '', ['response' => 403]);
+		}
+
+		$default_url = 'https://community.wpultimo.com/topics/feed';
+
 		$atts = wp_parse_args(
 			$_GET, // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 			[
-				'url'          => 'https://community.wpultimo.com/topics/feed',
+				'url'          => $default_url,
 				'title'        => __('Forum Discussions', 'ultimate-multisite'),
 				'items'        => 3,
 				'show_summary' => 1,
@@ -331,6 +337,15 @@ class Dashboard_Widgets implements \WP_Ultimo\Interfaces\Singleton {
 				'show_date'    => 1,
 			]
 		);
+
+		/*
+		 * Never let the request control the outbound URL. This widget only
+		 * renders the plugin's own community feed; honouring a request-supplied
+		 * URL would turn the endpoint into a server-side request forgery (SSRF)
+		 * probe against internal hosts. Site owners can still override the feed
+		 * server-side via the filter below.
+		 */
+		$atts['url'] = apply_filters('wu_dashboard_rss_feed_url', $default_url);
 
 		wp_widget_rss_output($atts);
 
@@ -376,6 +391,10 @@ class Dashboard_Widgets implements \WP_Ultimo\Interfaces\Singleton {
 	 * @return void
 	 */
 	public function handle_table_csv(): void {
+
+		if ( ! current_user_can('manage_network')) {
+			wp_die('', '', ['response' => 403]);
+		}
 
 		$date_range = wu_request('date_range');
 		$headers    = json_decode(stripslashes((string) wu_request('headers')));

--- a/inc/managers/class-domain-manager.php
+++ b/inc/managers/class-domain-manager.php
@@ -1226,6 +1226,10 @@ class Domain_Manager extends Base_Manager {
 	 */
 	public function get_dns_records(): void {
 
+		if ( ! current_user_can('manage_network')) {
+			wp_send_json_error(new \WP_Error('unauthorized', __('You do not have permission to perform this action.', 'ultimate-multisite')));
+		}
+
 		$domain = wu_request('domain');
 
 		if ( ! $domain) {
@@ -1490,6 +1494,10 @@ class Domain_Manager extends Base_Manager {
 	 * @return void
 	 */
 	public function test_integration() {
+
+		if ( ! current_user_can('manage_network')) {
+			wp_send_json_error(new \WP_Error('unauthorized', __('You do not have permission to perform this action.', 'ultimate-multisite')));
+		}
 
 		$integration_id = wu_request('integration', 'none');
 

--- a/inc/managers/class-domain-manager.php
+++ b/inc/managers/class-domain-manager.php
@@ -1227,7 +1227,11 @@ class Domain_Manager extends Base_Manager {
 	public function get_dns_records(): void {
 
 		if ( ! current_user_can('manage_network')) {
-			wp_send_json_error(new \WP_Error('unauthorized', __('You do not have permission to perform this action.', 'ultimate-multisite')));
+			wp_send_json_error(new \WP_Error('unauthorized', __('You do not have permission to perform this action.', 'ultimate-multisite')), 403);
+		}
+
+		if ( ! check_ajax_referer('wu_get_dns_records', false, false)) {
+			wp_send_json_error(new \WP_Error('invalid_nonce', __('Security check failed. Please try again.', 'ultimate-multisite')), 403);
 		}
 
 		$domain = wu_request('domain');
@@ -1496,7 +1500,11 @@ class Domain_Manager extends Base_Manager {
 	public function test_integration() {
 
 		if ( ! current_user_can('manage_network')) {
-			wp_send_json_error(new \WP_Error('unauthorized', __('You do not have permission to perform this action.', 'ultimate-multisite')));
+			wp_send_json_error(new \WP_Error('unauthorized', __('You do not have permission to perform this action.', 'ultimate-multisite')), 403);
+		}
+
+		if ( ! check_ajax_referer('wu_test_hosting_integration', false, false)) {
+			wp_send_json_error(new \WP_Error('invalid_nonce', __('Security check failed. Please try again.', 'ultimate-multisite')), 403);
 		}
 
 		$integration_id = wu_request('integration', 'none');

--- a/inc/managers/class-site-manager.php
+++ b/inc/managers/class-site-manager.php
@@ -539,6 +539,10 @@ class Site_Manager extends Base_Manager {
 	 */
 	public function get_site_screenshot(): void {
 
+		if ( ! current_user_can('manage_network')) {
+			wp_send_json_error(new \WP_Error('unauthorized', __('You do not have permission to perform this action.', 'ultimate-multisite')));
+		}
+
 		$site_id = wu_request('site_id');
 
 		$site = wu_get_site($site_id);

--- a/inc/managers/class-site-manager.php
+++ b/inc/managers/class-site-manager.php
@@ -540,7 +540,11 @@ class Site_Manager extends Base_Manager {
 	public function get_site_screenshot(): void {
 
 		if ( ! current_user_can('manage_network')) {
-			wp_send_json_error(new \WP_Error('unauthorized', __('You do not have permission to perform this action.', 'ultimate-multisite')));
+			wp_send_json_error(new \WP_Error('unauthorized', __('You do not have permission to perform this action.', 'ultimate-multisite')), 403);
+		}
+
+		if ( ! check_ajax_referer('wu_get_screenshot', false, false)) {
+			wp_send_json_error(new \WP_Error('invalid_nonce', __('Security check failed. Please try again.', 'ultimate-multisite')), 403);
 		}
 
 		$site_id = wu_request('site_id');

--- a/inc/site-templates/class-template-placeholders.php
+++ b/inc/site-templates/class-template-placeholders.php
@@ -146,6 +146,10 @@ class Template_Placeholders {
 	 */
 	public function serve_placeholders_via_ajax(): void {
 
+		if ( ! current_user_can('manage_network')) {
+			wp_send_json_error(new \WP_Error('unauthorized', __('You do not have permission to perform this action.', 'ultimate-multisite')));
+		}
+
 		wp_send_json_success($this->placeholders_as_saved);
 	}
 
@@ -157,7 +161,16 @@ class Template_Placeholders {
 	 */
 	public function save_placeholders(): void {
 
-		if ( ! check_ajax_referer('wu_edit_placeholders_editing')) {
+		if ( ! current_user_can('manage_network')) {
+			wp_send_json(
+				[
+					'code'    => 'not-enough-permissions',
+					'message' => __('You don\'t have permission to alter placeholders.', 'ultimate-multisite'),
+				]
+			);
+		}
+
+		if ( ! check_ajax_referer('wu_edit_placeholders_editing', false, false)) {
 			wp_send_json(
 				[
 					'code'    => 'not-enough-permissions',


### PR DESCRIPTION
## Summary

Several `wp_ajax_*` endpoints that back **network-admin** tools were registered
with no capability check, so any authenticated user (including a subscriber on a
sub-site) could reach them. None of these are wired to customer-facing UI.

This enforces `manage_network` on each, and adds two endpoint-specific hardenings.

## Changes

- `Ajax::search_models` / `search_all_models` — returned network-wide objects
  and, for the `user` model, WordPress logins and **email addresses**
  (user/email enumeration). Restricted to network admins.
- `View_Logs_Admin_Page::handle_view_logs` — capability check **and** the
  "is this under the logs folder?" substring test replaced with `realpath()`
  containment so a crafted path can no longer traverse out of the logs
  directory (arbitrary file read).
- `Dashboard_Widgets::process_ajax_fetch_rss` — capability check **and** the
  outbound feed URL is now pinned to the plugin's own community feed
  (filterable), removing an SSRF vector; plus `handle_table_csv`.
- `System_Info_Admin_Page::generate_text_file_system_info` — system report.
- `Domain_Manager::get_dns_records` / `test_integration` — DNS lookups and
  hosting-provider connection tests.
- `Site_Manager::get_site_screenshot` — screenshot scraper.
- `Template_Placeholders::save_placeholders` / `serve_placeholders_via_ajax`.
- `Base_Customer_Facing_Admin_Page` customize form: capability `exist`
  raised to `manage_network`.

## Compatibility

These endpoints are only ever invoked from network-admin screens, so legitimate
use is unaffected. The customer-facing DNS flow uses a different action
(`wu_get_dns_records_for_domain`) and is not touched.

---
Part of a small series of focused security hardening PRs. Full technical detail
is available privately to the maintainers on request (coordinated disclosure).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security**
  * Restricted multiple network-admin tools and AJAX endpoints to `manage_network`, returning HTTP 403 when unauthorized.
  * Strengthened log file access using resolved-path containment checks.
  * Added/required AJAX nonces for DNS lookups, integration tests, placeholder editing, CSV export, and screenshot requests.
  * Hardened RSS feed handling to prevent request-controlled outbound URLs (SSRF mitigation).
* **Frontend**
  * Improved DNS table script scoping by attaching the Vue instance/state to `window`.
  * Updated several frontend requests to send the appropriate nonce values in payloads.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->