### PR TITLE
Security: enforce payment ownership in the status-polling AJAX endpoint

### DIFF
--- a/inc/managers/class-gateway-manager.php
+++ b/inc/managers/class-gateway-manager.php
@@ -637,6 +637,22 @@ class Gateway_Manager extends Base_Manager {
 			wp_send_json_error(['message' => __('Payment not found.', 'ultimate-multisite')]);
 		}
 
+		/*
+		 * Enforce ownership. The payment hash is a reversible identifier (not a
+		 * secret), and the polling nonce is a static value localised into every
+		 * checkout/thank-you page, so neither binds the request to a payment.
+		 * Without this check any logged-in user could poll the status of — and
+		 * trigger gateway verification on — arbitrary payments. Only the owning
+		 * customer (or a network admin) may proceed.
+		 */
+		$current_customer = wu_get_current_customer();
+
+		$is_owner = $current_customer && (int) $payment->get_customer_id() === (int) $current_customer->get_id();
+
+		if ( ! $is_owner && ! current_user_can('manage_network')) {
+			wp_send_json_error(['message' => __('Payment not found.', 'ultimate-multisite')]);
+		}
+
 		// If already completed, return success
 		if ($payment->get_status() === \WP_Ultimo\Database\Payments\Payment_Status::COMPLETED) {
 			wp_send_json_success(


### PR DESCRIPTION
## Summary

`Gateway_Manager::ajax_check_payment_status()` looked a payment up by its hash
and then disclosed its status and called the gateway's
`verify_and_complete_payment()` with **no ownership check**. The payment hash is
a reversible identifier, and the `wu_payment_status_poll` nonce is a single
static value localised into every checkout/thank-you page, so neither restricts
which payment a caller may target — any logged-in user could poll arbitrary
payments and trigger gateway verification on them (IDOR).

## Changes

Require the current customer to own the payment (or be a network admin) before
proceeding, returning the same generic "not found" response on mismatch so the
endpoint doesn't reveal which payment ids exist.

## Compatibility

The legitimate caller is the customer who just checked out, polling their own
payment — unaffected. No API/DB changes.

---
Part of a small series of focused security hardening PRs. Full technical detail
is available privately to the maintainers on request (coordinated disclosure).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened payment status verification with enhanced access control. The payment status endpoint now enforces user ownership validation, ensuring customers can only access their own payment information. Unauthorized requests receive appropriate error responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->