### PR TITLE
GH#1505: test: fix event view admin page fixture

### DIFF
--- a/tests/WP_Ultimo/Admin_Pages/Event_View_Admin_Page_Test.php
+++ b/tests/WP_Ultimo/Admin_Pages/Event_View_Admin_Page_Test.php
@@ -8,7 +8,6 @@
 namespace WP_Ultimo\Admin_Pages;
 
 use WP_UnitTestCase;
-use WP_Ultimo\Faker;
 use WP_Ultimo\Models\Event;
 
 /**
@@ -35,10 +34,24 @@ class Event_View_Admin_Page_Test extends WP_UnitTestCase {
 
 		parent::setUp();
 
-		$faker = new Faker();
-		$faker->generate_fake_events(1);
+		$this->event = \wu_create_event(
+			[
+				'severity'    => Event::SEVERITY_INFO,
+				'initiator'   => 'system',
+				'author_id'   => 1,
+				'object_id'   => 6,
+				'object_type' => 'customer',
+				'slug'        => 'created',
+				'payload'     => [
+					'key'       => 'status',
+					'old_value' => 'none',
+					'new_value' => 'created',
+				],
+			]
+		);
 
-		$this->event = current($faker->get_fake_data_generated('events'));
+		$this->assertInstanceOf(Event::class, $this->event);
+		$this->assertGreaterThan(0, $this->event->get_id());
 
 		$this->page = new Event_View_Admin_Page();
 	}


### PR DESCRIPTION
## Summary

Replaced the Event View admin page test's broad Faker event fixture with a direct wu_create_event fixture and assertions that the persisted Event exists before page tests run.

## Files Changed

tests/WP_Ultimo/Admin_Pages/Event_View_Admin_Page_Test.php

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** vendor/bin/phpunit --filter Event_View_Admin_Page_Test; vendor/bin/phpcs tests/WP_Ultimo/Admin_Pages/Event_View_Admin_Page_Test.php

Resolves #1505


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.21.12 plugin for [OpenCode](https://opencode.ai) v1.17.9 with gpt-5.5 spent 5m and 121,883 tokens on this as a headless worker.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved event test fixture setup with explicit event definitions and validation.
  * Removed test dependency on generated fake data generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->