### PR TITLE
fix(checkout): relax optional postal code validation

### DIFF
--- a/inc/checkout/class-checkout.php
+++ b/inc/checkout/class-checkout.php
@@ -2758,6 +2758,31 @@ class Checkout {
 		}
 
 		/*
+		 * Relax the base billing rules for billing-address fields rendered by an
+		 * optional billing-address element. The base ZIP/Country rules use
+		 * required_with:<same field>, and Rakit treats an empty submitted field as
+		 * "present", so optional visible fields would still fail validation.
+		 */
+		$submitted_billing_country = trim((string) wu_request('billing_country', ''));
+
+		$optional_billing_rules = [
+			'billing_country'  => '' === $submitted_billing_country ? '' : 'country',
+			'billing_zip_code' => '',
+		];
+
+		foreach ($this->step['fields'] as $field_key => $field) {
+			if ( ! is_array($field)) {
+				continue;
+			}
+
+			$field_id = wu_get_isset($field, 'id', is_string($field_key) ? $field_key : '');
+
+			if (isset($optional_billing_rules[ $field_id ]) && ! wu_get_isset($field, 'required')) {
+				$validation_rules[ $field_id ] = $optional_billing_rules[ $field_id ];
+			}
+		}
+
+		/*
 		 * Relax billing field requirements when payment is not needed
 		 * (e.g. free trials with allow_trial_without_payment_method enabled).
 		 * Country is kept required for tax calculation at renewal time.
@@ -2775,7 +2800,11 @@ class Checkout {
 		 * against clients (REST, custom forms, automated tests) that bypass
 		 * the v-if hiding.
 		 */
-		$submitted_country = wu_request('billing_country');
+		$submitted_country = trim((string) wu_request('billing_country', ''));
+
+		if ('' === $submitted_country) {
+			$submitted_country = trim((string) wu_request('country', ''));
+		}
 
 		if ($submitted_country && isset($validation_rules['billing_zip_code'])) {
 			$resolved_country = wu_get_country($submitted_country);

--- a/tests/WP_Ultimo/Checkout/Checkout_Test.php
+++ b/tests/WP_Ultimo/Checkout/Checkout_Test.php
@@ -1587,6 +1587,42 @@ class Checkout_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Test optional billing address fields do not keep self-required ZIP rules.
+	 */
+	public function test_get_validation_rules_relaxes_optional_billing_address_fields(): void {
+
+		$checkout            = Checkout::get_instance();
+		$checkout->step      = [
+			'fields' => [
+				'billing_country'  => [
+					'type' => 'select',
+				],
+				'billing_zip_code' => [
+					'type' => 'text',
+				],
+			],
+		];
+		$checkout->steps     = [];
+		$checkout->step_name = null;
+
+		$this->ensure_session($checkout);
+
+		unset($_REQUEST['pre-flight'], $_REQUEST['checkout_form']);
+
+		$_REQUEST['billing_country']  = 'US';
+		$_REQUEST['billing_zip_code'] = '';
+		$_REQUEST['user_id']          = self::$customer->get_user_id();
+
+		$rules = $checkout->get_validation_rules();
+
+		$this->assertSame('country', $rules['billing_country']);
+		$this->assertSame('', $rules['billing_zip_code']);
+		$this->assertTrue($checkout->validate($rules));
+
+		unset($_REQUEST['billing_country'], $_REQUEST['billing_zip_code'], $_REQUEST['user_id']);
+	}
+
+	/**
 	 * Test get_validation_rules returns array.
 	 */
 	public function test_get_validation_rules_returns_array(): void {


### PR DESCRIPTION
## Summary

- Relax optional billing-address validation so an empty postal code no longer trips the self-referential `required_with:billing_zip_code` server rule.
- Preserve country validation when an optional country is supplied, while allowing the optional country field to remain blank.
- Add a regression test covering optional billing country + blank postal code validation.

## Verification

- `vendor/bin/phpcs inc/checkout/class-checkout.php`
- `vendor/bin/phpunit --filter 'test_get_validation_rules_relaxes_billing_for_free|test_get_validation_rules_relaxes_optional_billing_address_fields|Signup_Field_Billing_Address_Test'`
- `git diff --check`

<!-- aidevops:sig -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved validation handling for optional billing address fields during multi-step checkout to reduce unnecessary validation errors.
  * Enhanced billing country detection logic for more reliable form submission processing.

* **Tests**
  * Added test coverage for optional billing address field validation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->