### PR TITLE
ci: fix PR #1382 E2E cleanup failure

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -19,7 +19,7 @@ jobs:
 
     services:
       mailpit:
-        image: axllent/mailpit:latest
+        image: ghcr.io/axllent/mailpit:latest
         ports:
           - 1025:1025
           - 8025:8025
@@ -520,7 +520,12 @@ jobs:
 
       - name: Fix permissions for Cypress output
         if: always()
-        run: sudo chown -R $USER:$USER tests/e2e/cypress
+        run: |
+          if [ -d tests/e2e/cypress ]; then
+            sudo chown -R $USER:$USER tests/e2e/cypress
+          else
+            echo "Cypress output directory does not exist; skipping permission fix."
+          fi
 
       - name: Upload Cypress screenshots
         if: always()
@@ -540,4 +545,9 @@ jobs:
 
       - name: Stop WordPress Environment
         if: always()
-        run: npm run env:stop
+        run: |
+          if [ -f package.json ]; then
+            npm run env:stop
+          else
+            echo "package.json does not exist; checkout did not complete before cleanup."
+          fi

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -19,7 +19,7 @@ jobs:
 
     services:
       mailpit:
-        image: ghcr.io/axllent/mailpit:latest
+        image: ghcr.io/axllent/mailpit@sha256:3bd7c2f2696deb35a4780d152b404dceec99cb041b942c0877b3b22384714f85
         ports:
           - 1025:1025
           - 8025:8025

--- a/inc/class-sunrise.php
+++ b/inc/class-sunrise.php
@@ -335,7 +335,7 @@ class Sunrise {
 			$security_mode = (bool) (int) wu_get_setting_early('security_mode');
 
 			if ($security_mode) {
-				if (wu_get_isset($_GET, 'wu_secure') === wu_get_security_mode_key()) { // phpcs:ignore WordPress.Security.NonceVerification
+				if (hash_equals(wu_get_security_mode_key(), (string) wu_get_isset($_GET, 'wu_secure'))) { // phpcs:ignore WordPress.Security.NonceVerification
 					wu_save_setting_early('security_mode', false);
 				} else {
 					/**

--- a/inc/class-sunrise.php
+++ b/inc/class-sunrise.php
@@ -335,7 +335,9 @@ class Sunrise {
 			$security_mode = (bool) (int) wu_get_setting_early('security_mode');
 
 			if ($security_mode) {
-				if (hash_equals(wu_get_security_mode_key(), (string) wu_get_isset($_GET, 'wu_secure'))) { // phpcs:ignore WordPress.Security.NonceVerification
+				$provided_key = wu_get_isset($_GET, 'wu_secure'); // phpcs:ignore WordPress.Security.NonceVerification
+
+				if (is_string($provided_key) && hash_equals(wu_get_security_mode_key(false), $provided_key)) {
 					wu_save_setting_early('security_mode', false);
 				} else {
 					/**

--- a/inc/functions/sunrise.php
+++ b/inc/functions/sunrise.php
@@ -79,24 +79,47 @@ function wu_save_setting_early($key, $value) {
  * unpredictable. It used to be substr(md5(admin_email), 0, 6) — only ~24 bits
  * and derived from a frequently public/guessable value, which an attacker could
  * compute or brute-force. We now use a high-entropy random secret generated once
- * and stored as a network option. random_bytes() is used (not
- * wp_generate_password) because this runs from sunrise, before pluggable.php is
- * loaded. The current key is shown to admins on the settings screen, so rotating
- * it is transparent for the documented copy-the-URL workflow.
+ * and stored as a network option when the key is displayed to admins.
+ * random_bytes() is used (not wp_generate_password) because this runs from
+ * sunrise, before pluggable.php is loaded. Sunrise validation does not generate
+ * a new key while security mode is already active; if a random key has not been
+ * persisted yet, the legacy derived key remains valid until an admin loads the
+ * settings screen and sees the new random recovery URL.
  *
  * @since 2.0.20
+ *
+ * @param bool $generate Whether to generate and persist a random key when missing.
+ * @return string
  */
-function wu_get_security_mode_key(): string {
+function wu_get_security_mode_key($generate = true): string {
 
 	$key = (string) get_network_option(null, 'wu_security_mode_key', '');
 
 	if ('' === $key) {
+		if (! $generate) {
+			return wu_get_legacy_security_mode_key();
+		}
+
 		$key = bin2hex(random_bytes(16));
 
 		update_network_option(null, 'wu_security_mode_key', $key);
 	}
 
 	return $key;
+}
+
+/**
+ * Get the legacy security mode key used before high-entropy keys were persisted.
+ *
+ * @since 2.0.20
+ *
+ * @return string
+ */
+function wu_get_legacy_security_mode_key(): string {
+
+	$hash = md5((string) get_network_option(null, 'admin_email'));
+
+	return substr($hash, 0, 6);
 }
 
 /**

--- a/inc/functions/sunrise.php
+++ b/inc/functions/sunrise.php
@@ -100,9 +100,15 @@ function wu_get_security_mode_key($generate = true): string {
 			return wu_get_legacy_security_mode_key();
 		}
 
-		$key = bin2hex(random_bytes(16));
+		$generated_key = bin2hex(random_bytes(16));
 
-		update_network_option(null, 'wu_security_mode_key', $key);
+		add_network_option(null, 'wu_security_mode_key', $generated_key);
+
+		$key = (string) get_network_option(null, 'wu_security_mode_key', '');
+
+		if ('' === $key) {
+			return wu_get_legacy_security_mode_key();
+		}
 	}
 
 	return $key;

--- a/inc/functions/sunrise.php
+++ b/inc/functions/sunrise.php
@@ -72,15 +72,31 @@ function wu_save_setting_early($key, $value) {
 }
 
 /**
- * Get the security mode key used to disable security mode
+ * Get the security mode key used to disable security mode.
+ *
+ * This key is exposed in an unauthenticated query string (?wu_secure=KEY) that
+ * turns the network-wide recovery "security mode" off, so it must be
+ * unpredictable. It used to be substr(md5(admin_email), 0, 6) — only ~24 bits
+ * and derived from a frequently public/guessable value, which an attacker could
+ * compute or brute-force. We now use a high-entropy random secret generated once
+ * and stored as a network option. random_bytes() is used (not
+ * wp_generate_password) because this runs from sunrise, before pluggable.php is
+ * loaded. The current key is shown to admins on the settings screen, so rotating
+ * it is transparent for the documented copy-the-URL workflow.
  *
  * @since 2.0.20
  */
 function wu_get_security_mode_key(): string {
 
-	$hash = md5((string) get_network_option(null, 'admin_email'));
+	$key = (string) get_network_option(null, 'wu_security_mode_key', '');
 
-	return substr($hash, 0, 6);
+	if ('' === $key) {
+		$key = bin2hex(random_bytes(16));
+
+		update_network_option(null, 'wu_security_mode_key', $key);
+	}
+
+	return $key;
 }
 
 /**

--- a/tests/WP_Ultimo/Functions/Sunrise_Functions_Test.php
+++ b/tests/WP_Ultimo/Functions/Sunrise_Functions_Test.php
@@ -101,14 +101,16 @@ class Sunrise_Functions_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Test wu_get_security_mode_key returns a 6-character string.
+	 * Test wu_get_security_mode_key returns a high-entropy string.
 	 */
-	public function test_get_security_mode_key_returns_six_char_string(): void {
+	public function test_get_security_mode_key_returns_high_entropy_string(): void {
+
+		delete_network_option(null, 'wu_security_mode_key');
 
 		$key = wu_get_security_mode_key();
 
 		$this->assertIsString($key);
-		$this->assertSame(6, strlen($key));
+		$this->assertSame(32, strlen($key));
 	}
 
 	/**
@@ -116,20 +118,38 @@ class Sunrise_Functions_Test extends WP_UnitTestCase {
 	 */
 	public function test_get_security_mode_key_returns_hex_characters(): void {
 
+		delete_network_option(null, 'wu_security_mode_key');
+
 		$key = wu_get_security_mode_key();
 
-		$this->assertMatchesRegularExpression('/^[0-9a-f]{6}$/', $key);
+		$this->assertMatchesRegularExpression('/^[0-9a-f]{32}$/', $key);
 	}
 
 	/**
-	 * Test wu_get_security_mode_key is deterministic for same admin email.
+	 * Test wu_get_security_mode_key is stable after generation.
 	 */
-	public function test_get_security_mode_key_is_deterministic(): void {
+	public function test_get_security_mode_key_is_stable_after_generation(): void {
+
+		delete_network_option(null, 'wu_security_mode_key');
 
 		$key1 = wu_get_security_mode_key();
 		$key2 = wu_get_security_mode_key();
 
 		$this->assertSame($key1, $key2);
+	}
+
+	/**
+	 * Test wu_get_security_mode_key can preserve the legacy key without rotating.
+	 */
+	public function test_get_security_mode_key_without_generation_returns_legacy_key(): void {
+
+		delete_network_option(null, 'wu_security_mode_key');
+
+		$expected = substr(md5((string) get_network_option(null, 'admin_email')), 0, 6);
+		$key      = wu_get_security_mode_key(false);
+
+		$this->assertSame($expected, $key);
+		$this->assertSame('', get_network_option(null, 'wu_security_mode_key', ''));
 	}
 
 	/**

--- a/tests/WP_Ultimo/Functions/Sunrise_Functions_Test.php
+++ b/tests/WP_Ultimo/Functions/Sunrise_Functions_Test.php
@@ -139,6 +139,21 @@ class Sunrise_Functions_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Test wu_get_security_mode_key without generation returns a stored key.
+	 */
+	public function test_get_security_mode_key_without_generation_returns_persisted_key_when_available(): void {
+
+		delete_network_option(null, 'wu_security_mode_key');
+
+		$generated = wu_get_security_mode_key();
+		$stored    = get_network_option(null, 'wu_security_mode_key', '');
+
+		$this->assertSame($generated, $stored);
+		$this->assertSame($stored, wu_get_security_mode_key(false));
+		$this->assertMatchesRegularExpression('/^[0-9a-f]{32}$/', $stored);
+	}
+
+	/**
 	 * Test wu_get_security_mode_key can preserve the legacy key without rotating.
 	 */
 	public function test_get_security_mode_key_without_generation_returns_legacy_key(): void {


### PR DESCRIPTION
## Summary

- Carries forward PR #1382 security-mode hardening: 128-bit persisted random security-mode key, legacy recovery fallback before first generated key, and string-only `hash_equals()` validation.
- Fixes the failing E2E workflow cleanup path seen on PR #1382 when the Mailpit service container cannot be pulled before checkout runs.
- Switches Mailpit to the GHCR image and guards cleanup steps so missing checkout/Cypress directories do not mask the original service failure.

## Testing

- `git diff --check`
- `php -l inc/functions/sunrise.php && php -l inc/class-sunrise.php && php -l tests/WP_Ultimo/Functions/Sunrise_Functions_Test.php`
- `vendor/bin/phpcs inc/functions/sunrise.php inc/class-sunrise.php tests/WP_Ultimo/Functions/Sunrise_Functions_Test.php`
- `python3 - <<'PY' ... yaml.safe_load(.github/workflows/e2e.yml) ... PY`

For #1382

<!-- MERGE_SUMMARY: Carries forward the PR #1382 high-entropy security-mode recovery key fix and adds E2E workflow cleanup guards so service startup failures do not cascade into missing-checkout cleanup failures. -->
---
<!-- aidevops:sig -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security**
  * Strengthened security-mode unlock validation with defensive checks and timing-safe key comparison
  * Replaced deterministic keys with persisted high-entropy security keys and added a legacy fallback for migration

* **Chores**
  * CI workflow updated to use a pinned service image and to perform conditional cleanup only when appropriate

* **Tests**
  * Updated tests to validate the new high-entropy key behavior, persistence, and fallback paths
<!-- end of auto-generated comment: release notes by coderabbit.ai -->