### PR TITLE
fix: relax optional billing rules across checkout steps

### DIFF
--- a/inc/checkout/class-checkout.php
+++ b/inc/checkout/class-checkout.php
@@ -2770,7 +2770,9 @@ class Checkout {
 			'billing_zip_code' => '',
 		];
 
-		foreach ($this->step['fields'] as $field_key => $field) {
+		$billing_rule_fields = $this->checkout_form ? $this->checkout_form->get_all_fields() : $this->step['fields'];
+
+		foreach ($billing_rule_fields as $field_key => $field) {
 			if ( ! is_array($field)) {
 				continue;
 			}

--- a/tests/WP_Ultimo/Checkout/Checkout_Test.php
+++ b/tests/WP_Ultimo/Checkout/Checkout_Test.php
@@ -1623,6 +1623,67 @@ class Checkout_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Test optional billing fields on earlier checkout steps relax final validation.
+	 */
+	public function test_get_validation_rules_relaxes_optional_billing_address_fields_from_all_steps(): void {
+
+		$form = new \WP_Ultimo\Models\Checkout_Form([
+			'name'     => 'Optional Billing Multi-step ' . time(),
+			'slug'     => 'optional-billing-multi-step-' . time(),
+			'settings' => [
+				[
+					'id'     => 'billing-step',
+					'name'   => 'Billing Step',
+					'fields' => [
+						[
+							'id'   => 'billing_country',
+							'type' => 'select',
+						],
+						[
+							'id'   => 'billing_zip_code',
+							'type' => 'text',
+						],
+					],
+				],
+				[
+					'id'     => 'final-step',
+					'name'   => 'Final Step',
+					'fields' => [
+						[
+							'id'   => 'site_title',
+							'type' => 'text',
+						],
+					],
+				],
+			],
+		]);
+
+		$checkout                = Checkout::get_instance();
+		$checkout->checkout_form = $form;
+		$checkout->step          = $form->get_step('final-step', true);
+		$checkout->steps         = $form->get_steps_to_show();
+		$checkout->step_name     = 'final-step';
+
+		$this->ensure_session($checkout);
+
+		unset($_REQUEST['pre-flight'], $_REQUEST['checkout_form']);
+
+		$_REQUEST['billing_country']  = 'US';
+		$_REQUEST['billing_zip_code'] = '';
+		$_REQUEST['user_id']          = self::$customer->get_user_id();
+
+		$rules = $checkout->get_validation_rules();
+
+		$this->assertSame('country', $rules['billing_country']);
+		$this->assertSame('', $rules['billing_zip_code']);
+		$this->assertTrue($checkout->validate($rules));
+
+		unset($_REQUEST['billing_country'], $_REQUEST['billing_zip_code'], $_REQUEST['user_id']);
+
+		$checkout->checkout_form = null;
+	}
+
+	/**
 	 * Test get_validation_rules returns array.
 	 */
 	public function test_get_validation_rules_returns_array(): void {


### PR DESCRIPTION
## Summary

- Applies optional billing-address rule relaxation across all checkout form fields, not only the active step.
- Adds a regression test for billing country/ZIP fields on step 1 with validation running on step 2.

Resolves #1404

## Testing

- `WP_TESTS_DIR=/tmp/wordpress-tests-lib vendor/bin/phpunit --filter 'test_get_validation_rules_relaxes_optional_billing_address_fields'`
- `php -l inc/checkout/class-checkout.php && php -l tests/WP_Ultimo/Checkout/Checkout_Test.php`
- `vendor/bin/phpcs inc/checkout/class-checkout.php`

<!-- aidevops:sig -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation logic for optional billing address fields in multi-step checkout processes to ensure all relevant form fields are considered during validation.

* **Tests**
  * Added comprehensive test coverage for optional billing address field validation when using multi-step checkout forms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->