### PR TITLE
GH#1491: test: tighten settings redirect cleanup

### DIFF
--- a/tests/WP_Ultimo/Admin_Pages/Settings_Admin_Page_Test.php
+++ b/tests/WP_Ultimo/Admin_Pages/Settings_Admin_Page_Test.php
@@ -513,6 +513,8 @@ class Settings_Admin_Page_Test extends WP_UnitTestCase {
 			$this->assertSame('redirect_intercepted', $e->getMessage());
 		} finally {
 			remove_filter('wp_redirect', $redirect_filter);
+			$user->remove_cap('wu_edit_settings');
+			revoke_super_admin($user_id);
 			wp_set_current_user(0);
 		}
 


### PR DESCRIPTION
## Summary

Tightened Settings_Admin_Page_Test redirect-permission cleanup by reverting the temporary wu_edit_settings capability and super-admin grant in the existing finally block, alongside the callback-specific wp_redirect cleanup and current-user reset.

## Files Changed

tests/WP_Ultimo/Admin_Pages/Settings_Admin_Page_Test.php

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** vendor/bin/phpcs tests/WP_Ultimo/Admin_Pages/Settings_Admin_Page_Test.php; vendor/bin/phpunit --filter Settings_Admin_Page_Test

Resolves #1491


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.21.11 plugin for [OpenCode](https://opencode.ai) v1.17.9 with gpt-5.5 spent 3m and 72,022 tokens on this as a headless worker.