### PR TITLE
Robustness: null-deref, div-by-zero and control-flow guards

### DIFF
--- a/inc/functions/currency.php
+++ b/inc/functions/currency.php
@@ -210,6 +210,7 @@ function wu_get_currency_symbol($currency = '') {
 			break;
 		case 'BYN':
 			$currency_symbol = 'Br';
+			break;
 		case 'CHF':
 			$currency_symbol = 'CHF';
 			break;

--- a/inc/functions/discount-code.php
+++ b/inc/functions/discount-code.php
@@ -63,6 +63,10 @@ function wu_get_discount_codes($query = []) {
  */
 function wu_get_discounted_price($base_price, $amount, $type, $format = true) {
 
+	// Default to the base price so an unknown discount type fails safe to
+	// "no discount applied" instead of an undefined variable.
+	$discounted_price = $base_price;
+
 	if ('percentage' === $type) {
 		$discounted_price = $base_price - ($base_price * ($amount / 100));
 	} elseif ('absolute' === $type) {

--- a/inc/installers/class-migrator.php
+++ b/inc/installers/class-migrator.php
@@ -1871,7 +1871,7 @@ class Migrator extends Base_Installer {
 				'parent'             => 0,
 				'line_items'         => $line_items,
 				'status'             => wu_get_isset($map_status, $transaction->type, Payment_Status::COMPLETED),
-				'customer_id'        => $membership ? $customer->get_id() : false,
+				'customer_id'        => ($membership && $customer) ? $customer->get_id() : false,
 				'membership_id'      => $membership ? $membership->get_id() : false,
 				'product_id'         => $membership ? $membership->get_plan_id() : false,
 				'currency'           => $membership ? $membership->get_currency() : false,

--- a/inc/integrations/host-providers/class-cloudflare-host-provider.php
+++ b/inc/integrations/host-providers/class-cloudflare-host-provider.php
@@ -96,8 +96,10 @@ class Cloudflare_Host_Provider extends Base_Host_Provider {
 			]
 		);
 
-		foreach ($cloudflare_zones->result as $zone) {
-			$zone_ids[] = $zone->id;
+		if ( ! is_wp_error($cloudflare_zones) && ! empty($cloudflare_zones->result) && is_iterable($cloudflare_zones->result) ) {
+			foreach ($cloudflare_zones->result as $zone) {
+				$zone_ids[] = $zone->id;
+			}
 		}
 
 		foreach ($zone_ids as $zone_id) {

--- a/inc/integrations/host-providers/class-dns-record.php
+++ b/inc/integrations/host-providers/class-dns-record.php
@@ -505,7 +505,7 @@ class DNS_Record {
 						'id'       => $data['id'] ?? ($data['type'] . '-' . ($data['name'] ?? '@')),
 						'type'     => $data['type'] ?? 'A',
 						'name'     => $data['name'] ?? '@',
-						'content'  => $data['value'] ?? '',
+						'content'  => $data['content'] ?? $data['value'] ?? '',
 						'ttl'      => (int) ($data['ttl'] ?? 3600),
 						'priority' => isset($data['priority']) ? (int) $data['priority'] : null,
 						'proxied'  => false,

--- a/inc/models/class-membership.php
+++ b/inc/models/class-membership.php
@@ -1106,6 +1106,10 @@ class Membership extends Base_Model implements Limitable, Billable, Notable {
 
 		$duration = $this->get_duration();
 
+		if ( ! $duration ) {
+			return $amount;
+		}
+
 		$normalized_duration_unit = wu_convert_duration_unit_to_month($this->get_duration_unit());
 
 		return $amount / $duration * $normalized_duration_unit;

--- a/inc/models/class-site.php
+++ b/inc/models/class-site.php
@@ -2378,6 +2378,10 @@ class Site extends Base_Model implements Limitable, Notable {
 
 					$pending_site = maybe_unserialize($item);
 
+					if ( ! $pending_site instanceof self ) {
+						return null;
+					}
+
 					$pending_site->set_type('pending');
 
 					return $pending_site;
@@ -2385,7 +2389,7 @@ class Site extends Base_Model implements Limitable, Notable {
 				$results
 			);
 
-			return $results;
+			return array_values(array_filter($results));
 		}
 
 		$query = $query_args;

--- a/inc/sso/class-magic-link.php
+++ b/inc/sso/class-magic-link.php
@@ -125,6 +125,10 @@ class Magic_Link {
 
 		$site = wu_get_site($site_id);
 
+		if ( ! $site ) {
+			return false;
+		}
+
 		// Build the magic link URL.
 		$site_url = $site->get_active_site_url();
 

--- a/inc/sso/class-magic-link.php
+++ b/inc/sso/class-magic-link.php
@@ -100,6 +100,12 @@ class Magic_Link {
 			return false;
 		}
 
+		$site = wu_get_site($site_id);
+
+		if ( ! $site ) {
+			return false;
+		}
+
 		// Generate secure token.
 		$token = $this->generate_token();
 
@@ -122,12 +128,6 @@ class Magic_Link {
 		wu_switch_blog_and_run(
 			fn() => set_transient($transient_key, $token_data, self::TOKEN_EXPIRATION)
 		);
-
-		$site = wu_get_site($site_id);
-
-		if ( ! $site ) {
-			return false;
-		}
 
 		// Build the magic link URL.
 		$site_url = $site->get_active_site_url();


### PR DESCRIPTION
## Summary

A bundle of small, isolated robustness fixes found during a reliability review.
Each change is independent and a few lines; grouped for easier review.

- **functions/currency.php** — add missing `break;` so `BYN` no longer falls
  through and renders the `CHF` symbol.
- **functions/discount-code.php** — initialise `$discounted_price` to the base
  price so an unknown discount type fails safe instead of returning an undefined
  value.
- **models/class-membership.php** — `get_normalized_amount()` guards against a
  zero `duration` before dividing.
- **models/class-site.php** — `get_all_by_type('pending')` validates the
  unserialized value is a `Site` before calling `->set_type()`, and filters out
  bad rows.
- **sso/class-magic-link.php** — `generate_magic_link()` bails when
  `wu_get_site()` returns `false` (mirrors sibling methods) instead of
  dereferencing null.
- **installers/class-migrator.php** — guard `$customer` (not `$membership`)
  before `$customer->get_id()` when building migrated payment data.
- **integrations/host-providers/class-cloudflare-host-provider.php** — guard the
  zones API result before iterating `->result`.
- **integrations/host-providers/class-dns-record.php** — read the Hestia record
  `content` key (falling back to `value`) so record content isn't dropped.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Brazilian Real (BRL) currency symbol handling to avoid incorrect fall-through
  * Prevented discounted price calculations from using an undefined value for unsupported types
  * Hardened payment transaction customer ID assignment to avoid null dereferences
  * Improved Cloudflare DNS zone ID collection robustness against error/empty responses
  * Corrected DNS record content mapping for the Hestia provider
  * Avoided division-by-zero in normalized membership amount calculations
  * Validated and filtered pending site deserialization results
  * Made magic link generation fail safely when the target site is missing
<!-- end of auto-generated comment: release notes by coderabbit.ai -->