### PR TITLE
fix: guard post signup tracking without post object

### DIFF
--- a/inc/managers/class-post-signup-activity-manager.php
+++ b/inc/managers/class-post-signup-activity-manager.php
@@ -183,15 +183,19 @@ class Post_Signup_Activity_Manager {
 	 *
 	 * @since 2.5.0
 	 *
-	 * @param string   $new_status The new post status.
-	 * @param string   $old_status The old post status.
-	 * @param \WP_Post $post       The post object.
+	 * @param string        $new_status The new post status.
+	 * @param string        $old_status The old post status.
+	 * @param \WP_Post|null $post       The post object, or null when WordPress failed to create it.
 	 * @return void
 	 */
-	public function track_post_published(string $new_status, string $old_status, \WP_Post $post): void {
+	public function track_post_published(string $new_status, string $old_status, ?\WP_Post $post): void {
 
 		// Only fire on the first publish transition.
 		if ('publish' !== $new_status || 'publish' === $old_status) {
+			return;
+		}
+
+		if ( ! $post) {
 			return;
 		}
 

--- a/tests/WP_Ultimo/Managers/Post_Signup_Activity_Manager_Test.php
+++ b/tests/WP_Ultimo/Managers/Post_Signup_Activity_Manager_Test.php
@@ -45,7 +45,7 @@ class Post_Signup_Activity_Manager_Test extends \WP_UnitTestCase {
 	}
 
 	/**
-	 * register_event_types registers all four expected event slugs.
+	 * The register_event_types method registers all four expected event slugs.
 	 */
 	public function test_register_event_types_registers_all_slugs(): void {
 
@@ -68,9 +68,9 @@ class Post_Signup_Activity_Manager_Test extends \WP_UnitTestCase {
 	}
 
 	/**
-	 * on_post_published does nothing when the post status is not 'publish'.
+	 * The track_post_published method does nothing when the post status is not 'publish'.
 	 */
-	public function test_on_post_published_ignores_non_publish_status(): void {
+	public function test_track_post_published_ignores_non_publish_status(): void {
 
 		$post = $this->factory->post->create_and_get(
 			[
@@ -82,7 +82,7 @@ class Post_Signup_Activity_Manager_Test extends \WP_UnitTestCase {
 		$events_before = wu_get_events(['number' => 9999]);
 
 		// Simulate a draft-to-draft transition (should be ignored).
-		$this->manager->on_post_published('draft', 'draft', $post);
+		$this->manager->track_post_published('draft', 'draft', $post);
 
 		$events_after = wu_get_events(['number' => 9999]);
 
@@ -94,9 +94,9 @@ class Post_Signup_Activity_Manager_Test extends \WP_UnitTestCase {
 	}
 
 	/**
-	 * on_post_published does nothing when old and new status are both 'publish'.
+	 * The track_post_published method does nothing when old and new status are both 'publish'.
 	 */
-	public function test_on_post_published_ignores_re_save_of_published_post(): void {
+	public function test_track_post_published_ignores_re_save_of_published_post(): void {
 
 		$post = $this->factory->post->create_and_get(
 			[
@@ -108,7 +108,7 @@ class Post_Signup_Activity_Manager_Test extends \WP_UnitTestCase {
 		$events_before = wu_get_events(['number' => 9999]);
 
 		// Simulate a publish-to-publish transition (re-save, should be ignored).
-		$this->manager->on_post_published('publish', 'publish', $post);
+		$this->manager->track_post_published('publish', 'publish', $post);
 
 		$events_after = wu_get_events(['number' => 9999]);
 
@@ -120,9 +120,27 @@ class Post_Signup_Activity_Manager_Test extends \WP_UnitTestCase {
 	}
 
 	/**
-	 * on_post_published does nothing for excluded post types.
+	 * The track_post_published method does nothing when WordPress passes no post object.
 	 */
-	public function test_on_post_published_ignores_excluded_post_types(): void {
+	public function test_track_post_published_ignores_null_post(): void {
+
+		$events_before = wu_get_events(['number' => 9999]);
+
+		$this->manager->track_post_published('publish', 'draft', null);
+
+		$events_after = wu_get_events(['number' => 9999]);
+
+		$this->assertCount(
+			count($events_before),
+			$events_after,
+			'No event should be created when WordPress does not provide a post object.'
+		);
+	}
+
+	/**
+	 * The track_post_published method does nothing for excluded post types.
+	 */
+	public function test_track_post_published_ignores_excluded_post_types(): void {
 
 		$post = $this->factory->post->create_and_get(
 			[
@@ -133,7 +151,7 @@ class Post_Signup_Activity_Manager_Test extends \WP_UnitTestCase {
 
 		$events_before = wu_get_events(['number' => 9999]);
 
-		$this->manager->on_post_published('publish', 'draft', $post);
+		$this->manager->track_post_published('publish', 'draft', $post);
 
 		$events_after = wu_get_events(['number' => 9999]);
 
@@ -145,7 +163,7 @@ class Post_Signup_Activity_Manager_Test extends \WP_UnitTestCase {
 	}
 
 	/**
-	 * get_wu_site returns false when wu_get_site is not available.
+	 * The get_wu_site method returns false when wu_get_site is not available.
 	 */
 	public function test_get_wu_site_returns_false_for_unknown_blog(): void {
 


### PR DESCRIPTION
## Summary

- Accept a missing WordPress post object in post-signup activity tracking.
- Bail before reading post fields when `transition_post_status` fires after a failed post insert.
- Add regression coverage for the null-post hook argument and update stale test method references.

## Verification

- `php -l inc/managers/class-post-signup-activity-manager.php && php -l tests/WP_Ultimo/Managers/Post_Signup_Activity_Manager_Test.php`
- `vendor/bin/phpcs inc/managers/class-post-signup-activity-manager.php tests/WP_Ultimo/Managers/Post_Signup_Activity_Manager_Test.php`
- `git diff --check -- inc/managers/class-post-signup-activity-manager.php tests/WP_Ultimo/Managers/Post_Signup_Activity_Manager_Test.php`
- `vendor/bin/phpunit --filter Post_Signup_Activity_Manager_Test` could not run locally because `/tmp/wordpress-tests-lib/includes/functions.php` is not installed.


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.58 plugin for [OpenCode](https://opencode.ai) v1.17.4 with gpt-5.5 spent 21m and 237,343 tokens on this with the user in an interactive session.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved robustness when handling post objects that fail to load from the database, preventing potential errors.

* **Tests**
  * Expanded test coverage to verify proper handling of edge cases and null post scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->