### PR TITLE
Fix: load membership and customer with the correct helpers in PayPal Express IPN

### DIFF
--- a/inc/gateways/class-paypal-gateway.php
+++ b/inc/gateways/class-paypal-gateway.php
@@ -954,10 +954,11 @@ class PayPal_Gateway extends Base_PayPal_Gateway {
 
 		$custom = ! empty($posted['custom']) ? explode('|', (string) $posted['custom']) : [];
 
-		if (is_array($custom) && ! empty($custom)) {
+		// `custom` is built as "payment_id|membership_id|customer_id" (see set_express_checkout()).
+		if (is_array($custom) && count($custom) >= 3) {
 			$payment    = wu_get_payment(absint($custom[0]));
-			$membership = wu_get_payment(absint($custom[1]));
-			$customer   = wu_get_payment(absint($custom[2]));
+			$membership = wu_get_membership(absint($custom[1]));
+			$customer   = wu_get_customer(absint($custom[2]));
 		}
 
 		if ( ! empty($posted['recurring_payment_id'])) {


### PR DESCRIPTION
## Summary

In `PayPal_Gateway::process_webhooks()` the IPN `custom` field is
`payment_id|membership_id|customer_id`, but all three ids were loaded with
`wu_get_payment()`. So `$membership` and `$customer` were the wrong object type
(or `false`), leading to wrong-object data handling and a fatal when the later
code calls Membership-only methods (`is_active()`, `renew()`, …).

## Changes

- Use `wu_get_membership()` and `wu_get_customer()` for the respective ids.
- Guard the index count so a malformed `custom` value doesn't raise
  undefined-index warnings.

Affects the legacy PayPal Express (NVP) gateway IPN path only.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed PayPal gateway webhook processing to properly identify and link payments, memberships, and customers from PayPal transaction data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->