### PR TITLE
fix: preserve incomplete objects during duplication

### DIFF
--- a/inc/duplication/data.php
+++ b/inc/duplication/data.php
@@ -448,9 +448,9 @@ if ( ! class_exists('MUCD_Data') ) {
 		 */
 		public static function try_replace($row, $field, $from_string, $to_string) {
 			if (is_serialized($row[ $field ])) {
-				$double_serialize  = false;
-				$original_value    = $row[ $field ];
-				$row[ $field ]     = @unserialize($row[ $field ]);
+				$double_serialize = false;
+				$original_value   = $row[ $field ];
+				$row[ $field ]    = @unserialize($row[ $field ]);
 
 				// Safety: if unserialize failed, return the original value
 				// instead of re-serializing false — which would destroy the data.
@@ -471,9 +471,13 @@ if ( ! class_exists('MUCD_Data') ) {
 					}
 				}
 
+				if ($row[ $field ] instanceof __PHP_Incomplete_Class) {
+					return $original_value;
+				}
+
 				if (is_array($row[ $field ])) {
 					$row[ $field ] = self::replace_recursive($row[ $field ], $from_string, $to_string);
-				} elseif (is_object($row[ $field ]) || $row[ $field ] instanceof __PHP_Incomplete_Class) {
+				} elseif (is_object($row[ $field ])) {
 					$array_object = (array) $row[ $field ];
 					$array_object = self::replace_recursive($array_object, $from_string, $to_string);
 					foreach ($array_object as $key => $value) {

--- a/tests/WP_Ultimo/Duplication/MUCD_Data_Test.php
+++ b/tests/WP_Ultimo/Duplication/MUCD_Data_Test.php
@@ -303,6 +303,31 @@ class MUCD_Data_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Test try_replace preserves incomplete serialized objects unchanged.
+	 *
+	 * Production templates can contain serialized objects from plugins that are not
+	 * loaded during duplication. PHP unserializes those as __PHP_Incomplete_Class;
+	 * attempting to mutate them aborts checkout provisioning.
+	 */
+	public function test_try_replace_preserves_incomplete_serialized_object() {
+		$class_name = 'Missing\\Plugin\\Notification';
+		$old_url    = 'https://example.com/old/page';
+		$serialized = sprintf(
+			'O:%d:"%s":1:{s:3:"url";s:%d:"%s";}',
+			strlen($class_name),
+			$class_name,
+			strlen($old_url),
+			$old_url
+		);
+		$row        = ['meta_value' => $serialized];
+
+		$result = \MUCD_Data::try_replace($row, 'meta_value', 'example.com/old', 'example.com/new');
+
+		$this->assertSame($serialized, $result);
+		$this->assertStringContainsString($old_url, $result);
+	}
+
+	/**
 	 * Test try_replace with Elementor Kit-like serialized page settings.
 	 *
 	 * Simulates the _elementor_page_settings structure for a Kit post.


### PR DESCRIPTION
## Summary
- preserve serialized `__PHP_Incomplete_Class` option/meta values during site duplication instead of trying to mutate their properties
- add a regression covering incomplete serialized plugin objects in `MUCD_Data::try_replace()`

## Why
- production checkout evidence showed template duplication aborting on a serialized Yoast object class that was unavailable in the duplication runtime
- aborting after blog creation left the pending site stuck and host blogmeta unassigned

## Verification
- `php -l inc/duplication/data.php`
- `php -l tests/WP_Ultimo/Duplication/MUCD_Data_Test.php`
- WP-CLI probe: incomplete serialized object returns `preserved`
- `git diff --check`

## Notes
- `vendor/bin/phpunit --filter MUCD_Data_Test` is blocked locally by missing `/tmp/wordpress-tests-lib/includes/functions.php`
- PHPCS on these full legacy files still reports unrelated pre-existing violations outside this hotfix

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.58 plugin for [OpenCode](https://opencode.ai) v1.17.4 with gpt-5.5 spent 21h 30m and 2,546,286 tokens on this with the user in an interactive session.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced the site duplication process to properly handle and preserve serialized data from plugins that may be missing or not fully loaded, ensuring data integrity and preventing corruption during duplication operations.

* **Tests**
  * Added test coverage to verify incomplete serialized objects are correctly preserved during site duplication.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->