### PR TITLE
GH#1494: fix: preserve main site title during promotion

### DIFF
--- a/inc/site-exporter/class-main-site-promoter.php
+++ b/inc/site-exporter/class-main-site-promoter.php
@@ -72,6 +72,7 @@ class Main_Site_Promoter {
 
 		$main_site_id = wu_get_main_site_id();
 		$main_url     = get_site_url($main_site_id);
+		$main_title   = get_blog_option($main_site_id, 'blogname');
 		$source_url   = get_site_url($source_blog_id);
 		$source_title = get_blog_option($source_blog_id, 'blogname');
 		$backups      = [];
@@ -118,7 +119,7 @@ class Main_Site_Promoter {
 				return new \WP_Error('main_site_promotion_failed', __('The source site could not be copied into the main site.', 'ultimate-multisite'));
 			}
 
-			$this->restore_main_identity($main_site_id, $main_url, $source_title, (bool) $args['preserve_main_title']);
+			$this->restore_main_identity($main_site_id, $main_url, $main_title, $source_title, (bool) $args['preserve_main_title']);
 
 			wp_cache_flush();
 			clean_blog_cache($main_site_id);
@@ -270,18 +271,19 @@ class Main_Site_Promoter {
 	 *
 	 * @param int    $main_site_id        Main site blog ID.
 	 * @param string $main_url            Main site URL.
+	 * @param string $main_title          Original main site title.
 	 * @param string $source_title        Source site title.
-	 * @param bool   $preserve_main_title Whether to preserve the current main title.
+	 * @param bool   $preserve_main_title Whether to preserve the original main title.
 	 * @return void
 	 */
-	private function restore_main_identity($main_site_id, $main_url, $source_title, $preserve_main_title) {
+	private function restore_main_identity($main_site_id, $main_url, $main_title, $source_title, $preserve_main_title) {
 
 		update_blog_option($main_site_id, 'home', $main_url);
 		update_blog_option($main_site_id, 'siteurl', $main_url);
 
-		if (! $preserve_main_title) {
-			update_blog_option($main_site_id, 'blogname', $source_title);
-		}
+		$title_to_use = $preserve_main_title ? $main_title : $source_title;
+
+		update_blog_option($main_site_id, 'blogname', $title_to_use);
 	}
 
 	/**

--- a/tests/WP_Ultimo/Site_Exporter/Main_Site_Promoter_Test.php
+++ b/tests/WP_Ultimo/Site_Exporter/Main_Site_Promoter_Test.php
@@ -186,6 +186,81 @@ class Main_Site_Promoter_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Main title identity is restored when requested after the copy step rewrites it.
+	 */
+	public function test_promote_restores_original_main_title_when_preserved(): void {
+
+		$main_site_id        = wu_get_main_site_id();
+		$original_main_title = get_blog_option($main_site_id, 'blogname');
+		$main_title          = 'Original Main Title';
+		$source_title        = 'Copied Source Title';
+
+		update_blog_option($main_site_id, 'blogname', $main_title);
+		update_blog_option($this->source_blog_id, 'blogname', $source_title);
+
+		$override_filter = function () use ($main_site_id, $source_title) {
+			update_blog_option($main_site_id, 'blogname', $source_title);
+
+			return true;
+		};
+
+		add_filter('wu_main_site_promoter_override_site', $override_filter);
+
+		try {
+			$result = Main_Site_Promoter::get_instance()->promote(
+				$this->source_blog_id,
+				[
+					'backup'              => false,
+					'preserve_main_title' => true,
+				]
+			);
+
+			$this->assertIsArray($result);
+			$this->assertSame($main_title, get_blog_option($main_site_id, 'blogname'));
+		} finally {
+			remove_filter('wu_main_site_promoter_override_site', $override_filter);
+			update_blog_option($main_site_id, 'blogname', $original_main_title);
+		}
+	}
+
+	/**
+	 * Source title is applied when the main title should not be preserved.
+	 */
+	public function test_promote_uses_source_title_when_main_title_not_preserved(): void {
+
+		$main_site_id        = wu_get_main_site_id();
+		$original_main_title = get_blog_option($main_site_id, 'blogname');
+		$source_title        = 'Copied Source Title';
+
+		update_blog_option($main_site_id, 'blogname', 'Original Main Title');
+		update_blog_option($this->source_blog_id, 'blogname', $source_title);
+
+		$override_filter = function () use ($main_site_id) {
+			update_blog_option($main_site_id, 'blogname', 'Temporary Copied Title');
+
+			return true;
+		};
+
+		add_filter('wu_main_site_promoter_override_site', $override_filter);
+
+		try {
+			$result = Main_Site_Promoter::get_instance()->promote(
+				$this->source_blog_id,
+				[
+					'backup'              => false,
+					'preserve_main_title' => false,
+				]
+			);
+
+			$this->assertIsArray($result);
+			$this->assertSame($source_title, get_blog_option($main_site_id, 'blogname'));
+		} finally {
+			remove_filter('wu_main_site_promoter_override_site', $override_filter);
+			update_blog_option($main_site_id, 'blogname', $original_main_title);
+		}
+	}
+
+	/**
 	 * The caller's blog context is restored after promotion.
 	 */
 	public function test_promote_restores_caller_blog_context(): void {


### PR DESCRIPTION
## Summary

Captured the original main-site blogname before duplication and restored it when preserve_main_title is enabled; added regression coverage for preserved and source-title promotion behavior.

## Files Changed

inc/site-exporter/class-main-site-promoter.php,tests/WP_Ultimo/Site_Exporter/Main_Site_Promoter_Test.php

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** vendor/bin/phpunit --filter Main_Site_Promoter_Test; vendor/bin/phpcs inc/site-exporter/class-main-site-promoter.php tests/WP_Ultimo/Site_Exporter/Main_Site_Promoter_Test.php

Resolves #1494


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.21.11 plugin for [OpenCode](https://opencode.ai) v1.17.9 with gpt-5.5 spent 3m and 92,439 tokens on this as a headless worker.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced site title preservation during site promotion. The system now correctly captures and restores the main site's original title according to the configured preservation setting.

* **Tests**
  * Added test cases to validate site title handling during promotion operations, covering both preservation of the original main site title and replacement with source site title.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->