### PR TITLE
Security: DNS modal ownership check + Forge deploy-command domain validation

### DIFF
--- a/inc/integrations/providers/laravel-forge/class-laravel-forge-integration.php
+++ b/inc/integrations/providers/laravel-forge/class-laravel-forge-integration.php
@@ -265,6 +265,18 @@ class LaravelForge_Integration extends Integration {
 		$symlink_target = $this->get_credential('WU_FORGE_SYMLINK_TARGET');
 
 		if ($deploy_command) {
+			// Validate domain to prevent shell command injection via metacharacters,
+			// mirroring the symlink branch below.
+			if (! preg_match('/^[a-z0-9][a-z0-9\-\.]*[a-z0-9]$/i', $domain)) {
+				wu_log_add(
+					'integration-forge',
+					sprintf('Invalid domain format rejected for shell command: %s', $domain),
+					\Psr\Log\LogLevel::ERROR
+				);
+
+				return '';
+			}
+
 			return str_replace('{domain}', $domain, $deploy_command);
 		}
 

--- a/inc/ui/class-domain-mapping-element.php
+++ b/inc/ui/class-domain-mapping-element.php
@@ -781,7 +781,14 @@ class Domain_Mapping_Element extends Base_Element {
 		}
 
 		$dns_manager = \WP_Ultimo\Managers\DNS_Record_Manager::get_instance();
-		$provider    = $dns_manager->get_dns_provider();
+
+		// Same ownership gate the edit/add/delete DNS handlers enforce.
+		if (! $dns_manager->customer_can_manage_dns(get_current_user_id(), $domain->get_domain())) {
+			wp_send_json_error(new \WP_Error('permission-denied', __('You do not have permission to manage DNS for this domain.', 'ultimate-multisite')));
+			return;
+		}
+
+		$provider = $dns_manager->get_dns_provider();
 
 		wu_get_template(
 			'domain/dns-record-form',


### PR DESCRIPTION
## Summary

Two small hardening fixes.

- **`Domain_Mapping_Element::render_add_dns_record_modal()`** rendered the DNS
  record form for any `domain_id` with no ownership check, while its siblings
  (`render_edit_dns_record_modal`, `handle_add_dns_record`) all gate on
  `customer_can_manage_dns()`. Add the same gate so a customer cannot open the
  DNS form for a domain they don't own.
- **`Laravel_Forge_Integration::get_deploy_command()`** interpolated the mapped
  domain into the custom deploy-command branch with no validation, while the
  sibling symlink branch validates the domain format. Apply the same
  hostname-format check before building the shell command.