### PR TITLE
GH#1507: test: fix admin page PHPUnit regressions

### DIFF
--- a/inc/admin-pages/class-system-info-admin-page.php
+++ b/inc/admin-pages/class-system-info-admin-page.php
@@ -486,7 +486,7 @@ class System_Info_Admin_Page extends Base_Admin_Page {
 					'wp_post_revisions'      => [
 						'tooltip' => '',
 						'title'   => 'WP Options Transients',
-						'value'   => defined('WP_POST_REVISIONS') ? WP_POST_REVISIONS ?: __('Disabled', 'ultimate-multisite') : __('Not set', 'ultimate-multisite'),
+						'value'   => defined('WP_POST_REVISIONS') ? constant('WP_POST_REVISIONS') ?: __('Disabled', 'ultimate-multisite') : __('Not set', 'ultimate-multisite'),
 					],
 					'disable_wp_cron'        => [
 						'tooltip' => '',
@@ -743,6 +743,10 @@ class System_Info_Admin_Page extends Base_Admin_Page {
 		$settings = \WP_Ultimo\Settings::get_instance();
 
 		foreach ($settings->get_all() as $setting => $value) {
+			if (is_array($value)) {
+				continue;
+			}
+
 			$add = true;
 
 			foreach ($exclude as $ex) {

--- a/tests/WP_Ultimo/Admin/Network_Usage_Columns_Test.php
+++ b/tests/WP_Ultimo/Admin/Network_Usage_Columns_Test.php
@@ -52,23 +52,25 @@ class Network_Usage_Columns_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Test add_plugins_column adds a 'sites' column.
+	 * Test add_plugins_column adds the usage column used by WordPress.
 	 */
 	public function test_add_plugins_column(): void {
 		$columns = $this->columns->add_plugins_column([]);
 
 		$this->assertIsArray($columns);
-		$this->assertArrayHasKey('sites', $columns);
+		$this->assertArrayHasKey('active_blogs', $columns);
+		$this->assertSame('Usage', $columns['active_blogs']);
 	}
 
 	/**
-	 * Test add_themes_column adds a 'sites' column.
+	 * Test add_themes_column adds the usage column used by WordPress.
 	 */
 	public function test_add_themes_column(): void {
 		$columns = $this->columns->add_themes_column([]);
 
 		$this->assertIsArray($columns);
-		$this->assertArrayHasKey('sites', $columns);
+		$this->assertArrayHasKey('active_blogs', $columns);
+		$this->assertStringContainsString('Usage', $columns['active_blogs']);
 	}
 
 	/**

--- a/tests/WP_Ultimo/Admin_Pages/Migration_Alert_Admin_Page_Test.php
+++ b/tests/WP_Ultimo/Admin_Pages/Migration_Alert_Admin_Page_Test.php
@@ -114,7 +114,7 @@ class Migration_Alert_Admin_Page_Test extends WP_UnitTestCase {
 	// -------------------------------------------------------------------------
 
 	/**
-	 * get_logo returns a string.
+	 * Get_logo returns a string.
 	 */
 	public function test_get_logo_returns_string(): void {
 
@@ -124,7 +124,7 @@ class Migration_Alert_Admin_Page_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * get_logo returns non-empty string.
+	 * Get_logo returns non-empty string.
 	 */
 	public function test_get_logo_non_empty(): void {
 
@@ -134,7 +134,7 @@ class Migration_Alert_Admin_Page_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * get_logo contains logo.webp.
+	 * Get_logo contains logo.webp.
 	 */
 	public function test_get_logo_contains_logo_webp(): void {
 
@@ -148,7 +148,7 @@ class Migration_Alert_Admin_Page_Test extends WP_UnitTestCase {
 	// -------------------------------------------------------------------------
 
 	/**
-	 * get_title returns Migration.
+	 * Get_title returns Migration.
 	 */
 	public function test_get_title(): void {
 
@@ -163,7 +163,7 @@ class Migration_Alert_Admin_Page_Test extends WP_UnitTestCase {
 	// -------------------------------------------------------------------------
 
 	/**
-	 * get_menu_title returns string.
+	 * Get_menu_title returns string.
 	 */
 	public function test_get_menu_title_returns_string(): void {
 
@@ -173,7 +173,7 @@ class Migration_Alert_Admin_Page_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * get_menu_title contains Ultimate Multisite.
+	 * Get_menu_title contains Ultimate Multisite.
 	 */
 	public function test_get_menu_title_contains_ultimate_multisite(): void {
 
@@ -187,7 +187,7 @@ class Migration_Alert_Admin_Page_Test extends WP_UnitTestCase {
 	// -------------------------------------------------------------------------
 
 	/**
-	 * get_sections returns an array.
+	 * Get_sections returns an array.
 	 */
 	public function test_get_sections_returns_array(): void {
 
@@ -197,7 +197,7 @@ class Migration_Alert_Admin_Page_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * get_sections contains alert section.
+	 * Get_sections contains alert section.
 	 */
 	public function test_get_sections_contains_alert(): void {
 
@@ -207,7 +207,7 @@ class Migration_Alert_Admin_Page_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * get_sections alert has required keys.
+	 * Get_sections alert has required keys.
 	 */
 	public function test_get_sections_alert_has_required_keys(): void {
 
@@ -219,7 +219,7 @@ class Migration_Alert_Admin_Page_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * get_sections alert title is Alert!.
+	 * Get_sections alert title is Alert!.
 	 */
 	public function test_get_sections_alert_title(): void {
 
@@ -233,7 +233,7 @@ class Migration_Alert_Admin_Page_Test extends WP_UnitTestCase {
 	// -------------------------------------------------------------------------
 
 	/**
-	 * section_alert outputs HTML.
+	 * Section_alert outputs HTML.
 	 */
 	public function test_section_alert_outputs_html(): void {
 
@@ -251,7 +251,7 @@ class Migration_Alert_Admin_Page_Test extends WP_UnitTestCase {
 	// -------------------------------------------------------------------------
 
 	/**
-	 * handle_proceed deletes network options and redirects.
+	 * Handle_proceed deletes network options and redirects.
 	 */
 	public function test_handle_proceed_deletes_options_and_redirects(): void {
 

--- a/tests/WP_Ultimo/Admin_Pages/Migration_Alert_Admin_Page_Test.php
+++ b/tests/WP_Ultimo/Admin_Pages/Migration_Alert_Admin_Page_Test.php
@@ -259,9 +259,28 @@ class Migration_Alert_Admin_Page_Test extends WP_UnitTestCase {
 		update_network_option(null, \WP_Ultimo::NETWORK_OPTION_SETUP_FINISHED, true);
 		update_network_option(null, 'wu_is_migration_done', true);
 
-		// Expect redirect exception.
-		$this->expectException(\WPDieException::class);
+		$redirect_url = null;
 
-		$this->page->handle_proceed();
+		add_filter(
+			'wp_redirect',
+			function ($location) use (&$redirect_url) {
+				$redirect_url = $location;
+
+				throw new \RuntimeException('redirect_intercepted');
+			}
+		);
+
+		try {
+			$this->page->handle_proceed();
+		} catch (\RuntimeException $e) {
+			$this->assertSame('redirect_intercepted', $e->getMessage());
+		} finally {
+			remove_all_filters('wp_redirect');
+		}
+
+		$this->assertFalse(get_network_option(null, \WP_Ultimo::NETWORK_OPTION_SETUP_FINISHED));
+		$this->assertFalse(get_network_option(null, 'wu_is_migration_done'));
+		$this->assertNotNull($redirect_url, 'wp_redirect should have been called');
+		$this->assertStringContainsString('wp-ultimo-setup', $redirect_url);
 	}
 }

--- a/views/base/dash.php
+++ b/views/base/dash.php
@@ -6,6 +6,8 @@
  */
 defined('ABSPATH') || exit;
 
+$page_title = $page_title ?? (isset($page) && method_exists($page, 'get_title') ? $page->get_title() : '');
+
 ?>
 <div id="wp-ultimo-wrap" class="<?php wu_wrap_use_container(); ?> wrap wu-styling">
 	<h1 class="wp-heading-inline">


### PR DESCRIPTION
## Summary

Fixed admin page test regressions by aligning stale network usage column assertions with the active_blogs column, making the dash view robust when rendered directly, intercepting migration alert redirects before headers are sent while asserting option cleanup, and filtering array-valued Ultimate Multisite settings from system info.

## Files Changed

inc/admin-pages/class-system-info-admin-page.php,tests/WP_Ultimo/Admin/Network_Usage_Columns_Test.php,tests/WP_Ultimo/Admin_Pages/Migration_Alert_Admin_Page_Test.php,views/base/dash.php

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** vendor/bin/phpunit --filter 'Wizard_Admin_Page_Test|Network_Usage_Columns_Test|Template_Switching_Admin_Page_Test|Debug_Admin_Page_Test|Migration_Alert_Admin_Page_Test|Multisite_Setup_Admin_Page_Test|System_Info_Admin_Page_Test'; vendor/bin/phpunit --filter 'Network_Usage_Columns_Test|Template_Switching_Admin_Page_Test|Migration_Alert_Admin_Page_Test|System_Info_Admin_Page_Test'; vendor/bin/phpunit --filter 'Migration_Alert_Admin_Page_Test'; vendor/bin/phpcs inc/admin-pages/class-system-info-admin-page.php tests/WP_Ultimo/Admin/Network_Usage_Columns_Test.php tests/WP_Ultimo/Admin_Pages/Migration_Alert_Admin_Page_Test.php views/base/dash.php; pre-commit hook PHPCS/PHPStan passed on production PHP

Resolves #1507


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.21.12 plugin for [OpenCode](https://opencode.ai) v1.17.9 with gpt-5.5 spent 10m and 91,710 tokens on this as a headless worker.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Page titles now display properly in dashboard and admin views with improved fallback handling

* **Tests**
  * Updated assertions for network usage columns and plugin/theme display
  * Refined migration alert test flow and redirect handling

* **Chores**
  * Enhanced system information rendering

<!-- end of auto-generated comment: release notes by coderabbit.ai -->