### PR TITLE
Fix #1459: qualify multiple accounts compat test class

### DIFF
--- a/tests/WP_Ultimo/Multiple_Accounts_Compat_Test.php
+++ b/tests/WP_Ultimo/Multiple_Accounts_Compat_Test.php
@@ -22,7 +22,7 @@ class Multiple_Accounts_Compat_Test extends WP_UnitTestCase {
 	 */
 	public function test_add_column_content_returns_empty_string_for_null_unrelated_column(): void {
 
-		$output = Multiple_Accounts_Compat::get_instance()->add_column_content(null, 'bbp_user_role', 123);
+		$output = \WP_Ultimo\Compat\Multiple_Accounts_Compat::get_instance()->add_column_content(null, 'bbp_user_role', 123);
 
 		$this->assertSame('', $output);
 	}
@@ -32,7 +32,7 @@ class Multiple_Accounts_Compat_Test extends WP_UnitTestCase {
 	 */
 	public function test_add_column_content_preserves_unrelated_column_output(): void {
 
-		$output = Multiple_Accounts_Compat::get_instance()->add_column_content('Subscriber', 'role', 123);
+		$output = \WP_Ultimo\Compat\Multiple_Accounts_Compat::get_instance()->add_column_content('Subscriber', 'role', 123);
 
 		$this->assertSame('Subscriber', $output);
 	}


### PR DESCRIPTION
## Summary

- Qualifies `Multiple_Accounts_Compat` references in `tests/WP_Ultimo/Multiple_Accounts_Compat_Test.php` with the full `WP_Ultimo\Compat` namespace.
- Keeps the test namespace aligned with the source namespace while making class resolution explicit.

## Testing

- `vendor/bin/phpcs tests/WP_Ultimo/Multiple_Accounts_Compat_Test.php`
- `WP_TESTS_DIR=/tmp/wordpress-tests-lib vendor/bin/phpunit --filter Multiple_Accounts_Compat_Test`

Resolves #1459

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.88 plugin for [OpenCode](https://opencode.ai) v1.17.7 with gpt-5.5


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test code references for improved internal consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->