### PR TITLE
fix: prevent admin redirect loop on network domains

### DIFF
--- a/inc/domain-mapping/class-primary-domain.php
+++ b/inc/domain-mapping/class-primary-domain.php
@@ -39,7 +39,7 @@ class Primary_Domain {
 	/**
 	 * Adds mapped domain hosts to the list of allowed redirect hosts.
 	 *
-	 * wp_safe_redirect() validates the redirect target host against this list.
+	 * The wp_safe_redirect() function validates the redirect target host against this list.
 	 * Without this filter, redirects to mapped domains (which differ from the
 	 * network's own host) would be blocked and fall back to wp_admin_url().
 	 *
@@ -179,7 +179,9 @@ class Primary_Domain {
 			return;
 		}
 
-		$current_url = wp_parse_url(wu_get_current_url());
+		$current_full_url = wu_get_current_url();
+
+		$current_url = wp_parse_url($current_full_url);
 
 		$mapped_url = wp_parse_url($mapped_domain->get_url());
 
@@ -190,12 +192,12 @@ class Primary_Domain {
 		$redirect_url = false;
 
 		if ('force_map' === $redirect_settings && $current_url_to_compare !== $mapped_url_to_compare) {
-			$redirect_url = Domain_Mapping::get_instance()->replace_url(wu_get_current_url(), $mapped_domain);
+			$redirect_url = Domain_Mapping::get_instance()->replace_url($current_full_url, $mapped_domain);
 		} elseif ('force_network' === $redirect_settings && $current_url_to_compare === $mapped_url_to_compare) {
-			$redirect_url = wu_restore_original_url(wu_get_current_url(), $site->get_id());
+			$redirect_url = wu_restore_original_url($current_full_url, $site->get_id());
 		}
 
-		if ($redirect_url) {
+		if ($redirect_url && untrailingslashit($redirect_url) !== untrailingslashit($current_full_url)) {
 			/*
 			 * Use the redirect URL directly instead of parsing and rebuilding
 			 * query args with wp_parse_str() + add_query_arg(). That approach

--- a/tests/WP_Ultimo/Domain_Mapping/Primary_Domain_Test.php
+++ b/tests/WP_Ultimo/Domain_Mapping/Primary_Domain_Test.php
@@ -71,6 +71,7 @@ class Primary_Domain_Test extends \WP_UnitTestCase {
 	public function test_allowed_redirect_hosts_filter_registered() {
 
 		$instance = Primary_Domain::get_instance();
+		$instance->init();
 
 		$priority = has_filter(
 			'allowed_redirect_hosts',
@@ -82,6 +83,126 @@ class Primary_Domain_Test extends \WP_UnitTestCase {
 	}
 
 	/**
+	 * Test force_network does not redirect when the primary domain is the site's
+	 * own network subdomain.
+	 */
+	public function test_force_network_skips_redirect_when_primary_domain_is_network_subdomain() {
+
+		$site_domain = 'network-loop-' . uniqid() . '.example.org';
+		$blog_id     = self::factory()->blog->create(
+			[
+				'domain' => $site_domain,
+				'path'   => '/',
+			]
+		);
+
+		$this->assertNotWPError($blog_id);
+
+		$this->create_primary_domain_mapping($blog_id, $site_domain);
+
+		$previous_setting = wu_get_setting('force_admin_redirect', 'both');
+		$previous_server  = $_SERVER;
+		$previous_get     = $_GET; // phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Test restores superglobal state.
+		$previous_request = $_REQUEST; // phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Test restores superglobal state.
+
+		$redirect_filter = static function ($location) {
+			throw new \RuntimeException(esc_url_raw((string) $location));
+		};
+
+		switch_to_blog($blog_id);
+		add_filter('wp_redirect', $redirect_filter);
+
+		try {
+			wu_save_setting('force_admin_redirect', 'force_network');
+
+			$_GET     = [];
+			$_REQUEST = [];
+
+			$_SERVER['REQUEST_METHOD'] = 'GET';
+			$_SERVER['HTTP_HOST']      = $site_domain;
+			$_SERVER['REQUEST_URI']    = '/wp-admin/';
+
+			try {
+				Primary_Domain::get_instance()->maybe_redirect_to_mapped_or_network_domain();
+			} catch (\RuntimeException $exception) {
+				$this->fail('Unexpected redirect to ' . $exception->getMessage());
+			}
+		} finally {
+			remove_filter('wp_redirect', $redirect_filter);
+			restore_current_blog();
+
+			wu_save_setting('force_admin_redirect', $previous_setting);
+
+			$_SERVER  = $previous_server;
+			$_GET     = $previous_get;
+			$_REQUEST = $previous_request;
+		}
+	}
+
+	/**
+	 * Test force_network still redirects custom domains back to the network URL.
+	 */
+	public function test_force_network_redirects_custom_domain_to_network_domain() {
+
+		$site_domain   = 'network-target-' . uniqid() . '.example.org';
+		$custom_domain = 'custom-target-' . uniqid() . '.example.net';
+		$blog_id       = self::factory()->blog->create(
+			[
+				'domain' => $site_domain,
+				'path'   => '/',
+			]
+		);
+
+		$this->assertNotWPError($blog_id);
+
+		$this->create_primary_domain_mapping($blog_id, $custom_domain);
+
+		$previous_setting = wu_get_setting('force_admin_redirect', 'both');
+		$previous_server  = $_SERVER;
+		$previous_get     = $_GET; // phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Test restores superglobal state.
+		$previous_request = $_REQUEST; // phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Test restores superglobal state.
+
+		$redirect_filter = static function ($location) {
+			throw new \RuntimeException(esc_url_raw((string) $location));
+		};
+
+		switch_to_blog($blog_id);
+		add_filter('wp_redirect', $redirect_filter);
+
+		try {
+			wu_save_setting('force_admin_redirect', 'force_network');
+
+			$_GET     = [];
+			$_REQUEST = [];
+
+			$_SERVER['REQUEST_METHOD'] = 'GET';
+			$_SERVER['HTTP_HOST']      = $custom_domain;
+			$_SERVER['REQUEST_URI']    = '/wp-admin/edit.php?post_type=page';
+
+			try {
+				Primary_Domain::get_instance()->maybe_redirect_to_mapped_or_network_domain();
+
+				$this->fail('Expected a redirect back to the network domain.');
+			} catch (\RuntimeException $exception) {
+				$redirect_url = $exception->getMessage();
+
+				$this->assertSame($site_domain, wp_parse_url($redirect_url, PHP_URL_HOST));
+				$this->assertSame('/wp-admin/edit.php', wp_parse_url($redirect_url, PHP_URL_PATH));
+				$this->assertSame('post_type=page', wp_parse_url($redirect_url, PHP_URL_QUERY));
+			}
+		} finally {
+			remove_filter('wp_redirect', $redirect_filter);
+			restore_current_blog();
+
+			wu_save_setting('force_admin_redirect', $previous_setting);
+
+			$_SERVER  = $previous_server;
+			$_GET     = $previous_get;
+			$_REQUEST = $previous_request;
+		}
+	}
+
+	/**
 	 * Test that wp_safe_redirect is used (no phpcs:ignore suppression present).
 	 *
 	 * This is a static analysis guard: if someone reverts to wp_redirect with a
@@ -89,7 +210,7 @@ class Primary_Domain_Test extends \WP_UnitTestCase {
 	 */
 	public function test_no_wp_redirect_phpcs_ignore_in_source() {
 
-		$source = file_get_contents(
+		$source = file_get_contents( // phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents -- Reading a local source file in a test.
 			dirname(__DIR__, 3) . '/inc/domain-mapping/class-primary-domain.php'
 		);
 
@@ -111,7 +232,7 @@ class Primary_Domain_Test extends \WP_UnitTestCase {
 	 */
 	public function test_wp_safe_redirect_used_in_source() {
 
-		$source = file_get_contents(
+		$source = file_get_contents( // phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents -- Reading a local source file in a test.
 			dirname(__DIR__, 3) . '/inc/domain-mapping/class-primary-domain.php'
 		);
 
@@ -120,5 +241,43 @@ class Primary_Domain_Test extends \WP_UnitTestCase {
 			$source,
 			'class-primary-domain.php must use wp_safe_redirect().'
 		);
+	}
+
+	/**
+	 * Creates or updates a primary domain mapping for a test site.
+	 *
+	 * @param int    $blog_id Blog ID.
+	 * @param string $domain Domain name.
+	 * @return \WP_Ultimo\Models\Domain
+	 */
+	private function create_primary_domain_mapping($blog_id, $domain) {
+
+		$mapping = wu_get_domain_by_domain($domain);
+
+		if ( ! $mapping) {
+			$mapping = wu_create_domain(
+				[
+					'blog_id'        => $blog_id,
+					'domain'         => $domain,
+					'active'         => true,
+					'primary_domain' => true,
+					'secure'         => false,
+					'stage'          => \WP_Ultimo\Database\Domains\Domain_Stage::DONE,
+				]
+			);
+		} else {
+			$mapping->set_blog_id($blog_id);
+			$mapping->set_active(true);
+			$mapping->set_primary_domain(true);
+			$mapping->set_secure(false);
+			$mapping->set_stage(\WP_Ultimo\Database\Domains\Domain_Stage::DONE);
+
+			$mapping->save();
+		}
+
+		$this->assertNotWPError($mapping);
+		$this->assertInstanceOf(\WP_Ultimo\Models\Domain::class, $mapping);
+
+		return $mapping;
 	}
 }


### PR DESCRIPTION
## Summary

- Prevent `force_network` admin redirects from sending users to the same URL when the site's primary domain object is its own network subdomain.
- Reuse the captured current URL while building admin redirect targets.
- Add regression coverage for the network-subdomain no-op case and the custom-domain redirect case.

## Testing

- `vendor/bin/phpunit --no-coverage --filter Primary_Domain_Test`
- `vendor/bin/phpcs inc/domain-mapping/class-primary-domain.php tests/WP_Ultimo/Domain_Mapping/Primary_Domain_Test.php`
- `vendor/bin/phpstan analyse inc/domain-mapping/class-primary-domain.php tests/WP_Ultimo/Domain_Mapping/Primary_Domain_Test.php`

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.86 plugin for [OpenCode](https://opencode.ai) v1.17.7 with gpt-5.5


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated domain redirect validation documentation to clarify compatibility requirements.

* **Tests**
  * Added test coverage for domain mapping redirect behavior in different configuration scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->