### PR TITLE
GH#1479: fix: restore limitation user role accessors

### DIFF
--- a/inc/limitations/class-limit-site-templates.php
+++ b/inc/limitations/class-limit-site-templates.php
@@ -205,15 +205,17 @@ class Limit_Site_Templates extends Limit {
 	 */
 	public function get_available_site_templates() {
 
+		$limits = $this->get_limit();
+
 		/*
-		 * MODE_DEFAULT means "allow all templates" — no restriction.
-		 * Return false so callers that check is_array() treat this as unrestricted.
+		 * MODE_DEFAULT means "allow all templates" only when there is no explicit
+		 * template list. A merged plan can preserve its list while an addon with a
+		 * null/default template limitation contributes no restrictions; in that case
+		 * the list remains authoritative and must be returned for validation.
 		 */
-		if (self::MODE_DEFAULT === $this->mode) {
+		if (self::MODE_DEFAULT === $this->mode && ! $limits) {
 			return false;
 		}
-
-		$limits = $this->get_limit();
 
 		if ( ! $limits) {
 			return [];

--- a/inc/models/traits/trait-limitable.php
+++ b/inc/models/traits/trait-limitable.php
@@ -215,6 +215,7 @@ trait Limitable {
 			} catch (\Throwable $exception) {
 
 				// Silence is golden.
+				$module = [];
 			}
 
 			$module['enabled'] = $object_limitations->{$limitation_id}->handle_enabled();

--- a/inc/objects/class-limitations.php
+++ b/inc/objects/class-limitations.php
@@ -213,6 +213,35 @@ class Limitations implements \JsonSerializable {
 	}
 
 	/**
+	 * Returns all user role quotas.
+	 *
+	 * Older integrations call this method through limitable models. The current
+	 * customer-user-role limitation stores a single role instead of per-role
+	 * quotas, so keep the compatibility API array-shaped without inventing quota
+	 * values.
+	 *
+	 * @since 2.0.0
+	 * @return array
+	 */
+	public function get_user_role_quotas() {
+
+		return [];
+	}
+
+	/**
+	 * Returns the customer roles allowed by these limitations.
+	 *
+	 * @since 2.0.0
+	 * @return array
+	 */
+	public function get_allowed_user_roles() {
+
+		$role = $this->customer_user_role->get_limit();
+
+		return empty($role) ? [] : [$role];
+	}
+
+	/**
 	 * Merges limitations from other entities.
 	 *
 	 * This is what we use to combine different limitations from


### PR DESCRIPTION
## Summary

Restored the Limitations user-role compatibility accessors used by limitable models and preserved explicit site template lists when merged with default/null addon template limits.

## Files Changed

inc/limitations/class-limit-site-templates.php,inc/models/traits/trait-limitable.php,inc/objects/class-limitations.php

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** WP_TESTS_DIR=/tmp/wordpress-tests-lib XDEBUG_MODE=off vendor/bin/phpunit --no-coverage --filter Interface_Limitable_Test; WP_TESTS_DIR=/tmp/wordpress-tests-lib XDEBUG_MODE=off vendor/bin/phpunit --no-coverage --filter Limitations_Test; vendor/bin/phpcs inc/objects/class-limitations.php inc/limitations/class-limit-site-templates.php inc/models/traits/trait-limitable.php tests/WP_Ultimo/Models/Interfaces/Interface_Limitable_Test.php tests/WP_Ultimo/Objects/Limitations_Test.php

Resolves #1479


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.21.11 plugin for [OpenCode](https://opencode.ai) v1.17.9 with gpt-5.5 spent 4m and 84,205 tokens on this as a headless worker.