### PR TITLE
fix: guard multiple accounts user column output

### DIFF
--- a/inc/compat/class-multiple-accounts-compat.php
+++ b/inc/compat/class-multiple-accounts-compat.php
@@ -316,6 +316,8 @@ class Multiple_Accounts_Compat {
 	 */
 	public function add_column_content($output, $column, $user_id): string {
 
+		$output = (string) $output;
+
 		if ('multiple_accounts' === $column) {
 
 			// Get user email
@@ -334,6 +336,7 @@ class Multiple_Accounts_Compat {
 			$output .= sprintf(esc_html__('%s accounts using this email.', 'ultimate-multisite'), '<strong>' . esc_html($users->total_users) . '</strong>');
 			$output .= sprintf("<br><a href='%s' class=''>" . esc_html__('See all', 'ultimate-multisite') . ' &raquo;</a>', esc_attr(network_admin_url('users.php?s=' . $user->user_email)));
 		}
+
 		return $output;
 	}
 

--- a/tests/WP_Ultimo/Multiple_Accounts_Compat_Test.php
+++ b/tests/WP_Ultimo/Multiple_Accounts_Compat_Test.php
@@ -1,0 +1,39 @@
+<?php
+/**
+ * Tests for the Multiple_Accounts_Compat class.
+ *
+ * @package WP_Ultimo
+ * @subpackage Tests
+ */
+
+namespace WP_Ultimo\Compat;
+
+defined('ABSPATH') || exit;
+
+use WP_UnitTestCase;
+
+/**
+ * Test multiple accounts compatibility fixes.
+ */
+class Multiple_Accounts_Compat_Test extends WP_UnitTestCase {
+
+	/**
+	 * Test unrelated user columns tolerate null output from earlier filters.
+	 */
+	public function test_add_column_content_returns_empty_string_for_null_unrelated_column(): void {
+
+		$output = Multiple_Accounts_Compat::get_instance()->add_column_content(null, 'bbp_user_role', 123);
+
+		$this->assertSame('', $output);
+	}
+
+	/**
+	 * Test unrelated user columns preserve existing output from earlier filters.
+	 */
+	public function test_add_column_content_preserves_unrelated_column_output(): void {
+
+		$output = Multiple_Accounts_Compat::get_instance()->add_column_content('Subscriber', 'role', 123);
+
+		$this->assertSame('Subscriber', $output);
+	}
+}


### PR DESCRIPTION
## Summary

- Cast the Multiple Accounts users-column filter output to a string before returning it.
- Preserve existing output for unrelated user columns while tolerating null values from earlier filters.
- Add regression coverage for the null unrelated-column path reported with `bbp_user_role`.

## Verification

- `php -l inc/compat/class-multiple-accounts-compat.php`
- `php -l tests/WP_Ultimo/Multiple_Accounts_Compat_Test.php`
- `vendor/bin/phpcs inc/compat/class-multiple-accounts-compat.php tests/WP_Ultimo/Multiple_Accounts_Compat_Test.php`
- `vendor/bin/phpunit --filter Multiple_Accounts_Compat_Test`

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.88 plugin for [OpenCode](https://opencode.ai) v1.17.7 with gpt-5.5


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test coverage for multiple accounts compatibility functionality, verifying proper handling of column content when values are null or populated.

* **Refactor**
  * Improved code reliability through enhanced type handling and formatting adjustments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->