### PR TITLE
fix: clarify customer delete behavior

### DIFF
--- a/inc/admin-pages/class-customer-edit-admin-page.php
+++ b/inc/admin-pages/class-customer-edit-admin-page.php
@@ -306,7 +306,7 @@ class Customer_Edit_Admin_Page extends Edit_Admin_Page {
 			'delete_all'                => [
 				'type'      => 'toggle',
 				'title'     => __('Delete everything', 'ultimate-multisite'),
-				'desc'      => __('Sites, payments and memberships.', 'ultimate-multisite'),
+				'desc'      => __('Sites, payments and memberships. The user\'s WordPress account will not be removed.', 'ultimate-multisite'),
 				'html_attr' => [
 					'v-bind:value' => 'delete_all_confirmed',
 					'v-model'      => 'delete_all_confirmed',

--- a/lang/ultimate-multisite.pot
+++ b/lang/ultimate-multisite.pot
@@ -1082,7 +1082,7 @@ msgid "Delete everything"
 msgstr ""
 
 #: inc/admin-pages/class-customer-edit-admin-page.php:309
-msgid "Sites, payments and memberships."
+msgid "Sites, payments and memberships. The user's WordPress account will not be removed."
 msgstr ""
 
 #: inc/admin-pages/class-customer-edit-admin-page.php:317


### PR DESCRIPTION
## Summary

- Clarifies the customer delete modal's "Delete everything" option.
- Notes that the linked WordPress user account is not removed.
- Updates the translation template string.

## Verification

- `composer install`
- `php -l inc/admin-pages/class-customer-edit-admin-page.php`
- `vendor/bin/phpcs inc/admin-pages/class-customer-edit-admin-page.php`
- `git diff --check origin/main...HEAD`
- Pre-commit hook: PHPCS and PHPStan on the changed PHP file

---
<!-- aidevops:sig -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified customer deletion messaging to indicate that WordPress accounts remain active when removing sites, payments, and memberships.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->