### PR TITLE
fix: restore order bump product selector

### DIFF
--- a/inc/admin-pages/class-checkout-form-edit-admin-page.php
+++ b/inc/admin-pages/class-checkout-form-edit-admin-page.php
@@ -525,7 +525,15 @@ class Checkout_Form_Edit_Admin_Page extends Edit_Admin_Page {
 		foreach ($field_types as $field_type) {
 			$_fields = call_user_func($field_type['fields'], $attributes);
 
-			$additional_fields = array_merge($additional_fields, $_fields);
+			foreach ($_fields as $field_slug => $field) {
+				if (isset($additional_fields[ $field_slug ])) {
+					$additional_fields[ $field_slug ] = $this->merge_duplicate_field_type_field($additional_fields[ $field_slug ], $field);
+
+					continue;
+				}
+
+				$additional_fields[ $field_slug ] = $field;
+			}
 		}
 
 		$default_fields = \WP_Ultimo\Checkout\Signup_Fields\Base_Signup_Field::fields_list();
@@ -581,6 +589,33 @@ class Checkout_Form_Edit_Admin_Page extends Edit_Admin_Page {
 		);
 
 		return $fields;
+	}
+
+	/**
+	 * Merges editor fields that use the same attribute key across field types.
+	 *
+	 * Add-ons can register field types with editor attributes that collide with
+	 * core field attributes, for example an add-on field that also uses a
+	 * `product` selector. Keeping only the last field hides the earlier selector
+	 * because its Vue visibility condition is replaced. Preserve the first field
+	 * configuration and make it visible for both field types.
+	 *
+	 * @since 2.4.13
+	 *
+	 * @param array $existing_field Previously registered editor field.
+	 * @param array $new_field      New editor field using the same key.
+	 * @return array
+	 */
+	protected function merge_duplicate_field_type_field($existing_field, $new_field) {
+
+		$existing_show = wu_get_isset($existing_field, 'wrapper_html_attr', [])['v-show'] ?? '';
+		$new_show      = wu_get_isset($new_field, 'wrapper_html_attr', [])['v-show'] ?? '';
+
+		if ($existing_show && $new_show && $existing_show !== $new_show) {
+			$existing_field['wrapper_html_attr']['v-show'] = sprintf('(%s) || (%s)', $existing_show, $new_show);
+		}
+
+		return $existing_field;
 	}
 
 	/**

--- a/inc/checkout/signup-fields/class-signup-field-order-bump.php
+++ b/inc/checkout/signup-fields/class-signup-field-order-bump.php
@@ -110,6 +110,7 @@ class Signup_Field_Order_Bump extends Base_Signup_Field {
 	public function defaults() {
 
 		return [
+			'product'                     => '',
 			'order_bump_template'         => 'simple',
 			'display_product_description' => 0,
 		];
@@ -172,6 +173,7 @@ class Signup_Field_Order_Bump extends Base_Signup_Field {
 				'tooltip'     => '',
 				'order'       => 12,
 				'html_attr'   => [
+					'v-model'           => 'product',
 					'data-model'        => 'product',
 					'data-value-field'  => 'id',
 					'data-label-field'  => 'name',

--- a/tests/WP_Ultimo/Checkout/Signup_Fields/Signup_Field_Order_Bump_Test.php
+++ b/tests/WP_Ultimo/Checkout/Signup_Fields/Signup_Field_Order_Bump_Test.php
@@ -97,6 +97,8 @@ class Signup_Field_Order_Bump_Test extends WP_UnitTestCase {
 	public function test_defaults(): void {
 		$defaults = $this->field->defaults();
 		$this->assertIsArray( $defaults );
+		$this->assertArrayHasKey( 'product', $defaults );
+		$this->assertEquals( '', $defaults['product'] );
 		$this->assertArrayHasKey( 'order_bump_template', $defaults );
 		$this->assertEquals( 'simple', $defaults['order_bump_template'] );
 		$this->assertArrayHasKey( 'display_product_description', $defaults );
@@ -139,6 +141,14 @@ class Signup_Field_Order_Bump_Test extends WP_UnitTestCase {
 	public function test_get_fields_product_is_model_type(): void {
 		$fields = $this->field->get_fields();
 		$this->assertEquals( 'model', $fields['product']['type'] );
+	}
+
+	/**
+	 * Test product field is bound to modal state.
+	 */
+	public function test_get_fields_product_is_bound_to_modal_state(): void {
+		$fields = $this->field->get_fields();
+		$this->assertEquals( 'product', $fields['product']['html_attr']['v-model'] );
 	}
 
 	/**


### PR DESCRIPTION
## Summary

- Restore the order bump product selector in the checkout form field modal when another signup field registers a colliding `product` editor attribute.
- Preserve duplicate editor field visibility instead of letting later field types overwrite earlier ones.
- Add a default/binding regression for the order bump product field.

## Verification

- Browser-tested `wp-admin/network/admin.php?page=wp-ultimo-edit-checkout-form&id=1&slug=main-form&model=checkout_form`; the order bump modal now shows the Product selector.
- `vendor/bin/phpunit --filter Signup_Field_Order_Bump_Test`
- `vendor/bin/phpcs inc/admin-pages/class-checkout-form-edit-admin-page.php inc/checkout/signup-fields/class-signup-field-order-bump.php tests/WP_Ultimo/Checkout/Signup_Fields/Signup_Field_Order_Bump_Test.php`
- Pre-commit PHPCS + PHPStan passed.

---
<!-- aidevops:sig -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved duplicate field handling in the checkout form editor; fields with conflicting identifiers are now merged intelligently instead of being overwritten.

* **Improvements**
  * Enhanced order bump field initialization with product selection defaults.

* **Tests**
  * Added test coverage for product field initialization and state binding.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->