### PR TITLE
Security: allow-list the model identifier in Limitations::remove_limitations

### DIFF
--- a/inc/objects/class-limitations.php
+++ b/inc/objects/class-limitations.php
@@ -478,6 +478,18 @@ class Limitations implements \JsonSerializable {
 
 		global $wpdb;
 
+		/*
+		 * $slug is used to build the meta table and column names below, so it
+		 * must never be taken from request input verbatim. Validate it against
+		 * a fixed allow-list of the models that actually carry limitations to
+		 * prevent SQL injection through the identifier.
+		 */
+		$allowed_models = ['membership', 'product', 'customer', 'site'];
+
+		if ( ! in_array($slug, $allowed_models, true)) {
+			return;
+		}
+
 		$wu_prefix = 'wu_';
 
 		/*


### PR DESCRIPTION
## Summary

`Limitations::remove_limitations()` interpolated its `$slug` argument straight
into the meta **table name** and the id **column name** of a `DELETE` query.
`$slug` originates from request input (`model`) in
`handle_confirm_limitations_reset()`, and `wu_request()` does not make a value
identifier-safe, so a crafted value could inject SQL through the identifier
(the bound `%d` id is safe; the identifier is not).

## Changes

Validate `$slug` against a fixed allow-list of the models that actually carry
limitations (`membership`, `product`, `customer`, `site`) before it is used to
build any SQL.

## Compatibility

All legitimate callers pass one of the allow-listed models, so the reset flow is
unchanged.

---
Part of a small series of focused security hardening PRs. Full technical detail
is available privately to the maintainers on request (coordinated disclosure).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced validation for limitation removal operations to restrict processing to supported limitation types (membership, product, customer, and site).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->