### PR TITLE
fix: make passwordless login opt-in

### DIFF
--- a/inc/auth/class-passwordless-auth-manager.php
+++ b/inc/auth/class-passwordless-auth-manager.php
@@ -48,6 +48,10 @@ class Passwordless_Auth_Manager {
 		$this->passkeys = new Passkey_Service();
 		$this->otp      = new Email_OTP_Service();
 
+		if ( ! $this->is_enabled()) {
+			return;
+		}
+
 		add_action('init', [$this, 'register_assets']);
 		add_action('init', [$this, 'maybe_install_tables'], 5);
 
@@ -77,6 +81,17 @@ class Passwordless_Auth_Manager {
 	public function otp() {
 
 		return $this->otp;
+	}
+
+	/**
+	 * Checks if passwordless login is enabled.
+	 *
+	 * @since 2.13.2
+	 * @return bool
+	 */
+	public function is_enabled() {
+
+		return (bool) wu_get_setting('use_passwordless_login', 0);
 	}
 
 	/**
@@ -189,6 +204,10 @@ class Passwordless_Auth_Manager {
 	 */
 	public function enqueue_assets() {
 
+		if ( ! $this->is_enabled()) {
+			return;
+		}
+
 		if ( ! wp_script_is('wu-passwordless-auth', 'registered')) {
 			$this->register_assets();
 		}
@@ -225,6 +244,10 @@ class Passwordless_Auth_Manager {
 	 */
 	public function enqueue_login_assets() {
 
+		if ( ! $this->is_enabled()) {
+			return;
+		}
+
 		$this->enqueue_assets();
 
 		if ($this->is_password_fallback()) {
@@ -244,6 +267,10 @@ class Passwordless_Auth_Manager {
 	 * @return void
 	 */
 	public function render_wp_login_form() {
+
+		if ( ! $this->is_enabled()) {
+			return;
+		}
 
 		if ($this->is_password_fallback()) {
 			return;
@@ -272,6 +299,10 @@ class Passwordless_Auth_Manager {
 	 * @return string
 	 */
 	public function get_login_form_markup($args = []) {
+
+		if ( ! $this->is_enabled()) {
+			return '';
+		}
 
 		$args = wp_parse_args(
 			$args,
@@ -402,6 +433,7 @@ class Passwordless_Auth_Manager {
 	public function ajax_start() {
 
 		$this->verify_ajax_request();
+		$this->ensure_enabled_for_ajax();
 
 		$identifier = sanitize_text_field(wu_request('identifier'));
 		$user       = $this->find_user($identifier);
@@ -431,6 +463,7 @@ class Passwordless_Auth_Manager {
 	public function ajax_verify_otp() {
 
 		$this->verify_ajax_request();
+		$this->ensure_enabled_for_ajax();
 
 		$user = $this->otp->verify(wu_request('token'), wu_request('code'));
 
@@ -466,6 +499,7 @@ class Passwordless_Auth_Manager {
 	public function ajax_verify_passkey() {
 
 		$this->verify_ajax_request();
+		$this->ensure_enabled_for_ajax();
 
 		$credential = json_decode($this->get_json_request_value('credential'), true);
 
@@ -496,6 +530,7 @@ class Passwordless_Auth_Manager {
 	public function ajax_register_options() {
 
 		$this->verify_ajax_request();
+		$this->ensure_enabled_for_ajax();
 
 		if ( ! is_user_logged_in()) {
 			$this->send_error(new \WP_Error('not_logged_in', __('You need to be logged in to create a passkey.', 'ultimate-multisite')));
@@ -517,6 +552,7 @@ class Passwordless_Auth_Manager {
 	public function ajax_register_verify() {
 
 		$this->verify_ajax_request();
+		$this->ensure_enabled_for_ajax();
 
 		if ( ! is_user_logged_in()) {
 			$this->send_error(new \WP_Error('not_logged_in', __('You need to be logged in to create a passkey.', 'ultimate-multisite')));
@@ -550,6 +586,21 @@ class Passwordless_Auth_Manager {
 	protected function verify_ajax_request() {
 
 		check_ajax_referer('wu_passwordless_auth', 'nonce');
+	}
+
+	/**
+	 * Sends an error response when passwordless login is disabled.
+	 *
+	 * @since 2.13.2
+	 * @return void
+	 */
+	protected function ensure_enabled_for_ajax() {
+
+		if ($this->is_enabled()) {
+			return;
+		}
+
+		$this->send_error(new \WP_Error('passwordless_login_disabled', __('Passwordless login is disabled.', 'ultimate-multisite')));
 	}
 
 	/**

--- a/inc/checkout/class-checkout.php
+++ b/inc/checkout/class-checkout.php
@@ -3280,9 +3280,16 @@ class Checkout {
 		// Enqueue password styles (includes dashicons as dependency).
 		wp_enqueue_style('wu-password');
 
-		\WP_Ultimo\Auth\Passwordless_Auth_Manager::get_instance()->enqueue_assets();
+		$script_dependencies = ['jquery-core', 'wu-vue', 'moment', 'wu-block-ui', 'wu-functions', 'password-strength-meter', 'wu-password-strength', 'underscore', 'wp-polyfill', 'wp-hooks', 'wu-cookie-helpers', 'wu-password-toggle'];
 
-		wp_register_script('wu-checkout', wu_get_asset('checkout.js', 'js'), ['jquery-core', 'wu-vue', 'moment', 'wu-block-ui', 'wu-functions', 'password-strength-meter', 'wu-password-strength', 'underscore', 'wp-polyfill', 'wp-hooks', 'wu-cookie-helpers', 'wu-password-toggle', 'wu-passwordless-auth'], wu_get_version(), true);
+		$passwordless_auth = \WP_Ultimo\Auth\Passwordless_Auth_Manager::get_instance();
+
+		if ($passwordless_auth->is_enabled()) {
+			$passwordless_auth->enqueue_assets();
+			$script_dependencies[] = 'wu-passwordless-auth';
+		}
+
+		wp_register_script('wu-checkout', wu_get_asset('checkout.js', 'js'), $script_dependencies, wu_get_version(), true);
 
 		wp_set_script_translations('wu-password-toggle', 'ultimate-multisite');
 

--- a/inc/class-settings.php
+++ b/inc/class-settings.php
@@ -904,6 +904,17 @@ class Settings implements \WP_Ultimo\Interfaces\Singleton {
 
 		$this->add_field(
 			'login-and-registration',
+			'use_passwordless_login',
+			[
+				'title'   => __('Use Passwordless Login', 'ultimate-multisite'),
+				'desc'    => __('When enabled, login forms ask for an email address and let customers sign in with a passkey or a one-time email code. Keep this disabled to use regular username and password login.', 'ultimate-multisite'),
+				'type'    => 'toggle',
+				'default' => 0,
+			]
+		);
+
+		$this->add_field(
+			'login-and-registration',
 			'default_login_page',
 			[
 				'type'        => 'model',
@@ -2100,6 +2111,7 @@ class Settings implements \WP_Ultimo\Interfaces\Singleton {
 			'enable_registration'                => 1,
 			'enable_email_verification'          => 'free_only',
 			'enable_custom_login_page'           => 0,
+			'use_passwordless_login'             => 0,
 			'default_login_page'                 => 0,
 			'obfuscate_original_login_url'       => 0,
 			'subsite_custom_login_logo'          => 0,

--- a/inc/ui/class-login-form-element.php
+++ b/inc/ui/class-login-form-element.php
@@ -313,7 +313,11 @@ class Login_Form_Element extends Base_Element {
 
 		wp_set_script_translations('wu-password-toggle', 'ultimate-multisite');
 
-		\WP_Ultimo\Auth\Passwordless_Auth_Manager::get_instance()->enqueue_assets();
+		$passwordless_auth = \WP_Ultimo\Auth\Passwordless_Auth_Manager::get_instance();
+
+		if ($passwordless_auth->is_enabled()) {
+			$passwordless_auth->enqueue_assets();
+		}
 
 		// Enqueue password strength scripts for reset password page.
 		if ($this->is_reset_password_page()) {
@@ -802,21 +806,72 @@ class Login_Form_Element extends Base_Element {
 				$redirect_to = $atts['main_redirect_path'];
 			}
 
-			$fields = [
-				'passwordless_login' => [
-					'type'            => 'html',
-					'content'         => \WP_Ultimo\Auth\Passwordless_Auth_Manager::get_instance()->get_login_form_markup(
-						[
-							'context'       => 'login-form',
-							'redirect_to'   => $redirect_to,
-							'redirect_type' => $atts['redirect_type'],
-							'fallback_url'  => $this->get_passwordless_fallback_url($redirect_to),
-						]
-					),
-					'classes'         => '',
-					'wrapper_classes' => 'wu-w-full wu-bg-none',
-				],
-			];
+			$passwordless_auth = \WP_Ultimo\Auth\Passwordless_Auth_Manager::get_instance();
+
+			if ($passwordless_auth->is_enabled()) {
+				$fields = [
+					'passwordless_login' => [
+						'type'            => 'html',
+						'content'         => $passwordless_auth->get_login_form_markup(
+							[
+								'context'       => 'login-form',
+								'redirect_to'   => $redirect_to,
+								'redirect_type' => $atts['redirect_type'],
+								'fallback_url'  => $this->get_passwordless_fallback_url($redirect_to),
+							]
+						),
+						'classes'         => '',
+						'wrapper_classes' => 'wu-w-full wu-bg-none',
+					],
+				];
+			} else {
+				$fields = [
+					'log' => [
+						'type'        => 'text',
+						'title'       => $atts['label_username'],
+						'placeholder' => $atts['placeholder_username'],
+						'tooltip'     => '',
+						'html_attr'   => [
+							'autocomplete' => 'username',
+						],
+					],
+					'pwd' => [
+						'type'        => 'password',
+						'title'       => $atts['label_password'],
+						'placeholder' => $atts['placeholder_password'],
+						'tooltip'     => '',
+						'html_attr'   => [
+							'autocomplete' => 'current-password',
+						],
+					],
+				];
+
+				if ($atts['remember']) {
+					$fields['rememberme'] = [
+						'type'  => 'toggle',
+						'title' => $atts['label_remember'],
+						'desc'  => $atts['desc_remember'],
+					];
+				}
+
+				$fields['redirect_to'] = [
+					'type'  => 'hidden',
+					'value' => $redirect_to,
+				];
+
+				$fields['wu_login_form_redirect_type'] = [
+					'type'  => 'hidden',
+					'value' => $atts['redirect_type'],
+				];
+
+				$fields['wp-submit'] = [
+					'type'            => 'submit',
+					'title'           => $atts['label_log_in'],
+					'value'           => $atts['label_log_in'],
+					'classes'         => 'button button-primary wu-w-full',
+					'wrapper_classes' => 'wu-items-end wu-bg-none',
+				];
+			}
 
 			/*
 			 * Use wp_lostpassword_url() so the lostpassword_url filter keeps

--- a/tests/WP_Ultimo/Auth/Passwordless_Auth_Test.php
+++ b/tests/WP_Ultimo/Auth/Passwordless_Auth_Test.php
@@ -27,6 +27,8 @@ class Passwordless_Auth_Test extends \WP_UnitTestCase {
 
 		parent::set_up();
 
+		wu_save_setting('use_passwordless_login', 1);
+
 		$this->install_auth_tables();
 		$this->truncate_auth_tables();
 	}
@@ -40,6 +42,7 @@ class Passwordless_Auth_Test extends \WP_UnitTestCase {
 		remove_all_filters('wu_passwordless_should_send_otp');
 
 		$this->truncate_auth_tables();
+		wu_save_setting('use_passwordless_login', 0);
 
 		parent::tear_down();
 	}
@@ -318,6 +321,26 @@ class Passwordless_Auth_Test extends \WP_UnitTestCase {
 		$this->assertArrayNotHasKey('publicKey', $response['data']);
 
 		unset($_POST['nonce'], $_POST['identifier'], $_REQUEST['nonce'], $_REQUEST['identifier']);
+	}
+
+	/**
+	 * Tests passwordless AJAX endpoints fail closed when the setting is disabled.
+	 */
+	public function test_ajax_start_fails_when_passwordless_login_is_disabled() {
+
+		wu_save_setting('use_passwordless_login', 0);
+
+		$nonce = wp_create_nonce('wu_passwordless_auth');
+
+		$_POST['nonce']    = $nonce;
+		$_REQUEST['nonce'] = $nonce;
+
+		$response = $this->capture_ajax_json([Passwordless_Auth_Manager::get_instance(), 'ajax_start']);
+
+		$this->assertFalse($response['success']);
+		$this->assertSame('passwordless_login_disabled', $response['data']['code']);
+
+		unset($_POST['nonce'], $_REQUEST['nonce']);
 	}
 
 	/**

--- a/tests/WP_Ultimo/Settings_Test.php
+++ b/tests/WP_Ultimo/Settings_Test.php
@@ -190,7 +190,7 @@ class Settings_Test extends WP_UnitTestCase {
 	}
 
 	public function test_get_sections_caches_result() {
-		$first = $this->settings->get_sections();
+		$first  = $this->settings->get_sections();
 		$second = $this->settings->get_sections();
 		$this->assertSame($first, $second);
 	}
@@ -367,6 +367,12 @@ class Settings_Test extends WP_UnitTestCase {
 		$this->assertIsArray($defaults);
 	}
 
+	public function test_get_setting_defaults_disables_passwordless_login() {
+		$defaults = Settings::get_setting_defaults();
+		$this->assertArrayHasKey('use_passwordless_login', $defaults);
+		$this->assertSame(0, $defaults['use_passwordless_login']);
+	}
+
 	// ------------------------------------------------------------------
 	// General section fields
 	// ------------------------------------------------------------------
@@ -403,6 +409,13 @@ class Settings_Test extends WP_UnitTestCase {
 	public function test_login_section_has_enable_registration_field() {
 		$section = $this->settings->get_section('login-and-registration');
 		$this->assertArrayHasKey('enable_registration', $section['fields']);
+	}
+
+	public function test_login_section_has_use_passwordless_login_field() {
+		$section = $this->settings->get_section('login-and-registration');
+		$this->assertArrayHasKey('use_passwordless_login', $section['fields']);
+		$this->assertSame('toggle', $section['fields']['use_passwordless_login']['type']);
+		$this->assertSame(0, $section['fields']['use_passwordless_login']['default']);
 	}
 
 	public function test_login_section_has_default_role_field() {

--- a/tests/e2e/cypress/integration/login.spec.js
+++ b/tests/e2e/cypress/integration/login.spec.js
@@ -1,44 +1,46 @@
+/* global cy, Cypress, describe, it */
+
 describe("Login", () => {
-  describe("User Interface", () => {
-    it("Should show the email-first passwordless login form", () => {
-      cy.visit("/wp-login.php");
-      cy.get(".wu-passwordless-auth").should("be.visible");
-      cy.get(".wu-passwordless-email").should("be.visible");
-      cy.get("#user_pass").should("not.be.visible");
-    });
+	describe("User Interface", () => {
+		it("Should show the username and password login form by default", () => {
+			cy.visit("/wp-login.php");
+			cy.get(".wu-passwordless-auth").should("not.exist");
+			cy.get("#user_login").should("be.visible");
+			cy.get("#user_pass").should("be.visible");
+		});
 
-    it("Should be able to login by the user interface", () => {
-      cy.loginByForm(
-        Cypress.env("admin").username,
-        Cypress.env("admin").password
-      );
-    });
+		it("Should be able to login by the user interface", () => {
+			cy.loginByForm(
+				Cypress.env("admin").username,
+				Cypress.env("admin").password
+			);
+		});
 
-    it("Should be able to logout by the user interface", () => {
-      cy.loginByApi(
-        Cypress.env("admin").username,
-        Cypress.env("admin").password
-      );
-      cy.visit("/wp-admin/");
-      cy.location("pathname")
-        .should("not.contain", "/wp-login.php")
-        .and("equal", "/wp-admin/");
-      cy.get("#wp-admin-bar-logout > a").click({ force: true });
-      cy.location("pathname").should("contain", "/wp-login.php");
-      cy.location("search").should("contain", "loggedout=true");
-    });
-  });
+		it("Should be able to logout by the user interface", () => {
+			cy.loginByApi(
+				Cypress.env("admin").username,
+				Cypress.env("admin").password
+			);
+			cy.visit("/wp-admin/");
+			cy.location("pathname")
+				.should("not.contain", "/wp-login.php")
+				.and("equal", "/wp-admin/");
+			cy.get("#wp-admin-bar-logout > a").click({ force: true });
+			cy.location("pathname").should("contain", "/wp-login.php");
+			cy.location("search").should("contain", "loggedout=true");
+		});
+	});
 
-  describe("Application Interface", () => {
-    it("Should be able to login by the application interface", () => {
-      cy.loginByApi(
-        Cypress.env("admin").username,
-        Cypress.env("admin").password
-      );
-      cy.visit("/wp-admin/");
-      cy.location("pathname")
-        .should("not.contain", "/wp-login.php")
-        .and("equal", "/wp-admin/");
-    });
-  });
+	describe("Application Interface", () => {
+		it("Should be able to login by the application interface", () => {
+			cy.loginByApi(
+				Cypress.env("admin").username,
+				Cypress.env("admin").password
+			);
+			cy.visit("/wp-admin/");
+			cy.location("pathname")
+				.should("not.contain", "/wp-login.php")
+				.and("equal", "/wp-admin/");
+		});
+	});
 });

--- a/views/checkout/partials/inline-login-prompt.php
+++ b/views/checkout/partials/inline-login-prompt.php
@@ -9,6 +9,8 @@
  */
 defined('ABSPATH') || exit;
 
+$passwordless_auth = \WP_Ultimo\Auth\Passwordless_Auth_Manager::get_instance();
+
 ?>
 
 <div id="wu-inline-login-prompt-<?php echo esc_attr($field_type); ?>" class="wu-bg-blue-50 wu-border wu-border-blue-200 wu-rounded wu-p-4 wu-mt-2 wu-mb-4">
@@ -16,16 +18,36 @@ defined('ABSPATH') || exit;
 		<p class="wu-m-0 wu-font-semibold wu-text-blue-900 wu-text-sm">
 			<?php esc_html_e('Already have an account?', 'ultimate-multisite'); ?>
 		</p>
-		<p class="wu-m-0 wu-mt-1 wu-text-blue-900 wu-text-sm">
-			<?php esc_html_e('Continue with a passkey or a one-time email code. No password is required.', 'ultimate-multisite'); ?>
-		</p>
+		<?php if ($passwordless_auth->is_enabled()) : ?>
+			<p class="wu-m-0 wu-mt-1 wu-text-blue-900 wu-text-sm">
+				<?php esc_html_e('Continue with a passkey or a one-time email code. No password is required.', 'ultimate-multisite'); ?>
+			</p>
+		<?php endif; ?>
 	</div>
 
-	<?php echo \WP_Ultimo\Auth\Passwordless_Auth_Manager::get_instance()->get_inline_login_markup($field_type); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
+	<?php if ($passwordless_auth->is_enabled()) : ?>
+		<?php echo $passwordless_auth->get_inline_login_markup($field_type); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
+	<?php else : ?>
+		<div class="wu-mb-3">
+			<label for="wu-inline-login-password-<?php echo esc_attr($field_type); ?>" class="wu-block wu-text-sm wu-font-medium wu-text-gray-700 wu-mb-1">
+				<?php esc_html_e('Password', 'ultimate-multisite'); ?>
+			</label>
+			<input
+				type="password"
+				id="wu-inline-login-password-<?php echo esc_attr($field_type); ?>"
+				class="form-control wu-w-full"
+				autocomplete="current-password"
+				placeholder="<?php esc_attr_e('Enter your password', 'ultimate-multisite'); ?>"
+			/>
+		</div>
+
+		<div id="wu-login-error-<?php echo esc_attr($field_type); ?>" class="wu-bg-red-100 wu-text-red-800 wu-p-3 wu-rounded wu-text-sm wu-mb-3 wu-hidden">
+		</div>
+	<?php endif; ?>
 
 	<?php
 	/**
-	 * Fires inside the inline passwordless login prompt.
+	 * Fires inside the inline login prompt.
 	 *
 	 * Useful for adding captcha widgets or additional fields.
 	 *
@@ -35,4 +57,24 @@ defined('ABSPATH') || exit;
 	 */
 	do_action('wu_inline_login_prompt_before_submit', $field_type);
 	?>
+
+	<?php if ( ! $passwordless_auth->is_enabled()) : ?>
+		<div class="wu-flex wu-flex-wrap wu-items-center wu-justify-between wu-gap-2">
+			<a
+				href="<?php echo esc_url(wp_lostpassword_url(wu_get_current_url())); ?>"
+				class="wu-text-sm wu-text-blue-600 hover:wu-text-blue-800 wu-no-underline"
+				target="_blank"
+			>
+				<?php esc_html_e('Forgot password?', 'ultimate-multisite'); ?>
+			</a>
+
+			<button
+				type="button"
+				id="wu-inline-login-submit-<?php echo esc_attr($field_type); ?>"
+				class="wu-bg-blue-600 wu-text-white wu-px-4 wu-py-2 wu-rounded hover:wu-bg-blue-700 disabled:wu-opacity-50 disabled:wu-cursor-not-allowed wu-border-0 wu-text-sm wu-font-medium wu-cursor-pointer"
+			>
+				<?php esc_html_e('Sign in', 'ultimate-multisite'); ?>
+			</button>
+		</div>
+	<?php endif; ?>
 </div>


### PR DESCRIPTION
## Summary

- Add a disabled-by-default `Use Passwordless Login` setting under Login & Registration.
- Gate passwordless assets, markup, wp-login injection, checkout dependencies, and AJAX handlers behind the setting.
- Restore username/password login as the default WP login, custom login form, and checkout inline-login experience.

Follow-up to #1358.

## Verification

- `php -l inc/class-settings.php inc/auth/class-passwordless-auth-manager.php inc/ui/class-login-form-element.php inc/checkout/class-checkout.php views/checkout/partials/inline-login-prompt.php tests/WP_Ultimo/Settings_Test.php tests/WP_Ultimo/Auth/Passwordless_Auth_Test.php`
- `bash bin/check-env.sh`
- `vendor/bin/phpcs inc/class-settings.php inc/auth/class-passwordless-auth-manager.php inc/ui/class-login-form-element.php inc/checkout/class-checkout.php views/checkout/partials/inline-login-prompt.php tests/WP_Ultimo/Settings_Test.php tests/WP_Ultimo/Auth/Passwordless_Auth_Test.php`
- `./node_modules/.bin/eslint tests/e2e/cypress/integration/login.spec.js --max-warnings=0`
- `vendor/bin/phpunit --filter Settings_Test`
- `vendor/bin/phpunit --filter Passwordless_Auth_Test`
- `vendor/bin/phpunit --filter Login_Form_Element_Test`
- `git diff --check`

## Notes

- PHPUnit still emits an existing PHP 8.4 deprecation notice in `inc/sso/jasny/Broker/Session.php`.
- ESLint still emits the existing Browserslist data-age advisory.


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.49 plugin for [OpenCode](https://opencode.ai) v1.17.1 with gpt-5.5 spent 16h 54m and 2,784,885 tokens on this with the user in an interactive session.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a passwordless login toggle in Login & Registration settings. When disabled (default), users see the standard username/password login form. When enabled, passwordless authentication becomes available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->