### PR TITLE
ci: add CodeQL analysis workflow

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -30,14 +30,16 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v3
+        uses: github/codeql-action/init@dd903d2e4f5405488e5ef1422510ee31c8b32357 # v3
         with:
           languages: ${{ matrix.language }}
           queries: +security-and-quality
 
       - name: Perform CodeQL analysis
-        uses: github/codeql-action/analyze@v3
+        uses: github/codeql-action/analyze@dd903d2e4f5405488e5ef1422510ee31c8b32357 # v3
         with:
           category: /language:${{ matrix.language }}

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,44 @@
+name: CodeQL
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    - cron: '32 4 * * 1'
+  workflow_dispatch:
+
+permissions:
+  actions: read
+  contents: read
+  pull-requests: read
+  security-events: write
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    strategy:
+      fail-fast: false
+      matrix:
+        language:
+          - javascript-typescript
+          - php
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: ${{ matrix.language }}
+          queries: +security-and-quality
+
+      - name: Perform CodeQL analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: /language:${{ matrix.language }}

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -26,7 +26,6 @@ jobs:
       matrix:
         language:
           - javascript-typescript
-          - php
 
     steps:
       - name: Checkout repository


### PR DESCRIPTION
## Summary

- Add a CodeQL workflow for JavaScript/TypeScript analysis.
- Run analysis on pull requests, pushes to `main`, a weekly schedule, and manual dispatch.
- Enable `+security-and-quality` queries so GitHub receives code quality/code scanning results for the supported analyzed language.
- Leave PHP quality coverage to the existing PHPCS/PHPStan workflow because CodeQL does not support PHP analysis.

## Verification

- `git diff --check`
- Python workflow validation for required CodeQL entries, absence of unsupported PHP CodeQL language, and whitespace
- Pre-commit hook passed: no PHP, JS, or CSS files to check

## Notes

- No plugin runtime code changes.
- After this merges to `main`, rerun checks or update open PR branches so the CodeQL code quality requirement receives fresh results.


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.57 plugin for [OpenCode](https://opencode.ai) v1.17.4 with gpt-5.5 spent 13m and 221,882 tokens on this with the user in an interactive session.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added an automated CodeQL security analysis workflow that runs on pushes and pull requests to main, on a weekly schedule, and via manual dispatch; currently configured for JavaScript/TypeScript projects.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->