### PR TITLE
Robustness: guard process_checkout() against missing cart and invalid gateway

### DIFF
--- a/inc/checkout/class-checkout.php
+++ b/inc/checkout/class-checkout.php
@@ -3047,7 +3047,7 @@ class Checkout {
 		 * so get_meta() returns its `false` default. Bail cleanly instead of
 		 * fatally calling a method on a boolean.
 		 */
-		if ( ! $this->order instanceof \WP_Ultimo\Checkout\Cart) {
+		if ( ! ($this->order instanceof \WP_Ultimo\Checkout\Cart)) {
 			$this->errors = new \WP_Error('no-cart', __('This checkout session has expired or cannot be resumed. Please start over.', 'ultimate-multisite'));
 
 			return false;

--- a/inc/checkout/class-checkout.php
+++ b/inc/checkout/class-checkout.php
@@ -3039,6 +3039,20 @@ class Checkout {
 		 * It ensure that the cart is the same used in beginning of the process.
 		 */
 		$this->order = $payment->get_meta('wu_original_cart');
+
+		/*
+		 * The original cart is only stored for payments created through the
+		 * normal checkout flow (process_order). Payments created elsewhere
+		 * (webhooks, admin, the register API) have no 'wu_original_cart' meta,
+		 * so get_meta() returns its `false` default. Bail cleanly instead of
+		 * fatally calling a method on a boolean.
+		 */
+		if ( ! $this->order instanceof \WP_Ultimo\Checkout\Cart) {
+			$this->errors = new \WP_Error('no-cart', __('This checkout session has expired or cannot be resumed. Please start over.', 'ultimate-multisite'));
+
+			return false;
+		}
+
 		$this->order->set_membership($membership);
 		$this->order->set_customer($customer);
 		$this->order->set_payment($payment);
@@ -3058,7 +3072,7 @@ class Checkout {
 				$gateway = wu_get_gateway($payment->get_gateway());
 			} elseif ($this->order->should_collect_payment() === false) {
 				$gateway = wu_get_gateway('free');
-			} elseif ($gateway->get_id() === 'free') {
+			} elseif ($gateway && $gateway->get_id() === 'free') {
 					$this->errors = new \WP_Error('no-gateway', __('Payment gateway not registered.', 'ultimate-multisite'));
 
 					return false;


### PR DESCRIPTION
## Summary

Two reachable fatals on the synchronous final-checkout path in
`Checkout::process_checkout()`:

1. `$payment->get_meta('wu_original_cart')` returns its `false` default for any
   payment **not** created by the normal checkout flow (webhook / admin /
   register-API payments). The next line called `$this->order->set_membership()`
   on that boolean → `Error: Call to a member function … on bool`. Sibling
   consumers (`Discount_Code_Manager`, `Base_Stripe_Gateway`) already validate
   this meta with `is_a(..., Cart::class)`; this path did not.
2. The `elseif ($gateway->get_id() === 'free')` branch dereferenced `$gateway`,
   which is `false` when an unknown `gateway` request value is supplied.

## Changes

- Bail with a clean `WP_Error` when the stored cart isn't a `Cart`.
- Guard the gateway dereference so a `false` gateway falls through to the
  existing "gateway not registered" error.

Both are robustness/DoS fixes; valid checkouts are unaffected.

> Note: this PR intentionally does **not** add the CSRF nonce / payment-ownership
> check on this same path — those are real but carry caching/UX trade-offs and
> are described in the private advisory for maintainer review.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Checkout now validates stored cart data and halts with a clear error when cart information is missing or invalid, preventing downstream failures.
  * Payment gateway selection is more robust against missing/null gateways, avoiding runtime errors in edge-case payment flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->