### PR TITLE
Security: reject unsafe manifest plugin paths during site import

### DIFF
--- a/inc/site-exporter/mu-migration/includes/commands/class-mu-migration-import.php
+++ b/inc/site-exporter/mu-migration/includes/commands/class-mu-migration-import.php
@@ -599,6 +599,23 @@ class ImportCommand extends MUMigrationBase {
 			$installed_plugins = WP_PLUGIN_DIR;
 			$check_plugins     = false !== $blog_plugins && false !== $network_plugins;
 			foreach ( $plugins as $plugin_name => $plugin ) {
+				/*
+				 * $plugin_name comes from the imported site manifest (untrusted
+				 * JSON). A plugin basename is "<folder>/<file>.php" or
+				 * "<file>.php" — never absolute and never containing a
+				 * parent-directory segment. Reject anything else so a crafted
+				 * manifest cannot drive rename()/activate_plugin() to a path
+				 * outside WP_PLUGIN_DIR (path traversal / arbitrary inclusion).
+				 */
+				if ( ! is_string($plugin_name) || '' === $plugin_name
+					|| false !== strpos($plugin_name, "\0")
+					|| 0 === strpos($plugin_name, '/')
+					|| 0 === strpos($plugin_name, '\\')
+					|| preg_match('#(^|[\\\\/])\.\.([\\\\/]|$)#', $plugin_name) ) {
+					WP_CLI::warning(sprintf(__('Skipping plugin with unsafe path: %s', 'mu-migration'), (string) $plugin_name));
+					continue;
+				}
+
 				$plugin_folder  = dirname($plugin_name);
 				$fullPluginPath = $plugins_dir . '/' . $plugin_folder;
 


### PR DESCRIPTION
## Summary

`move_and_activate_plugins()` builds `rename()` / `activate_plugin()` targets
from the **plugin keys of the imported site manifest** (untrusted JSON inside the
import package). Those keys were used without validation, so a crafted manifest
could use a path-traversal key (e.g. `../../..`) to relocate files or activate a
PHP file **outside** `WP_PLUGIN_DIR` — a second-order path-traversal /
arbitrary-inclusion risk when a network admin imports a site package from an
untrusted source (e.g. a template marketplace).

## Changes

Validate each plugin key before use: reject non-strings, absolute paths, NUL
bytes and any parent-directory (`..`) segment, skipping them with a warning.

The import action itself remains network-admin-gated; this hardens what a
malicious *package* can do once an admin chooses to import it.