### PR TITLE
fix: use yoda-safe redirect host checks

### DIFF
--- a/inc/domain-mapping/class-primary-domain.php
+++ b/inc/domain-mapping/class-primary-domain.php
@@ -66,10 +66,10 @@ class Primary_Domain {
 
 		$site = get_site(get_current_blog_id());
 
-		if ($site && ! empty($site->domain)) {
+		if ($site instanceof \WP_Site && '' !== $site->domain) {
 			$site_host = wp_parse_url('http://' . $site->domain, PHP_URL_HOST);
 
-			if ($site_host) {
+			if (is_string($site_host) && '' !== $site_host) {
 				$hosts[] = $site_host;
 			}
 		}


### PR DESCRIPTION
## Summary

- Updated the primary-domain redirect host guard to use explicit `WP_Site` and string checks.
- Replaced truthy redirect-host checks with Yoda-safe comparisons for the follow-up review finding.

Resolves #1453

## Testing

- `vendor/bin/phpcs inc/domain-mapping/class-primary-domain.php`
- Pre-commit hook ran PHPCS and PHPStan on `inc/domain-mapping/class-primary-domain.php`

MERGE_SUMMARY: Updated `inc/domain-mapping/class-primary-domain.php` so the site-domain branch uses an explicit `WP_Site` check and Yoda-safe string comparisons, satisfying the review follow-up while preserving redirect host behavior.

<!-- aidevops:sig -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Strengthened validation logic for domain redirect handling with explicit type checking and stricter value requirements to improve robustness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->