### PR TITLE
test: fix site exporter promoter test namespace

### DIFF
--- a/tests/WP_Ultimo/Site_Exporter/Main_Site_Promoter_Test.php
+++ b/tests/WP_Ultimo/Site_Exporter/Main_Site_Promoter_Test.php
@@ -2,18 +2,19 @@
 /**
  * Tests for the main-site promotion service.
  *
- * @package WP_Ultimo\Tests\Site_Exporter
+ * @package WP_Ultimo\Site_Exporter
+ * @subpackage Tests
  */
 
-namespace WP_Ultimo\Tests\Site_Exporter;
+namespace WP_Ultimo\Site_Exporter;
 
-use WP_Ultimo\Site_Exporter\Main_Site_Promoter;
 use WP_UnitTestCase;
 
 /**
  * Test class for Main_Site_Promoter.
  *
- * @package WP_Ultimo\Tests\Site_Exporter
+ * @package WP_Ultimo\Site_Exporter
+ * @subpackage Tests
  * @since 2.5.1
  */
 class Main_Site_Promoter_Test extends WP_UnitTestCase {


### PR DESCRIPTION
## Summary

- Fixes the `Main_Site_Promoter_Test` namespace to mirror the source namespace, `WP_Ultimo\Site_Exporter`.
- Aligns the test file package annotations with the source namespace and marks them as tests.
- Removes the redundant same-namespace `Main_Site_Promoter` import.

Resolves #1495

## Testing

- `php -l tests/WP_Ultimo/Site_Exporter/Main_Site_Promoter_Test.php`
- `vendor/bin/phpcs tests/WP_Ultimo/Site_Exporter/Main_Site_Promoter_Test.php`
- `vendor/bin/phpunit --filter Main_Site_Promoter_Test`

<!-- aidevops:sig -->
