### PR TITLE
fix: clarify checkout step loading copy

### DIFF
--- a/assets/js/checkout.js
+++ b/assets/js/checkout.js
@@ -1702,10 +1702,14 @@
 					jQuery(this).find('button[type="submit"]').prop('disabled', true);
 
 					// Show loading message with status text
+					const loadingText = wu_checkout.is_last_step
+						? (wu_checkout.i18n.provisioning_site || 'Provisioning your site — this can take up to 60 seconds.')
+						: (wu_checkout.i18n.recording_responses || 'Recording Your Responses...');
+
 					const loadingMessage = '<div style="text-align: center;">' +
 					'<div class="spinner is-active wu-float-none" style="float: none !important; margin-bottom: 12px;"></div>' +
 					'<div style="font-size: 14px; line-height: 1.5;">' +
-					(wu_checkout.i18n.provisioning_site || 'Provisioning your site — this can take up to 60 seconds.') +
+					loadingText +
 					'</div>' +
 					'</div>';
 

--- a/inc/checkout/class-checkout.php
+++ b/inc/checkout/class-checkout.php
@@ -2112,6 +2112,7 @@ class Checkout {
 			'cancel'               => __('Cancel', 'ultimate-multisite'),
 			'email_exists'         => __('A customer with the same email address or username already exists.', 'ultimate-multisite'),
 			'provisioning_site'    => __('Provisioning your site — this can take up to 60 seconds.', 'ultimate-multisite'),
+			'recording_responses'  => __('Recording Your Responses...', 'ultimate-multisite'),
 			// Client-side validation messages (%s = field label, %d = numeric limit).
 			/* translators: %s: field label */
 			'field_required'       => __('%s is required.', 'ultimate-multisite'),
@@ -2204,6 +2205,7 @@ class Checkout {
 			'needs_billing_info' => true,
 			'auto_renew'         => true,
 			'products'           => array_unique($products),
+			'is_last_step'       => $this->is_last_step(),
 		];
 
 		/*

--- a/lang/ultimate-multisite.pot
+++ b/lang/ultimate-multisite.pot
@@ -8083,6 +8083,10 @@ msgstr ""
 msgid "Provisioning your site — this can take up to 60 seconds."
 msgstr ""
 
+#: inc/checkout/class-checkout.php:2111
+msgid "Recording Your Responses..."
+msgstr ""
+
 #. translators: %s: field label
 #: inc/checkout/class-checkout.php:2113
 #, php-format

--- a/tests/unit/Checkout_Step_Fields_Test.php
+++ b/tests/unit/Checkout_Step_Fields_Test.php
@@ -18,7 +18,7 @@ final class Checkout_Step_Fields_Test extends TestCase {
 	 *
 	 * @return array
 	 */
-	private function build_step_fields_map(): array {
+	private function build_checkout_variables(string $step_name = 'account'): array {
 
 		$form = wu_create_checkout_form(
 			[
@@ -119,6 +119,8 @@ final class Checkout_Step_Fields_Test extends TestCase {
 
 		// Inject the seeded form into the real checkout singleton (public prop).
 		$checkout->checkout_form = $form;
+		$checkout->steps         = $form->get_steps_to_show();
+		$checkout->step_name     = $step_name;
 
 		$vars = $checkout->get_checkout_variables();
 
@@ -127,6 +129,18 @@ final class Checkout_Step_Fields_Test extends TestCase {
 			$vars,
 			'get_checkout_variables() must expose step_fields so the Vue validator can scope validation per step. If this key is gone, Step 1 demands every field and registration is blocked.'
 		);
+
+		return $vars;
+	}
+
+	/**
+	 * Builds and returns the step_fields checkout variable.
+	 *
+	 * @return array
+	 */
+	private function build_step_fields_map(): array {
+
+		$vars = $this->build_checkout_variables();
 
 		return $vars['step_fields'];
 	}
@@ -212,5 +226,19 @@ final class Checkout_Step_Fields_Test extends TestCase {
 				"Step '{$step_id}' contains every field — fields are not partitioned per step, so Step 1 would demand all of them."
 			);
 		}
+	}
+
+	/**
+	 * Guards the loading-copy decision used by the multi-step Vue form.
+	 */
+	public function test_checkout_variables_expose_step_specific_loading_copy(): void {
+
+		$account_vars = $this->build_checkout_variables('account');
+		$payment_vars = $this->build_checkout_variables('payment');
+
+		$this->assertArrayHasKey('recording_responses', $account_vars['i18n']);
+		$this->assertSame('Recording Your Responses...', $account_vars['i18n']['recording_responses']);
+		$this->assertFalse($account_vars['is_last_step'], 'The first step must not show the provisioning copy.');
+		$this->assertTrue($payment_vars['is_last_step'], 'The final step should keep the provisioning copy.');
 	}
 }


### PR DESCRIPTION
## Summary

- Show “Recording Your Responses...” while a multi-step checkout advances before the final step.
- Keep the existing “Provisioning your site — this can take up to 60 seconds.” copy for the final checkout step.
- Expose the step-state/loading-copy variables and add regression coverage for the distinction.

## Verification

- `vendor/bin/phpcs inc/checkout/class-checkout.php tests/unit/Checkout_Step_Fields_Test.php`
- `vendor/bin/phpunit --filter Checkout_Step_Fields_Test`
- `eslint assets/js/checkout.js --ignore-pattern '*.min.js'` (via local hook/lint-staged during commit)


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.55 plugin for [OpenCode](https://opencode.ai) v1.17.3 with gpt-5.5


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Checkout now displays context-aware loading messages: "Recording Your Responses…" on standard steps and "Provisioning your site…" on the final step.

* **Tests**
  * Added test coverage for step-specific checkout loading messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->