### PR TITLE
GH#1390: fix(test): harden passwordless login helper

### DIFF
--- a/tests/e2e/cypress/support/commands/login.js
+++ b/tests/e2e/cypress/support/commands/login.js
@@ -43,15 +43,19 @@ Cypress.Commands.add("loginByForm", (username, password) => {
       }
 
       cy.get("body").then(($body) => {
-		if ($body.find(".wu-passwordless-auth").length) {
-			cy.get(".wu-passwordless-auth").should("be.visible");
-			cy.get(".wu-passwordless-email").should("be.visible");
-			if ($body.find("#user_pass").length) {
-				cy.get("#user_pass").should("not.be.visible");
-			} else {
-				cy.get("#user_pass").should("not.exist");
-			}
-			cy.loginByApi(username, password);
+        if ($body.find(".wu-passwordless-auth").length) {
+          const has_password_field = Boolean($body.find("#user_pass").length);
+
+          cy.get(".wu-passwordless-auth").should("be.visible");
+          cy.get(".wu-passwordless-email").should("be.visible");
+
+          if (has_password_field) {
+            cy.get("#user_pass").should("not.be.visible");
+          } else {
+            cy.get("#user_pass").should("not.exist");
+          }
+
+          cy.loginByApi(username, password);
           cy.visit("/wp-admin/");
           return;
         }


### PR DESCRIPTION
## Summary

Hardened the Cypress passwordless login helper so it records whether #user_pass exists before asserting either hidden or absent states, preserving both expected passwordless login variants.

## Files Changed

tests/e2e/cypress/support/commands/login.js

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** node --check tests/e2e/cypress/support/commands/login.js; attempted node_modules/.bin/eslint tests/e2e/cypress/support/commands/login.js, but @wordpress/eslint-plugin is missing from node_modules

Resolves #1390


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.46 plugin for [OpenCode](https://opencode.ai) v1.16.2 with gpt-5.5 spent 1m and 87,994 tokens on this as a headless worker.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved passwordless authentication login test coverage and assertions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->