### PR TITLE
fix: allow guzzle promises 2.5 with php-dns

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,6 +24,70 @@
     },
     "repositories": [
         {
+            "type": "package",
+            "package": {
+                "name": "remotelyliving/php-dns",
+                "version": "4.3.0",
+                "source": {
+                    "type": "git",
+                    "url": "https://github.com/remotelyliving/php-dns.git",
+                    "reference": "fa1eebebe6275487e947cd2109874ce960dd7717"
+                },
+                "dist": {
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/remotelyliving/php-dns/zipball/fa1eebebe6275487e947cd2109874ce960dd7717",
+                    "reference": "fa1eebebe6275487e947cd2109874ce960dd7717",
+                    "shasum": ""
+                },
+                "require": {
+                    "ext-filter": "*",
+                    "ext-intl": "*",
+                    "ext-json": "*",
+                    "ext-mbstring": "*",
+                    "guzzlehttp/guzzle": "^7.0 || ^6.0",
+                    "guzzlehttp/promises": "^1.3 || ^2.5",
+                    "php": ">=7.4",
+                    "psr/cache": "^1.0 || ^2.0",
+                    "psr/log": "^1.0 || ^2.0 || ^3.0",
+                    "spatie/dns": "^1.5",
+                    "symfony/event-dispatcher": "^6.0 || ^5.0 || ^4.0 || ^3.0"
+                },
+                "require-dev": {
+                    "bmitch/churn-php": "^1.5",
+                    "maglnet/composer-require-checker": "@stable",
+                    "php-coveralls/php-coveralls": "^2.1",
+                    "phpunit/phpunit": "^9.0",
+                    "psy/psysh": "^0.9.9",
+                    "rector/rector": "^0.12.8",
+                    "squizlabs/php_codesniffer": "^3.3",
+                    "symfony/cache": "^4.3",
+                    "vimeo/psalm": "^4.10"
+                },
+                "type": "library",
+                "autoload": {
+                    "psr-4": {
+                        "RemotelyLiving\\PHPDNS\\": "src/"
+                    }
+                },
+                "notification-url": "https://packagist.org/downloads/",
+                "license": [
+                    "MIT"
+                ],
+                "authors": [
+                    {
+                        "name": "chthomas",
+                        "email": "christian.h.thomas@me.com"
+                    }
+                ],
+                "description": "A php library for abstracting DNS querying",
+                "support": {
+                    "issues": "https://github.com/remotelyliving/php-dns/issues",
+                    "source": "https://github.com/remotelyliving/php-dns/tree/4.3.0"
+                },
+                "time": "2021-12-22T02:56:43+00:00"
+            }
+        },
+        {
             "type": "path",
             "url": "composer-plugins/wp-ultimo-autoloader-plugin"
         }

--- a/composer.json
+++ b/composer.json
@@ -115,7 +115,7 @@
         "rakit/validation": "dev-master#ff003a35cdf5030a5f2482299f4c93f344a35b29",
         "ifsnop/mysqldump-php": "^2.12",
         "mpdf/mpdf": "^8.2.0",
-        "remotelyliving/php-dns": "^4.3.0",
+        "remotelyliving/php-dns": "4.3.0",
         "nyholm/psr7": "^1.8.0",
         "scssphp/scssphp": "^1.11.1",
         "cweagans/composer-patches": "^1.7",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "25f64335dc20fe4a18af3f77340bf469",
+    "content-hash": "e52eff354e3dca1ea3cc05a2a14fd2fe",
     "packages": [
         {
             "name": "amphp/amp",
@@ -1266,25 +1266,26 @@
         },
         {
             "name": "guzzlehttp/guzzle",
-            "version": "7.9.3",
+            "version": "7.12.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/guzzle.git",
-                "reference": "7b2f29fe81dc4da0ca0ea7d42107a0845946ea77"
+                "reference": "d34627490fbc03bf5c5d7cfed81f2faa19519425"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/7b2f29fe81dc4da0ca0ea7d42107a0845946ea77",
-                "reference": "7b2f29fe81dc4da0ca0ea7d42107a0845946ea77",
+                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/d34627490fbc03bf5c5d7cfed81f2faa19519425",
+                "reference": "d34627490fbc03bf5c5d7cfed81f2faa19519425",
                 "shasum": ""
             },
             "require": {
                 "ext-json": "*",
-                "guzzlehttp/promises": "^1.5.3 || ^2.0.3",
-                "guzzlehttp/psr7": "^2.7.0",
+                "guzzlehttp/promises": "^2.5",
+                "guzzlehttp/psr7": "^2.12.1",
                 "php": "^7.2.5 || ^8.0",
                 "psr/http-client": "^1.0",
-                "symfony/deprecation-contracts": "^2.2 || ^3.0"
+                "symfony/deprecation-contracts": "^2.5 || ^3.0",
+                "symfony/polyfill-php80": "^1.24"
             },
             "provide": {
                 "psr/http-client-implementation": "1.0"
@@ -1293,8 +1294,9 @@
                 "bamarni/composer-bin-plugin": "^1.8.2",
                 "ext-curl": "*",
                 "guzzle/client-integration-tests": "3.0.2",
+                "guzzlehttp/test-server": "^0.5.1",
                 "php-http/message-factory": "^1.1",
-                "phpunit/phpunit": "^8.5.39 || ^9.6.20",
+                "phpunit/phpunit": "^8.5.52 || ^9.6.34",
                 "psr/log": "^1.1 || ^2.0 || ^3.0"
             },
             "suggest": {
@@ -1372,7 +1374,7 @@
             ],
             "support": {
                 "issues": "https://github.com/guzzle/guzzle/issues",
-                "source": "https://github.com/guzzle/guzzle/tree/7.9.3"
+                "source": "https://github.com/guzzle/guzzle/tree/7.12.1"
             },
             "funding": [
                 {
@@ -1388,33 +1390,38 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-03-27T13:37:11+00:00"
+            "time": "2026-06-18T14:12:49+00:00"
         },
         {
             "name": "guzzlehttp/promises",
-            "version": "1.5.3",
+            "version": "2.5.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/promises.git",
-                "reference": "67ab6e18aaa14d753cc148911d273f6e6cb6721e"
+                "reference": "4360e982f87f5f258bf872d094647791db2f4c8e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/promises/zipball/67ab6e18aaa14d753cc148911d273f6e6cb6721e",
-                "reference": "67ab6e18aaa14d753cc148911d273f6e6cb6721e",
+                "url": "https://api.github.com/repos/guzzle/promises/zipball/4360e982f87f5f258bf872d094647791db2f4c8e",
+                "reference": "4360e982f87f5f258bf872d094647791db2f4c8e",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.5"
+                "php": "^7.2.5 || ^8.0",
+                "symfony/deprecation-contracts": "^2.5 || ^3.0"
             },
             "require-dev": {
-                "symfony/phpunit-bridge": "^4.4 || ^5.1"
+                "bamarni/composer-bin-plugin": "^1.8.2",
+                "phpunit/phpunit": "^8.5.52 || ^9.6.34"
             },
             "type": "library",
+            "extra": {
+                "bamarni-bin": {
+                    "bin-links": true,
+                    "forward-command": false
+                }
+            },
             "autoload": {
-                "files": [
-                    "src/functions_include.php"
-                ],
                 "psr-4": {
                     "GuzzleHttp\\Promise\\": "src/"
                 }
@@ -1451,7 +1458,7 @@
             ],
             "support": {
                 "issues": "https://github.com/guzzle/promises/issues",
-                "source": "https://github.com/guzzle/promises/tree/1.5.3"
+                "source": "https://github.com/guzzle/promises/tree/2.5.0"
             },
             "funding": [
                 {
@@ -1467,27 +1474,29 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-05-21T12:31:43+00:00"
+            "time": "2026-06-02T12:23:43+00:00"
         },
         {
             "name": "guzzlehttp/psr7",
-            "version": "2.9.0",
+            "version": "2.12.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/psr7.git",
-                "reference": "7d0ed42f28e42d61352a7a79de682e5e67fec884"
+                "reference": "172ef2f4e9824c1e058b7f30be8ae25a02c0f2b7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/psr7/zipball/7d0ed42f28e42d61352a7a79de682e5e67fec884",
-                "reference": "7d0ed42f28e42d61352a7a79de682e5e67fec884",
+                "url": "https://api.github.com/repos/guzzle/psr7/zipball/172ef2f4e9824c1e058b7f30be8ae25a02c0f2b7",
+                "reference": "172ef2f4e9824c1e058b7f30be8ae25a02c0f2b7",
                 "shasum": ""
             },
             "require": {
                 "php": "^7.2.5 || ^8.0",
                 "psr/http-factory": "^1.0",
                 "psr/http-message": "^1.1 || ^2.0",
-                "ralouphie/getallheaders": "^3.0"
+                "ralouphie/getallheaders": "^3.0",
+                "symfony/deprecation-contracts": "^2.5 || ^3.0",
+                "symfony/polyfill-php80": "^1.24"
             },
             "provide": {
                 "psr/http-factory-implementation": "1.0",
@@ -1495,9 +1504,9 @@
             },
             "require-dev": {
                 "bamarni/composer-bin-plugin": "^1.8.2",
-                "http-interop/http-factory-tests": "0.9.0",
+                "http-interop/http-factory-tests": "1.1.0",
                 "jshttp/mime-db": "1.54.0.1",
-                "phpunit/phpunit": "^8.5.44 || ^9.6.25"
+                "phpunit/phpunit": "^8.5.52 || ^9.6.34"
             },
             "suggest": {
                 "laminas/laminas-httphandlerrunner": "Emit PSR-7 responses"
@@ -1568,7 +1577,7 @@
             ],
             "support": {
                 "issues": "https://github.com/guzzle/psr7/issues",
-                "source": "https://github.com/guzzle/psr7/tree/2.9.0"
+                "source": "https://github.com/guzzle/psr7/tree/2.12.1"
             },
             "funding": [
                 {
@@ -1584,7 +1593,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-03-10T16:41:02+00:00"
+            "time": "2026-06-18T09:49:37+00:00"
         },
         {
             "name": "ifsnop/mysqldump-php",
@@ -3062,7 +3071,7 @@
                 "ext-json": "*",
                 "ext-mbstring": "*",
                 "guzzlehttp/guzzle": "^7.0 || ^6.0",
-                "guzzlehttp/promises": "^1.3",
+                "guzzlehttp/promises": "^1.3 || ^2.5",
                 "php": ">=7.4",
                 "psr/cache": "^1.0 || ^2.0",
                 "psr/log": "^1.0 || ^2.0 || ^3.0",
@@ -3234,16 +3243,16 @@
         },
         {
             "name": "setasign/fpdi",
-            "version": "v2.6.6",
+            "version": "v2.6.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Setasign/FPDI.git",
-                "reference": "de0cf35911be3e9ea63b48e0f307883b1c7c48ac"
+                "reference": "881945be29a4996ad3d008eb18ddc01fa3df890c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Setasign/FPDI/zipball/de0cf35911be3e9ea63b48e0f307883b1c7c48ac",
-                "reference": "de0cf35911be3e9ea63b48e0f307883b1c7c48ac",
+                "url": "https://api.github.com/repos/Setasign/FPDI/zipball/881945be29a4996ad3d008eb18ddc01fa3df890c",
+                "reference": "881945be29a4996ad3d008eb18ddc01fa3df890c",
                 "shasum": ""
             },
             "require": {
@@ -3255,7 +3264,7 @@
             },
             "require-dev": {
                 "phpunit/phpunit": "^8.5.52",
-                "setasign/fpdf": "~1.8.6",
+                "setasign/fpdf": "^1.9.0",
                 "setasign/tfpdf": "~1.33",
                 "squizlabs/php_codesniffer": "^3.5",
                 "tecnickcom/tcpdf": "^6.8"
@@ -3294,7 +3303,7 @@
             ],
             "support": {
                 "issues": "https://github.com/Setasign/FPDI/issues",
-                "source": "https://github.com/Setasign/FPDI/tree/v2.6.6"
+                "source": "https://github.com/Setasign/FPDI/tree/v2.6.8"
             },
             "funding": [
                 {
@@ -3302,7 +3311,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-03-13T08:38:20+00:00"
+            "time": "2026-06-11T10:37:24+00:00"
         },
         {
             "name": "spatie/dns",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "e52eff354e3dca1ea3cc05a2a14fd2fe",
+    "content-hash": "a7c66a4c175ca451efc114556a00cf44",
     "packages": [
         {
             "name": "amphp/amp",


### PR DESCRIPTION
## Summary

- Adds a Composer package override for `remotelyliving/php-dns` 4.3.0 using the same upstream source/dist reference, widening only its `guzzlehttp/promises` requirement to `^1.3 || ^2.5`.
- Updates the lockfile to resolve `guzzlehttp/promises` 2.5.0.
- Applies targeted lockfile updates for `guzzlehttp/guzzle`, `guzzlehttp/psr7`, and `setasign/fpdi` so Composer audit has no active vulnerability advisories after the dependency change.

## Verification

- `composer update remotelyliving/php-dns guzzlehttp/promises guzzlehttp/guzzle guzzlehttp/psr7 setasign/fpdi --no-interaction`
- `composer prohibits guzzlehttp/promises 2.5.0 --locked`
- `composer audit --no-interaction --abandoned=report`
- `composer validate --no-interaction`
- `git diff --check -- composer.json composer.lock`

## Notes

- PHPUnit is intentionally not claimed here; it will be run after PR creation per the interactive request.


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.21.8 plugin for [OpenCode](https://opencode.ai) v1.17.8 with gpt-5.5 spent 2h 51m and 323,623 tokens on this with the user in an interactive session.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the project’s package repository configuration to ensure the DNS library is consistently resolved.
  * Tightened the DNS library requirement to an exact version (4.3.0) for more reliable dependency management.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->