### PR TITLE
fix: preserve decimal tax rates in order totals

### DIFF
--- a/inc/checkout/class-cart.php
+++ b/inc/checkout/class-cart.php
@@ -2229,7 +2229,13 @@ class Cart implements \JsonSerializable {
 		$tax_brackets = [];
 
 		foreach ($line_items as $line_item) {
-			$tax_bracket = $line_item->get_tax_rate();
+			$tax_rate = $line_item->get_tax_rate();
+
+			if ( ! $tax_rate) {
+				continue;
+			}
+
+			$tax_bracket = (string) $tax_rate;
 
 			if (isset($tax_brackets[ $tax_bracket ])) {
 				$tax_brackets[ $tax_bracket ] += $line_item->get_tax_total();

--- a/inc/models/class-payment.php
+++ b/inc/models/class-payment.php
@@ -685,11 +685,13 @@ class Payment extends Base_Model implements Notable {
 		$tax_brackets = [];
 
 		foreach ($line_items as $line_item) {
-			$tax_bracket = $line_item->get_tax_rate();
+			$tax_rate = $line_item->get_tax_rate();
 
-			if ( ! $tax_bracket) {
+			if ( ! $tax_rate) {
 				continue;
 			}
+
+			$tax_bracket = (string) $tax_rate;
 
 			if (isset($tax_brackets[ $tax_bracket ])) {
 				$tax_brackets[ $tax_bracket ] += $line_item->get_tax_total();

--- a/tests/WP_Ultimo/Tax/Tax_Breakthrough_Test.php
+++ b/tests/WP_Ultimo/Tax/Tax_Breakthrough_Test.php
@@ -1,0 +1,81 @@
+<?php
+/**
+ * Tests for tax breakthrough rate grouping.
+ *
+ * @package WP_Ultimo
+ * @subpackage Tests\Tax
+ */
+
+namespace WP_Ultimo\Tax;
+
+use WP_Ultimo\Checkout\Cart;
+use WP_Ultimo\Checkout\Line_Item;
+use WP_Ultimo\Models\Payment;
+use WP_UnitTestCase;
+
+/**
+ * Tests tax breakthrough precision for cart and payment summaries.
+ */
+class Tax_Breakthrough_Test extends WP_UnitTestCase {
+
+	/**
+	 * Test cart tax breakthrough preserves decimal tax rates.
+	 */
+	public function test_cart_tax_breakthrough_preserves_decimal_tax_rates(): void {
+		$cart = new Cart([]);
+
+		$cart->add_line_item($this->create_taxed_line_item('rate_725', 7.25));
+		$cart->add_line_item($this->create_taxed_line_item('rate_775', 7.75));
+
+		$breakthrough = $cart->get_tax_breakthrough();
+
+		$this->assertArrayHasKey('7.25', $breakthrough);
+		$this->assertArrayHasKey('7.75', $breakthrough);
+		$this->assertArrayNotHasKey(7, $breakthrough);
+		$this->assertEquals(7.25, $breakthrough['7.25']);
+		$this->assertEquals(7.75, $breakthrough['7.75']);
+	}
+
+	/**
+	 * Test payment tax breakthrough preserves decimal tax rates.
+	 */
+	public function test_payment_tax_breakthrough_preserves_decimal_tax_rates(): void {
+		$payment = new Payment();
+
+		$payment->set_line_items(
+			[
+				$this->create_taxed_line_item('rate_725', 7.25),
+				$this->create_taxed_line_item('rate_775', 7.75),
+			]
+		);
+
+		$breakthrough = $payment->get_tax_breakthrough();
+
+		$this->assertArrayHasKey('7.25', $breakthrough);
+		$this->assertArrayHasKey('7.75', $breakthrough);
+		$this->assertArrayNotHasKey(7, $breakthrough);
+		$this->assertEquals(7.25, $breakthrough['7.25']);
+		$this->assertEquals(7.75, $breakthrough['7.75']);
+	}
+
+	/**
+	 * Create a line item with a decimal tax rate.
+	 *
+	 * @param string $hash     Line item hash.
+	 * @param float  $tax_rate Tax rate percentage.
+	 * @return Line_Item
+	 */
+	private function create_taxed_line_item(string $hash, float $tax_rate): Line_Item {
+		return new Line_Item(
+			[
+				'type'       => 'product',
+				'hash'       => $hash,
+				'title'      => sprintf('Rate %s', $tax_rate),
+				'unit_price' => 100.00,
+				'quantity'   => 1,
+				'taxable'    => true,
+				'tax_rate'   => $tax_rate,
+			]
+		);
+	}
+}


### PR DESCRIPTION
## Summary

- Preserve decimal tax rate keys in cart and payment tax breakdowns so order summaries can display rates like 7.25% accurately.
- Skip zero-rate entries when building cart tax breakdowns, matching payment behavior.
- Add focused coverage for cart and payment decimal tax breakdown grouping.

## Verification

- Browser checkout with taxes enabled, a taxable $100 plan, and a US/CA 7.25% tax rate showed $7.25 tax and $107.25 total on the thank-you order details.
- `vendor/bin/phpunit --filter Tax_Breakthrough_Test`
- `vendor/bin/phpcs inc/models/class-payment.php inc/checkout/class-cart.php tests/WP_Ultimo/Tax/Tax_Breakthrough_Test.php`
- Pre-commit hook: PHPCS and PHPStan passed on staged PHP files.

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.52 plugin for [OpenCode](https://opencode.ai) v1.17.3 with gpt-5.5


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved tax rate handling in cart and payment processing to preserve decimal tax rates and filter out invalid entries, ensuring more accurate tax calculations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->