### PR TITLE
docs: link wiki to new docs site

### DIFF
--- a/.wiki/Home.md
+++ b/.wiki/Home.md
@@ -1,6 +1,8 @@
 # Ultimate Multisite Documentation
 
-Welcome to the Ultimate Multisite documentation. This wiki contains all the information you need to get started with Ultimate Multisite.
+Looking for the latest documentation? Visit the new Ultimate Multisite docs at [ultimatemultisite.com/docs](https://ultimatemultisite.com/docs/).
+
+This GitHub wiki remains available for legacy and reference material.
 
 ## Documentation Categories
 

--- a/.wiki/_Sidebar.md
+++ b/.wiki/_Sidebar.md
@@ -1,6 +1,7 @@
 # Documentation
 
 - [Home](Home)
+- [New docs site](https://ultimatemultisite.com/docs/)
 
 ## Getting Started
 - [Ultimate Multisite 101](wp-ultimo-101)


### PR DESCRIPTION
## Summary

- Add the new docs-site link to the wiki home page source.
- Add the new docs-site link to the wiki sidebar source so future wiki syncs keep it visible.

## Verification

- `git diff origin/main...HEAD -- .wiki/Home.md .wiki/_Sidebar.md`
- Pre-commit hook passed: no PHP, JS, or CSS files to check.

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.79 plugin for [OpenCode](https://opencode.ai) v1.17.7 with gpt-5.5 spent 3h 26m and 119,678 tokens on this with the user in an interactive session.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Home page updated to direct users to the latest online documentation
  * GitHub wiki clarified as available for legacy reference material
  * New sidebar navigation link added for convenient access to current documentation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->