### PR TITLE
fix: recover interrupted pending site polling

### DIFF
--- a/assets/js/thank-you.js
+++ b/assets/js/thank-you.js
@@ -95,12 +95,14 @@
 		if (! document.getElementById("wu-sites")) {
 			return;
 		}
+		const has_pending_site = [ true, 1, "1", "true" ].includes(wu_thank_you.has_pending_site);
 		const { Vue, defineComponent } = window.wu_vue;
 		window.wu_sites = new Vue(defineComponent({
 			el: "#wu-sites",
 			data() {
 				return {
 					creating: wu_thank_you.creating,
+					has_pending_site,
 					next_queue: parseInt(wu_thank_you.next_queue, 10) + 5,
 					random: 0,
 					progress_in_seconds: 0,
@@ -156,15 +158,17 @@
 					if (response.publish_status === "completed") {
 						this.creating = false;
 						this.site_ready = true;
-						// Cache-bust redirect only when we actually watched the site transition
-						// through "running" during THIS page load, AND we have not already done
-						// a redirect (is_post_redirect).  Both guards are required:
-						//  • running_count === 0 → gateway completed before page loaded; the PHP
-						//    template already has the correct state, no reload needed.
+						// Cache-bust redirect when this page rendered a pending site and the
+						// poller later observes completion, or when we watched the site transition
+						// through "running" during THIS page load. Both guards are required:
+						//  • has_pending_site === true → PHP rendered the pending badge, so the
+						//    page needs a fresh server render to show Ready/Admin/Visit links.
+						//  • running_count > 0 → the page observed active publishing and should
+						//    refresh after completion even if the initial render was ambiguous.
 						//  • is_post_redirect === true → we already navigated once; a second
 						//    redirect would start an infinite loop (completed page → redirect →
 						//    completed again → redirect …).
-						if (this.running_count > 0 && ! this.is_post_redirect) {
+						if ((this.has_pending_site || this.running_count > 0) && ! this.is_post_redirect) {
 							setTimeout(() => {
 								const sep = window.location.href.indexOf("?") > -1 ? "&" : "?";
 								window.location.href = window.location.href.split("#")[ 0 ] + sep + "_t=" + Date.now();
@@ -210,10 +214,12 @@
 						//     stopped unexpectedly; do one location.reload() for fresh server state.
 						//     The reloaded page will have running_count = 0, so this branch can
 						//     only fire once before falling through to case 2 or 3.
-						//  2. wu_thank_you.creating === false (PHP already reports site done) →
+						//  2. has_pending_site === false and wu_thank_you.creating === false
+						//     (PHP already reports site done) →
 						//     mark ready and stop polling; no navigation needed.
-						//  3. wu_thank_you.creating === true but never saw "running" (webhook
-						//     delay, job not started yet) → keep slow-polling; do NOT reload.
+						//  3. has_pending_site === true but never saw "running" (webhook delay,
+						//     interrupted loopback, or job not started yet) → keep slow-polling;
+						//     do NOT mark the PHP-rendered pending badge as ready client-side.
 						this.creating = false;
 						this.stopped_count++;
 						if (this.stopped_count >= 3) {
@@ -223,11 +229,12 @@
 								// reload before the first navigation clears the page.
 								this._reload_done = true;
 								window.location.reload();
-							} else if (! wu_thank_you.creating) {
+							} else if (! this.has_pending_site && ! wu_thank_you.creating) {
 								// Case 2: PHP already reported creation complete — mark ready.
 								this.site_ready = true;
 							} else {
 								// Case 3: still waiting for job to start — keep slow-polling.
+								fetch(wu_thank_you.wp_cron_url);
 								setTimeout(this.check_site_created, 3e3);
 							}
 						} else {

--- a/inc/managers/class-membership-manager.php
+++ b/inc/managers/class-membership-manager.php
@@ -186,7 +186,7 @@ class Membership_Manager extends Base_Manager {
 			header('Connection: close');
 		}
 
-		echo $response;
+		echo $response; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Safe JSON from wp_json_encode().
 
 		$this->finish_pending_site_publish_response();
 	}
@@ -298,6 +298,12 @@ class Membership_Manager extends Base_Manager {
 			exit;
 		}
 
+		if ($this->recover_interrupted_pending_site($membership, $pending_site)) {
+			wp_send_json(['publish_status' => 'completed']);
+
+			exit;
+		}
+
 		/*
 		 * Detect stale publishing state. When the PHP process that was
 		 * creating the site gets killed mid-execution, is_publishing
@@ -337,6 +343,81 @@ class Membership_Manager extends Base_Manager {
 		wp_send_json(['publish_status' => $pending_site->is_publishing() ? 'running' : 'stopped']);
 
 		exit;
+	}
+
+	/**
+	 * Finalizes a pending site when the raw blog exists but publish cleanup stopped.
+	 *
+	 * The loopback fast-path can be interrupted after the template/site is created
+	 * but before Site::save() stores membership metadata and before the pending_site
+	 * membership meta row is removed. In that state the checkout poller sees a
+	 * non-publishing pending site forever while the raw blog already exists. Recover
+	 * the association immediately instead of waiting for the delayed watchdog.
+	 *
+	 * @since 2.13.2
+	 *
+	 * @param \WP_Ultimo\Models\Membership $membership   Membership being polled.
+	 * @param \WP_Ultimo\Models\Site       $pending_site Pending site object.
+	 * @return bool True when the existing blog was finalized.
+	 */
+	protected function recover_interrupted_pending_site($membership, $pending_site) {
+
+		if ($pending_site->is_publishing()) {
+			return false;
+		}
+
+		$domain = $pending_site->get_domain();
+		$path   = $pending_site->get_path() ?: '/';
+
+		if (empty($domain)) {
+			return false;
+		}
+
+		$blog_id = get_blog_id_from_url($domain, $path);
+
+		if ( ! $blog_id || (int) wu_get_main_site_id() === (int) $blog_id) {
+			return false;
+		}
+
+		$existing_membership_id = (int) get_site_meta($blog_id, \WP_Ultimo\Models\Site::META_MEMBERSHIP_ID, true);
+		$existing_customer_id   = (int) get_site_meta($blog_id, \WP_Ultimo\Models\Site::META_CUSTOMER_ID, true);
+
+		if ($existing_membership_id && $existing_membership_id !== (int) $membership->get_id()) {
+			return false;
+		}
+
+		if ($existing_customer_id && $existing_customer_id !== (int) $membership->get_customer_id()) {
+			return false;
+		}
+
+		$pending_site->set_blog_id($blog_id);
+		$pending_site->set_type('customer_owned');
+		$pending_site->set_membership_id($membership->get_id());
+		$pending_site->set_customer_id($membership->get_customer_id());
+
+		switch_to_blog($blog_id);
+
+		foreach ($pending_site->get_signup_options() as $key => $value) {
+			update_option($key, $value);
+		}
+
+		restore_current_blog();
+
+		foreach ($pending_site->get_signup_meta() as $key => $value) {
+			update_site_meta($blog_id, $key, $value);
+		}
+
+		update_site_meta($blog_id, \WP_Ultimo\Models\Site::META_MEMBERSHIP_ID, $membership->get_id());
+		update_site_meta($blog_id, \WP_Ultimo\Models\Site::META_CUSTOMER_ID, $membership->get_customer_id());
+		update_site_meta($blog_id, \WP_Ultimo\Models\Site::META_TYPE, $pending_site->get_type());
+		update_site_meta($blog_id, \WP_Ultimo\Models\Site::META_TEMPLATE_ID, $pending_site->get_template_id());
+
+		$membership->delete_pending_site();
+		wu_unschedule_action('wu_async_publish_pending_site', ['membership_id' => $membership->get_id()], 'membership');
+
+		do_action('wu_pending_site_published', $pending_site, $membership);
+
+		return true;
 	}
 
 	/**

--- a/tests/WP_Ultimo/Managers/Membership_Manager_Test.php
+++ b/tests/WP_Ultimo/Managers/Membership_Manager_Test.php
@@ -12,6 +12,7 @@ use WP_Ultimo\Managers\Membership_Manager;
 use WP_Ultimo\Models\Membership;
 use WP_Ultimo\Models\Customer;
 use WP_Ultimo\Models\Product;
+use WP_Ultimo\Models\Site;
 use WP_Ultimo\Database\Memberships\Membership_Status;
 
 /**
@@ -326,6 +327,72 @@ class Membership_Manager_Test extends \WP_UnitTestCase {
 			$response['publish_status'] ?? null,
 			'poll handler should report completed after clearing a stale pending_site cache entry'
 		);
+	}
+
+	/**
+	 * Test pending-site poll recovers when the blog exists but ownership meta is missing.
+	 */
+	public function test_check_pending_site_created_recovers_existing_unattached_blog(): void {
+
+		global $current_site;
+
+		$membership = $this->create_membership();
+		$domain     = 'pending-recovery-' . wp_rand() . '.' . $current_site->domain;
+		$path       = '/';
+		$blog_id    = wpmu_create_blog(
+			$domain,
+			$path,
+			'Pending Recovery Site',
+			$this->customer->get_user_id(),
+			[],
+			get_current_network_id()
+		);
+
+		if (is_wp_error($blog_id)) {
+			$this->fail('Could not create partial test blog: ' . $blog_id->get_error_message());
+		}
+
+		try {
+			delete_site_meta($blog_id, Site::META_MEMBERSHIP_ID);
+			delete_site_meta($blog_id, Site::META_CUSTOMER_ID);
+			update_site_meta($blog_id, Site::META_TYPE, 'site_template');
+
+			$membership->create_pending_site(
+				[
+					'title'         => 'Pending Recovery Site',
+					'domain'        => $domain,
+					'path'          => $path,
+					'is_publishing' => false,
+				]
+			);
+
+			$response = $this->call_check_pending_site_created($membership);
+
+			$this->assertSame(
+				'completed',
+				$response['publish_status'] ?? null,
+				'poll handler should finalize an existing blog left unattached by an interrupted loopback publish'
+			);
+
+			$refreshed = wu_get_membership($membership->get_id());
+
+			$this->assertFalse(
+				$refreshed->get_pending_site(),
+				'pending_site meta should be removed after recovery finalizes the existing blog'
+			);
+
+			$this->assertSame(
+				(string) $membership->get_id(),
+				(string) get_site_meta($blog_id, Site::META_MEMBERSHIP_ID, true)
+			);
+			$this->assertSame(
+				(string) $membership->get_customer_id(),
+				(string) get_site_meta($blog_id, Site::META_CUSTOMER_ID, true)
+			);
+			$this->assertSame('customer_owned', get_site_meta($blog_id, Site::META_TYPE, true));
+		} finally {
+			wpmu_delete_blog($blog_id, true);
+		}
 	}
 
 	// ========================================================================


### PR DESCRIPTION
## Summary

- Recover checkout polling when a raw blog exists but pending-site publish cleanup was interrupted before ownership metadata was written.
- Keep the thank-you poller active while the page was rendered with a pending site, and cache-bust refresh when polling observes completion.
- Add regression coverage for the partial-blog/pending-site state.

## Verification

- `php -l inc/managers/class-membership-manager.php && php -l tests/WP_Ultimo/Managers/Membership_Manager_Test.php`
- `vendor/bin/phpcs inc/managers/class-membership-manager.php tests/WP_Ultimo/Managers/Membership_Manager_Test.php`
- `npx eslint assets/js/thank-you.js --ignore-pattern '*.min.js'`
- `git diff --check`
- Local WP-CLI simulation of partial publish state: recovery returned `ok: true`, cleared `pending_site`, and wrote matching `wu_membership_id`, `wu_customer_id`, and `wu_type=customer_owned`.

## Notes

- `vendor/bin/phpunit --filter 'Membership_Manager_Test::test_check_pending_site_created'` could not run in this checkout because `/tmp/wordpress-tests-lib/includes/functions.php` is missing.
- `npm run lint:js -- assets/js/thank-you.js` is not suitable here because the npm script ignores the file argument and lints the entire legacy asset tree; direct ESLint was used for the touched file.


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.57 plugin for [OpenCode](https://opencode.ai) v1.17.4 with gpt-5.5


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved site creation reliability when the publishing process is interrupted or incomplete
  * Enhanced detection and recovery of pending sites stuck in intermediate states
  * Better handling to prevent failed deployments from persisting indefinitely

<!-- end of auto-generated comment: release notes by coderabbit.ai -->