### PR TITLE
GH#1389: test: cover passwordless login fallback

### DIFF
--- a/inc/ui/class-login-form-element.php
+++ b/inc/ui/class-login-form-element.php
@@ -578,6 +578,22 @@ class Login_Form_Element extends Base_Element {
 	}
 
 	/**
+	 * Returns the password fallback URL for the passwordless login form.
+	 *
+	 * This keeps the custom login form's "Use password instead" link pointed at
+	 * the standard login handler while preserving the same post-login redirect.
+	 *
+	 * @since 2.5.2
+	 *
+	 * @param string $redirect_to Redirect URL to preserve after password login.
+	 * @return string
+	 */
+	protected function get_passwordless_fallback_url($redirect_to) {
+
+		return add_query_arg('wu_password_fallback', '1', wp_login_url($redirect_to));
+	}
+
+	/**
 	 * The content to be output on the screen.
 	 *
 	 * Should return HTML markup to be used to display the block.
@@ -794,7 +810,7 @@ class Login_Form_Element extends Base_Element {
 							'context'       => 'login-form',
 							'redirect_to'   => $redirect_to,
 							'redirect_type' => $atts['redirect_type'],
-							'fallback_url'  => add_query_arg('wu_password_fallback', '1', wp_login_url($redirect_to)),
+							'fallback_url'  => $this->get_passwordless_fallback_url($redirect_to),
 						]
 					),
 					'classes'         => '',

--- a/tests/WP_Ultimo/UI/Login_Form_Element_Test.php
+++ b/tests/WP_Ultimo/UI/Login_Form_Element_Test.php
@@ -1,0 +1,37 @@
+<?php
+/**
+ * Tests for Login_Form_Element class.
+ *
+ * @package WP_Ultimo\Tests
+ */
+
+namespace WP_Ultimo\UI;
+
+use WP_UnitTestCase;
+
+/**
+ * Test class for Login_Form_Element.
+ */
+class Login_Form_Element_Test extends WP_UnitTestCase {
+
+	/**
+	 * Test passwordless fallback URL includes the password escape hatch flag.
+	 */
+	public function test_passwordless_fallback_url_preserves_redirect_and_escape_hatch(): void {
+
+		$element     = Login_Form_Element::get_instance();
+		$reflection  = new \ReflectionClass($element);
+		$method      = $reflection->getMethod('get_passwordless_fallback_url');
+		$redirect_to = network_home_url('/wp-admin/?from=custom-login');
+
+		$method->setAccessible(true);
+
+		$fallback_url = $method->invoke($element, $redirect_to);
+		$query        = [];
+
+		parse_str((string) wp_parse_url($fallback_url, PHP_URL_QUERY), $query);
+
+		$this->assertSame('1', $query['wu_password_fallback']);
+		$this->assertSame($redirect_to, $query['redirect_to']);
+	}
+}


### PR DESCRIPTION
## Summary

Extracted the passwordless login fallback URL into a dedicated helper and added a regression test proving the custom login form keeps the Use password instead escape hatch with the original redirect.

## Files Changed

inc/ui/class-login-form-element.php,tests/WP_Ultimo/UI/Login_Form_Element_Test.php

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** vendor/bin/phpcs inc/ui/class-login-form-element.php tests/WP_Ultimo/UI/Login_Form_Element_Test.php; WP_TESTS_DIR=/tmp/wordpress-tests-lib vendor/bin/phpunit --filter Login_Form_Element_Test

Resolves #1389


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.46 plugin for [OpenCode](https://opencode.ai) v1.16.2 with gpt-5.5 spent 3m and 188,584 tokens on this as a headless worker.