### PR TITLE
docs: trim changelog for wp.org limit

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -252,470 +252,179 @@ No personal data, domains, IP addresses, or payment information are collected.
 
 == Changelog ==
 Version [2.13.1] - Released on 2026-06-08
-- Fix: Pending site fallback timing now handles longer provisioning queues so customers are less likely to hit checkout timeouts.
-- Fix: Checkout progress no longer reuses stale live-state after the active checkout session has moved forward.
-- Fix: Pending sites now launch loopback publishing without requiring cron scheduling.
-- Fix: Pending site dispatch now works reliably on FrankenPHP environments.
-- Fix: Divi cloned sites no longer receive stale CSS cache from previous template operations.
-- Fix: WordPress cron URLs now target the correct site context to avoid cross-site scheduling failures.
-- Improved: Restored cross-domain SSO e2e coverage to keep mapped-domain login flows verified.
+- Fix: Pending site provisioning now tolerates longer queues and works on FrankenPHP, reducing checkout timeouts.
+- Fix: Checkout progress no longer shows stale live-state after the active session moves forward.
+- Fix: Divi clones no longer inherit stale CSS cache, and multisite cron URLs now use the correct site context.
 
 Version [2.13.0] - Released on 2026-06-05
-- New: Added sovereign-tenant support for customer account, checkout, billing, site, invoice, template switching, and domain mapping flows so tenant networks can direct customers back to the main site for managed actions.
-- New: Added renewal-credential checks for recurring memberships so gateways can disable auto-renewal when a saved billing agreement, subscription, or vault token is missing.
-- New: Added HMAC-verified loopback publishing for pending site creation to make checkout-to-site provisioning more reliable on hosts where background jobs are delayed.
-- New: Added developer extension points for SSO URLs, checkout-form base domains, and automatic domain-record creation.
-- Fix: SSO is more reliable across mapped domains, anonymous broker visits, logout, and cross-plugin dependency conflicts.
-- Fix: Pending site creation now recovers from stale publish flags and avoids leaving customers stuck on the site-creation screen.
-- Fix: Domain records are no longer created for shared checkout-form base domains, and unused host-provider background jobs are skipped when no integration is active.
-- Fix: Checkout, billing address, password reset, email verification, template switching, tours, and customer dashboard edge cases no longer block normal customer flows.
-- Fix: Broadcast emails now keep recipients private while avoiding SMTP/plugin fatal errors when recipient lists or mail transports fail.
-- Fix: Membership renewals, expiration display, and payment collection edge cases now avoid immediate expirations, crashes, or missed required payments.
-- Improved: WordPress compatibility is tested up to 7.0, production Vue assets are rebuilt from npm sources, and Cypress end-to-end coverage now exercises more checkout, setup, SSO, and gateway flows.
+- New: Sovereign-tenant support now routes customer account, checkout, billing, site, invoice, template switching, and domain mapping actions back to the main site when needed.
+- New: Recurring memberships now detect missing renewal credentials so gateways can disable auto-renewal safely.
+- Improved: Pending site publishing is more reliable on hosts where background jobs are delayed.
+- Fix: SSO is more reliable across mapped domains, anonymous broker visits, logout, and plugin conflicts.
+- Fix: Checkout, billing address, password reset, email verification, template switching, tours, dashboard, renewal, and payment edge cases no longer block normal customer flows.
+- Fix: Broadcast emails keep recipients private and avoid fatal errors when recipient lists or mail transports fail.
 
 Version [2.12.0] - Released on 2026-05-15
-- New: Added Hostinger (hPanel) as a supported host provider with domain mapping integration
-- New: Site Exporter now handles network import bundles for streamlined network-wide site restoration
-- Fix: BCC broadcast emails now use an undisclosed-recipients header to prevent exposing recipient addresses
-- Fix: Membership expiration date is no longer corrupted when saving with a non-date value
-- Fix: Stripe membership updates now correctly clear discounts without calling the deprecated deleteDiscount API
-- Fix: SSO redirects on domain-mapped sites are now capped to prevent infinite redirect loops
-- Fix: Setup wizard image picker selection now correctly updates the underlying data model
-- Fix: Site Exporter CLI now preserves the correct default network site selection
-- Improved: Removed bundled wp-cli from the plugin package, reducing plugin size
+- New: Hostinger (hPanel) is now supported for domain mapping.
+- New: Site Exporter now supports network import bundles for network-wide site restoration.
+- Fix: Broadcast emails no longer expose BCC recipients.
+- Fix: Membership expiration dates, Stripe discount updates, SSO redirect loops, and setup wizard image selection now behave correctly.
 
 Version [2.11.1] - Released on 2026-05-12
-- Fix: SSO no longer fails when $current_blog is unpopulated during early WordPress bootstrap, preventing errors on configurations where WP initialises in an unexpected order
+- Fix: SSO no longer fails when WordPress initialises site context later than expected.
 
 Version [2.11.0] - Released on 2026-05-11
-- New: Site exports now bundle a self-booting index.php so the ZIP can be installed on a fresh host without a separate plugin install
-- New: Network export lets administrators export all subsites in a single archive from the Site Export admin page
-- New: Allow Site Templates plan toggle is now enforced via a fallback chain, correctly restricting template availability for plan limits
-- New: Checkout form editor warns when a product is added without a required field configured
-- New: Import/Export settings tab now clearly describes its scope and links directly to the Site Export tool
-- Fix: Password reset URL is now correctly rewritten on subsites so customers can reset their password from subsite login pages
-- Fix: Welcome emails now send reliably after site duplication
-- Fix: Auto-generated password signups now correctly send the set-your-password email
-- Fix: Template switching now allows sites with no current template to switch to a new one
-- Fix: Cloudways integration excludes wildcard domains from Let's Encrypt SSL requests, keeping them as domain aliases only
-- Fix: Template switching no longer renders a broken image when the current template has no image URL
-- Fix: Settings page and Setup Wizard no longer fatal on Closure rendering; credits textarea no longer shows [object Object]
-- Fix: Domain mapping no longer calls get_option(blog_charset) during early WordPress bootstrap
-- Fix: Enhance integration uses domainId from GET list response for domain deletion
-- Fix: WPEngine integration method signatures corrected to prevent PHP fatals when addons extend integration classes
-- Fix: Site deletion now returns WP_Error on exception instead of failing silently
-- Fix: Setup wizard now uses a deterministic network URL on multisite setup success
-- Fix: Checkout editor Add Field modal and toolbar are now usable on mobile devices
-- Fix: WU Tours no longer errors with wu_tours is not defined; tour now displays only once as intended
-- Fix: Checkout email field no longer shows a redundant Log in to renew notice
-- Fix: Site exports now include plugins, themes, and uploads; themes are activated on import
-- Fix: Template switching element conversion no longer errors for certain element configurations
+- New: Site exports are self-booting, include plugins, themes, and uploads, and network export can bundle all subsites in one archive.
+- New: Checkout form editor warns when products are missing required fields, and plan limits now restrict template availability reliably.
+- Fix: Password reset, welcome, and set-password emails now work correctly on subsites and duplicated sites.
+- Fix: Template switching now handles missing current templates, missing images, and complex element configurations.
+- Fix: Cloudways, Enhance, WPEngine, domain mapping, setup wizard, site deletion, mobile checkout editor, and tour display issues were resolved.
 
 Version [2.10.1] - Released on 2026-05-05
-- Fix: Unavailable templates are now hidden from the customer panel template grid
-- Fix: Template switching no longer truncates the current template description text
-- Fix: Fatal error prevented when global $wp_query is null during early-hook query access
-- Fix: Stripe checkout preflight now correctly handles null or WP_Error customer objects
-- Fix: Site deletion now propagates errors to prevent silent redirect on failure
+- Fix: Unavailable templates are hidden from the customer template grid, and template descriptions are no longer truncated.
+- Fix: Stripe checkout preflight, early query access, and site deletion errors now fail safely instead of causing crashes or silent redirects.
 
 Version [2.10.0] - Released on 2026-05-05
-- New: PayPal guided setup wizard for manual credential entry with OAuth flag gate for seamless gateway configuration
-- New: Template switch customer panel redesigned with current-template card, persistent grid, and "Reset current template" button
-- Fix: Template switching no longer hangs the UI on AJAX failure
-- Fix: Template switching permission states secured against unauthorized access
-- Fix: Site override inputs validated before saving
-- Fix: Billing address prompt now shown when address is empty
-- Fix: PHP 8.1 null-to-string deprecation notices resolved
-- Fix: Currents lazy-loaded before init hook to prevent timing issues
-- Fix: Filtered SSO path respected across all login flows
-- Fix: Blank site identity options preserved on save
+- New: PayPal setup now includes a guided manual credential wizard.
+- New: Template switching panel now shows the current template, a persistent grid, and a reset option.
+- Fix: Template switching no longer hangs on AJAX failure and now enforces permissions correctly.
+- Fix: Billing address prompts, SSO paths, blank site identity options, and site override validation now work reliably.
 
 Version [2.9.3] - Released on 2026-05-04
-- Fix: Mapped domain URLs no longer contain duplicate port numbers
-- Fix: Redirect hosts and cookie domains now strip port numbers, preventing authentication failures on non-standard ports
-- Fix: CyberPanel integration now correctly uses child domains for domain mapping
-- Fix: Cookie-less cross-domain SSO token redirects are handled reliably in all cases
-- Fix: SSO login flow correctly carries return_url through cross-domain redirects, including when visiting the main login page while already logged in
-- Fix: 13 bugs in site template switching (override_site) that could cause customer site corruption are resolved
-- Fix: Checkout form editor is now fully functional on mobile devices
-- Fix: Auto-generated site URLs now use available domains correctly
+- Fix: Mapped domains and redirects now handle non-standard ports correctly, preventing authentication failures.
+- Fix: Cross-domain SSO preserves return URLs and works more reliably without third-party cookies.
+- Fix: CyberPanel domain mapping, mobile checkout form editing, auto-generated site URLs, and template switching stability were improved.
 
 Version [2.9.2] - Released on 2026-05-01
-- Fix: Screenshot URLs no longer contain a doubled https:// scheme when the site URL already includes a protocol
-- Fix: Add-on sunrise.php path now resolved relative to WP_CONTENT_DIR instead of WP_PLUGIN_DIR, fixing add-on activation on non-standard WordPress installs
+- Fix: Screenshot URLs no longer include duplicate protocols.
+- Fix: Add-ons now activate correctly on non-standard WordPress installs where sunrise.php lives outside the plugin directory.
 
 Version [2.9.1] - Released on 2026-05-01
-- New: Checkout Forms added to admin bar quick links
-- Fix: Trial period now correctly applied for returning customers whose cancelled subscription had zero renewals
-- Fix: Site import no longer fails when the target URL has no http:// scheme
-- Fix: Export modal now downloads the ZIP file immediately on synchronous export
-- Improved: Screenshot provider switched to Microlink (free, 1024x768 viewport) with thum.io fallback, replacing unreliable mShots
+- New: Checkout Forms are available from admin bar quick links.
+- Fix: Trial periods now apply correctly for returning customers with cancelled subscriptions that had no renewals.
+- Fix: Site import, export downloads, and screenshot generation are more reliable.
 
 Version [2.9.0] - Released on 2026-04-30
-- New: Single-site export and import added under Tools > Export & Import
-- Fix: Export ZIP files now served through an authenticated download endpoint
-- Fix: SQL injection risk and query issues in pending export/import queries corrected
-- Fix: Pending site not published when admin manually verifies customer email
-- Fix: Orphaned pending_site records cleaned up when membership is missing
-- Fix: Settings nav padding and search anchor navigation corrected
-- Fix: Pending sites now shown first in the All Sites view
-- Fix: Screenshot provider (mShots) User-Agent header added to prevent 403 errors
-- Fix: Import cron schedule circular dependency resolved
-- Fix: Tour IDs normalised to underscores in user settings keys
-- Improved: ZipArchive now used instead of Alchemy/Zippy for better compatibility
+- New: Single-site export and import are available in the admin dashboard.
+- Fix: Export ZIP downloads are authenticated, and pending export/import queries were secured.
+- Fix: Pending sites now publish after manual email verification, are easier to find in All Sites, and are cleaned up when memberships are missing.
+- Improved: Export/import compatibility and screenshot reliability were improved.
 
 Version [2.8.0] - Released on 2026-04-29
-- New: Enable Jumper toggle added to Other Options settings UI
-- New: Status column added to the checkout forms list table
-- New: Addon sunrise file loader for custom MU-plugin sunrise extensions
-- Improved: Removed error-reporting opt-in setting from settings page
-- Fix: Thank-you page site card — image now constrained and links styled correctly
-- Fix: Screenshot provider switched from thum.io to WordPress.com mShots
-- Fix: Enable Registration and Default Role now set correct defaults on fresh install
-- Fix: get_site_url() no longer returns empty when domain includes a port
-- Fix: Clone media files now copied correctly when copy_media setting was empty
-- Fix: Object cache invalidated correctly after network-activate sitemeta write
-- Fix: Custom domain auto-promoted to primary on DNS verification for 3-part domains
-- Fix: Pending membership cancelled when expired payment is cleaned up
-- Fix: Password strength checker rebound after inline login prompt dismissed
-- Fix: Infinite page reload stopped on thank-you page when site already created
-- Fix: WP core registration option synced on plugin activation and settings save
-- Fix: Null expiration guard added in calculate_expiration for PHP 8.4 compatibility
-- Fix: Duplicate signups blocked when customer already has an active membership
-- Fix: Null check added for date_expiration in checkout
-- Fix: Site provisioning hardened — limitations, membership inference, domain promotion
-- Fix: Pre-install check status label corrected to NOT Activated when check fails
-- Fix: Checkout domain used for email verification URLs
-- Fix: Auto-login after checkout when no password field is present
-- Fix: Free memberships no longer expire — treated as lifetime
-- Fix: Email verification gate holds site publish until customer verifies email
-- Fix: SES v2 API endpoint base path and identity route corrected
-- Fix: wu_inline_login_error hook emitted in pre-submit catch block
+- New: Added an Enable Jumper setting and checkout form status column.
+- Fix: Thank-you page cards, screenshots, registration defaults, domains with ports, cloned media, custom domain promotion, and password strength checks now work correctly.
+- Fix: Duplicate signups are blocked, free memberships are lifetime, and email verification now holds site publishing until verification completes.
+- Fix: Site provisioning, pending membership cleanup, auto-login, SES email delivery, and PHP 8.4 expiration handling were hardened.
 
 Version [2.7.0] - Released on 2026-04-22
-- New: Inline login hooks for smoother user experience during checkout and signup
-- Fix: Reclaim orphan pending_site on WooCommerce order completion
-- Fix: Prevent duplicate WordPress users on checkout retry
-- Fix: Preserve pending_site in transient when membership is cancelled
-- Fix: Add null-guard for $this->membership in downgrade cart type paths
-- Fix: Fix set_demo_behavior fatal TypeError on PHP 8 when null passed via attributes()
-- Fix: Fix various PHP warnings
-- Improved: Replace captcha-specific code with generic JavaScript hooks
+- Improved: Inline login during checkout and signup is smoother.
+- Fix: WooCommerce order completion can reclaim orphan pending sites, and checkout retries no longer create duplicate WordPress users.
+- Fix: Membership cancellation, downgrade paths, demo products, and PHP warnings were stabilised.
 
 Version [2.6.3] - Released on 2026-04-17
-- Fix: Reverted billing-period switch scheduling as a downgrade — the feature introduced in 2.6.2 caused unexpected renewal behaviour and has been rolled back for further refinement.
-- Fix: Site duplication now falls back to subdomain for blogname when the site title is empty, preventing malformed hostnames.
-- Fix: Core wp_blogs and wp_blogmeta tables are now protected from accidental DROP TABLE during site table management.
-- Fix: Admin styles for wu-form modals now load correctly on addon pages.
+- Fix: Billing-period switch scheduling was rolled back to avoid unexpected renewal behaviour.
+- Fix: Site duplication no longer creates malformed hostnames when the site title is empty.
+- Fix: Core multisite tables are protected from accidental deletion, and admin modals load styles correctly on addon pages.
 
 Version [2.6.2] - Released on 2026-04-16
-- Fix: Switching a membership from a longer billing period (e.g. yearly) to a shorter one (e.g. monthly) is now scheduled as a downgrade for the next renewal instead of being blocked with an "active agreement" error.
-- Fix: Encrypted OAuth client secrets are now always regenerated during release builds, so connecting to ultimatemultisite.com no longer fails with "invalid_client / No client id supplied".
-- Fix: Standardised GitHub owner slug to Ultimate-Multisite so badge URLs, installation links, and update checks all resolve correctly.
-- Fix: Network activation error handler now shows the real WP_Error message when WordPress returns an array payload, instead of the generic fallback.
-- Improved: GitHub releases are now published immediately instead of as drafts, so the zip is available right after tagging.
+- Fix: Switching from a longer billing period to a shorter one is handled as a renewal-time downgrade instead of being blocked.
+- Fix: Connecting to ultimatemultisite.com no longer fails with missing OAuth client credentials.
+- Fix: Network activation now shows the real WordPress error message when activation fails.
 
 Version [2.6.1] - Released on 2026-04-15
-- New: Template selection field added to single-step and multi-step checkout form templates.
-- New: Network Activate button in setup wizard for non-network-active plugin installs.
-- New: Atomic increment_item() method on BerlinDB Query class for safe concurrent updates.
-- New: CyberPanel host icon SVG added.
-- Improved: Renamed Cloudflare for SaaS to Cloudflare Custom Hostnames in user-facing strings.
-- Improved: WordPress.org plugin directory listed as recommended installation method.
-- Improved: Better guidance for users who install the wrong ZIP file.
-- Improved: Renamed Composer package from devstone/ to ultimate-multisite/.
-- Improved: Skip plugin autoloader when Bedrock root autoloader has already loaded dependencies.
-- Fix: Default role in Login & Registration settings no longer incorrectly shows Administrator.
-- Fix: Old WP Ultimo logo replaced with dashicons-networking SVG for menu icon.
-- Fix: Network-activate handler moved to external JS file for reliable loading.
-- Fix: Remaining network activation reliability gaps closed.
-- Fix: Redirect integration wizard finish button to integrations settings tab.
-- Fix: Replace missing Tailwind classes with WP button classes on setup wizard complete step.
-- Fix: Write directly to sitemeta for reliable network activation during install.
-- Fix: Autoloader no longer skips WP_Ultimo\Hooks when sunrise pre-loads BerlinDB.
-- Fix: Preserve saved gateway and skip paid gateways on free carts at checkout.
-- Fix: Prevent PWYW pricing type from being reset to free on save.
-- Fix: Remove extra padding-right on number inputs and fix flex group overflow.
-- Fix: Placeholder option falsy comparison corrected with explicit value attribute.
-- Fix: Select list 'checked' attribute corrected to 'selected' for option elements.
-- Fix: Success banner now shows immediately on multisite wizard complete page.
-- Fix: Button type and data-ajax-nonce added to kses allowlist for AJAX buttons.
+- New: Template selection fields were added to single-step and multi-step checkout forms.
+- New: Setup wizard can now network-activate the plugin when needed.
+- Improved: Cloudflare for SaaS was renamed to Cloudflare Custom Hostnames in user-facing screens.
+- Fix: Default role display, menu icon rendering, integration wizard redirects, setup wizard success banner, free-cart gateway handling, PWYW pricing saves, and select field rendering now work correctly.
 
 Version [2.6.0] - Released on 2026-04-13
-- New: CyberPanel hosting integration with domain mapping and auto-SSL.
-- Fix: Redirect loop and 403 error when accessing subsite wp-admin.
-- Fix: PHP 8.1+ TypeError that hides Save button on Domain Mapping settings.
-- Fix: Subdomain slug sanitization in wu_create_site to prevent malformed hostnames.
-- Fix: Missing postmeta for nav_menu_item, attachment, and Elementor posts on site clone.
-- Fix: Elementor Kit postmeta preserved across all URL replacement passes during duplication.
-- Fix: Template switch guard when get_available_site_templates returns false.
-- Fix: Stale is_publishing flag auto-reset to prevent infinite 'Creating' spinner.
-- Fix: PayPal button branding skipped when checkout does not require payment.
-- Fix: AJAX search_models and selectize templates restored after accidental removal.
-- Fix: Default gateway pre-selection removed and dead valid_password validation cleaned up.
-- Fix: mpdf psr-http-message-shim patch updated for v2 interface compatibility.
-- Fix: Activity-stream assets skipped on non-network admin dashboard.
-- Improved: Cloudflare integration loop guard, UI void types, and static analysis fixes.
-- Improved: Checkout pending site creation dual retry path removed for reliability.
+- New: CyberPanel hosting integration now supports domain mapping and auto-SSL.
+- Fix: Subsite wp-admin redirects, Domain Mapping settings, malformed subdomains, cloned menu/attachment/Elementor data, template switching, stuck site creation spinners, PayPal buttons, AJAX searches, and dashboard assets were corrected.
 
 Version [2.5.2] - Released on 2026-04-10
-- Fix: PHP return type declarations removed from base/abstract classes to restore addon compatibility.
-- Improved: SVN deploy reliability in release workflow.
-- Fix: DejaVuSansMono.ttf missing exception when viewing invoices.
-- Fix: Command palette icons missing and console errors on WordPress 7.
-- Fix: Menu icon not rendering on all admin pages (now uses SVG data URI).
-- Improved: GitHub Actions CI upgraded to Node.js 24.
-- Improved: Release workflow now validates WP_Ultimo::VERSION constant.
+- Fix: Addon compatibility was restored for extensions that subclass core Ultimate Multisite classes.
+- Fix: Invoices, command palette icons, and admin menu icons no longer trigger missing asset errors.
 
 Version [2.5.1] - Released on 2026-04-09
-- Fix: Dashboard activity-stream widget CSS not loading on network admin dashboard.
-- Fix: Multi-network site routing failure caused by hard-coded site_id default.
-- Fix: Domain normalization before root-domain comparison in wu_create_site.
-- Fix: Client-side checkout validation no longer flags fields on other steps.
-- Fix: Over-strict validation_rules() rejecting minimal abilities input.
-- Fix: Template selection blocked when product uses default (allow all) mode.
-- Improved: SVN deploy now downloads artifact instead of rebuilding with --no-dev.
-- Improved: Dev files excluded from release archive.
+- Fix: Dashboard activity styles, multi-network routing, domain normalization, checkout validation, ability validation, and default template selection now work correctly.
 
 Version [2.5.0] - Released on 2026-04-06
-- New: Simple checkout form template with auto-generated credentials for streamlined signups.
-- New: PayPal PPCP (PayPal Commerce Platform) integration with full compliance review.
-- New: WordPress Command Palette replaces legacy Jumper navigation.
-- New: Addon management infrastructure with manifest and CI workflow.
-- New: WP REST API standard pagination on all wu/v2 collection endpoints.
-- New: Resubscription flow for cancelled memberships.
-- New: Reactivation flow for cancelled memberships.
-- New: Client-side JavaScript validation on checkout forms.
-- New: Cloudflare Custom Hostnames integration for automatic SSL on mapped domains.
-- New: DNS record management for mapped domains.
-- New: Template Library behind WU_TEMPLATE_LIBRARY_ENABLED feature flag.
-- New: External Cron Service behind WU_EXTERNAL_CRON_ENABLED feature flag.
-- New: Amazon SES transactional email integration.
-- New: WordPress.org SVN deploy in release workflow.
-- New: Downgrade handling in four limit classes.
-- New: WP Performance Action in CI workflow with regression detection.
-- New: Signup flow metrics and post-signup activity tracking.
-- New: Plesk and Laravel Forge hosting integrations.
-- New: Demo product support.
-- New: Comprehensive unit test coverage across 90+ files (admin pages, gateways, models, managers, signup fields, list tables, API schemas).
-- Fix: GlotPress compatibility for cross-domain SSO.
-- Fix: PayPal merchant_id in purchase_units, debug header logging, and merchant status validation.
-- Fix: Safari/iOS autofill not triggering password strength check on checkout.
-- Fix: Pay-what-you-want product pricing bugs.
-- Fix: Coupon removal button and duplicate field ID on checkout form.
-- Fix: Site_Manager::get_collection_params() fatal error.
-- Fix: REST API serialization bugs for Notes, Limitations, and Membership meta.
-- Fix: Currency precision defaults to 2 to prevent wizard failures and NaN prices.
-- Fix: Cookie domain scoped to most specific subdomain for subsite auth.
-- Fix: Stripe deprecated redirectToCheckout replaced with direct URL redirect.
-- Fix: Password reset stays on subsite domain.
-- Fix: Addon pricing now only charges for new products during upgrades.
-- Fix: Widen jetpack-autoloader constraint and fix paragonie/random_compat replace.
-- Fix: PHP 8.2 compatibility improvements.
-- Fix: Numerous admin UI, checkout, and SSO stability improvements.
-- Revert: FrankenPHP integration removed pending further testing.
+- New: Simple checkout, PayPal Commerce Platform, Command Palette navigation, resubscription/reactivation flows, client-side checkout validation, Cloudflare Custom Hostnames, DNS record management, Template Library, External Cron Service, Amazon SES, Plesk, Laravel Forge, and demo products were added.
+- New: Downgrade handling and signup activity tracking were added for membership flows.
+- Fix: Cross-domain SSO, PayPal merchant validation, Safari autofill password checks, PWYW pricing, coupons, currency precision, subsite password resets, addon upgrade pricing, admin UI, checkout, and SSO stability were improved.
 
 Version [2.4.13] - Released on 2026-XX-XX
-- Fix: Selectize dropdowns with more than 1000 options (e.g. TLD lists) were silently truncated due to the library's default maxOptions limit.
-- Fix: Returning to checkout after an abandoned signup no longer charges full price instead of the trial price.
-- Fix: Returning to a checkout URL after a cancelled payment no longer shows an "invalid status" error.
-- Fix: A declined credit card no longer permanently blocks the customer from starting a free trial.
-- Fix: Choosing a site name that is already taken now shows a clear error message instead of silently adding a number to the name.
-- Fix: Customers who cancel during an active trial are no longer incorrectly marked as having used their trial.
-- Fix: If site creation fails during signup, the system can now retry automatically instead of getting stuck on "Creating your site" forever.
-- Fix: Site screenshots are no longer taken before the template has finished copying, which was producing blank images.
-- Fix: Site creation for complex templates no longer times out on servers with strict PHP execution limits.
-- Fix: The "pending payment" popup no longer appears on every login after an abandoned checkout.
-- Fix: Customers with an abandoned checkout can now choose a different plan without being blocked by the old pending payment notice.
-- Fix: The "thank you" page now detects when a site is ready within seconds instead of waiting up to 4 minutes, even with payment gateways that process asynchronously (e.g. Stripe).
-- Fix: The "thank you" page no longer breaks if the network connection drops briefly during site creation polling.
-- Fix: The "thank you" page now works correctly with CDN and page caching plugins that serve stale content after site creation completes.
-- Fix: PHP 8.2 compatibility issue in folder creation that could cause a critical error during the setup wizard.
+- Fix: Large dropdowns no longer truncate options.
+- Fix: Abandoned checkouts, cancelled payments, declined cards, trial reuse, pending payment prompts, and plan changes now recover correctly.
+- Fix: Site name conflicts now show clear errors, failed site creation can retry, complex templates avoid timeout failures, and thank-you page polling is faster and more resilient.
 
 Version [2.4.12] - Released on 2026-02-27
-- New: Send Invoice and Resend Invoice workflows for payments.
-- New: Standalone "Pay Invoice" checkout form for invoice payments without a membership.
-- New: Payment Methods element displaying current card info and change payment method flow via Stripe Billing Portal.
-- New: System events for invoice sent, recurring payment failure, and membership expired with email notifications.
-- New: Checkout form debug autofill button when WP_ULTIMO_DEBUG is enabled.
-- New: Domain meta table for storing metadata on domain records.
-- New: Extensibility hooks on domain mapping widget and domain list table.
-- New: Node Management capability interface for hosting integrations.
-- Fix: Password strength validation no longer blocks checkout when the meter element is absent.
-- Fix: %2F being stripped from SSO redirect URLs breaking some WooCommerce URLs.
-- Fix: Stripe Checkout gateway updated to current API — uses price_data format, proper subscription/payment mode, and skips zero-amount items.
-- Fix: Removed deprecated Stripe API version pin and product type parameter.
-- Fix: Membership cancellation now properly cancels the gateway subscription before the local membership.
-- Fix: Payments no longer require a membership, enabling standalone invoices.
-- Fix: Cart no longer overrides duration for products with independent billing cycles.
-- Fix: Network installer correctly sets core multisite table names.
-- Fix: Admin page save handlers now return proper bool values.
-- Improved: "Change Payment Method" replaces the destructive "Cancel Payment Method" flow.
-- Improved: Integration wizard API key fields use password input type to prevent browser autofill.
-- Improved: Integration wizard shows error state on test failure and improved navigation.
-- Improved: Addon settings grouped under dedicated admin bar submenu.
-- Improved: Select2 multi-select preserves saved option ordering.
-- Improved: PayPal fires payment_failed event on IPN failures.
-- New: Addon compatibility headers (`UM requires at least`) with network admin version mismatch notices.
-- New: `wu_get_checkout_form_by_slug` filter for addon-registered virtual checkout forms.
-- New: Cart filters `wu_cart_show_no_changes_error` and `wu_cart_addon_include_existing_plan` for addon checkout flows.
-- New: `wu-register-domain` added to checkout element slug list for addon checkout pages.
-- Fix: AJAX search_models not passing query parameters to model functions.
-- Fix: Template validation failing when an addon product is selected at checkout.
-- Fix: New subdomain sites created with http:// instead of https:// causing infinite redirects.
-- Fix: mPDF PSR-log aware trait patch applied to wrong file on some Composer versions.
-- Improved: Default minimum password strength lowered from "strong" to "medium" for better usability.
-- Improved: Dashboard first-steps widget shows contextual action labels for completed steps.
+- New: Payment admins can send and resend invoices, and customers can pay standalone invoices without a membership.
+- New: Payment Methods element shows current card details and uses Stripe Billing Portal for payment method changes.
+- New: Invoice sent, recurring payment failure, and membership expired events can send customer emails.
+- Fix: Password strength validation, SSO redirects, Stripe Checkout, membership cancellation, independent billing cycles, network installation, addon checkout validation, subdomain HTTPS redirects, and invoice PDF rendering were corrected.
+- Improved: Payment method changes, integration wizard fields, addon settings, Select2 ordering, PayPal payment failures, password strength defaults, and first-steps widget labels are clearer.
 
 Version [2.4.11] - Released on 2026-02-16
-- New: Settings API for remote settings management.
-- New: Pay-What-You-Want (PWYW) pricing with per-product custom amounts and recurring options.
-- New: Billing-period controls for discount codes and membership creation.
-- New: Better error page for customers and admins.
-- New: Stripe Connect via secure proxy server — platform credentials no longer distributed in plugin code.
-- New: Stripe Checkout Element with automatic billing address handling and removal of application fees.
-- New: Multisite Setup Wizard — guides single-site installs through enabling and configuring WordPress Multisite.
-- New: Modular hosting integration system with encrypted credential storage.
-- New: Form field normalization CSS for consistent checkout and login styling across all themes and page builders.
-- Fix: Password strength setting not being applied during checkout.
-- Fix: Encoded characters stripped from URLs during SSO and domain mapping redirects.
-- Fix: Inline login prompt stability and missing validation for existing emails at checkout.
-- Fix: Site title field error caused by third-party plugin conflicts.
-- Fix: URL replacement failing for Elementor content on subdirectory multisite installs.
-- Fix: Country and state selection issues in checkout.
-- Fix: Duplicate Country/ZIP fields appearing on Stripe checkout.
-- Fix: Invoice PDF download failing with expired nonce.
-- Fix: Settings page crash on PHP 8.4.
-- Fix: Single-site compatibility issues and dashboard widget setup status detection.
-- Fix: Rewrite rules now flushed when signup pages are created or modified.
-- Improved: Admin pages no longer loaded on frontend and cron requests for better performance.
-- Improved: Security hardening for input validation, credential storage, and cart processing.
-- Improved: Expanded automated test coverage across checkout, payments, and admin functionality.
+- New: PWYW pricing, billing-period controls, improved error pages, Stripe Connect, Stripe Checkout Element, Multisite Setup Wizard, hosting integrations, and consistent checkout/login field styling were added.
+- Fix: Checkout password strength, SSO/domain redirects, inline login, site title fields, Elementor URL replacement, country/state selection, Stripe checkout fields, invoice downloads, PHP 8.4 settings crashes, single-site setup, and rewrite rules were corrected.
+- Improved: Frontend performance and security for validation, credential storage, and cart processing were improved.
 
 Version [2.4.10] - Released on 2026-01-23
-- New: Configurable minimum password strength setting with Medium, Strong, and Super Strong options.
-- New: Super Strong password requirements include 12+ characters, uppercase, lowercase, numbers, and special characters - compatible with WPMU DEV Defender Pro rules.
-- New: Real-time password requirement hints during checkout with translatable strings.
-- New: Themed password field styling with visibility toggle and color fallbacks for page builders (Elementor, Kadence, Beaver Builder).
-- New: Opt-in anonymous usage tracking to help improve the plugin.
-- New: Rating reminder notice after 30 days of installation.
-- New: WooCommerce Subscriptions compatibility layer for site duplication.
-- Improved: JSON response handling for pending site creation in non-FastCGI environments.
+- New: Configurable checkout password strength, real-time password hints, password visibility toggle, opt-in usage tracking, rating reminder, and WooCommerce Subscriptions duplication compatibility were added.
+- Improved: Pending site creation responses are more reliable outside FastCGI environments.
 
 Version [2.4.9] - Released on 2025-12-23
-- New: Inline login prompt at checkout for existing users - returning customers can sign in directly without leaving the checkout flow.
-- New: GitHub Actions workflow for PR builds with WordPress Playground testing - enables one-click browser-based testing of pull requests.
-- Fixed: Template switching now preserves images - URLs in post content are correctly updated when switching templates.
-- Fixed: Email manager initialization during setup wizard - system emails are now correctly created.
-- Fixed: Template switching permission and capability checks improved with better error messaging.
-- Fixed: Multiple primary domains being set.
-- Improved: Template selection logic with better null safety and smart fallbacks for pre-selected templates.
-- Improved: Compatibility for legacy filter `wu_create_site_meta` from WP Ultimo v1.
-- Improved: Added support for Runcloud V3 API
+- New: Existing users can log in during checkout without leaving the flow.
+- Improved: Runcloud V3 hosting support was added.
+- Fix: Template switching preserves images, system emails are created during setup, permissions show clearer errors, and only one primary domain is set.
 
 Version [2.4.8] - Released on 2025-11-21
-- New: Added MCP (Model Context Protocol) Server integration.
-- New: Added support for multi-network installations with network-specific customers, memberships, and products.
-- New: Added magic login links for SSO when third-party cookies are disabled.
-- New: Added admin notice when invalid COOKIE_DOMAIN constant is detected.
-- Fixed: WooCommerce subscriptions incorrectly set to staging mode when site is duplicated.
-- Fixed: Single-Sign-On (SSO) authentication issues with custom domains.
-- Fixed: Template switching functionality and improved singleton pattern usage across codebase.
-- Improved: Enhanced domain mapping element and login form handling.
-- Improved: Better redirect handling for sites within the network.
-- Improved: Faster site creation after checkout.
+- New: Multi-network installations can use network-specific customers, memberships, and products.
+- New: Magic login links support SSO when third-party cookies are disabled, and admins are warned about invalid COOKIE_DOMAIN settings.
+- Fix: WooCommerce subscriptions, custom-domain SSO, template switching, domain mapping, login forms, redirects, and site creation speed were improved.
 
 Version [2.4.7] - Released on 2025-10-31
-- Fixed: Conflict with YesCookie plugin.
-- Improved: Thumbnail image quality on template selection in the checkout.
-- Fixed: Redirect from secondary domains to primary domain.
-- Fixed: Choosing templates for checkout form builder.
-- Fixed: Extra domain creation with subdirectory installation.
-- Improved: Allow html in custom domain instructions.
+- Fix: YesCookie plugin conflicts, secondary-domain redirects, checkout form template selection, and extra domain creation on subdirectory installs were resolved.
+- Improved: Template thumbnails are sharper and custom domain instructions can include HTML.
 
 Version [2.4.6] - Released on 2025-10-15
-- Fixed: Toggle switches in RTL languages.
-- Fixed: Rendering admin pages for legacy addons.
-- Fixed: Some Stripe API errors.
-- Improved: Better site URL autogeneration and added preview option.
-- Fixed: Escaping too much HTML.
-- Fixed: Saving HTML in credits field.
-- Improved: Type safety in code.
-- Fixed: Downgrading during a trial extending the trial period.
-
+- Fix: RTL toggles, legacy addon admin pages, Stripe errors, overly escaped HTML, credits HTML saving, and trial downgrade periods were corrected.
+- Improved: Site URL autogeneration now includes a preview.
 
 Version [2.4.5] - Released on 2025-09-30
-- Fixed: Custom domain check when downgrading.
-- Fixed: Bug in Action Scheduler.
-- Fixed: Hosting integration wizard freezing during setup.
-- Improved: More robust handling for login URL obfuscation when 404 template unavailable.
-- Improved: Better error messaging for installer with sanitized HTML display.
-- Added: Recommended plugins installer functionality.
-- Added: New end-to-end testing framework.
-- Added: Option to include a "Powered by..." message in the footer of customer sites.
-- Added: Install recommended "user-switching" plugin during setup wizard.
-- Improved: Autogeneration of site urls and usernames to be more human friendly.
-- Improved: Code style and return type consistency across codebase.
+- Added: Recommended plugin installation, optional "Powered by" footer message, and setup wizard User Switching installation.
+- Fix: Custom domain downgrade checks, scheduled actions, hosting integration wizard freezes, login URL obfuscation, installer errors, and generated site URLs/usernames were improved.
 
 Version [2.4.4] - Released on 2025-09-17
-- Fixed: Saving email templates without stripping html
-- New: Option to allow site owners to edit users on their site
-- Fixed: Invoices not loading when logo is not set
-- Fixed: Verify DNS settings when using a reverse proxy
-- Improved: Lazy load limitations for better performance and compatibility
-- New: Add Admin Notice if sunrise.php is not setup
-- New: Option to not always create www. subdomains with hosting integrations
-- Improved: Plugin renamed to Ultimate Multisite
+- New: Site owners can be allowed to edit users, admins are warned when sunrise.php is missing, and hosting integrations can skip automatic www subdomains.
+- Fix: Email templates, invoices without logos, DNS checks behind reverse proxies, and limitation loading were improved.
+- Improved: Plugin renamed to Ultimate Multisite.
 
 Version [2.4.3] - Released on 2025-08-15
-- Fixed: Bug in Slim SEO plugin
-- New: Addon Marketplace
-- Fixed: Custom logo not showing on emails and invoices
-- Fixed: Limitations failing to load
+- New: Addon Marketplace added.
+- Fix: Slim SEO compatibility, email/invoice logos, and limitation loading were corrected.
 
 Version [2.4.2] - Released on 2025-08-07
-- Fixed: Authentication of the API
-- Fixed: Saving checkout fields
-- Fixed: Creating Products and Sites
-- Fixed: Duplicating sites
-- Improved: Performance of switch_blog
-- Improved: Remove extra queries related update_meta_data hook and 1.X compat
-- New: Addon Marketplace
-- Improved: Update currencies to support all supported by Stripe
-- Improved: Template previewer
+- Fix: API authentication, checkout field saving, product creation, site creation, and site duplication were corrected.
+- Improved: Multisite switching performance, Stripe currency support, and the template previewer were improved.
 
 Version [2.4.1] - Released on 2025-07-17
-- Improved: Update Stripe PHP Library to latest version
-- Improved: Update JS libs
-- Fixed: Fatal error that may occur when upgrading from old name.
-- Improved: Added check for custom domain count when downgrading.
+- Fix: Upgrade fatal errors after the plugin rename were corrected.
+- Improved: Stripe compatibility and custom domain downgrade checks were improved.
 
 Version [2.4.0] - Released on 2025-07-07
-- Improved: Prep Plugin for release on WordPress.org
-- Improved: Update translation text domain
-- Fixed: Escape everything that should be escaped.
-- Fixed: Add nonce checks where needed.
-- Fixed: Sanitize all inputs.
-- Improved: Apply Code style changes across the codebase.
-- Fixed: Many deprecation notices.
-- Improved: Load order of many filters.
-- Improved: Add Proper Build script
-- Improved: Use emojii flags
-- Fixed: i18n deprecation notice for translating too early
-- Improved: Put all scripts in footer and load async
-- Improved: Add discounts to thank you page
-- Improved: Prevent downgrading a plan if the post type would be over the limit
-- Fixed: Styles on thank you page of legacy checkout
+- Fix: Security hardening added escaping, nonce checks, and input sanitization.
+- Fix: Deprecation and translation timing notices were reduced.
+- Improved: Scripts load more efficiently, country flags display as emoji, discounts appear on the thank-you page, and downgrade limits prevent plans from exceeding post type quotas.
+- Fix: Legacy checkout thank-you page styles were corrected.
 
 Version [2.3.4] - Released on 2024-01-31
-- Fixed: Unable to check out with any payment gateway
-- Fixed: Warning Undefined global variable $pagenow
+- Fix: Checkout works with payment gateways again.
+- Fix: A WordPress admin warning for $pagenow was resolved.
 
 Version [2.3.3] - Released on 2024-01-29
-
-- Improved: Plugin renamed to Multisite Ultimate
-- Removed: Enforcement of paid license
-- Fixed: Incompatibilities with WordPress 6.7 and i18n timing
-- Improved: Reduced plugin size by removing many unnecessary files and shrinking images
-
-For the complete changelog history, visit: https://github.com/superdav42/multisite-ultimate/releases
+- Improved: Plugin renamed to Multisite Ultimate.
+- Removed: Paid license enforcement.
+- Fix: WordPress 6.7 and translation timing compatibility were improved.
+- Improved: Plugin package size was reduced.


### PR DESCRIPTION
## Summary

- Trimmed `readme.txt` changelog entries to stay under the WordPress.org 5,000-word limit.
- Combined redundant release notes into concise, user-facing bullets.
- Removed documentation, build, tooling, testing, and development-only changelog items.

## Verification

- `git diff --check origin/main...HEAD`
- Changelog word count: 1,940 words
- Exclusion scan found no documentation/build/tooling/testing/development-only terms
- Pre-commit hook passed: no PHP files; no JS/CSS files

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.82 plugin for [OpenCode](https://opencode.ai) v1.17.7 with gpt-5.5 spent 45m and 169,292 tokens on this with the user in an interactive session.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated release notes with clarifications and refined descriptions across recent versions
  * Added fixes for site provisioning queue tolerance, Divi CSS cache handling, and multisite cron context
  * Revised previous release notes with improved categorization and enhanced wording for clarity

<!-- end of auto-generated comment: release notes by coderabbit.ai -->