### PR TITLE
fix: purge Divi uploads cache on clone

### DIFF
--- a/inc/compat/class-general-compat.php
+++ b/inc/compat/class-general-compat.php
@@ -360,8 +360,8 @@ class General_Compat {
 		switch_to_blog($blog_id);
 
 		try {
-			foreach ($this->get_divi_static_css_cache_directories($blog_id) as $cache_dir) {
-				$this->delete_divi_static_css_cache_directory($cache_dir);
+			foreach ($this->get_divi_static_css_cache_directories($blog_id) as $cache) {
+				$this->delete_divi_static_css_cache_directory($cache['dir'], $cache['root']);
 			}
 		} finally {
 			restore_current_blog();
@@ -407,26 +407,57 @@ class General_Compat {
 	 */
 	private function get_divi_static_css_cache_directories(int $blog_id): array {
 
-		$cache_root = trailingslashit(WP_CONTENT_DIR) . 'et-cache';
-		$paths      = [];
-		$site       = function_exists('get_site') ? get_site($blog_id) : null;
-		$network_id = $site && isset($site->site_id) ? (int) $site->site_id : 0;
+		$content_cache_root = trailingslashit(WP_CONTENT_DIR) . 'et-cache';
+		$paths              = [];
+		$site               = function_exists('get_site') ? get_site($blog_id) : null;
+		$network_id         = $site && isset($site->site_id) ? (int) $site->site_id : 0;
 
 		if (0 === $network_id && function_exists('get_current_network_id')) {
 			$network_id = (int) get_current_network_id();
 		}
 
 		if (0 < $network_id) {
-			$paths[] = trailingslashit($cache_root) . $network_id . '/' . $blog_id;
+			$paths[] = [
+				'root' => $content_cache_root,
+				'dir'  => trailingslashit($content_cache_root) . $network_id . '/' . $blog_id,
+			];
 		}
 
 		/*
 		 * Older Divi/static-resource layouts did not include the network ID in
 		 * the path. Keep this as a no-op fallback when that directory is absent.
 		 */
-		$paths[] = trailingslashit($cache_root) . $blog_id;
+		$paths[] = [
+			'root' => $content_cache_root,
+			'dir'  => trailingslashit($content_cache_root) . $blog_id,
+		];
 
-		return array_values(array_unique($paths));
+		$upload_dir = function_exists('wp_upload_dir') ? wp_upload_dir(null, false) : [];
+
+		if ( ! empty($upload_dir['basedir'])) {
+			$uploads_base = untrailingslashit((string) $upload_dir['basedir']);
+
+			/*
+			 * Divi falls back to wp_upload_dir()['basedir']/et-cache when
+			 * WP_CONTENT_DIR is not writable. In multisite this basedir is already
+			 * scoped to the cloned blog (for example uploads/sites/{blog_id}), so
+			 * the blog cache directory is the et-cache root itself.
+			 */
+			$paths[] = [
+				'root' => $uploads_base,
+				'dir'  => trailingslashit($uploads_base) . 'et-cache',
+			];
+		}
+
+		$unique = [];
+
+		foreach ($paths as $path) {
+			$key = wp_normalize_path($path['root'] . '|' . $path['dir']);
+
+			$unique[ $key ] = $path;
+		}
+
+		return array_values($unique);
 	}
 
 	/**
@@ -434,12 +465,11 @@ class General_Compat {
 	 *
 	 * @since 2.5.1
 	 *
-	 * @param string $cache_dir Cache directory path.
+	 * @param string $cache_dir  Cache directory path.
+	 * @param string $cache_root Cache root path used for safety checks.
 	 * @return void
 	 */
-	private function delete_divi_static_css_cache_directory(string $cache_dir): void {
-
-		$cache_root = trailingslashit(WP_CONTENT_DIR) . 'et-cache';
+	private function delete_divi_static_css_cache_directory(string $cache_dir, string $cache_root): void {
 
 		if ('' === $cache_dir || ! is_dir($cache_dir)) {
 			return;

--- a/tests/WP_Ultimo/General_Compat_Test.php
+++ b/tests/WP_Ultimo/General_Compat_Test.php
@@ -80,6 +80,45 @@ class General_Compat_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Test Divi uploads fallback et-cache is deleted only for the cloned site.
+	 */
+	public function test_clear_divi_static_css_cache_deletes_uploads_fallback_cache_only(): void {
+
+		if ( ! is_multisite()) {
+			$this->markTestSkipped('Divi cache purge tests require multisite');
+		}
+
+		$blog_id       = self::factory()->blog->create();
+		$other_blog_id = self::factory()->blog->create();
+
+		switch_to_blog($blog_id);
+		$upload_dir = wp_upload_dir(null, false);
+		restore_current_blog();
+
+		switch_to_blog($other_blog_id);
+		$other_upload_dir = wp_upload_dir(null, false);
+		restore_current_blog();
+
+		$cache_dir = trailingslashit($upload_dir['basedir']) . 'et-cache';
+		$other_dir = trailingslashit($other_upload_dir['basedir']) . 'et-cache';
+
+		$this->cache_dirs = [$cache_dir, $other_dir];
+
+		wp_mkdir_p($cache_dir . '/4');
+		wp_mkdir_p($other_dir . '/4');
+
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents -- Test fixture setup.
+		file_put_contents($cache_dir . '/4/et-core-unified-deferred-4.min.css', 'stale divi css');
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents -- Test fixture setup.
+		file_put_contents($other_dir . '/4/et-core-unified-deferred-4.min.css', 'other divi css');
+
+		General_Compat::get_instance()->clear_divi_static_css_cache(['site_id' => $blog_id]);
+
+		$this->assertDirectoryDoesNotExist($cache_dir);
+		$this->assertDirectoryExists($other_dir);
+	}
+
+	/**
 	 * Test Divi et-cache symlinks do not delete files outside the cache tree.
 	 */
 	public function test_clear_divi_static_css_cache_does_not_follow_symlinks(): void {


### PR DESCRIPTION
## Summary

- Extend Divi clone cache purge to include Divi's uploads-directory fallback cache root (`wp_upload_dir()['basedir']/et-cache`).
- Keep the existing standard `wp-content/et-cache/{network_id}/{blog_id}` and legacy `wp-content/et-cache/{blog_id}` purge paths.
- Preserve safety checks by validating each candidate directory against its own cache root before recursive deletion.
- Add a multisite regression test proving only the cloned site's uploads fallback cache is removed.

## Verification

- `vendor/bin/phpunit --filter General_Compat_Test` — OK, 4 tests / 7 assertions.
- `vendor/bin/phpcs inc/compat/class-general-compat.php tests/WP_Ultimo/General_Compat_Test.php` — OK.
- `vendor/bin/phpstan analyse inc/compat/class-general-compat.php tests/WP_Ultimo/General_Compat_Test.php` — OK.
- Local reproduction with customer-provided `/home/dave/Divi.zip` (Divi 4.27.6): created Divi template site, cloned via `Site_Duplicator::duplicate_site()`, verified cloned page regenerates the required `.et_pb_section_0` / `.et_pb_image_0` CSS rules.
- Direct hook simulation: pre-created stale files in both `wp-content/et-cache/1/{blog_id}` and `uploads/sites/{blog_id}/et-cache`; `do_action('wu_duplicate_site', ['from_site_id' => 58, 'site_id' => 60])` removed both cloned-site cache directories.

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.53 plugin for [OpenCode](https://opencode.ai) v1.17.3 with gpt-5.5


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved Divi static CSS cache clearing in multisite environments to properly isolate cache deletion to the target site and prevent cross-site conflicts
  * Enhanced cache directory detection to support multiple storage locations, including uploads directory fallback when standard cache locations are not writable

<!-- end of auto-generated comment: release notes by coderabbit.ai -->