### PR TITLE
fix: preserve force network redirects for mapped domains

### DIFF
--- a/inc/domain-mapping/class-primary-domain.php
+++ b/inc/domain-mapping/class-primary-domain.php
@@ -64,7 +64,17 @@ class Primary_Domain {
 			$hosts[] = $domain->get_domain();
 		}
 
-		return $hosts;
+		$site = get_site(get_current_blog_id());
+
+		if ($site && ! empty($site->domain)) {
+			$site_host = wp_parse_url('http://' . $site->domain, PHP_URL_HOST);
+
+			if ($site_host) {
+				$hosts[] = $site_host;
+			}
+		}
+
+		return array_unique($hosts);
 	}
 
 	/**

--- a/inc/functions/domain.php
+++ b/inc/functions/domain.php
@@ -106,11 +106,11 @@ function wu_restore_original_url($url, $blog_id) {
 	$site = wu_get_site($blog_id);
 
 	if ($site) {
-		$original_site_url = $site->get_site_url();
+		$wp_site = get_site($blog_id);
 
 		$mapped_domain_url = $site->get_active_site_url();
 
-		$original_domain = trim(preg_replace('#^https?://#', '', $original_site_url), '/');
+		$original_domain = $wp_site ? trim($wp_site->domain . $wp_site->path, '/') : trim(preg_replace('#^https?://#', '', $site->get_site_url()), '/');
 
 		$mapped_domain = wp_parse_url($mapped_domain_url, PHP_URL_HOST);
 

--- a/tests/WP_Ultimo/Domain_Mapping/Primary_Domain_Test.php
+++ b/tests/WP_Ultimo/Domain_Mapping/Primary_Domain_Test.php
@@ -155,18 +155,26 @@ class Primary_Domain_Test extends \WP_UnitTestCase {
 
 		$this->assertNotWPError($blog_id);
 
-		$this->create_primary_domain_mapping($blog_id, $custom_domain);
+		$mapping = $this->create_primary_domain_mapping($blog_id, $custom_domain);
 
 		$previous_setting = wu_get_setting('force_admin_redirect', 'both');
 		$previous_server  = $_SERVER;
 		$previous_get     = $_GET; // phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Test restores superglobal state.
 		$previous_request = $_REQUEST; // phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Test restores superglobal state.
 
+		$domain_mapping           = \WP_Ultimo\Domain_Mapping::get_instance();
+		$previous_current_mapping = $domain_mapping->current_mapping;
+
 		$redirect_filter = static function ($location) {
 			throw new \RuntimeException(esc_url_raw((string) $location));
 		};
 
 		switch_to_blog($blog_id);
+
+		$domain_mapping->current_mapping = $mapping;
+
+		add_filter('home_url', [$domain_mapping, 'mangle_url'], -10, 4);
+		add_filter('site_url', [$domain_mapping, 'mangle_url'], -10, 4);
 		add_filter('wp_redirect', $redirect_filter);
 
 		try {
@@ -192,6 +200,11 @@ class Primary_Domain_Test extends \WP_UnitTestCase {
 			}
 		} finally {
 			remove_filter('wp_redirect', $redirect_filter);
+			remove_filter('site_url', [$domain_mapping, 'mangle_url'], -10);
+			remove_filter('home_url', [$domain_mapping, 'mangle_url'], -10);
+
+			$domain_mapping->current_mapping = $previous_current_mapping;
+
 			restore_current_blog();
 
 			wu_save_setting('force_admin_redirect', $previous_setting);


### PR DESCRIPTION
## Summary

- Restore `force_network` redirects from custom/mapped domain admin URLs after PR #1450 was merged.
- Derive the original network URL from unfiltered `WP_Site` domain/path so domain-mapping URL filters cannot turn the target back into the mapped domain.
- Add the original network host to allowed redirect hosts and extend regression coverage to simulate active mapped-domain filters.

## Testing

- `vendor/bin/phpunit --no-coverage --filter Primary_Domain_Test`
- `vendor/bin/phpcs inc/domain-mapping/class-primary-domain.php inc/functions/domain.php tests/WP_Ultimo/Domain_Mapping/Primary_Domain_Test.php`
- `vendor/bin/phpstan analyse inc/domain-mapping/class-primary-domain.php inc/functions/domain.php tests/WP_Ultimo/Domain_Mapping/Primary_Domain_Test.php`

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.88 plugin for [OpenCode](https://opencode.ai) v1.17.7 with gpt-5.5


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced domain redirect handling to include the primary site domain in allowed redirect hosts alongside mapped domains.
  * Improved URL restoration logic for mapped domain scenarios with better fallback behavior.

* **Tests**
  * Updated domain mapping tests to verify redirect behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->