### PR TITLE
fix tests: restore multisite HTTP host fixtures (#1472)

### DIFF
--- a/tests/WP_Ultimo/Managers/Site_Manager_Test.php
+++ b/tests/WP_Ultimo/Managers/Site_Manager_Test.php
@@ -1669,8 +1669,8 @@ class Site_Manager_Test extends \WP_UnitTestCase {
 
 		$site = new \WP_Ultimo\Models\Site();
 
-		// Default is 1
-		$this->assertEquals(1, $site->get_site_id());
+		// Unsaved sites defer network selection to save() instead of hard-coding network 1.
+		$this->assertEquals(0, $site->get_site_id());
 
 		$site->set_site_id(2);
 		$this->assertEquals(2, $site->get_site_id());

--- a/tests/WP_Ultimo/Models/Domain_Test.php
+++ b/tests/WP_Ultimo/Models/Domain_Test.php
@@ -604,8 +604,8 @@ class Domain_Test extends WP_UnitTestCase {
 		$domain = new Domain();
 		$rules  = $domain->validation_rules();
 
-		$this->assertStringContainsString('required', $rules['stage']);
 		$this->assertStringContainsString('in:', $rules['stage']);
+		$this->assertStringContainsString('default:checking-dns', $rules['stage']);
 		$this->assertStringContainsString('checking-dns', $rules['stage']);
 		$this->assertStringContainsString('done', $rules['stage']);
 		$this->assertStringContainsString('failed', $rules['stage']);

--- a/tests/WP_Ultimo/Models/Site_Test.php
+++ b/tests/WP_Ultimo/Models/Site_Test.php
@@ -123,9 +123,9 @@ class Site_Test extends \WP_UnitTestCase {
 
 		// Test field constraints
 		$this->assertStringContainsString('required', $validation_rules['title'], 'Title should be required.');
-		$this->assertStringContainsString('required', $validation_rules['customer_id'], 'Customer ID should be required.');
 		$this->assertStringContainsString('integer', $validation_rules['customer_id'], 'Customer ID should be integer.');
-		$this->assertStringContainsString('min:2', $validation_rules['description'], 'Description should have minimum length.');
+		$this->assertStringContainsString('default:', $validation_rules['customer_id'], 'Customer ID should be optional for regular WordPress subsites.');
+		$this->assertStringContainsString('default:', $validation_rules['description'], 'Description should be optional metadata.');
 	}
 
 	/**
@@ -135,15 +135,16 @@ class Site_Test extends \WP_UnitTestCase {
 		$test_domain = 'test-example.com';
 		$test_path   = '/test-path';
 
-		$this->site->set_domain($test_domain);
-		$this->site->set_path($test_path);
+		$site = new Site();
+		$site->set_domain($test_domain);
+		$site->set_path($test_path);
 
-		$this->assertEquals($test_domain, $this->site->get_domain(), 'Domain should be set and retrieved correctly.');
-		$this->assertEquals($test_path, $this->site->get_path(), 'Path should be set and retrieved correctly.');
+		$this->assertEquals($test_domain, $site->get_domain(), 'Domain should be set and retrieved correctly.');
+		$this->assertEquals($test_path, $site->get_path(), 'Path should be set and retrieved correctly.');
 
 		// Test URL generation
 		$expected_url = set_url_scheme(esc_url(sprintf($test_domain . '/' . trim($test_path, '/'))));
-		$this->assertEquals($expected_url, $this->site->get_site_url(), 'Site URL should be generated correctly.');
+		$this->assertEquals($expected_url, $site->get_site_url(), 'Unsaved site URL should be generated from domain and path.');
 	}
 
 	/**
@@ -300,16 +301,17 @@ class Site_Test extends \WP_UnitTestCase {
 		$domain = 'test-site.com';
 		$path   = '/my-site';
 
-		$this->site->set_domain($domain);
-		$this->site->set_path($path);
+		$site = new Site();
+		$site->set_domain($domain);
+		$site->set_path($path);
 
 		// Test site URL
-		$site_url     = $this->site->get_site_url();
+		$site_url     = $site->get_site_url();
 		$expected_url = set_url_scheme(esc_url(sprintf($domain . '/' . trim($path, '/'))));
-		$this->assertEquals($expected_url, $site_url, 'Site URL should be generated correctly.');
+		$this->assertEquals($expected_url, $site_url, 'Unsaved site URL should be generated correctly.');
 
 		// Test active site URL (without mapped domain)
-		$active_url = $this->site->get_active_site_url();
+		$active_url = $site->get_active_site_url();
 		$this->assertEquals($expected_url, $active_url, 'Active site URL should match site URL when no mapping exists.');
 	}
 

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -15,8 +15,26 @@ if ( ! isset( $_SERVER['REMOTE_ADDR'] ) ) {
 	$_SERVER['REMOTE_ADDR'] = '127.0.0.1';
 }
 
+// WordPress multisite site-creation and URL helpers expect a host-like web
+// request environment. Keep it deterministic for CLI-based PHPUnit runs.
+if ( ! isset( $_SERVER['HTTP_HOST'] ) ) {
+	$_SERVER['HTTP_HOST'] = 'example.org';
+}
+
+if ( ! isset( $_SERVER['SERVER_NAME'] ) ) {
+	$_SERVER['SERVER_NAME'] = 'example.org';
+}
+
+if ( ! isset( $_SERVER['REQUEST_URI'] ) ) {
+	$_SERVER['REQUEST_URI'] = '/';
+}
+
 if ( ! $_tests_dir ) {
-	$_tests_dir = rtrim(sys_get_temp_dir(), '/\\') . '/wordpress-tests-lib';
+	if ( file_exists('/tmp/wordpress-tests-lib/includes/functions.php') ) {
+		$_tests_dir = '/tmp/wordpress-tests-lib';
+	} else {
+		$_tests_dir = rtrim(sys_get_temp_dir(), '/\\') . '/wordpress-tests-lib';
+	}
 }
 
 // Forward custom PHPUnit Polyfills configuration to PHPUnit bootstrap file.


### PR DESCRIPTION
## Summary

- Seed deterministic HTTP host/server request globals in the PHPUnit bootstrap for multisite site creation.
- Prefer the shared `/tmp/wordpress-tests-lib` checkout when `WP_TESTS_DIR` is unset so sandbox temp dirs do not select a stale tests lib.
- Align stale model assertions with current optional site/domain defaults and persisted-site URL behavior.

Resolves #1472

## Verification

- `WP_TESTS_DIR=/tmp/wordpress-tests-lib XDEBUG_MODE=off vendor/bin/phpunit --no-coverage --filter Site_Test` — OK (91 tests, 245 assertions)
- `WP_TESTS_DIR=/tmp/wordpress-tests-lib XDEBUG_MODE=off vendor/bin/phpunit --no-coverage --filter 'WP_Ultimo\\Models\\Domain_Test'` — OK (67 tests, 157 assertions)
- `WP_TESTS_DIR=/tmp/wordpress-tests-lib XDEBUG_MODE=off vendor/bin/phpunit --no-coverage --filter 'WP_Ultimo\\Tests\\Managers\\Site_Manager_Test'` — OK (226 tests, 408 assertions, 4 skipped)
- `WP_TESTS_DIR=/tmp/wordpress-tests-lib XDEBUG_MODE=off vendor/bin/phpunit --no-coverage --filter 'WP_Ultimo\\Managers\\Domain_Manager_Test'` — OK (145 tests, 337 assertions)
- `vendor/bin/phpcs tests/bootstrap.php tests/WP_Ultimo/Models/Site_Test.php tests/WP_Ultimo/Models/Domain_Test.php` — OK

## Notes

- Broad unqualified `--filter Domain_Test` also matches other domain-named classes in this suite; the exact model filter above isolates `WP_Ultimo\Models\Domain_Test`.
- `Site_Duplicator_Test` still has pre-existing postmeta-copy assertion failures outside the bootstrap/model assertion changes in this PR.

<!-- aidevops:sig -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test expectations for site management and domain validation rules.
  * Improved test environment configuration for consistent multisite URL handling.
  * Refactored test cases to verify updated validation behavior and URL generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->