### PR TITLE
fix: skip incomplete nested objects during duplication

### DIFF
--- a/inc/duplication/data.php
+++ b/inc/duplication/data.php
@@ -499,6 +499,8 @@ if ( ! class_exists('MUCD_Data') ) {
 				}
 			} elseif (is_array($row[ $field ])) {
 				$row[ $field ] = self::replace_recursive($row[ $field ], $from_string, $to_string);
+			} elseif ($row[ $field ] instanceof __PHP_Incomplete_Class) {
+				return $row[ $field ];
 			} elseif (is_object($row[ $field ])) {
 				$array_object = (array) $row[ $field ];
 				$array_object = self::replace_recursive($array_object, $from_string, $to_string);

--- a/tests/WP_Ultimo/Duplication/MUCD_Data_Test.php
+++ b/tests/WP_Ultimo/Duplication/MUCD_Data_Test.php
@@ -325,6 +325,35 @@ class MUCD_Data_Test extends WP_UnitTestCase {
 
 		$this->assertSame($serialized, $result);
 		$this->assertStringContainsString($old_url, $result);
+
+		$incomplete_object = @unserialize($serialized);
+		$nested_payload    = serialize(
+			[
+				'notice' => $incomplete_object,
+				'url'    => $old_url,
+			]
+		);
+		$warnings          = 0;
+
+		set_error_handler(
+			static function ($errno, $errstr) use (&$warnings) {
+				if (false !== strpos($errstr, 'incomplete object')) {
+					++$warnings;
+				}
+
+				return true;
+			}
+		);
+
+		try {
+			$nested_result = \MUCD_Data::try_replace(['meta_value' => $nested_payload], 'meta_value', 'example.com/old', 'example.com/new');
+		} finally {
+			restore_error_handler();
+		}
+
+		$this->assertSame(0, $warnings);
+		$this->assertStringContainsString($old_url, $nested_result);
+		$this->assertStringContainsString('https://example.com/new/page', $nested_result);
 	}
 
 	/**


### PR DESCRIPTION
## Summary
- preserve nested `__PHP_Incomplete_Class` values that appear after serialized arrays/objects are unserialized during duplication
- extend the incomplete-object regression to cover nested object payloads while still rewriting scalar URLs in the same payload

## Why
- production checkout still aborted after PR #1419 because the missing Yoast object was nested inside an unserialized payload and hit the generic object mutation branch
- this keeps checkout provisioning from aborting after tenant DB creation but before pending-site cleanup and blogmeta assignment

## Verification
- `php -l inc/duplication/data.php`
- `php -l tests/WP_Ultimo/Duplication/MUCD_Data_Test.php`
- WP-CLI probe: `warnings=0 old=yes new=yes` for nested incomplete object payload
- `git diff --check`

## Notes
- `vendor/bin/phpunit --filter MUCD_Data_Test` remains blocked locally by missing `/tmp/wordpress-tests-lib/includes/functions.php`

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.58 plugin for [OpenCode](https://opencode.ai) v1.17.4 with gpt-5.5 spent 21h 59m and 2,624,029 tokens on this with the user in an interactive session.