### PR TITLE
test: cover WebAuthn RP ID port handling

### DIFF
--- a/tests/WP_Ultimo/Auth/WebAuthn_Helper_Test.php
+++ b/tests/WP_Ultimo/Auth/WebAuthn_Helper_Test.php
@@ -1,0 +1,56 @@
+<?php
+/**
+ * WebAuthn helper tests.
+ *
+ * @package WP_Ultimo
+ * @subpackage Auth
+ */
+
+namespace WP_Ultimo\Auth;
+
+class WebAuthn_Helper_Test extends \WP_UnitTestCase {
+
+	public function test_get_rp_id_strips_port_from_bracketed_ipv6_host() {
+
+		$previous_host          = $_SERVER['HTTP_HOST'] ?? null;
+		$_SERVER['HTTP_HOST']   = '[::1]:8080';
+		$helper                 = new WebAuthn_Helper();
+		$restore_previous_host  = static function () use ($previous_host) {
+			if (null === $previous_host) {
+				unset($_SERVER['HTTP_HOST']);
+
+				return;
+			}
+
+			$_SERVER['HTTP_HOST'] = $previous_host;
+		};
+
+		try {
+			$this->assertSame('::1', $helper->get_rp_id());
+		} finally {
+			$restore_previous_host();
+		}
+	}
+
+	public function test_get_rp_id_strips_port_from_hostname() {
+
+		$previous_host          = $_SERVER['HTTP_HOST'] ?? null;
+		$_SERVER['HTTP_HOST']   = 'example.com:8443';
+		$helper                 = new WebAuthn_Helper();
+		$restore_previous_host  = static function () use ($previous_host) {
+			if (null === $previous_host) {
+				unset($_SERVER['HTTP_HOST']);
+
+				return;
+			}
+
+			$_SERVER['HTTP_HOST'] = $previous_host;
+		};
+
+		try {
+			$this->assertSame('example.com', $helper->get_rp_id());
+		} finally {
+			$restore_previous_host();
+		}
+	}
+}

--- a/tests/WP_Ultimo/Auth/WebAuthn_Helper_Test.php
+++ b/tests/WP_Ultimo/Auth/WebAuthn_Helper_Test.php
@@ -10,47 +10,40 @@ namespace WP_Ultimo\Auth;
 
 class WebAuthn_Helper_Test extends \WP_UnitTestCase {
 
+	protected $previous_host;
+
+	public function setUp(): void {
+
+		parent::setUp();
+
+		// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized, WordPress.Security.ValidatedSanitizedInput.MissingUnslash
+		$this->previous_host = $_SERVER['HTTP_HOST'] ?? null;
+	}
+
+	public function tearDown(): void {
+
+		if (null === $this->previous_host) {
+			unset($_SERVER['HTTP_HOST']);
+		} else {
+			$_SERVER['HTTP_HOST'] = $this->previous_host;
+		}
+
+		parent::tearDown();
+	}
+
 	public function test_get_rp_id_strips_port_from_bracketed_ipv6_host() {
 
-		$previous_host          = $_SERVER['HTTP_HOST'] ?? null;
-		$_SERVER['HTTP_HOST']   = '[::1]:8080';
-		$helper                 = new WebAuthn_Helper();
-		$restore_previous_host  = static function () use ($previous_host) {
-			if (null === $previous_host) {
-				unset($_SERVER['HTTP_HOST']);
+		$_SERVER['HTTP_HOST'] = '[::1]:8080';
+		$helper               = new WebAuthn_Helper();
 
-				return;
-			}
-
-			$_SERVER['HTTP_HOST'] = $previous_host;
-		};
-
-		try {
-			$this->assertSame('::1', $helper->get_rp_id());
-		} finally {
-			$restore_previous_host();
-		}
+		$this->assertSame('::1', $helper->get_rp_id());
 	}
 
 	public function test_get_rp_id_strips_port_from_hostname() {
 
-		$previous_host          = $_SERVER['HTTP_HOST'] ?? null;
-		$_SERVER['HTTP_HOST']   = 'example.com:8443';
-		$helper                 = new WebAuthn_Helper();
-		$restore_previous_host  = static function () use ($previous_host) {
-			if (null === $previous_host) {
-				unset($_SERVER['HTTP_HOST']);
+		$_SERVER['HTTP_HOST'] = 'example.com:8443';
+		$helper               = new WebAuthn_Helper();
 
-				return;
-			}
-
-			$_SERVER['HTTP_HOST'] = $previous_host;
-		};
-
-		try {
-			$this->assertSame('example.com', $helper->get_rp_id());
-		} finally {
-			$restore_previous_host();
-		}
+		$this->assertSame('example.com', $helper->get_rp_id());
 	}
 }


### PR DESCRIPTION
## Summary

- Adds WebAuthn helper regression coverage for bracketed IPv6 `HTTP_HOST` values with ports.
- Confirms regular `host:port` RP ID extraction continues stripping the port.

Resolves #1388

## Testing

- `vendor/bin/phpcs tests/WP_Ultimo/Auth/WebAuthn_Helper_Test.php`
- `WP_TESTS_DIR=/tmp/wordpress-tests-lib vendor/bin/phpunit --filter WebAuthn_Helper_Test`

<!-- MERGE_SUMMARY
summary: Added regression coverage for WebAuthn RP ID extraction so bracketed IPv6 hosts with ports resolve to the bracketless address while regular host:port values still strip the port.
testing: vendor/bin/phpcs tests/WP_Ultimo/Auth/WebAuthn_Helper_Test.php; WP_TESTS_DIR=/tmp/wordpress-tests-lib vendor/bin/phpunit --filter WebAuthn_Helper_Test
-->

<!-- aidevops:sig -->
