### PR TITLE
feat: add main site promotion workflow

### DIFF
--- a/inc/site-exporter/class-main-site-promoter.php
+++ b/inc/site-exporter/class-main-site-promoter.php
@@ -1,0 +1,310 @@
+<?php
+/**
+ * Promotes a subsite into the existing WordPress main site.
+ *
+ * @package WP_Ultimo\Site_Exporter
+ * @subpackage Site_Exporter
+ * @since 2.5.1
+ */
+
+namespace WP_Ultimo\Site_Exporter;
+
+use WP_Ultimo\Helpers\Site_Duplicator;
+
+// Exit if accessed directly
+defined('ABSPATH') || exit;
+
+/**
+ * Main site promoter service.
+ *
+ * Copies a selected subsite into the current WordPress main site without changing
+ * WordPress bootstrap constants or the main-site blog ID.
+ *
+ * @since 2.5.1
+ */
+class Main_Site_Promoter {
+
+	use \WP_Ultimo\Traits\Singleton;
+
+	/**
+	 * Initialize the singleton.
+	 *
+	 * @since 2.5.1
+	 * @return void
+	 */
+	public function init(): void {
+
+		// No hooks are registered by the service itself.
+	}
+
+	/**
+	 * Promote a source subsite into the current main site.
+	 *
+	 * @since 2.5.1
+	 *
+	 * @param int   $source_blog_id Source subsite blog ID.
+	 * @param array $args           Promotion arguments.
+	 * @return array|\WP_Error Promotion result or error.
+	 */
+	public function promote($source_blog_id, $args = []) {
+
+		$source_blog_id = absint($source_blog_id);
+		$caller_blog_id = get_current_blog_id();
+		$stack_snapshot = isset($GLOBALS['_wp_switched_stack']) ? $GLOBALS['_wp_switched_stack'] : [];
+		$switched       = isset($GLOBALS['switched']) ? (bool) $GLOBALS['switched'] : false;
+
+		$args = wp_parse_args(
+			$args,
+			[
+				'force'               => false,
+				'backup'              => true,
+				'copy_files'          => true,
+				'keep_users'          => true,
+				'preserve_main_title' => true,
+			]
+		);
+
+		$validation = $this->validate($source_blog_id, $args);
+
+		if (is_wp_error($validation)) {
+			return $validation;
+		}
+
+		$main_site_id = wu_get_main_site_id();
+		$main_url     = get_site_url($main_site_id);
+		$source_url   = get_site_url($source_blog_id);
+		$source_title = get_blog_option($source_blog_id, 'blogname');
+		$backups      = [];
+
+		try {
+			if ($args['backup']) {
+				$backups = $this->create_backups($main_site_id, $source_blog_id, $args);
+
+				if (is_wp_error($backups)) {
+					return $backups;
+				}
+			}
+
+			/**
+			 * Allow tests and integrations to override the copy/import step.
+			 *
+			 * Return null to use the default Site_Duplicator pipeline.
+			 *
+			 * @since 2.5.1
+			 *
+			 * @param null|bool|\WP_Error $result         Override result.
+			 * @param int                 $source_blog_id Source subsite blog ID.
+			 * @param int                 $main_site_id   Main site blog ID.
+			 * @param array               $args           Promotion arguments.
+			 */
+			$override = apply_filters('wu_main_site_promoter_override_site', null, $source_blog_id, $main_site_id, $args);
+
+			if (null === $override) {
+				$override = Site_Duplicator::override_site(
+					$source_blog_id,
+					$main_site_id,
+					[
+						'copy_files' => (bool) $args['copy_files'],
+						'keep_users' => (bool) $args['keep_users'],
+					]
+				);
+			}
+
+			if (is_wp_error($override)) {
+				return $override;
+			}
+
+			if (false === $override) {
+				return new \WP_Error('main_site_promotion_failed', __('The source site could not be copied into the main site.', 'ultimate-multisite'));
+			}
+
+			$this->restore_main_identity($main_site_id, $main_url, $source_title, (bool) $args['preserve_main_title']);
+
+			wp_cache_flush();
+			clean_blog_cache($main_site_id);
+
+			return [
+				'source_blog_id'        => $source_blog_id,
+				'main_site_id'          => $main_site_id,
+				'source_url'            => $source_url,
+				'main_url'              => $main_url,
+				'backup_exports'        => $backups,
+				'source_site_preserved' => true,
+			];
+		} catch (\Throwable $exception) {
+			return new \WP_Error('main_site_promotion_exception', $exception->getMessage());
+		} finally {
+			$this->restore_blog_context($caller_blog_id, $stack_snapshot, $switched);
+		}
+	}
+
+	/**
+	 * Validate a promotion request.
+	 *
+	 * @since 2.5.1
+	 *
+	 * @param int   $source_blog_id Source subsite blog ID.
+	 * @param array $args           Promotion arguments.
+	 * @return true|\WP_Error True when valid, otherwise WP_Error.
+	 */
+	private function validate($source_blog_id, array $args) {
+
+		if (! is_multisite()) {
+			return new \WP_Error('main_site_promotion_requires_multisite', __('Promoting a subsite to the main site requires WordPress multisite.', 'ultimate-multisite'));
+		}
+
+		if (! $source_blog_id) {
+			return new \WP_Error('main_site_promotion_invalid_source', __('A valid source site is required.', 'ultimate-multisite'));
+		}
+
+		$source_site = get_site($source_blog_id);
+
+		if (! $source_site) {
+			return new \WP_Error('main_site_promotion_source_not_found', __('The source site could not be found.', 'ultimate-multisite'));
+		}
+
+		if ((int) wu_get_main_site_id() === $source_blog_id) {
+			return new \WP_Error('main_site_promotion_source_is_main', __('The current main site cannot be promoted into itself.', 'ultimate-multisite'));
+		}
+
+		if (empty($args['force']) && ((int) $source_site->archived || (int) $source_site->spam || (int) $source_site->deleted)) {
+			return new \WP_Error('main_site_promotion_source_inactive', __('Archived, spam, or deleted sites cannot be promoted unless force is enabled.', 'ultimate-multisite'));
+		}
+
+		$main_site = get_site(wu_get_main_site_id());
+
+		if (! $main_site) {
+			return new \WP_Error('main_site_promotion_main_not_found', __('The WordPress main site could not be found.', 'ultimate-multisite'));
+		}
+
+		if (empty($args['force']) && ((int) $main_site->archived || (int) $main_site->spam || (int) $main_site->deleted)) {
+			return new \WP_Error('main_site_promotion_main_inactive', __('The current main site is archived, spam, or deleted. Use force only after reviewing the site status.', 'ultimate-multisite'));
+		}
+
+		return true;
+	}
+
+	/**
+	 * Export the current main site and source subsite before mutation.
+	 *
+	 * @since 2.5.1
+	 *
+	 * @param int   $main_site_id   Main site blog ID.
+	 * @param int   $source_blog_id Source subsite blog ID.
+	 * @param array $args           Promotion arguments.
+	 * @return array|\WP_Error Backup filenames or error.
+	 */
+	private function create_backups($main_site_id, $source_blog_id, array $args) {
+
+		$export_options = [
+			'uploads' => true,
+			'themes'  => false,
+			'plugins' => false,
+		];
+
+		/**
+		 * Filters backup export options used before main-site promotion.
+		 *
+		 * @since 2.5.1
+		 *
+		 * @param array $export_options Export options.
+		 * @param int   $main_site_id   Main site blog ID.
+		 * @param int   $source_blog_id Source subsite blog ID.
+		 * @param array $args           Promotion arguments.
+		 */
+		$export_options = apply_filters('wu_main_site_promoter_backup_export_options', $export_options, $main_site_id, $source_blog_id, $args);
+
+		$main_backup = $this->export_site($main_site_id, $export_options);
+
+		if (is_wp_error($main_backup)) {
+			return $main_backup;
+		}
+
+		$source_backup = $this->export_site($source_blog_id, $export_options);
+
+		if (is_wp_error($source_backup)) {
+			return $source_backup;
+		}
+
+		return [
+			'main_site' => $main_backup,
+			'source'    => $source_backup,
+		];
+	}
+
+	/**
+	 * Export a site synchronously for backup.
+	 *
+	 * @since 2.5.1
+	 *
+	 * @param int   $site_id Site blog ID.
+	 * @param array $options Export options.
+	 * @return string|true|\WP_Error Export filename/result or error.
+	 */
+	private function export_site($site_id, array $options) {
+
+		/**
+		 * Allow tests and integrations to short-circuit promotion backup exports.
+		 *
+		 * Return null to use wu_exporter_export().
+		 *
+		 * @since 2.5.1
+		 *
+		 * @param null|string|true|\WP_Error $export  Export result.
+		 * @param int                        $site_id Site blog ID.
+		 * @param array                      $options Export options.
+		 */
+		$export = apply_filters('wu_main_site_promoter_export_site', null, $site_id, $options);
+
+		if (null !== $export) {
+			return $export;
+		}
+
+		return wu_exporter_export($site_id, $options, false);
+	}
+
+	/**
+	 * Restore main-site identity after the content copy/import.
+	 *
+	 * @since 2.5.1
+	 *
+	 * @param int    $main_site_id        Main site blog ID.
+	 * @param string $main_url            Main site URL.
+	 * @param string $source_title        Source site title.
+	 * @param bool   $preserve_main_title Whether to preserve the current main title.
+	 * @return void
+	 */
+	private function restore_main_identity($main_site_id, $main_url, $source_title, $preserve_main_title) {
+
+		update_blog_option($main_site_id, 'home', $main_url);
+		update_blog_option($main_site_id, 'siteurl', $main_url);
+
+		if (! $preserve_main_title) {
+			update_blog_option($main_site_id, 'blogname', $source_title);
+		}
+	}
+
+	/**
+	 * Restore the caller's blog context and switch stack.
+	 *
+	 * @since 2.5.1
+	 *
+	 * @param int   $caller_blog_id Caller blog ID.
+	 * @param array $stack_snapshot Original switch stack.
+	 * @param bool  $switched       Original switched flag.
+	 * @return void
+	 */
+	private function restore_blog_context($caller_blog_id, array $stack_snapshot, $switched) {
+
+		while (function_exists('ms_is_switched') && ms_is_switched()) {
+			restore_current_blog();
+		}
+
+		if (get_current_blog_id() !== (int) $caller_blog_id) {
+			switch_to_blog((int) $caller_blog_id);
+		}
+
+		$GLOBALS['_wp_switched_stack'] = $stack_snapshot;
+		$GLOBALS['switched']           = (bool) $switched;
+	}
+}

--- a/inc/site-exporter/class-site-exporter.php
+++ b/inc/site-exporter/class-site-exporter.php
@@ -154,6 +154,8 @@ final class Site_Exporter {
 		if (defined('WP_CLI') && WP_CLI) {
 			call_user_func(['WP_CLI', 'add_command'], 'wp-ultimo import-network', [$this, 'wp_cli_import_network']);
 			call_user_func(['WP_CLI', 'add_command'], 'wu import-network', [$this, 'wp_cli_import_network']);
+			call_user_func(['WP_CLI', 'add_command'], 'wp-ultimo promote-main-site', [$this, 'wp_cli_promote_main_site']);
+			call_user_func(['WP_CLI', 'add_command'], 'wu promote-main-site', [$this, 'wp_cli_promote_main_site']);
 		}
 
 		// Authenticated file download handler (GH#1010)
@@ -282,6 +284,21 @@ final class Site_Exporter {
 			'<a href="%s">%s</a>',
 			esc_url($export_url),
 			__('Export', 'ultimate-multisite')
+		);
+
+		$promote_url = add_query_arg(
+			[
+				'page'    => 'wu-site-export',
+				'site_id' => $blog_id,
+				'action'  => 'promote_main_site',
+			],
+			network_admin_url('sites.php')
+		);
+
+		$actions['promote_main_site'] = sprintf(
+			'<a href="%s">%s</a>',
+			esc_url($promote_url),
+			__('Promote to Main Site', 'ultimate-multisite')
 		);
 
 		return $actions;
@@ -730,6 +747,8 @@ final class Site_Exporter {
 
 			<?php if ('export' === $action && $site_id) : ?>
 				<?php $this->render_export_form($site_id); ?>
+			<?php elseif ('promote_main_site' === $action && $site_id) : ?>
+				<?php $this->render_promote_main_site_form($site_id); ?>
 			<?php else : ?>
 				<?php $this->render_export_import_dashboard($exports, $pending_exports, $pending_imports); ?>
 			<?php endif; ?>
@@ -822,6 +841,86 @@ final class Site_Exporter {
 				<p class="submit">
 					<input type="submit" class="button button-primary" value="<?php esc_attr_e('Export Site', 'ultimate-multisite'); ?>">
 					<a href="<?php echo esc_url(network_admin_url('sites.php?page=wu-site-export')); ?>" class="button"><?php esc_html_e('Cancel', 'ultimate-multisite'); ?></a>
+				</p>
+			</form>
+		</div>
+		<?php
+	}
+
+	/**
+	 * Render the confirmation form for promoting a subsite into the main site.
+	 *
+	 * @since 2.5.1
+	 *
+	 * @param int $site_id Source site ID.
+	 * @return void
+	 */
+	private function render_promote_main_site_form(int $site_id): void {
+
+		$blog_details = get_blog_details($site_id);
+
+		if (! $blog_details) {
+			wp_die(esc_html__('Site not found.', 'ultimate-multisite'));
+		}
+
+		if (is_main_site($site_id)) {
+			wp_die(esc_html__('The current main site cannot be promoted into itself.', 'ultimate-multisite'));
+		}
+
+		$promote_url = wp_nonce_url(
+			add_query_arg(
+				[
+					'page'    => 'wu-site-export',
+					'action'  => 'do_promote_main_site',
+					'site_id' => $site_id,
+				],
+				network_admin_url('sites.php')
+			),
+			'wu_promote_main_site_' . $site_id
+		);
+
+		?>
+		<div class="card" style="max-width: 700px;">
+			<h2><?php esc_html_e('Promote Subsite to Main Site', 'ultimate-multisite'); ?></h2>
+
+			<div class="notice notice-warning inline" style="margin: 0 0 15px 0;">
+				<p><strong><?php esc_html_e('Warning:', 'ultimate-multisite'); ?></strong> <?php esc_html_e('This will overwrite the current main site content with the selected subsite content.', 'ultimate-multisite'); ?></p>
+			</div>
+
+			<p>
+				<?php
+				printf(
+					/* translators: 1: site name, 2: site URL */
+					esc_html__('Selected source site: %1$s (%2$s)', 'ultimate-multisite'),
+					'<strong>' . esc_html($blog_details->blogname) . '</strong>',
+					esc_html($blog_details->siteurl)
+				);
+				?>
+			</p>
+
+			<ul class="ul-disc">
+				<li><?php esc_html_e('The current main site and source subsite will be exported before any destructive copy runs.', 'ultimate-multisite'); ?></li>
+				<li><?php esc_html_e('The source subsite will not be deleted or archived by default.', 'ultimate-multisite'); ?></li>
+				<li><?php esc_html_e('The WordPress main site ID and bootstrap constants remain unchanged.', 'ultimate-multisite'); ?></li>
+				<li><?php esc_html_e('Source URLs and upload paths will be rewritten to the current main-site URL and uploads location.', 'ultimate-multisite'); ?></li>
+			</ul>
+
+			<form method="post" action="<?php echo esc_url($promote_url); ?>">
+				<table class="form-table">
+					<tr>
+						<th scope="row"><?php esc_html_e('Main Site Title', 'ultimate-multisite'); ?></th>
+						<td>
+							<label>
+								<input type="checkbox" name="preserve_main_title" value="1" checked>
+								<?php esc_html_e('Keep the current main site title after promotion', 'ultimate-multisite'); ?>
+							</label>
+						</td>
+					</tr>
+				</table>
+
+				<p class="submit">
+					<input type="submit" class="button button-primary" value="<?php esc_attr_e('Promote to Main Site', 'ultimate-multisite'); ?>">
+					<a href="<?php echo esc_url(network_admin_url('sites.php')); ?>" class="button"><?php esc_html_e('Cancel', 'ultimate-multisite'); ?></a>
 				</p>
 			</form>
 		</div>
@@ -1083,6 +1182,59 @@ final class Site_Exporter {
 			exit;
 		}
 
+		// Handle main-site promotion.
+		if ('do_promote_main_site' === $action) {
+			$site_id = absint(wu_request('site_id', 0));
+
+			if (! is_multisite()) {
+				wp_die(esc_html__('Promoting a subsite to the main site requires WordPress multisite.', 'ultimate-multisite'));
+			}
+
+			if (! $site_id || ! wp_verify_nonce(wu_request('_wpnonce'), 'wu_promote_main_site_' . $site_id)) {
+				wp_die(esc_html__('Security check failed.', 'ultimate-multisite'));
+			}
+
+			if (! current_user_can('manage_network')) {
+				wp_die(esc_html__('You do not have permission to promote sites.', 'ultimate-multisite'));
+			}
+
+			$result = Main_Site_Promoter::get_instance()->promote(
+				$site_id,
+				[
+					'preserve_main_title' => ! empty($_POST['preserve_main_title']),
+				]
+			);
+
+			if (is_wp_error($result)) {
+				wp_safe_redirect(
+					add_query_arg(
+						[
+							'page'    => 'wu-site-export',
+							'message' => 'promote_main_site_error',
+							'error'   => rawurlencode($result->get_error_message()),
+						],
+						$base_url
+					)
+				);
+				exit;
+			}
+
+			$backup_exports = $result['backup_exports'] ?? [];
+
+			wp_safe_redirect(
+				add_query_arg(
+					[
+						'page'          => 'wu-site-export',
+						'message'       => 'promote_main_site_complete',
+						'source_backup' => rawurlencode((string) ($backup_exports['source'] ?? '')),
+						'main_backup'   => rawurlencode((string) ($backup_exports['main_site'] ?? '')),
+					],
+					$base_url
+				)
+			);
+			exit;
+		}
+
 		// Handle delete
 		if ('delete' === $action) {
 			$file = wu_request('file', '');
@@ -1233,6 +1385,26 @@ final class Site_Exporter {
 				];
 				$error_text     = $error_messages[ $error ] ?? __('An error occurred during import.', 'ultimate-multisite');
 				echo '<div class="notice notice-error is-dismissible"><p>' . esc_html($error_text) . '</p></div>';
+				break;
+			case 'promote_main_site_complete':
+				$main_backup   = sanitize_file_name(rawurldecode(wu_request('main_backup', '')));
+				$source_backup = sanitize_file_name(rawurldecode(wu_request('source_backup', '')));
+				$backup_text   = array_filter([$main_backup, $source_backup]);
+				$notice        = __('Subsite promoted to the main site successfully. The original source subsite was left intact.', 'ultimate-multisite');
+
+				if ($backup_text) {
+					$notice .= ' ' . sprintf(
+						/* translators: %s backup export filenames. */
+						__('Backups created: %s', 'ultimate-multisite'),
+						implode(', ', $backup_text)
+					);
+				}
+
+				echo '<div class="notice notice-success is-dismissible"><p>' . esc_html($notice) . '</p></div>';
+				break;
+			case 'promote_main_site_error':
+				$error = rawurldecode(wu_request('error', ''));
+				echo '<div class="notice notice-error is-dismissible"><p>' . esc_html($error ?: __('The subsite could not be promoted to the main site.', 'ultimate-multisite')) . '</p></div>';
 				break;
 		}
 	}
@@ -2759,6 +2931,74 @@ final class Site_Exporter {
 		}
 
 		call_user_func(['WP_CLI', 'success'], __('Network import completed.', 'ultimate-multisite'));
+	}
+
+	/**
+	 * WP-CLI wrapper for promoting a subsite into the main site.
+	 *
+	 * ## OPTIONS
+	 *
+	 * <source-blog-id>
+	 * : Blog ID of the subsite to copy into the current main site.
+	 *
+	 * [--yes]
+	 * : Confirm the destructive overwrite of the current main site.
+	 *
+	 * [--force]
+	 * : Allow archived, spam, or deleted source/main sites.
+	 *
+	 * [--skip-backup]
+	 * : Skip the required backup exports. Intended only for controlled tests.
+	 *
+	 * [--source-title]
+	 * : Replace the main site's title with the source subsite title.
+	 *
+	 * @since 2.5.1
+	 *
+	 * @param array $args       Positional CLI arguments.
+	 * @param array $assoc_args Associative CLI arguments.
+	 * @return void
+	 */
+	public function wp_cli_promote_main_site(array $args, array $assoc_args): void {
+
+		$source_blog_id = absint($args[0] ?? 0);
+
+		if (! $source_blog_id) {
+			call_user_func(['WP_CLI', 'error'], __('A source blog ID is required.', 'ultimate-multisite'));
+		}
+
+		if (empty($assoc_args['yes'])) {
+			call_user_func(['WP_CLI', 'error'], __('This command overwrites the current main site. Re-run with --yes to confirm.', 'ultimate-multisite'));
+		}
+
+		$result = Main_Site_Promoter::get_instance()->promote(
+			$source_blog_id,
+			[
+				'force'               => ! empty($assoc_args['force']),
+				'backup'              => empty($assoc_args['skip-backup']),
+				'preserve_main_title' => empty($assoc_args['source-title']),
+			]
+		);
+
+		if (is_wp_error($result)) {
+			call_user_func(['WP_CLI', 'error'], $result->get_error_message());
+		}
+
+		$backup_exports = $result['backup_exports'] ?? [];
+
+		if ($backup_exports) {
+			call_user_func(
+				['WP_CLI', 'line'],
+				sprintf(
+					/* translators: 1: main-site backup filename, 2: source-site backup filename. */
+					__('Backups created. Main site: %1$s Source site: %2$s', 'ultimate-multisite'),
+					(string) ($backup_exports['main_site'] ?? ''),
+					(string) ($backup_exports['source'] ?? '')
+				)
+			);
+		}
+
+		call_user_func(['WP_CLI', 'success'], __('Subsite promoted to the main site. The source subsite was left intact.', 'ultimate-multisite'));
 	}
 
 	/**

--- a/tests/WP_Ultimo/Site_Exporter/Main_Site_Promoter_Test.php
+++ b/tests/WP_Ultimo/Site_Exporter/Main_Site_Promoter_Test.php
@@ -1,0 +1,219 @@
+<?php
+/**
+ * Tests for the main-site promotion service.
+ *
+ * @package WP_Ultimo\Tests\Site_Exporter
+ */
+
+namespace WP_Ultimo\Tests\Site_Exporter;
+
+use WP_Ultimo\Site_Exporter\Main_Site_Promoter;
+use WP_UnitTestCase;
+
+/**
+ * Test class for Main_Site_Promoter.
+ *
+ * @package WP_Ultimo\Tests\Site_Exporter
+ * @since 2.5.1
+ */
+class Main_Site_Promoter_Test extends WP_UnitTestCase {
+
+	/**
+	 * Source blog ID.
+	 *
+	 * @var int
+	 */
+	private int $source_blog_id = 0;
+
+	/**
+	 * Set up a source subsite.
+	 */
+	public function set_up(): void {
+
+		parent::set_up();
+
+		if (! is_multisite()) {
+			$this->markTestSkipped('Main-site promotion requires multisite.');
+		}
+
+		$this->source_blog_id = self::factory()->blog->create(
+			[
+				'domain' => 'promote-source.example.com',
+				'path'   => '/',
+				'title'  => 'Promote Source',
+			]
+		);
+	}
+
+	/**
+	 * Clean up the source subsite.
+	 */
+	public function tear_down(): void {
+
+		if ($this->source_blog_id) {
+			wpmu_delete_blog($this->source_blog_id, true);
+		}
+
+		parent::tear_down();
+	}
+
+	/**
+	 * Promoting the current main site is rejected.
+	 */
+	public function test_promote_rejects_current_main_site(): void {
+
+		$result = Main_Site_Promoter::get_instance()->promote(wu_get_main_site_id());
+
+		$this->assertWPError($result);
+		$this->assertSame('main_site_promotion_source_is_main', $result->get_error_code());
+	}
+
+	/**
+	 * Missing source IDs return a clear validation error.
+	 */
+	public function test_promote_rejects_missing_source_site(): void {
+
+		$result = Main_Site_Promoter::get_instance()->promote(999999);
+
+		$this->assertWPError($result);
+		$this->assertSame('main_site_promotion_source_not_found', $result->get_error_code());
+	}
+
+	/**
+	 * Backup exports are attempted before the destructive copy step.
+	 */
+	public function test_promote_exports_main_and_source_before_copy(): void {
+
+		$main_site_id = wu_get_main_site_id();
+		$events       = [];
+
+		$export_filter = function ($export, $site_id) use (&$events) {
+			$events[] = 'export:' . $site_id;
+
+			return 'backup-' . $site_id . '.zip';
+		};
+
+		$override_filter = function ($result, $source_blog_id, $target_blog_id) use (&$events) {
+			$events[] = 'copy:' . $source_blog_id . ':' . $target_blog_id;
+
+			return true;
+		};
+
+		add_filter('wu_main_site_promoter_export_site', $export_filter, 10, 2);
+		add_filter('wu_main_site_promoter_override_site', $override_filter, 10, 3);
+
+		$result = Main_Site_Promoter::get_instance()->promote($this->source_blog_id);
+
+		remove_filter('wu_main_site_promoter_export_site', $export_filter, 10);
+		remove_filter('wu_main_site_promoter_override_site', $override_filter, 10);
+
+		$this->assertIsArray($result);
+		$this->assertSame(
+			[
+				'export:' . $main_site_id,
+				'export:' . $this->source_blog_id,
+				'copy:' . $this->source_blog_id . ':' . $main_site_id,
+			],
+			$events
+		);
+		$this->assertSame('backup-' . $main_site_id . '.zip', $result['backup_exports']['main_site']);
+		$this->assertSame('backup-' . $this->source_blog_id . '.zip', $result['backup_exports']['source']);
+		$this->assertNotFalse(get_site($this->source_blog_id), 'Source subsite must remain intact.');
+	}
+
+	/**
+	 * Backup failures stop before the copy step starts.
+	 */
+	public function test_promote_stops_when_backup_fails(): void {
+
+		$copy_called = false;
+
+		$export_filter = function () {
+			return new \WP_Error('backup_failed', 'Backup failed.');
+		};
+
+		$override_filter = function () use (&$copy_called) {
+			$copy_called = true;
+
+			return true;
+		};
+
+		add_filter('wu_main_site_promoter_export_site', $export_filter);
+		add_filter('wu_main_site_promoter_override_site', $override_filter);
+
+		$result = Main_Site_Promoter::get_instance()->promote($this->source_blog_id);
+
+		remove_filter('wu_main_site_promoter_export_site', $export_filter);
+		remove_filter('wu_main_site_promoter_override_site', $override_filter);
+
+		$this->assertWPError($result);
+		$this->assertSame('backup_failed', $result->get_error_code());
+		$this->assertFalse($copy_called, 'Copy must not run after a backup failure.');
+	}
+
+	/**
+	 * Main URL identity is restored after the copy step rewrites options.
+	 */
+	public function test_promote_restores_main_url_identity(): void {
+
+		$main_site_id = wu_get_main_site_id();
+		$main_home    = get_blog_option($main_site_id, 'home');
+		$main_siteurl = get_blog_option($main_site_id, 'siteurl');
+		$source_url   = get_site_url($this->source_blog_id);
+
+		$export_filter = function ($export, $site_id) {
+			return 'backup-' . $site_id . '.zip';
+		};
+
+		$override_filter = function () use ($main_site_id, $source_url) {
+			update_blog_option($main_site_id, 'home', $source_url);
+			update_blog_option($main_site_id, 'siteurl', $source_url);
+
+			return true;
+		};
+
+		add_filter('wu_main_site_promoter_export_site', $export_filter, 10, 2);
+		add_filter('wu_main_site_promoter_override_site', $override_filter);
+
+		$result = Main_Site_Promoter::get_instance()->promote($this->source_blog_id);
+
+		remove_filter('wu_main_site_promoter_export_site', $export_filter, 10);
+		remove_filter('wu_main_site_promoter_override_site', $override_filter);
+
+		$this->assertIsArray($result);
+		$this->assertSame($main_home, get_blog_option($main_site_id, 'home'));
+		$this->assertSame($main_siteurl, get_blog_option($main_site_id, 'siteurl'));
+	}
+
+	/**
+	 * The caller's blog context is restored after promotion.
+	 */
+	public function test_promote_restores_caller_blog_context(): void {
+
+		$export_filter = function ($export, $site_id) {
+			return 'backup-' . $site_id . '.zip';
+		};
+
+		$override_filter = function () {
+			switch_to_blog(wu_get_main_site_id());
+
+			return true;
+		};
+
+		add_filter('wu_main_site_promoter_export_site', $export_filter, 10, 2);
+		add_filter('wu_main_site_promoter_override_site', $override_filter);
+
+		switch_to_blog($this->source_blog_id);
+
+		$result = Main_Site_Promoter::get_instance()->promote($this->source_blog_id);
+
+		$this->assertIsArray($result);
+		$this->assertSame($this->source_blog_id, get_current_blog_id());
+		$this->assertTrue(ms_is_switched());
+
+		restore_current_blog();
+
+		remove_filter('wu_main_site_promoter_export_site', $export_filter, 10);
+		remove_filter('wu_main_site_promoter_override_site', $override_filter);
+	}
+}


### PR DESCRIPTION
## Summary

- Added `Main_Site_Promoter` to validate subsite-to-main promotion, export the current main site and source subsite before mutation, keep the source subsite intact, and restore main-site URL identity after copying.
- Added network-admin “Promote to Main Site” confirmation flow and `wp wu promote-main-site <source-blog-id> --yes` / `wp wp-ultimo promote-main-site` CLI entry points.
- Added PHPUnit coverage for validation, backup-before-copy ordering, source preservation, main URL restoration, context restoration, and backup failure short-circuiting.

Resolves #1469

## Testing

- `php -l inc/site-exporter/class-main-site-promoter.php`
- `php -l inc/site-exporter/class-site-exporter.php`
- `vendor/bin/phpcs inc/site-exporter/class-main-site-promoter.php inc/site-exporter/class-site-exporter.php tests/WP_Ultimo/Site_Exporter/Main_Site_Promoter_Test.php`
- `vendor/bin/phpstan analyse inc/site-exporter/class-main-site-promoter.php inc/site-exporter/class-site-exporter.php`
- `WP_TESTS_DIR=/tmp/wordpress-tests-lib vendor/bin/phpunit --filter Main_Site_Promoter_Test`

Note: `vendor/bin/phpstan analyse` repository-wide still reports pre-existing baseline issues outside this change.

<!-- aidevops:sig -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Promote any subsite to the main site in multisite installations via network admin UI or WP-CLI.
  * Automatic backup creation for both the main site and source subsite before promotion.
  * Option to preserve the main site's title during promotion.
  * Built-in validation and safety checks to prevent invalid operations.

* **Tests**
  * Comprehensive test coverage for the promotion workflow and edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->