### PR TITLE
fix: avoid fragile pending site loopback

### DIFF
--- a/inc/managers/class-membership-manager.php
+++ b/inc/managers/class-membership-manager.php
@@ -298,12 +298,6 @@ class Membership_Manager extends Base_Manager {
 			exit;
 		}
 
-		if ($this->recover_interrupted_pending_site($membership, $pending_site)) {
-			wp_send_json(['publish_status' => 'completed']);
-
-			exit;
-		}
-
 		/*
 		 * Detect stale publishing state. When the PHP process that was
 		 * creating the site gets killed mid-execution, is_publishing
@@ -343,81 +337,6 @@ class Membership_Manager extends Base_Manager {
 		wp_send_json(['publish_status' => $pending_site->is_publishing() ? 'running' : 'stopped']);
 
 		exit;
-	}
-
-	/**
-	 * Finalizes a pending site when the raw blog exists but publish cleanup stopped.
-	 *
-	 * The loopback fast-path can be interrupted after the template/site is created
-	 * but before Site::save() stores membership metadata and before the pending_site
-	 * membership meta row is removed. In that state the checkout poller sees a
-	 * non-publishing pending site forever while the raw blog already exists. Recover
-	 * the association immediately instead of waiting for the delayed watchdog.
-	 *
-	 * @since 2.13.2
-	 *
-	 * @param \WP_Ultimo\Models\Membership $membership   Membership being polled.
-	 * @param \WP_Ultimo\Models\Site       $pending_site Pending site object.
-	 * @return bool True when the existing blog was finalized.
-	 */
-	protected function recover_interrupted_pending_site($membership, $pending_site) {
-
-		if ($pending_site->is_publishing()) {
-			return false;
-		}
-
-		$domain = $pending_site->get_domain();
-		$path   = $pending_site->get_path() ?: '/';
-
-		if (empty($domain)) {
-			return false;
-		}
-
-		$blog_id = get_blog_id_from_url($domain, $path);
-
-		if ( ! $blog_id || (int) wu_get_main_site_id() === (int) $blog_id) {
-			return false;
-		}
-
-		$existing_membership_id = (int) get_site_meta($blog_id, \WP_Ultimo\Models\Site::META_MEMBERSHIP_ID, true);
-		$existing_customer_id   = (int) get_site_meta($blog_id, \WP_Ultimo\Models\Site::META_CUSTOMER_ID, true);
-
-		if ($existing_membership_id && $existing_membership_id !== (int) $membership->get_id()) {
-			return false;
-		}
-
-		if ($existing_customer_id && $existing_customer_id !== (int) $membership->get_customer_id()) {
-			return false;
-		}
-
-		$pending_site->set_blog_id($blog_id);
-		$pending_site->set_type('customer_owned');
-		$pending_site->set_membership_id($membership->get_id());
-		$pending_site->set_customer_id($membership->get_customer_id());
-
-		switch_to_blog($blog_id);
-
-		foreach ($pending_site->get_signup_options() as $key => $value) {
-			update_option($key, $value);
-		}
-
-		restore_current_blog();
-
-		foreach ($pending_site->get_signup_meta() as $key => $value) {
-			update_site_meta($blog_id, $key, $value);
-		}
-
-		update_site_meta($blog_id, \WP_Ultimo\Models\Site::META_MEMBERSHIP_ID, $membership->get_id());
-		update_site_meta($blog_id, \WP_Ultimo\Models\Site::META_CUSTOMER_ID, $membership->get_customer_id());
-		update_site_meta($blog_id, \WP_Ultimo\Models\Site::META_TYPE, $pending_site->get_type());
-		update_site_meta($blog_id, \WP_Ultimo\Models\Site::META_TEMPLATE_ID, $pending_site->get_template_id());
-
-		$membership->delete_pending_site();
-		wu_unschedule_action('wu_async_publish_pending_site', ['membership_id' => $membership->get_id()], 'membership');
-
-		do_action('wu_pending_site_published', $pending_site, $membership);
-
-		return true;
 	}
 
 	/**

--- a/inc/models/class-membership.php
+++ b/inc/models/class-membership.php
@@ -2132,6 +2132,20 @@ class Membership extends Base_Model implements Limitable, Billable, Notable {
 		$loopback_started   = false;
 		$args               = ['membership_id' => $this->get_id()];
 
+		if ($use_loopback && ! $can_finish_request) {
+			/*
+			 * Runtimes such as FrankenPHP do not expose a finish_request()
+			 * primitive. A 0.01s non-blocking admin-ajax loopback can outlive
+			 * or abort independently from the checkout request, leaving customers
+			 * waiting for the 5-minute watchdog. In that environment, rely on the
+			 * immediate Action Scheduler path and dispatch the queue now.
+			 */
+			wu_enqueue_async_action('wu_async_publish_pending_site', $args, 'membership');
+			$this->dispatch_pending_site_async_queue();
+
+			return;
+		}
+
 		if ($use_loopback) {
 			$this->schedule_pending_site_async_watchdog($args);
 
@@ -2168,8 +2182,6 @@ class Membership extends Base_Model implements Limitable, Billable, Notable {
 			if (is_wp_error($result)) {
 				// translators: %s full error message.
 				wu_log_add("membership-{$this->get_id()}", sprintf(__('Failed to trigger async site creation. The site will not be created until the next cron run which is much slower: %s', 'ultimate-multisite'), $result->get_error_message()));
-			} elseif ( ! $can_finish_request) {
-				$loopback_started = true;
 			} else {
 				$code = (int) wp_remote_retrieve_response_code($result);
 				if ($code < 200 || $code >= 300) {

--- a/tests/WP_Ultimo/Managers/Membership_Manager_Test.php
+++ b/tests/WP_Ultimo/Managers/Membership_Manager_Test.php
@@ -12,7 +12,6 @@ use WP_Ultimo\Managers\Membership_Manager;
 use WP_Ultimo\Models\Membership;
 use WP_Ultimo\Models\Customer;
 use WP_Ultimo\Models\Product;
-use WP_Ultimo\Models\Site;
 use WP_Ultimo\Database\Memberships\Membership_Status;
 
 /**
@@ -327,72 +326,6 @@ class Membership_Manager_Test extends \WP_UnitTestCase {
 			$response['publish_status'] ?? null,
 			'poll handler should report completed after clearing a stale pending_site cache entry'
 		);
-	}
-
-	/**
-	 * Test pending-site poll recovers when the blog exists but ownership meta is missing.
-	 */
-	public function test_check_pending_site_created_recovers_existing_unattached_blog(): void {
-
-		global $current_site;
-
-		$membership = $this->create_membership();
-		$domain     = 'pending-recovery-' . wp_rand() . '.' . $current_site->domain;
-		$path       = '/';
-		$blog_id    = wpmu_create_blog(
-			$domain,
-			$path,
-			'Pending Recovery Site',
-			$this->customer->get_user_id(),
-			[],
-			get_current_network_id()
-		);
-
-		if (is_wp_error($blog_id)) {
-			$this->fail('Could not create partial test blog: ' . $blog_id->get_error_message());
-		}
-
-		try {
-			delete_site_meta($blog_id, Site::META_MEMBERSHIP_ID);
-			delete_site_meta($blog_id, Site::META_CUSTOMER_ID);
-			update_site_meta($blog_id, Site::META_TYPE, 'site_template');
-
-			$membership->create_pending_site(
-				[
-					'title'         => 'Pending Recovery Site',
-					'domain'        => $domain,
-					'path'          => $path,
-					'is_publishing' => false,
-				]
-			);
-
-			$response = $this->call_check_pending_site_created($membership);
-
-			$this->assertSame(
-				'completed',
-				$response['publish_status'] ?? null,
-				'poll handler should finalize an existing blog left unattached by an interrupted loopback publish'
-			);
-
-			$refreshed = wu_get_membership($membership->get_id());
-
-			$this->assertFalse(
-				$refreshed->get_pending_site(),
-				'pending_site meta should be removed after recovery finalizes the existing blog'
-			);
-
-			$this->assertSame(
-				(string) $membership->get_id(),
-				(string) get_site_meta($blog_id, Site::META_MEMBERSHIP_ID, true)
-			);
-			$this->assertSame(
-				(string) $membership->get_customer_id(),
-				(string) get_site_meta($blog_id, Site::META_CUSTOMER_ID, true)
-			);
-			$this->assertSame('customer_owned', get_site_meta($blog_id, Site::META_TYPE, true));
-		} finally {
-			wpmu_delete_blog($blog_id, true);
-		}
 	}
 
 	// ========================================================================
@@ -1467,13 +1400,13 @@ class Membership_Manager_Test extends \WP_UnitTestCase {
 	}
 
 	/**
-	 * Test publish_pending_site_async uses non-blocking loopback without finish support.
+	 * Test publish_pending_site_async skips loopback without finish support.
 	 *
 	 * Runtimes such as FrankenPHP do not expose fastcgi_finish_request(), so the
-	 * checkout request must trigger site creation in a separate non-blocking
-	 * loopback request rather than waiting for Action Scheduler cron.
+	 * checkout request must enqueue and dispatch Action Scheduler directly instead
+	 * of relying on a fragile 0.01s admin-ajax loopback.
 	 */
-	public function test_publish_pending_site_async_uses_non_blocking_loopback_without_finish_support(): void {
+	public function test_publish_pending_site_async_skips_loopback_without_finish_support(): void {
 
 		$membership = $this->create_membership();
 
@@ -1484,13 +1417,15 @@ class Membership_Manager_Test extends \WP_UnitTestCase {
 
 		$membership->update_pending_site($pending_site);
 
-		$captured_args = null;
-		$http_filter   = function ($preempt, $r, $url) use (&$captured_args) {
+		$publish_loopback_requests = 0;
+		$http_filter               = function ($preempt, $r, $url) use (&$publish_loopback_requests) {
+			unset($preempt, $r);
+
 			if (strpos($url, 'wu_publish_pending_site') !== false) {
-				$captured_args = $r;
+				++$publish_loopback_requests;
 			}
 
-			return ['response' => ['code' => false]];
+			return new \WP_Error('http_blocked_for_test', 'HTTP requests are blocked during this test.');
 		};
 
 		add_filter(
@@ -1504,12 +1439,10 @@ class Membership_Manager_Test extends \WP_UnitTestCase {
 
 		$membership->publish_pending_site_async();
 
-		$this->assertIsArray($captured_args, 'Loopback HTTP request should fire without finish-request support.');
-		$this->assertFalse($captured_args['blocking'], 'Loopback should be non-blocking without finish-request support.');
-		$this->assertSame(0.01, $captured_args['timeout'], 'Non-blocking loopback should use a tiny timeout.');
+		$this->assertSame(0, $publish_loopback_requests, 'Pending-site loopback should not fire without finish-request support.');
 		$this->assertTrue(
-			as_has_scheduled_action('wu_async_publish_pending_site', ['membership_id' => $membership->get_id()], 'membership'),
-			'Action Scheduler fallback should still be queued when the non-blocking loopback starts.'
+			wu_switch_blog_and_run(fn() => as_has_scheduled_action('wu_async_publish_pending_site', ['membership_id' => $membership->get_id()], 'membership')),
+			'Action Scheduler publish action should be queued without finish-request support.'
 		);
 
 		remove_filter('wu_publish_pending_site_can_finish_request', '__return_false');


### PR DESCRIPTION
## Summary

- Follow-up to #1415: remove the backend recovery helper/test that finalized partially-created blogs during polling.
- Fix the root publish path instead: when the runtime lacks `fastcgi_finish_request()` / `litespeed_finish_request()`, skip the fragile 0.01s pending-site admin-ajax loopback and enqueue/dispatch the immediate Action Scheduler publish action.
- Update the no-finish regression so it asserts no `wu_publish_pending_site` loopback is attempted and the publish action is queued in the main-site scheduler context.

## Verification

- `php -l inc/models/class-membership.php && php -l inc/managers/class-membership-manager.php && php -l tests/WP_Ultimo/Managers/Membership_Manager_Test.php`
- `vendor/bin/phpcs inc/models/class-membership.php inc/managers/class-membership-manager.php tests/WP_Ultimo/Managers/Membership_Manager_Test.php`
- `git diff --check`
- WP-CLI runtime probe with `wu_publish_pending_site_can_finish_request=false`: `publish_loopback_requests=0`, `http_requests=0`, `has_scheduled_main=yes`.

## Notes

- Focused PHPUnit could not run because the WordPress PHPUnit test library is not installed in this checkout.
- Direct production investigation showed the humansite checkout path is not currently taking the sovereign/multi-tenancy path; the runtime lacks finish-request support, so the fragile non-blocking pending-site loopback was the root risk.

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.57 plugin for [OpenCode](https://opencode.ai) v1.17.4 with gpt-5.5



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved pending site publishing handling for runtimes with limited PHP request control support. The system now properly queues publishing jobs through Action Scheduler when immediate request finishing isn't available.

* **Refactor**
  * Simplified pending site creation workflow by removing manual recovery logic for interrupted operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->