### PR TITLE
test: preserve redirect filter cleanup

### DIFF
--- a/tests/WP_Ultimo/Admin_Pages/Setup_Wizard_Admin_Page_Test.php
+++ b/tests/WP_Ultimo/Admin_Pages/Setup_Wizard_Admin_Page_Test.php
@@ -149,6 +149,28 @@ class Setup_Wizard_Admin_Page_Test extends WP_UnitTestCase {
 		return $redirect_url;
 	}
 
+	public function test_capture_redirect_preserves_existing_wp_redirect_filters(): void {
+
+		$existing_filter = static function ($location) {
+			return $location;
+		};
+
+		add_filter('wp_redirect', $existing_filter, 20);
+
+		try {
+			$redirect_url = $this->capture_redirect(
+				static function () {
+					wp_safe_redirect(network_admin_url('admin.php?page=wp-ultimo-setup'));
+				}
+			);
+
+			$this->assertStringContainsString('admin.php?page=wp-ultimo-setup', $redirect_url);
+			$this->assertSame(20, has_filter('wp_redirect', $existing_filter));
+		} finally {
+			remove_filter('wp_redirect', $existing_filter, 20);
+		}
+	}
+
 	// -------------------------------------------------------------------------
 	// Page properties
 	// -------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Adds regression coverage for the setup wizard redirect capture helper.
- Verifies pre-existing `wp_redirect` filters remain registered after redirect capture.
- Confirms the helper still captures the setup wizard redirect target.

## Testing

- `bash bin/check-env.sh && vendor/bin/phpcs tests/WP_Ultimo/Admin_Pages/Setup_Wizard_Admin_Page_Test.php && vendor/bin/phpunit --filter Setup_Wizard_Admin_Page_Test`

Resolves #1492

MERGE_SUMMARY: Added regression coverage proving the setup wizard redirect capture helper leaves pre-existing `wp_redirect` filters registered while still capturing the redirect target.

<!-- aidevops:sig -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test coverage for redirect functionality to ensure the system properly maintains and respects pre-existing filter configurations while processing redirects, preserving priority levels and filter integrity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->