### PR TITLE
fix: display six-month legacy pricing

### DIFF
--- a/views/checkout/templates/pricing-table/legacy.php
+++ b/views/checkout/templates/pricing-table/legacy.php
@@ -224,7 +224,7 @@ if (null !== $first_recurring_product) {
 				</span>
 
 				<?php
-				foreach ([3, 12] as $freq) :
+				foreach ([3, 6, 12] as $freq) :
 					$price_variation = $product->get_price_variation($freq, 'month');
 
 					if ( ! $price_variation) {
@@ -303,10 +303,16 @@ if (null !== $first_recurring_product) {
 
 				/**
 				 *
-				 * Display quarterly and Annually plans, to be hidden.
+				 * Display multi-month and annual plans, to be hidden.
 				 */
 				$prices_total = [
 					3  => __('every 3 months', 'ultimate-multisite'),
+					6  => sprintf(
+						// translators: %1$s: the duration number, %2$s: the duration unit.
+						__('every %1$s %2$s', 'ultimate-multisite'),
+						6,
+						wu_get_translatable_string('months')
+					),
 					12 => __('yearly', 'ultimate-multisite'),
 				];
 


### PR DESCRIPTION
## Summary

- Display six-month price variations in the legacy checkout pricing table.
- Add the matching six-month total billing line alongside existing quarterly and annual totals.

## Verification

- `php -l views/checkout/templates/pricing-table/legacy.php`
- `vendor/bin/phpcs views/checkout/templates/pricing-table/legacy.php`
- `git diff --check`
- Commit pre-commit hook passed PHPCS and PHPStan for the staged PHP file.

## Notes

- Full PHPUnit was not run because the WordPress test suite is not available in this environment.

---
<!-- aidevops:sig -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for 6-month billing frequency in pricing table display, providing customers with additional billing cycle options alongside existing frequencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->