### PR TITLE
fix: clarify product type choices

### DIFF
--- a/inc/admin-pages/class-product-edit-admin-page.php
+++ b/inc/admin-pages/class-product-edit-admin-page.php
@@ -688,6 +688,22 @@ class Product_Edit_Admin_Page extends Edit_Admin_Page {
 	}
 
 	/**
+	 * Returns the product type options with short usage descriptions.
+	 *
+	 * @since 2.13.2
+	 * @return array
+	 */
+	protected function get_product_type_options() {
+
+		return [
+			Product_Type::PLAN    => __('Plan — Subscription tier that creates and manages customer sites.', 'ultimate-multisite'),
+			Product_Type::PACKAGE => __('Package — Add-on sold with plans to unlock extra features or resources.', 'ultimate-multisite'),
+			Product_Type::SERVICE => __('Service — Work or support customers can buy without creating a site.', 'ultimate-multisite'),
+			Product_Type::DEMO    => __('Demo — Temporary trial site for prospects to test before buying.', 'ultimate-multisite'),
+		];
+	}
+
+	/**
 	 * Returns the list of sections and its fields for the product page.
 	 *
 	 * Can be filtered via 'wu_product_options_sections'.
@@ -726,10 +742,10 @@ class Product_Edit_Admin_Page extends Edit_Admin_Page {
 						'type'        => 'select',
 						'title'       => __('Product Type', 'ultimate-multisite'),
 						'placeholder' => __('Product Type', 'ultimate-multisite'),
-						'desc'        => __('Different product types have different options.', 'ultimate-multisite'),
+						'desc'        => __('Choose the type that matches what this product should do: use Plan for subscription tiers that create customer sites; Package for paid add-ons; Service for work or support that does not create a site; and Demo for temporary trial sites.', 'ultimate-multisite'),
 						'value'       => $this->get_object()->get_type(),
 						'tooltip'     => '',
-						'options'     => Product_Type::to_array(),
+						'options'     => $this->get_product_type_options(),
 						'html_attr'   => [
 							'v-model' => 'product_type',
 						],

--- a/lang/ultimate-multisite.pot
+++ b/lang/ultimate-multisite.pot
@@ -4526,6 +4526,22 @@ msgstr ""
 msgid "This image is used on product list tables and other places."
 msgstr ""
 
+#: inc/admin-pages/class-product-edit-admin-page.php:699
+msgid "Plan — Subscription tier that creates and manages customer sites."
+msgstr ""
+
+#: inc/admin-pages/class-product-edit-admin-page.php:700
+msgid "Package — Add-on sold with plans to unlock extra features or resources."
+msgstr ""
+
+#: inc/admin-pages/class-product-edit-admin-page.php:701
+msgid "Service — Work or support customers can buy without creating a site."
+msgstr ""
+
+#: inc/admin-pages/class-product-edit-admin-page.php:702
+msgid "Demo — Temporary trial site for prospects to test before buying."
+msgstr ""
+
 #: inc/admin-pages/class-product-edit-admin-page.php:705
 msgid "General product options such as product slug, type, etc."
 msgstr ""
@@ -4547,13 +4563,13 @@ msgstr ""
 msgid "Lowercase alpha-numeric characters with dashes or underlines. No spaces allowed."
 msgstr ""
 
-#: inc/admin-pages/class-product-edit-admin-page.php:727
-#: inc/admin-pages/class-product-edit-admin-page.php:728
+#: inc/admin-pages/class-product-edit-admin-page.php:743
+#: inc/admin-pages/class-product-edit-admin-page.php:744
 msgid "Product Type"
 msgstr ""
 
-#: inc/admin-pages/class-product-edit-admin-page.php:729
-msgid "Different product types have different options."
+#: inc/admin-pages/class-product-edit-admin-page.php:745
+msgid "Choose the type that matches what this product should do: use Plan for subscription tiers that create customer sites; Package for paid add-ons; Service for work or support that does not create a site; and Demo for temporary trial sites."
 msgstr ""
 
 #: inc/admin-pages/class-product-edit-admin-page.php:738


### PR DESCRIPTION
## Summary

- Add short descriptions to each Product Type option on the product edit page.
- Replace the generic Product Type help text with instructions for when to use Plan, Package, Service, and Demo.
- Update the POT entries for the new admin UI strings.

## Verification

- `php -l inc/admin-pages/class-product-edit-admin-page.php`
- `vendor/bin/phpcs inc/admin-pages/class-product-edit-admin-page.php`
- `vendor/bin/phpstan analyse inc/admin-pages/class-product-edit-admin-page.php`
- `git diff --check`
- Pre-commit hook passed PHPCS and PHPStan for the staged PHP file.

## Not run

- PHPUnit, because the WordPress test suite is unavailable in this local environment.

---
<!-- aidevops:sig -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced product type selection with clearer descriptions for each type (Plan, Package, Service, Demo), helping users choose the correct type for their use case.

* **Documentation**
  * Improved help text for the Product Type field with specific guidance on which type to select for different business needs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->