### PR TITLE
chore: require PHP 8.2

### DIFF
--- a/.github/workflows/addon-integration-test.yml
+++ b/.github/workflows/addon-integration-test.yml
@@ -30,7 +30,7 @@ on:
         description: "JSON array of PHP versions to test"
         required: false
         type: string
-        default: '["8.2"]'
+        default: '["8.2", "8.3", "8.4", "8.5"]'
       run-e2e:
         description: "Whether to run E2E (Cypress) tests"
         required: false

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -14,7 +14,7 @@ jobs:
     timeout-minutes: 45  # Increased for setup wizard + Stripe test clock advancement
     strategy:
       matrix:
-        php: ["8.2", "8.3", "8.4", "8.5"]
+        php: ["8.5"]
         browser: ["chrome"]   # Start with Chrome only for reliability
 
     services:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -14,7 +14,7 @@ jobs:
     timeout-minutes: 45  # Increased for setup wizard + Stripe test clock advancement
     strategy:
       matrix:
-        php: ["8.1", "8.2"]  # Reduced PHP versions for faster CI
+        php: ["8.2", "8.3", "8.4", "8.5"]
         browser: ["chrome"]   # Start with Chrome only for reliability
 
     services:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@accd6127cb78bee3e8082180cb391013d204ef9f # v2
         with:
-          php-version: '7.4'
+          php-version: '8.2'
           extensions: mbstring, intl, curl
           tools: composer, wp-cli
 
@@ -125,7 +125,7 @@ jobs:
             ## Notes
             
             - Compatible with WordPress 5.3+
-            - Requires PHP 7.4.30+
+            - Requires PHP 8.2+
             - Always backup your site before upgrading
 
   deploy-to-wporg:

--- a/.wiki/frequently-asked-questions.md
+++ b/.wiki/frequently-asked-questions.md
@@ -15,7 +15,7 @@ No. Ultimate Multisite requires WordPress multisite, subdirectory, or subdomain.
 Ultimate Multisite requires:
 
 **WordPress Version** : v5.3+ (Recommended: Last Stable Version)  
-**PHP Version** : 7.4.x (Support to > 8.0 coming soon)  
+**PHP Version** : 8.2+
 **MySQL Version** : v5+ (Recommended: Version 5.6, in case you don't have 8.0 available on your hosting provider)
 
 _Multisite (subdomain or subdirectory) also needs to be activated._ [How to Install WordPress Multisite](https://support.delta.nextpress.co/hc/wp-ultimo/articles/1677127280-how-do-i-install-word_press-multisite).

--- a/.wiki/wp-ultimo-requirements.md
+++ b/.wiki/wp-ultimo-requirements.md
@@ -34,13 +34,13 @@ After you have Multisite enabled on WordPress, it is time to install Ultimate Mu
 
   * WordPress: v5.3+ (Recommended: Last stable version)
 
-  * PHP: 7.4.x (support to > 8.0 coming soon)
+  * PHP: 8.2+
 
   * MySQL: v5+ (Recommended: 5.6, in case you don't have 8.0 available on your hosting provider)
 
 These are the only software requirements for Ultimate Multisite.
 
-Keep in mind that Ultimate Multisite may work with PHP 8.0 but we recommend running it with PHP 7.4.x.
+Keep in mind that Ultimate Multisite requires PHP 8.2 or higher.
 
 Also, we recommend installing it on **main domains** , not subdomains or subdirectories. It might work on subdomains/subdirectories, but it might present some errors.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@
 UI text, docs, and user-facing strings. The code namespace `WP_Ultimo` and the `wu_`
 function/hook prefix are preserved for backwards compatibility — do not rename them.
 
-WordPress Multisite WaaS plugin (formerly WP Ultimo). PHP 7.4+, WP 5.3+, GPL v2.
+WordPress Multisite WaaS plugin (formerly WP Ultimo). PHP 8.2+, WP 5.3+, GPL v2.
 Root namespace: `WP_Ultimo`. Text domain: `ultimate-multisite`.
 
 ## Build / Test / Lint Commands
@@ -125,7 +125,7 @@ assets/                  # JS, CSS, images, fonts
 - **i18n**: All user-facing strings via `__()`, `esc_html__()`, etc. with domain `ultimate-multisite`.
 - **Sanitization**: Use `wu_clean()` or WordPress sanitization functions. Custom sanitizers
   registered in `.phpcs.xml.dist`.
-- **PHP compat**: Must work on PHP 7.4+. Platform set to 7.4.1 in composer.json.
+- **PHP compat**: Must work on PHP 8.2+. Platform set to 8.2.0 in composer.json.
 
 ### Naming Conventions
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,7 @@ Thank you for your interest in contributing to Multisite Ultimate! This document
 
 ### Prerequisites
 
-- PHP 7.4+ (8.1+ recommended for development)
+- PHP 8.2+
 - Node.js 16+ and npm
 - Composer
 - Git

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 <p align="center">
   <a href="http://www.gnu.org/licenses/gpl-2.0.html"><img src="https://img.shields.io/badge/License-GPL%20v2-blue.svg" alt="License: GPL v2"></a>
   <a href="https://wordpress.org/"><img src="https://img.shields.io/badge/WordPress-6.8%20Tested-green.svg" alt="WordPress: 6.8 Tested"></a>
-  <a href="https://php.net/"><img src="https://img.shields.io/badge/PHP-7.4.0%2B-purple.svg" alt="PHP: 7.4.0+"></a>
+  <a href="https://php.net/"><img src="https://img.shields.io/badge/PHP-8.2%2B-purple.svg" alt="PHP: 8.2+"></a>
   <a href="https://php.net/"><img src="https://img.shields.io/badge/Up%20To%20PHP-8.4.6-purple.svg" alt="Up To PHP: 8.4.6"></a>
   <a href="https://github.com/Ultimate-Multisite/ultimate-multisite/releases"><img src="https://img.shields.io/github/v/release/Ultimate-Multisite/ultimate-multisite" alt="Latest Release"></a>
 </p>
@@ -45,7 +45,7 @@ This plugin was formerly known as WP Ultimo and is now community maintained.
 ## 📋 Requirements
 
 - WordPress Multisite 5.3 or higher
-- PHP 7.4.30 or higher
+- PHP 8.2 or higher
 - MySQL 5.6 or higher
 
 ## 🔧 Installation

--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
     ],
     "type": "wordpress-plugin",
     "require": {
-        "php": ">=7.4.1",
+        "php": ">=8.2",
         "automattic/jetpack-autoloader": "^3.0 || ^4.0 || ^5.0",
         "wp-ultimo/autoloader-plugin": "dev-main",
         "wordpress/abilities-api": "^0.4.0",
@@ -80,7 +80,7 @@
     },
     "config": {
         "platform": {
-            "php": "7.4.1"
+            "php": "8.2.0"
         },
         "allow-plugins": {
             "composer/installers": true,

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "f96bc9847525d14a2e249a3cfac6f05e",
+    "content-hash": "25f64335dc20fe4a18af3f77340bf469",
     "packages": [
         {
             "name": "amphp/amp",
@@ -7449,13 +7449,13 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": ">=7.4.1",
+        "php": ">=8.2",
         "ext-json": "*",
         "ext-curl": "*"
     },
     "platform-dev": {},
     "platform-overrides": {
-        "php": "7.4.1"
+        "php": "8.2.0"
     },
     "plugin-api-version": "2.9.0"
 }

--- a/inc/class-requirements.php
+++ b/inc/class-requirements.php
@@ -36,7 +36,7 @@ class Requirements {
 	 * @since 2.0.0
 	 * @var string
 	 */
-	public static $php_version = '7.4.1';
+	public static $php_version = '8.2';
 
 	/**
 	 * Recommended PHP Version

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: aanduque, superdav42, vvwb, surferking, mahyarrezghi, josevega, pa
 Donate link: https://github.com/sponsors/superdav42/
 Tags: multisite, domain mapping, wordpress multisite, multisite saas, waas
 Requires at least: 5.3
-Requires PHP: 7.4.30
+Requires PHP: 8.2
 Tested up to: 7.0
 Stable tag: 2.13.1
 License: GPLv2
@@ -168,7 +168,7 @@ Ultimate Multisite uses [Microlink](https://microlink.io/) as its primary screen
 == Requirements ==
 
 - WordPress Multisite 5.3 or higher
-- PHP 7.4.30 or higher
+- PHP 8.2 or higher
 - MySQL 5.6 or higher
 
 == Screenshots ==

--- a/tests/WP_Ultimo/Site_Exporter/Self_Boot_Builder_Test.php
+++ b/tests/WP_Ultimo/Site_Exporter/Self_Boot_Builder_Test.php
@@ -156,11 +156,11 @@ class Self_Boot_Builder_Test extends WP_UnitTestCase {
 	// -------------------------------------------------------------------------
 
 	/**
-	 * The rendered index.php must be syntactically valid PHP 7.4.
+	 * The rendered index.php must be syntactically valid PHP 8.2.
 	 *
 	 * Runs `php -l` on the rendered output in a subprocess.
 	 */
-	public function test_self_boot_index_template_is_php_74_compatible(): void {
+	public function test_self_boot_index_template_is_php_82_compatible(): void {
 		$rendered = Self_Boot_Builder::render_index_template('single-site', []);
 
 		if (empty($rendered)) {

--- a/ultimate-multisite.php
+++ b/ultimate-multisite.php
@@ -12,7 +12,7 @@
  * Domain Path: /lang
  * Network:     true
  * Requires at least: 5.3
- * Requires PHP: 7.4.30
+ * Requires PHP: 8.2
  *
  * Ultimate Multisite is distributed under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 2 of the License, or

--- a/views/site-exporter/self-boot/readme.txt
+++ b/views/site-exporter/self-boot/readme.txt
@@ -41,7 +41,7 @@ QUICK START (Browser Wizard — recommended)
 REQUIREMENTS
 --------------------------------------------------------------------------------
 
-- PHP 7.4 or later (PHP 8.x recommended)
+- PHP 8.2 or later
 - MySQL 5.7+ or MariaDB 10.2+
 - Outbound HTTPS to wordpress.org (unless core was bundled)
 - ZipArchive PHP extension


### PR DESCRIPTION
## Summary

- Raise Ultimate Multisite's declared minimum PHP version to 8.2 in plugin metadata, runtime requirements, Composer platform constraints, and supporting documentation.
- Refresh composer.lock platform metadata for the new PHP requirement.
- Keep PHPUnit/addon test coverage on PHP 8.2, 8.3, 8.4, and 8.5, while limiting the main E2E workflow to PHP 8.5 only to control CI cost.

## Verification

- `php -l ultimate-multisite.php && php -l inc/class-requirements.php`
- `vendor/bin/phpcs ultimate-multisite.php inc/class-requirements.php`
- `composer validate --no-check-publish`
- Workflow YAML parse for changed workflows
- Tracked grep for old PHP 7.4 / 8.1 workflow requirement references
- E2E workflow grep confirming PHP 8.2, 8.3, and 8.4 are not in the E2E matrix
- `git diff --check`

## Notes

- `composer validate --no-check-publish` passes with existing warnings about the `version` field and commit-pinned packages.

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.55 plugin for [OpenCode](https://opencode.ai) v1.17.3 with gpt-5.5 spent 58m and 303,609 tokens on this with the user in an interactive session.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated minimum PHP version requirement to 8.2 across plugin metadata, CI workflows, and project documentation.
  * Updated CI/CD pipelines to test against PHP 8.2, 8.3, 8.4, and 8.5.

* **Documentation**
  * Updated system requirements documentation to reflect PHP 8.2+ as the new minimum version.

* **Tests**
  * Updated test compatibility validation to target PHP 8.2 standards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->