### PR TITLE
fix: protect active multisite tables from cleanup

### DIFF
--- a/inc/class-orphaned-tables-manager.php
+++ b/inc/class-orphaned-tables-manager.php
@@ -223,39 +223,65 @@ class Orphaned_Tables_Manager {
 		global $wpdb;
 
 		$orphaned_tables = [];
-
-		// Get all site IDs
-		$site_ids = get_sites(
-			[
-				'fields' => 'ids',
-				'number' => 0,
-			]
-		);
+		$site_ids        = array_fill_keys($this->get_existing_site_ids(), true);
 
 		// Get all tables from the database
 		$all_tables = $wpdb->get_col('SHOW TABLES'); // phpcs:ignore WordPress.DB.DirectDatabaseQuery
 
 		foreach ($all_tables as $table) {
-			// Check if table matches multisite pattern (prefix + number + underscore)
-			$pattern = '/^' . preg_quote($wpdb->prefix, '/') . '([0-9]+)_(.+)/';
+			$site_id = $this->get_table_site_id($table);
 
-			if (preg_match($pattern, $table, $matches)) {
-				$site_id      = (int) $matches[1];
-				$table_suffix = $matches[2];
+			if (0 === $site_id || 1 === $site_id) {
+				continue;
+			}
 
-				// Skip if this is the main site (usually ID 1)
-				if (1 === $site_id) {
-					continue;
-				}
-
-				// Check if site ID exists in active sites
-				if (! in_array($site_id, $site_ids, true)) {
-					$orphaned_tables[] = $table;
-				}
+			// Check if site ID exists in wp_blogs, across every network.
+			if (! isset($site_ids[ $site_id ])) {
+				$orphaned_tables[] = $table;
 			}
 		}
 
 		return $orphaned_tables;
+	}
+
+	/**
+	 * Get blog IDs that still have a wp_blogs row.
+	 *
+	 * The cleanup process must not rely on get_sites() here because site queries
+	 * can be filtered or scoped by multi-network context. A table is orphaned only
+	 * when its blog ID no longer has a row in wp_blogs.
+	 *
+	 * @since 2.0.0
+	 * @return array<int>
+	 */
+	private function get_existing_site_ids(): array {
+
+		global $wpdb;
+
+		$site_ids = $wpdb->get_col("SELECT blog_id FROM {$wpdb->blogs}"); // phpcs:ignore WordPress.DB.DirectDatabaseQuery
+
+		return array_map('intval', $site_ids ?: []);
+	}
+
+	/**
+	 * Extract the site ID from a multisite table name.
+	 *
+	 * @since 2.0.0
+	 * @param string $table Table name.
+	 * @return int Site ID, or 0 when the table is not a per-site multisite table.
+	 */
+	private function get_table_site_id(string $table): int {
+
+		global $wpdb;
+
+		$base_prefix = $wpdb->base_prefix ?: $wpdb->prefix;
+		$pattern     = '/^' . preg_quote($base_prefix, '/') . '([0-9]+)_(.+)/';
+
+		if (! preg_match($pattern, $table, $matches)) {
+			return 0;
+		}
+
+		return (int) $matches[1];
 	}
 
 	/**
@@ -270,14 +296,16 @@ class Orphaned_Tables_Manager {
 		global $wpdb;
 
 		$deleted_count = 0;
+		$site_ids      = array_fill_keys($this->get_existing_site_ids(), true);
 
 		foreach ($tables as $table) {
 			// Sanitize table name to prevent SQL injection
 			$table = sanitize_key($table);
 
-			// Verify the table still exists and matches our pattern
-			$pattern = '/^' . preg_quote($wpdb->prefix, '/') . '([0-9]+)_(.+)/';
-			if (! preg_match($pattern, $table)) {
+			$site_id = $this->get_table_site_id($table);
+
+			// Verify the table still matches our pattern and no wp_blogs row exists.
+			if (0 === $site_id || 1 === $site_id || isset($site_ids[ $site_id ])) {
 				continue;
 			}
 

--- a/inc/class-orphaned-tables-manager.php
+++ b/inc/class-orphaned-tables-manager.php
@@ -222,8 +222,14 @@ class Orphaned_Tables_Manager {
 
 		global $wpdb;
 
-		$orphaned_tables = [];
-		$site_ids        = array_fill_keys($this->get_existing_site_ids(), true);
+		$orphaned_tables   = [];
+		$existing_site_ids = $this->get_existing_site_ids();
+
+		if (is_wp_error($existing_site_ids)) {
+			return [];
+		}
+
+		$site_ids = array_fill_keys($existing_site_ids, true);
 
 		// Get all tables from the database
 		$all_tables = $wpdb->get_col('SHOW TABLES'); // phpcs:ignore WordPress.DB.DirectDatabaseQuery
@@ -252,15 +258,22 @@ class Orphaned_Tables_Manager {
 	 * when its blog ID no longer has a row in wp_blogs.
 	 *
 	 * @since 2.0.0
-	 * @return array<int>
+	 * @return array<int>|\WP_Error
 	 */
-	private function get_existing_site_ids(): array {
+	private function get_existing_site_ids() {
 
 		global $wpdb;
 
 		$site_ids = $wpdb->get_col("SELECT blog_id FROM {$wpdb->blogs}"); // phpcs:ignore WordPress.DB.DirectDatabaseQuery
 
-		return array_map('intval', $site_ids ?: []);
+		if (! is_array($site_ids) || '' !== $wpdb->last_error) {
+			return new \WP_Error(
+				'wu_orphaned_tables_site_lookup_failed',
+				__('Unable to read site IDs from wp_blogs.', 'ultimate-multisite')
+			);
+		}
+
+		return array_map('intval', $site_ids);
 	}
 
 	/**
@@ -295,8 +308,14 @@ class Orphaned_Tables_Manager {
 
 		global $wpdb;
 
-		$deleted_count = 0;
-		$site_ids      = array_fill_keys($this->get_existing_site_ids(), true);
+		$deleted_count     = 0;
+		$existing_site_ids = $this->get_existing_site_ids();
+
+		if (is_wp_error($existing_site_ids)) {
+			return 0;
+		}
+
+		$site_ids = array_fill_keys($existing_site_ids, true);
 
 		foreach ($tables as $table) {
 			// Sanitize table name to prevent SQL injection

--- a/tests/WP_Ultimo/Orphaned_Tables_Manager_Test.php
+++ b/tests/WP_Ultimo/Orphaned_Tables_Manager_Test.php
@@ -23,6 +23,87 @@ class Orphaned_Tables_Manager_Test extends \WP_UnitTestCase {
 	}
 
 	/**
+	 * Create a wp_blogs row and options table for cleanup safety tests.
+	 *
+	 * @param int $network_id Network ID to store in the wp_blogs row.
+	 * @return array{0:int,1:string}
+	 */
+	protected function create_blog_row_with_options_table(int $network_id = 999): array {
+
+		global $wpdb;
+
+		$blog_id = ((int) $wpdb->get_var("SELECT MAX(blog_id) FROM {$wpdb->blogs}")) + 1000; // phpcs:ignore WordPress.DB.DirectDatabaseQuery
+		$table   = $wpdb->base_prefix . $blog_id . '_options';
+
+		$inserted = $wpdb->insert(
+			$wpdb->blogs,
+			[
+				'blog_id'      => $blog_id,
+				'site_id'      => $network_id,
+				'domain'       => "orphaned-tables-{$blog_id}.example.org",
+				'path'         => '/',
+				'registered'   => current_time('mysql', true),
+				'last_updated' => current_time('mysql', true),
+				'public'       => 1,
+				'archived'     => 0,
+				'mature'       => 0,
+				'spam'         => 0,
+				'deleted'      => 0,
+				'lang_id'      => 0,
+			],
+			[
+				'%d',
+				'%d',
+				'%s',
+				'%s',
+				'%s',
+				'%s',
+				'%d',
+				'%d',
+				'%d',
+				'%d',
+				'%d',
+				'%d',
+			]
+		);
+
+		$this->assertNotFalse($inserted, 'Failed to insert the test blog row.');
+
+		$created = $wpdb->query(
+			// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+			"CREATE TABLE {$table} (
+				option_id bigint(20) unsigned NOT NULL auto_increment,
+				option_name varchar(191) NOT NULL default '',
+				option_value longtext NOT NULL,
+				autoload varchar(20) NOT NULL default 'yes',
+				PRIMARY KEY  (option_id),
+				UNIQUE KEY option_name (option_name)
+			) {$wpdb->get_charset_collate()}"
+		); // phpcs:ignore WordPress.DB.DirectDatabaseQuery, WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+
+		$this->assertNotFalse($created, 'Failed to create the test options table.');
+
+		clean_blog_cache($blog_id);
+
+		return [$blog_id, $table];
+	}
+
+	/**
+	 * Remove test wp_blogs row and options table.
+	 *
+	 * @param int    $blog_id Blog ID.
+	 * @param string $table Options table name.
+	 */
+	protected function remove_blog_row_with_options_table(int $blog_id, string $table): void {
+
+		global $wpdb;
+
+		$wpdb->query("DROP TABLE IF EXISTS {$table}"); // phpcs:ignore WordPress.DB.DirectDatabaseQuery, WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+		$wpdb->delete($wpdb->blogs, ['blog_id' => $blog_id], ['%d']);
+		clean_blog_cache($blog_id);
+	}
+
+	/**
 	 * Test singleton returns correct instance.
 	 */
 	public function test_singleton_returns_correct_instance(): void {
@@ -78,33 +159,55 @@ class Orphaned_Tables_Manager_Test extends \WP_UnitTestCase {
 
 		$orphaned = $this->get_instance()->find_orphaned_tables();
 
-		// Get active site IDs
-		$site_ids = get_sites(
-			[
-				'fields' => 'ids',
-				'number' => 0,
-			]
-		);
-
 		global $wpdb;
+
+		// Get all blog IDs directly from wp_blogs, across every network.
+		$site_ids = array_map('intval', $wpdb->get_col("SELECT blog_id FROM {$wpdb->blogs}") ?: []); // phpcs:ignore WordPress.DB.DirectDatabaseQuery
 
 		$checked = 0;
 
 		foreach ( $orphaned as $table ) {
-			$pattern = '/^' . preg_quote($wpdb->prefix, '/') . '([0-9]+)_/';
+			$pattern = '/^' . preg_quote($wpdb->base_prefix, '/') . '([0-9]+)_/';
 
 			if ( preg_match($pattern, $table, $matches) ) {
 				$site_id = (int) $matches[1];
 
 				// Orphaned tables should NOT belong to active sites
 				$this->assertNotContains($site_id, $site_ids, "Table {$table} belongs to active site {$site_id}");
-				$checked++;
+				++$checked;
 			}
 		}
 
 		// If no orphaned tables exist, the test passes trivially — mark it as such
 		if ( 0 === $checked ) {
 			$this->assertTrue(true, 'No orphaned tables found — nothing to check.');
+		}
+	}
+
+	/**
+	 * Test find_orphaned_tables ignores filtered site query results.
+	 */
+	public function test_find_orphaned_tables_ignores_filtered_site_queries(): void {
+
+		[$blog_id, $table] = $this->create_blog_row_with_options_table();
+
+		$filter = static function ($site_data, $query) {
+			if ('ids' !== $query->query_vars['fields']) {
+				return $site_data;
+			}
+
+			return [1];
+		};
+
+		add_filter('sites_pre_query', $filter, 10, 2);
+
+		try {
+			$orphaned = $this->get_instance()->find_orphaned_tables();
+
+			$this->assertNotContains($table, $orphaned, 'Tables with a wp_blogs row must not be treated as orphaned when get_sites() is filtered.');
+		} finally {
+			remove_filter('sites_pre_query', $filter, 10);
+			$this->remove_blog_row_with_options_table($blog_id, $table);
 		}
 	}
 
@@ -130,6 +233,25 @@ class Orphaned_Tables_Manager_Test extends \WP_UnitTestCase {
 
 		// Should not delete tables that don't match the multisite pattern
 		$this->assertSame(0, $result);
+	}
+
+	/**
+	 * Test delete_orphaned_tables protects tables with a wp_blogs row.
+	 */
+	public function test_delete_orphaned_tables_skips_tables_with_blog_rows(): void {
+
+		global $wpdb;
+
+		[$blog_id, $table] = $this->create_blog_row_with_options_table();
+
+		try {
+			$result = $this->get_instance()->delete_orphaned_tables([$table]);
+
+			$this->assertSame(0, $result);
+			$this->assertSame($table, $wpdb->get_var($wpdb->prepare('SHOW TABLES LIKE %s', $table)));
+		} finally {
+			$this->remove_blog_row_with_options_table($blog_id, $table);
+		}
 	}
 
 	/**

--- a/tests/WP_Ultimo/Orphaned_Tables_Manager_Test.php
+++ b/tests/WP_Ultimo/Orphaned_Tables_Manager_Test.php
@@ -81,7 +81,12 @@ class Orphaned_Tables_Manager_Test extends \WP_UnitTestCase {
 			) {$wpdb->get_charset_collate()}"
 		); // phpcs:ignore WordPress.DB.DirectDatabaseQuery, WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 
-		$this->assertNotFalse($created, 'Failed to create the test options table.');
+		if (false === $created) {
+			$wpdb->delete($wpdb->blogs, ['blog_id' => $blog_id], ['%d']);
+			clean_blog_cache($blog_id);
+
+			$this->fail('Failed to create the test options table.');
+		}
 
 		clean_blog_cache($blog_id);
 
@@ -250,6 +255,27 @@ class Orphaned_Tables_Manager_Test extends \WP_UnitTestCase {
 			$this->assertSame(0, $result);
 			$this->assertSame($table, $wpdb->get_var($wpdb->prepare('SHOW TABLES LIKE %s', $table)));
 		} finally {
+			$this->remove_blog_row_with_options_table($blog_id, $table);
+		}
+	}
+
+	/**
+	 * Test cleanup fails closed when wp_blogs cannot be read.
+	 */
+	public function test_cleanup_fails_closed_when_blog_lookup_fails(): void {
+
+		global $wpdb;
+
+		[$blog_id, $table] = $this->create_blog_row_with_options_table();
+		$blogs_table       = $wpdb->blogs;
+		$wpdb->blogs       = $wpdb->base_prefix . 'missing_blogs_for_cleanup_test';
+
+		try {
+			$this->assertSame([], $this->get_instance()->find_orphaned_tables());
+			$this->assertSame(0, $this->get_instance()->delete_orphaned_tables([$table]));
+			$this->assertSame($table, $wpdb->get_var($wpdb->prepare('SHOW TABLES LIKE %s', $table)));
+		} finally {
+			$wpdb->blogs = $blogs_table;
 			$this->remove_blog_row_with_options_table($blog_id, $table);
 		}
 	}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved orphaned table detection by validating site existence via direct database lookups, reducing false positives.
  * Improved deletion safety by skipping removal when a table still corresponds to an existing site, and consistently handling shared versus base prefixes.

* **Tests**
  * Added new test cases for filter/queried-site edge scenarios and deletion skip behavior when site rows exist.
  * Updated existing tests to align “active site” checks and table parsing with the safer detection logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->