### PR TITLE
test: assert payment missing line item response

### DIFF
--- a/tests/WP_Ultimo/Admin_Pages/Payment_Edit_Admin_Page_Test.php
+++ b/tests/WP_Ultimo/Admin_Pages/Payment_Edit_Admin_Page_Test.php
@@ -1037,6 +1037,7 @@ class Payment_Edit_Admin_Page_Test extends WP_UnitTestCase {
 
 		$this->assertFalse($response['success']);
 		$this->assertSame('not-found', $response['data'][0]['code']);
+		$this->assertSame('Payment not found.', $response['data'][0]['message']);
 	}
 
 	// -------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Added a regression assertion for the missing-payment line-item modal JSON response.
- Verifies the handler returns the `not-found` error message instead of allowing a fatal path to be treated as expected behavior.

Resolves #1490

## Testing

- `vendor/bin/phpunit --filter Payment_Edit_Admin_Page_Test` (passes: 59 tests, 89 assertions, 4 skipped)
- `vendor/bin/phpcs tests/WP_Ultimo/Admin_Pages/Payment_Edit_Admin_Page_Test.php` (reports pre-existing file-level violations: multiple object structures, array spacing, empty catch)

<!-- MERGE_SUMMARY
Implemented issue #1490 by strengthening the Payment_Edit_Admin_Page line-item modal missing-payment regression test. The test now verifies the JSON error response includes the `not-found` code and the expected `Payment not found.` message, keeping the contract on graceful wp_send_json_error handling rather than fatal errors.

Verification: vendor/bin/phpunit --filter Payment_Edit_Admin_Page_Test passed with 59 tests, 89 assertions, 4 skipped. PHPCS was run on the modified file and reported existing file-level/style findings unrelated to this one-line assertion.
-->

<!-- aidevops:sig -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved validation testing for payment error handling to ensure accurate error messages are returned in error scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->