### PR TITLE
feat: add Iranian Toman currency

### DIFF
--- a/inc/functions/currency.php
+++ b/inc/functions/currency.php
@@ -158,6 +158,7 @@ function wu_get_currencies(): array {
 			'ZAR' => __('South African Rand', 'ultimate-multisite'),
 			'ZMW' => __('Zambian Kwacha', 'ultimate-multisite'),
 			'IRR' => __('Iranian Rial', 'ultimate-multisite'),
+			'IRT' => __('Iranian Toman', 'ultimate-multisite'),
 		]
 	);
 
@@ -196,6 +197,9 @@ function wu_get_currency_symbol($currency = '') {
 		case 'IRR':
 			$currency_symbol = '﷼';
 			break;
+		case 'IRT':
+			$currency_symbol = 'تومان';
+			break;
 		case 'AFN':
 			$currency_symbol = '؋';
 			break;
@@ -210,6 +214,7 @@ function wu_get_currency_symbol($currency = '') {
 			break;
 		case 'BYN':
 			$currency_symbol = 'Br';
+			break;
 		case 'CHF':
 			$currency_symbol = 'CHF';
 			break;
@@ -458,6 +463,7 @@ function wu_is_zero_decimal_currency($currency = 'USD') {
 		'KMF', // Comorian Franc
 		'KRW', // South Korean Won
 		'IRR', // Iranian Rial
+		'IRT', // Iranian Toman
 		'MGA', // Malagasy Ariary
 		'PYG', // Paraguayan Guarani
 		'RWF', // Rwandan Franc

--- a/lang/ultimate-multisite.pot
+++ b/lang/ultimate-multisite.pot
@@ -16353,6 +16353,10 @@ msgstr ""
 msgid "Iranian Rial"
 msgstr ""
 
+#: inc/functions/currency.php:161
+msgid "Iranian Toman"
+msgstr ""
+
 #: inc/functions/customer.php:176
 msgid "The email address is invalid."
 msgstr ""

--- a/tests/WP_Ultimo/Functions/Currency_Functions_Test.php
+++ b/tests/WP_Ultimo/Functions/Currency_Functions_Test.php
@@ -35,6 +35,8 @@ class Currency_Functions_Test extends WP_UnitTestCase {
 		$this->assertArrayHasKey('GBP', $currencies);
 		$this->assertArrayHasKey('BRL', $currencies);
 		$this->assertArrayHasKey('JPY', $currencies);
+		$this->assertArrayHasKey('IRR', $currencies);
+		$this->assertArrayHasKey('IRT', $currencies);
 	}
 
 	/**
@@ -75,6 +77,14 @@ class Currency_Functions_Test extends WP_UnitTestCase {
 	public function test_get_currency_symbol_brl(): void {
 		$symbol = wu_get_currency_symbol('BRL');
 		$this->assertEquals('R$', $symbol);
+	}
+
+	/**
+	 * Test wu_get_currency_symbol returns correct symbols for IRT.
+	 */
+	public function test_get_currency_symbol_irt(): void {
+		$symbol = wu_get_currency_symbol('IRT');
+		$this->assertEquals('تومان', $symbol);
 	}
 
 	/**
@@ -139,6 +149,13 @@ class Currency_Functions_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Test wu_is_zero_decimal_currency returns true for IRT.
+	 */
+	public function test_is_zero_decimal_currency_irt(): void {
+		$this->assertTrue(wu_is_zero_decimal_currency('IRT'));
+	}
+
+	/**
 	 * Test wu_is_zero_decimal_currency returns false for USD.
 	 */
 	public function test_is_zero_decimal_currency_usd(): void {
@@ -173,6 +190,14 @@ class Currency_Functions_Test extends WP_UnitTestCase {
 	 */
 	public function test_stripe_currency_multiplier_krw(): void {
 		$multiplier = wu_stripe_get_currency_multiplier('KRW');
+		$this->assertEquals(1, $multiplier);
+	}
+
+	/**
+	 * Test wu_stripe_get_currency_multiplier returns 1 for IRT.
+	 */
+	public function test_stripe_currency_multiplier_irt(): void {
+		$multiplier = wu_stripe_get_currency_multiplier('IRT');
 		$this->assertEquals(1, $multiplier);
 	}
 


### PR DESCRIPTION
## Summary

- Add `IRT` / Iranian Toman to the core Ultimate Multisite currency list.
- Add the Toman display symbol and treat IRT as zero-decimal like IRR.
- Cover IRT listing, symbol, and multiplier behavior in currency helper tests.
- Fix a missing BYN switch break surfaced by PHPCS while validating the touched helper.

## Testing

- `php -l inc/functions/currency.php`
- `vendor/bin/phpcs inc/functions/currency.php tests/WP_Ultimo/Functions/Currency_Functions_Test.php`

## Notes

- `vendor/bin/phpunit --filter Currency_Functions_Test` is currently blocked in this worktree because `/tmp/wordpress-tests-lib/wp-tests-config.php` is missing.


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.86 plugin for [OpenCode](https://opencode.ai) v1.17.7 with gpt-5.5
