### PR TITLE
Security: escape attacker-influenced data rendered in admin views (XSS)

### DIFF
--- a/inc/list-tables/class-webhook-list-table.php
+++ b/inc/list-tables/class-webhook-list-table.php
@@ -97,7 +97,7 @@ class Webhook_List_Table extends Base_List_Table {
 	 */
 	public function column_webhook_url($item) {
 
-		$trimmed_url = mb_strimwidth((string) $item->get_webhook_url(), 0, 50, '...');
+		$trimmed_url = esc_html(mb_strimwidth((string) $item->get_webhook_url(), 0, 50, '...'));
 
 		return "<span class='wu-py-1 wu-px-2 wu-bg-gray-200 wu-rounded-sm wu-text-gray-700 wu-text-xs wu-font-mono'>{$trimmed_url}</span>";
 	}
@@ -112,7 +112,7 @@ class Webhook_List_Table extends Base_List_Table {
 	 */
 	public function column_event($item) {
 
-		$event = $item->get_event();
+		$event = esc_html((string) $item->get_event());
 
 		return "<span class='wu-py-1 wu-px-2 wu-bg-gray-200 wu-rounded-sm wu-text-gray-700 wu-text-xs wu-font-mono'>{$event}</span>";
 	}

--- a/inc/list-tables/class-webhook-list-table.php
+++ b/inc/list-tables/class-webhook-list-table.php
@@ -65,14 +65,14 @@ class Webhook_List_Table extends Base_List_Table {
 			'<a href="%s"><strong>%s</strong></a>
 				<span data-loading="wu_action_button_loading_%s" id="wu_action_button_loading" class="wu-blinking-animation wu-text-gray-600 wu-my-1 wu-text-2xs wu-uppercase wu-font-semibold hidden" >%s</span>',
 			wu_network_admin_url('wp-ultimo-edit-webhook', $url_atts),
-			$item->get_name(),
+			esc_html($item->get_name()),
 			$item->get_id(),
 			__('Sending Test..', 'ultimate-multisite')
 		);
 
 		$actions = [
 			'edit'   => sprintf('<a href="%s">%s</a>', wu_network_admin_url('wp-ultimo-edit-webhook', $url_atts), __('Edit', 'ultimate-multisite')),
-			'test'   => sprintf('<a id="action_button" data-title="' . $item->get_name() . '" data-page="list" data-action="wu_send_test_event" data-event="' . $item->get_event() . '" data-object="' . $item->get_id() . '" data-url="%s" href="">%s</a>', $item->get_webhook_url(), __('Send Test', 'ultimate-multisite')),
+			'test'   => sprintf('<a id="action_button" data-title="' . esc_attr($item->get_name()) . '" data-page="list" data-action="wu_send_test_event" data-event="' . esc_attr($item->get_event()) . '" data-object="' . esc_attr($item->get_id()) . '" data-url="%s" href="">%s</a>', esc_url($item->get_webhook_url()), __('Send Test', 'ultimate-multisite')),
 			'delete' => sprintf(
 				'<a title="%s" class="wubox" href="%s">%s</a>',
 				__('Delete', 'ultimate-multisite'),

--- a/inc/models/class-event.php
+++ b/inc/models/class-event.php
@@ -271,23 +271,32 @@ class Event extends Base_Model {
 
 		$payload = json_decode(json_encode($payload), true); // phpcs:ignore WordPress.WP.AlternativeFunctions.json_encode_json_encode
 
-		$interpolation_keys = [];
+		/*
+		 * The message templates (get_default_system_messages) intentionally
+		 * contain HTML (e.g. <strong>{{model}}</strong>) and the rendered result
+		 * is output with Vue v-html in the activity-stream widget. The
+		 * interpolated payload values, however, include attacker-influenced model
+		 * fields (customer display names, site titles, etc.), so every value must
+		 * be HTML-escaped before substitution to prevent stored XSS — while the
+		 * template's own markup is preserved.
+		 */
+		$interpolation = [];
 
-		foreach ($payload as $key => &$value) {
-			$interpolation_keys[] = "{{{$key}}}";
-
+		foreach ($payload as $key => $value) {
 			if (is_array($value)) {
-				$value = implode(' &rarr; ', wu_array_flatten($value));
+				$value = implode(' &rarr; ', array_map('esc_html', wu_array_flatten($value)));
+			} else {
+				$value = esc_html((string) $value);
 			}
+
+			$interpolation[ "{{{$key}}}" ] = $value;
 		}
 
-		$interpolation = array_combine($interpolation_keys, $payload);
+		$interpolation['{{payload}}'] = implode(' - ', array_map('esc_html', wu_array_flatten($payload, true)));
 
-		$interpolation['{{payload}}'] = implode(' - ', wu_array_flatten($payload, true));
+		$interpolation['{{model}}'] = esc_html(wu_slug_to_name($this->object_type));
 
-		$interpolation['{{model}}'] = wu_slug_to_name($this->object_type);
-
-		$interpolation['{{object_id}}'] = $this->object_id;
+		$interpolation['{{object_id}}'] = esc_html((string) $this->object_id);
 
 		return strtr($message, $interpolation);
 	}

--- a/inc/template-library/class-api-client.php
+++ b/inc/template-library/class-api-client.php
@@ -153,8 +153,12 @@ class API_Client {
 			'slug'              => $template['slug'] ?? '',
 			'name'              => $template['name'] ?? '',
 			'description'       => $template['description'] ?? '',
-			'short_description' => $template['short_description'] ?? '',
-			'price_html'        => $template['price_html'] ?? '',
+			// short_description and price_html are rendered with Vue v-html in the
+			// Template Library grid; the data is fetched over HTTP from the remote
+			// marketplace, so sanitize the HTML to allowed post markup to neutralize
+			// any injected script while preserving legitimate formatting.
+			'short_description' => wp_kses_post($template['short_description'] ?? ''),
+			'price_html'        => wp_kses_post($template['price_html'] ?? ''),
 			'permalink'         => $template['permalink'] ?? '',
 			'is_free'           => empty($template['prices']['price'] ?? 0),
 			'prices'            => $template['prices'] ?? [],

--- a/views/events/widget-payload.php
+++ b/views/events/widget-payload.php
@@ -10,7 +10,7 @@ defined('ABSPATH') || exit;
 
 	<li class="wu-p-4 wu-m-0" v-show="!loading" v-cloak>
 
-	<pre id="wu_payload_content" v-html="payload" class="wu-overflow-auto wu-p-4 wu-m-0 wu-mt-2 wu-rounded wu-content-center wu-bg-gray-800 wu-text-white wu-font-mono wu-border wu-border-solid wu-border-gray-300 wu-max-h-screen wu-overflow-y-auto"></pre>
+	<pre id="wu_payload_content" v-text="payload" class="wu-overflow-auto wu-p-4 wu-m-0 wu-mt-2 wu-rounded wu-content-center wu-bg-gray-800 wu-text-white wu-font-mono wu-border wu-border-solid wu-border-gray-300 wu-max-h-screen wu-overflow-y-auto"></pre>
 
 	</li>
 


### PR DESCRIPTION
## Summary

Several network-admin views render untrusted data as HTML, allowing stored XSS
that fires in an admin's browser.

## Changes

- **`Event::interpolate_message()`** substituted payload values (customer display
  names, site titles/descriptions, …) into HTML message templates without
  escaping; the result is rendered with Vue `v-html` in the activity-stream
  widget. Escape each interpolated value with `esc_html()` while preserving the
  template's own markup.
- **`views/events/widget-payload.php`** rendered the JSON payload dump with
  `v-html`; switched to `v-text` (it is preformatted debug text).
- **Template library** — `short_description` / `price_html` are fetched from the
  remote marketplace API and rendered with `v-html`; sanitize them server-side
  with `wp_kses_post()` so injected script is stripped while formatting is kept.
- **Webhook list table** `column_name` interpolated the webhook name/event/url
  into HTML and `data-*` attributes unescaped; apply `esc_html()` / `esc_attr()`
  / `esc_url()`.

No functional change for non-malicious data.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Webhook names, URLs and action metadata properly escape special characters to prevent display issues.
  * Template library descriptions and price HTML are sanitized to preserve allowed markup while blocking unsafe content.
  * Event payload widget now renders payloads as plain text to avoid unintended HTML rendering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->