### PR TITLE
fix: prevent checkout field option leakage

### DIFF
--- a/inc/ui/class-field.php
+++ b/inc/ui/class-field.php
@@ -362,6 +362,15 @@ class Field implements \JsonSerializable {
 
 		if (is_array($attr)) {
 			foreach ($attr as $key => $value) {
+				/*
+				 * Nested field definitions are metadata, not values to resolve now.
+				 * Resolving them can execute editor callbacks while rendering parent
+				 * attributes, leaking markup from hidden child fields into the parent.
+				 */
+				if ('fields' === $key) {
+					continue;
+				}
+
 				$attr[ $key ] = $this->resolve_attribute_value($value);
 			}
 

--- a/tests/WP_Ultimo/UI/Field_Test.php
+++ b/tests/WP_Ultimo/UI/Field_Test.php
@@ -185,6 +185,45 @@ class Field_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Test nested field definition callbacks in option metadata are not resolved.
+	 */
+	public function test_options_do_not_resolve_nested_field_definition_callbacks(): void {
+		$fields_callback_was_called  = false;
+		$nested_description_rendered = false;
+
+		$field = new Field('test_field', [
+			'type'    => 'select-icon',
+			'options' => [
+				'custom' => [
+					'title'  => 'Custom',
+					'fields' => function () use (&$fields_callback_was_called, &$nested_description_rendered) {
+						$fields_callback_was_called = true;
+
+						return [
+							'nested_remove' => [
+								'desc' => function () use (&$nested_description_rendered) {
+									$nested_description_rendered = true;
+
+									print 'leaked nested description';
+								},
+							],
+						];
+					},
+				],
+			],
+		]);
+
+		ob_start();
+		$options = $field->options;
+		$output  = ob_get_clean();
+
+		$this->assertSame('', $output);
+		$this->assertFalse($fields_callback_was_called);
+		$this->assertFalse($nested_description_rendered);
+		$this->assertIsCallable($options['custom']['fields']);
+	}
+
+	/**
 	 * Test field with html attributes.
 	 */
 	public function test_field_with_html_attr(): void {
@@ -222,7 +261,7 @@ class Field_Test extends WP_UnitTestCase {
 			'title' => 'Test',
 		]);
 
-		$json = json_encode($field);
+		$json = wp_json_encode($field);
 
 		$this->assertIsString($json);
 		$this->assertJson($json);


### PR DESCRIPTION
## Summary

- Prevent field option metadata from resolving nested `fields` callbacks while rendering parent field attributes.
- Stops hidden repeater remove controls from leaking into the checkout add-field type picker.
- Adds regression coverage for nested field definition callbacks staying callable and unexecuted.

## Testing

- `vendor/bin/phpunit --filter 'WP_Ultimo\\UI\\Field_Test'`
- `vendor/bin/phpcs inc/ui/class-field.php tests/WP_Ultimo/UI/Field_Test.php`
- `git diff --check`
- WP-CLI modal render check: field type wrapper has `remove_count_in_field_type => 0`


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.52 plugin for [OpenCode](https://opencode.ai) v1.17.3 with gpt-5.5 spent 26m and 395,603 tokens on this with the user in an interactive session.
