### PR TITLE
fix(auth): document passwordless redirect precedence

### DIFF
--- a/assets/js/passwordless-auth.js
+++ b/assets/js/passwordless-auth.js
@@ -301,6 +301,7 @@
 				return;
 			}
 
+			// Prefer the server-issued redirect over the client-seeded fallback.
 			window.location.assign(data.redirect_url || state.redirectUrl || window.location.href);
 		}
 


### PR DESCRIPTION
## Summary

- Document that the passwordless login finish flow prefers the server-issued `data.redirect_url` over the client-seeded fallback.
- Preserves the existing reload branch and redirect precedence that addresses the open-redirect review feedback.

## Testing

- `npx eslint assets/js/passwordless-auth.js --quiet`

Resolves #1384

<!-- aidevops:sig -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated internal documentation for authentication redirect handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->