### PR TITLE
fix: harden checkout thank-you flow

### DIFF
--- a/inc/checkout/class-checkout.php
+++ b/inc/checkout/class-checkout.php
@@ -3383,9 +3383,13 @@ class Checkout {
 	 */
 	public function get_next_step_name() {
 
-		$steps = $this->steps;
+		$steps = $this->get_steps_or_empty_array();
 
 		$keys = array_column($steps, 'id');
+
+		if (empty($keys)) {
+			return $this->step_name;
+		}
 
 		$current_step_index = array_search($this->step_name, array_values($keys), true);
 
@@ -3411,7 +3415,7 @@ class Checkout {
 	 */
 	public function is_first_step() {
 
-		$step_names = array_column($this->steps, 'id');
+		$step_names = array_column($this->get_steps_or_empty_array(), 'id');
 
 		if (empty($step_names)) {
 			return true;
@@ -3449,13 +3453,29 @@ class Checkout {
 			return false;
 		}
 
-		$step_names = array_column($this->steps, 'id');
+		$step_names = array_column($this->get_steps_or_empty_array(), 'id');
 
 		if (empty($step_names)) {
 			return true;
 		}
 
 		return array_pop($step_names) === $this->step_name;
+	}
+
+	/**
+	 * Returns checkout steps as an array.
+	 *
+	 * Payment return and thank-you requests can enqueue checkout scripts after the
+	 * checkout form context has been cleared, leaving the public steps property
+	 * unset/null. Treat that state as an empty one-step flow instead of fataling
+	 * when navigation helpers call array_column().
+	 *
+	 * @since 2.13.2
+	 * @return array
+	 */
+	protected function get_steps_or_empty_array() {
+
+		return is_array($this->steps) ? $this->steps : [];
 	}
 
 	/**

--- a/inc/models/class-membership.php
+++ b/inc/models/class-membership.php
@@ -2128,6 +2128,13 @@ class Membership extends Base_Model implements Limitable, Billable, Notable {
 		$use_loopback       = (bool) apply_filters('wu_publish_pending_site_use_loopback', true, $this);
 		$can_finish_request = function_exists('litespeed_finish_request')
 			|| function_exists('fastcgi_finish_request');
+		$server_software    = isset($_SERVER['SERVER_SOFTWARE']) ? sanitize_text_field(wp_unslash($_SERVER['SERVER_SOFTWARE'])) : '';
+		$is_frankenphp      = 'frankenphp' === PHP_SAPI || false !== stripos($server_software, 'frankenphp');
+
+		if ($is_frankenphp) {
+			$can_finish_request = false;
+		}
+
 		$can_finish_request = (bool) apply_filters('wu_publish_pending_site_can_finish_request', $can_finish_request, $this);
 		$loopback_started   = false;
 		$args               = ['membership_id' => $this->get_id()];

--- a/tests/WP_Ultimo/Checkout/Checkout_Test.php
+++ b/tests/WP_Ultimo/Checkout/Checkout_Test.php
@@ -536,6 +536,17 @@ class Checkout_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Test is_first_step with null steps.
+	 */
+	public function test_is_first_step_null_steps(): void {
+
+		$checkout        = Checkout::get_instance();
+		$checkout->steps = null;
+
+		$this->assertTrue($checkout->is_first_step());
+	}
+
+	/**
 	 * Test is_first_step when on first step.
 	 */
 	public function test_is_first_step_on_first(): void {
@@ -625,6 +636,18 @@ class Checkout_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Test is_last_step with null steps returns true.
+	 */
+	public function test_is_last_step_null_steps(): void {
+
+		$checkout            = Checkout::get_instance();
+		$checkout->steps     = null;
+		$checkout->step_name = null;
+
+		$this->assertTrue($checkout->is_last_step());
+	}
+
+	/**
 	 * Test is_last_step returns false when pre-flight param is set.
 	 */
 	public function test_is_last_step_pre_flight_returns_false(): void {
@@ -702,6 +725,18 @@ class Checkout_Test extends WP_UnitTestCase {
 		$checkout->step_name = null;
 
 		$this->assertEquals('step-2', $checkout->get_next_step_name());
+	}
+
+	/**
+	 * Test get_next_step_name with null steps returns current step.
+	 */
+	public function test_get_next_step_name_null_steps_returns_current(): void {
+
+		$checkout            = Checkout::get_instance();
+		$checkout->steps     = null;
+		$checkout->step_name = 'thank-you';
+
+		$this->assertEquals('thank-you', $checkout->get_next_step_name());
 	}
 
 	/**


### PR DESCRIPTION
## Summary

- Prevent thank-you/payment-return requests from fataling when checkout scripts are enqueued after the checkout form steps have been cleared (`steps === null`).
- Treat null/non-array checkout steps as an empty one-step flow in checkout navigation helpers.
- Treat FrankenPHP as not safe for the pending-site loopback finish-request path, so checkout publishing uses the immediate Action Scheduler path instead of waiting for the delayed watchdog.
- Add regression coverage for null checkout steps.

## Production evidence

- Retest after #1416 created order `JJJ3D441EL` and site `checkout-post1416-20260613000702.humansite.builders`.
- The site eventually finalized via watchdog action `85987`, but the thank-you URL returned HTTP 500.
- PHP error log: `array_column(): Argument #1 ($array) must be of type array, null given` in `inc/checkout/class-checkout.php:3452` from `Checkout->is_last_step()` during checkout script registration.

## Verification

- `php -l inc/checkout/class-checkout.php && php -l inc/models/class-membership.php && php -l tests/WP_Ultimo/Checkout/Checkout_Test.php`
- `vendor/bin/phpcs inc/checkout/class-checkout.php inc/models/class-membership.php`
- `git diff --check`
- WP-CLI probe: null checkout steps return `first=yes last=yes next=thank-you` without fatal.
- WP-CLI probe: no-finish pending-site publish path returns `publish_loopback_requests=0 has_scheduled_main=yes`.

## Notes

- Focused PHPUnit is still blocked in this checkout because `/tmp/wordpress-tests-lib/includes/functions.php` is missing.
- Full local PHPCS on `tests/WP_Ultimo/Checkout/Checkout_Test.php` reports pre-existing unrelated violations outside the touched lines; production files pass PHPCS.

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.57 plugin for [OpenCode](https://opencode.ai) v1.17.4 with gpt-5.5



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved stability of the multi-step checkout process when checkout steps are unavailable, unset, or missing
  * Enhanced server environment compatibility and improved handling of asynchronous operations in specific server configurations

* **Tests**
  * Expanded automated test coverage for checkout flow edge cases, including step navigation scenarios with unset steps

<!-- end of auto-generated comment: release notes by coderabbit.ai -->