### PR TITLE
fix: preserve exporter incomplete objects

### DIFF
--- a/inc/site-exporter/database/class-replace.php
+++ b/inc/site-exporter/database/class-replace.php
@@ -350,6 +350,8 @@ class Replace {
 				$data = $_tmp;
 
 				unset($_tmp);
+			} elseif ($data instanceof \__PHP_Incomplete_Class) {
+				return $data;
 			} elseif (is_object($data)) {
 				$_tmp  = $data;
 				$props = get_object_vars($data);

--- a/tests/WP_Ultimo/Site_Exporter_Test.php
+++ b/tests/WP_Ultimo/Site_Exporter_Test.php
@@ -263,4 +263,51 @@ class Site_Exporter_Test extends WP_UnitTestCase {
 
 		$this->assertArrayHasKey('network_export', $actions, 'network_export bulk action must be added');
 	}
+
+	/**
+	 * Test exporter replace preserves incomplete serialized objects unchanged.
+	 */
+	public function test_recursive_unserialize_replace_preserves_incomplete_objects(): void {
+
+		$class_name = 'Missing\\Plugin\\Notification';
+		$old_url    = 'https://example.com/old/page';
+		$serialized = sprintf(
+			'O:%d:"%s":1:{s:3:"url";s:%d:"%s";}',
+			strlen($class_name),
+			$class_name,
+			strlen($old_url),
+			$old_url
+		);
+		// phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.serialize_serialize -- Regression fixture must build serialized PHP payload.
+		$payload  = serialize(
+			[
+				// phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged, WordPress.PHP.DiscouragedPHPFunctions.serialize_unserialize -- Intentionally creates an incomplete object fixture.
+				'notice' => @unserialize($serialized),
+				'url'    => $old_url,
+			]
+		);
+		$warnings = 0;
+		$replace  = (new \ReflectionClass(\WP_Ultimo\Site_Exporter\Database\Replace::class))->newInstanceWithoutConstructor();
+
+		// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_set_error_handler -- Regression test asserts no incomplete-object warning is emitted.
+		set_error_handler(
+			static function ($errno, $errstr) use (&$warnings) {
+				if (false !== strpos($errstr, 'incomplete object')) {
+					++$warnings;
+				}
+
+				return true;
+			}
+		);
+
+		try {
+			$result = $replace->recursive_unserialize_replace('example.com/old', 'example.com/new', $payload);
+		} finally {
+			restore_error_handler();
+		}
+
+		$this->assertSame(0, $warnings);
+		$this->assertStringContainsString($old_url, $result);
+		$this->assertStringContainsString('https://example.com/new/page', $result);
+	}
 }


### PR DESCRIPTION
## Summary

- Preserve `__PHP_Incomplete_Class` values in the site exporter database search/replace path before object property mutation.
- Add a regression covering serialized payloads that contain an incomplete object plus replaceable URL data.

## Verification

- `php -l inc/site-exporter/database/class-replace.php`
- `php -l tests/WP_Ultimo/Site_Exporter_Test.php`
- `vendor/bin/phpcs inc/site-exporter/database/class-replace.php tests/WP_Ultimo/Site_Exporter_Test.php`
- `git diff --check`
- Standalone exporter probe: `warnings=0 old=yes new=yes`

## Not Run

- `vendor/bin/phpunit --filter test_recursive_unserialize_replace_preserves_incomplete_objects` is blocked locally because `/tmp/wordpress-tests-lib/includes/functions.php` is missing.

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.58 plugin for [OpenCode](https://opencode.ai) v1.17.4 with gpt-5.5


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed handling of certain serialized data formats during database export operations to prevent processing errors.

* **Tests**
  * Added regression test to ensure proper handling of edge-case serialized data during export operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->