### PR TITLE
GH#1464: fix: escape broadcast product chip output

### DIFF
--- a/inc/list-tables/class-broadcast-list-table.php
+++ b/inc/list-tables/class-broadcast-list-table.php
@@ -182,13 +182,20 @@ class Broadcast_List_Table extends Base_List_Table {
 
 				$email = $customer->get_email_address();
 
-				$html = "<a href='" . esc_url($customer_link) . "' class='wu-p-2 wu-flex wu-flex-grow wu-bg-gray-100 wu-rounded wu-items-center wu-border wu-border-solid wu-border-gray-300'>
-										{$avatar}
-										<div class='wu-pl-2'>
-												<strong class='wu-block'>" . esc_html($display_name) . " <small class='wu-font-normal'>(#" . esc_html((string) $id) . ")</small></strong>
-												<small>" . esc_html($email) . "</small>
-										</div>
-								</a>";
+				$html = sprintf(
+					'<a href="%s" class="wu-p-2 wu-flex wu-flex-grow wu-bg-gray-100 wu-rounded wu-items-center wu-border wu-border-solid wu-border-gray-300">
+						%s
+						<div class="wu-pl-2">
+							<strong class="wu-block">%s <small class="wu-font-normal">(#%s)</small></strong>
+							<small>%s</small>
+						</div>
+					</a>',
+					esc_url($customer_link),
+					$avatar,
+					esc_html($display_name),
+					esc_html((string) $id),
+					esc_html($email)
+				);
 
 				return $html;
 			default:
@@ -328,13 +335,20 @@ class Broadcast_List_Table extends Base_List_Table {
 
 				$product_link = wu_network_admin_url('wp-ultimo-edit-product', $url_atts);
 
-				$html = "<a href='{$product_link}' class='wu-p-2 wu-flex wu-flex-grow wu-bg-gray-100 wu-rounded wu-items-center wu-border wu-border-solid wu-border-gray-300'>
-						{$image}
-						<div class='wu-pl-2'>
-								<strong class='wu-block'>{$name} <small class='wu-font-normal'>(#{$id})</small></strong>
-								<small>{$description}</small>
+				$html = sprintf(
+					'<a href="%s" class="wu-p-2 wu-flex wu-flex-grow wu-bg-gray-100 wu-rounded wu-items-center wu-border wu-border-solid wu-border-gray-300">
+						%s
+						<div class="wu-pl-2">
+							<strong class="wu-block">%s <small class="wu-font-normal">(#%s)</small></strong>
+							<small>%s</small>
 						</div>
-				</a>";
+					</a>',
+					esc_url($product_link),
+					$image,
+					esc_html($name),
+					esc_html((string) $id),
+					esc_html($description)
+				);
 				break;
 		}
 


### PR DESCRIPTION
## Summary

Escaped the Broadcast list table single customer/product chip URLs and dynamic labels using esc_url()/esc_html() with sprintf-rendered markup.

## Files Changed

inc/list-tables/class-broadcast-list-table.php

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** php -l inc/list-tables/class-broadcast-list-table.php (pass); vendor/bin/phpcs inc/list-tables/class-broadcast-list-table.php (pass)

Resolves #1464


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.88 plugin for [OpenCode](https://opencode.ai) v1.17.7 with gpt-5.5 spent 2m and 45,217 tokens on this as a headless worker.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Improved security measures for broadcast list table display, ensuring proper handling of user-generated content in customer and product listings.

---

*No user-facing functionality changes in this release.*

<!-- end of auto-generated comment: release notes by coderabbit.ai -->