### PR TITLE
docs: mark 2.4.13 as unreleased

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -353,7 +353,7 @@ Version [2.5.0] - Released on 2026-04-06
 - New: Downgrade handling and signup activity tracking were added for membership flows.
 - Fix: Cross-domain SSO, PayPal merchant validation, Safari autofill password checks, PWYW pricing, coupons, currency precision, subsite password resets, addon upgrade pricing, admin UI, checkout, and SSO stability were improved.
 
-Version [2.4.13] - Released on 2026-XX-XX
+Version [2.4.13] - Unreleased
 - Fix: Large dropdowns no longer truncate options.
 - Fix: Abandoned checkouts, cancelled payments, declined cards, trial reuse, pending payment prompts, and plan changes now recover correctly.
 - Fix: Site name conflicts now show clear errors, failed site creation can retry, complex templates avoid timeout failures, and thank-you page polling is faster and more resilient.


### PR DESCRIPTION
## Summary

- Marked the `readme.txt` changelog entry for version 2.4.13 as `Unreleased`.
- Removed the malformed `2026-XX-XX` release-date placeholder without guessing a release date.

## Testing

- `python3` assertion verified `readme.txt` no longer contains `2026-XX-XX` and includes `Version [2.4.13] - Unreleased`.

Resolves #1434


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.84 plugin for [OpenCode](https://opencode.ai) v1.17.7 with gpt-5.5 spent 2m and 40,399 tokens on this as a headless worker.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the changelog to mark Version 2.4.13 as unreleased instead of showing a placeholder release date.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->