### PR TITLE
test: cover passkey usage update failure

### DIFF
--- a/tests/WP_Ultimo/Auth/Passwordless_Auth_Test.php
+++ b/tests/WP_Ultimo/Auth/Passwordless_Auth_Test.php
@@ -181,6 +181,107 @@ class Passwordless_Auth_Test extends \WP_UnitTestCase {
 	}
 
 	/**
+	 * Tests passkey authentication fails closed when usage cannot be persisted.
+	 */
+	public function test_passkey_authentication_fails_when_usage_update_fails() {
+
+		$user = self::factory()->user->create_and_get(
+			[
+				'user_email' => 'passkey-update-failure@example.test',
+			]
+		);
+
+		$credential = (object) [
+			'id'         => 789,
+			'user_id'    => $user->ID,
+			'sign_count' => 1,
+			'public_key' => 'public-key',
+		];
+
+		$challenge = (object) [
+			'id'      => 456,
+			'user_id' => $user->ID,
+			'rp_id'   => 'example.test',
+			'origin'  => 'https://example.test',
+		];
+
+		$helper = $this->getMockBuilder(WebAuthn_Helper::class)
+			->onlyMethods(['parse_client_data', 'is_origin_allowed', 'parse_assertion_authenticator_data', 'verify_assertion_signature'])
+			->getMock();
+
+		$helper->method('parse_client_data')->willReturn(
+			[
+				'challenge' => 'challenge',
+				'origin'    => 'https://example.test',
+				'_raw'      => 'client-data',
+			]
+		);
+
+		$helper->method('is_origin_allowed')->willReturn(true);
+		$helper->method('parse_assertion_authenticator_data')->willReturn(
+			[
+				'rp_id_hash' => hash('sha256', 'example.test', true),
+				'sign_count' => 2,
+			]
+		);
+		$helper->method('verify_assertion_signature')->willReturn(true);
+
+		$credentials = $this->getMockBuilder(Passkey_Credential_Store::class)
+			->onlyMethods(['find_by_credential_id', 'update_usage'])
+			->getMock();
+
+		$credentials->method('find_by_credential_id')->willReturn($credential);
+		$credentials->expects($this->once())
+			->method('update_usage')
+			->with((int) $credential->id, 2)
+			->willReturn(false);
+
+		$challenges = $this->getMockBuilder(WebAuthn_Challenge_Store::class)
+			->onlyMethods(['get_valid', 'mark_used'])
+			->getMock();
+
+		$challenges->method('get_valid')->willReturn($challenge);
+		$challenges->expects($this->once())
+			->method('mark_used')
+			->with((int) $challenge->id)
+			->willReturn(true);
+
+		$service = new Passkey_Service();
+
+		$this->set_protected_property($service, 'helper', $helper);
+		$this->set_protected_property($service, 'credentials', $credentials);
+		$this->set_protected_property($service, 'challenges', $challenges);
+
+		$result = $service->verify_authentication(
+			[
+				'rawId'    => 'credential-id',
+				'response' => [
+					'authenticatorData' => 'authenticator-data',
+					'clientDataJSON'    => 'client-data',
+					'signature'         => 'signature',
+				],
+			]
+		);
+
+		$this->assertWPError($result);
+		$this->assertSame('credential_update_failed', $result->get_error_code());
+	}
+
+	/**
+	 * Sets a protected property for dependency injection in tests.
+	 *
+	 * @param object $target   Object to modify.
+	 * @param string $property Property name.
+	 * @param mixed  $value Property value.
+	 */
+	protected function set_protected_property($target, $property, $value) {
+
+		$reflection = new \ReflectionProperty($target, $property);
+		$reflection->setAccessible(true);
+		$reflection->setValue($target, $value);
+	}
+
+	/**
 	 * Installs auth tables.
 	 */
 	protected function install_auth_tables() {


### PR DESCRIPTION
## Summary

- Adds regression coverage for passkey authentication when credential usage persistence fails.
- Asserts `verify_authentication()` returns `credential_update_failed` after the challenge is consumed but `update_usage()` returns false.
- Uses PHPUnit mocks for passkey helper, credential store, and challenge store so the test targets the fail-closed branch directly.

## Testing

- `vendor/bin/phpcs tests/WP_Ultimo/Auth/Passwordless_Auth_Test.php`
- `WP_TESTS_DIR=/tmp/wordpress-tests-lib vendor/bin/phpunit --filter test_passkey_authentication_fails_when_usage_update_fails`

Resolves #1386


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.46 plugin for [OpenCode](https://opencode.ai) v1.16.2 with gpt-5.5 spent 6m and 129,537 tokens on this as a headless worker.
