### PR TITLE
Security: escape customer/product output in the Broadcast list table

### DIFF
--- a/inc/list-tables/class-broadcast-list-table.php
+++ b/inc/list-tables/class-broadcast-list-table.php
@@ -182,11 +182,11 @@ class Broadcast_List_Table extends Base_List_Table {
 
 				$email = $customer->get_email_address();
 
-				$html = "<a href='{$customer_link}' class='wu-p-2 wu-flex wu-flex-grow wu-bg-gray-100 wu-rounded wu-items-center wu-border wu-border-solid wu-border-gray-300'>
+				$html = "<a href='" . esc_url($customer_link) . "' class='wu-p-2 wu-flex wu-flex-grow wu-bg-gray-100 wu-rounded wu-items-center wu-border wu-border-solid wu-border-gray-300'>
 										{$avatar}
 										<div class='wu-pl-2'>
-												<strong class='wu-block'>{$display_name} <small class='wu-font-normal'>(#{$id})</small></strong>
-												<small>{$email}</small>
+												<strong class='wu-block'>" . esc_html($display_name) . " <small class='wu-font-normal'>(#" . esc_html((string) $id) . ")</small></strong>
+												<small>" . esc_html($email) . "</small>
 										</div>
 								</a>";
 
@@ -215,7 +215,7 @@ class Broadcast_List_Table extends Base_List_Table {
 
 					$customer_link = wu_network_admin_url('wp-ultimo-edit-customer', $url_atts);
 
-					$html .= "<div class='wu-flex wu--mr-4'><a role='tooltip' aria-label='{$tooltip_name}' href='{$customer_link}'>{$avatar}</a></div>";
+					$html .= "<div class='wu-flex wu--mr-4'><a role='tooltip' aria-label='" . esc_attr($tooltip_name) . "' href='" . esc_url($customer_link) . "'>{$avatar}</a></div>";
 				}
 
 				if ($targets_count < 7) {
@@ -363,7 +363,7 @@ class Broadcast_List_Table extends Base_List_Table {
 		</div>';
 			}
 
-			$html .= "<div class='wu-flex wu--mr-4'><a role='tooltip' aria-label='{$product_name}' href='{$product_link}'>{$image}</a></div>";
+			$html .= "<div class='wu-flex wu--mr-4'><a role='tooltip' aria-label='" . esc_attr($product_name) . "' href='" . esc_url($product_link) . "'>{$image}</a></div>";
 		}
 
 		if ($product_count > 1 && $product_count < 5) {


### PR DESCRIPTION
## Summary

`column_target_customers()` and `column_target_products()` interpolated customer
display names, email addresses and product names directly into HTML — including
into single-quoted `aria-label` attributes. A customer controls their own
display name (WordPress does not HTML-escape display names on save), so a crafted
name is stored and then rendered unescaped when a network admin views the
**Broadcasts** list — a stored XSS that fires in the network-admin context.

## Changes

Escape each interpolated value for its context: `esc_url()` for links,
`esc_attr()` for attribute values, `esc_html()` for text nodes.

## Compatibility

Output-only change; rendered markup is identical for non-malicious data.

---
Part of a small series of focused security hardening PRs. Full technical detail
is available privately to the maintainers on request (coordinated disclosure).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced data rendering for customer and product targets in broadcast lists to properly handle special characters in names, IDs, emails, and links.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->