### PR TITLE
GH#1506: test: centralize ajax json test helper

### DIFF
--- a/tests/WP_Ultimo/Ajax_JSON_Test_Trait.php
+++ b/tests/WP_Ultimo/Ajax_JSON_Test_Trait.php
@@ -1,0 +1,81 @@
+<?php
+/**
+ * Shared helpers for testing AJAX handlers that emit JSON responses.
+ *
+ * @package WP_Ultimo
+ * @subpackage Tests
+ */
+
+namespace WP_Ultimo\Tests;
+
+defined('ABSPATH') || exit;
+
+/**
+ * Installs an AJAX context and die handler around wp_send_json_* calls.
+ */
+trait Ajax_JSON_Test_Trait {
+
+	/**
+	 * Install an AJAX die handler so wp_send_json_* does not stop PHPUnit.
+	 *
+	 * @return callable The installed handler.
+	 */
+	protected function install_ajax_json_die_handler(): callable {
+
+		add_filter('wp_doing_ajax', '__return_true');
+
+		$handler = function () {
+			return function ($message) {
+				throw new \WPAjaxDieContinueException(esc_html((string) $message));
+			};
+		};
+
+		add_filter('wp_die_ajax_handler', $handler, 1);
+
+		return $handler;
+	}
+
+	/**
+	 * Remove an AJAX die handler installed by install_ajax_json_die_handler().
+	 *
+	 * @param callable $handler The handler returned by install_ajax_json_die_handler().
+	 * @return void
+	 */
+	protected function remove_ajax_json_die_handler(callable $handler): void {
+
+		remove_filter('wp_doing_ajax', '__return_true');
+		remove_filter('wp_die_ajax_handler', $handler, 1);
+	}
+
+	/**
+	 * Capture a wp_send_json_* response from an AJAX handler.
+	 *
+	 * @param callable $ajax_handler The handler to run.
+	 * @return array{output: string, decoded: array, exception: bool}
+	 */
+	protected function capture_ajax_json_response(callable $ajax_handler): array {
+
+		$handler          = $this->install_ajax_json_die_handler();
+		$exception_caught = false;
+
+		ob_start();
+
+		try {
+			$ajax_handler();
+		} catch (\WPAjaxDieContinueException $exception) {
+			$exception_caught = true;
+			unset($exception);
+		} finally {
+			$output = ob_get_clean();
+			$this->remove_ajax_json_die_handler($handler);
+		}
+
+		$decoded = json_decode($output, true);
+
+		return [
+			'output'    => $output,
+			'decoded'   => is_array($decoded) ? $decoded : [],
+			'exception' => $exception_caught,
+		];
+	}
+}

--- a/tests/WP_Ultimo/Managers/Membership_Manager_Test.php
+++ b/tests/WP_Ultimo/Managers/Membership_Manager_Test.php
@@ -13,6 +13,7 @@ use WP_Ultimo\Models\Membership;
 use WP_Ultimo\Models\Customer;
 use WP_Ultimo\Models\Product;
 use WP_Ultimo\Database\Memberships\Membership_Status;
+use WP_Ultimo\Tests\Ajax_JSON_Test_Trait;
 
 /**
  * Test Membership Manager functionality.
@@ -20,6 +21,7 @@ use WP_Ultimo\Database\Memberships\Membership_Status;
 class Membership_Manager_Test extends \WP_UnitTestCase {
 
 	use Manager_Test_Trait;
+	use Ajax_JSON_Test_Trait;
 
 	/**
 	 * Test customer.
@@ -128,38 +130,6 @@ class Membership_Manager_Test extends \WP_UnitTestCase {
 	}
 
 	/**
-	 * Install an AJAX die handler so wp_send_json() does not stop PHPUnit.
-	 *
-	 * @return callable The installed handler.
-	 */
-	private function install_ajax_die_handler(): callable {
-
-		add_filter('wp_doing_ajax', '__return_true');
-
-		$handler = function () {
-			return function ($message) {
-				throw new \WPAjaxDieContinueException(esc_html((string) $message));
-			};
-		};
-
-		add_filter('wp_die_ajax_handler', $handler, 1);
-
-		return $handler;
-	}
-
-	/**
-	 * Remove the AJAX die handler.
-	 *
-	 * @param callable $handler The handler returned by install_ajax_die_handler().
-	 * @return void
-	 */
-	private function remove_ajax_die_handler(callable $handler): void {
-
-		remove_filter('wp_doing_ajax', '__return_true');
-		remove_filter('wp_die_ajax_handler', $handler, 1);
-	}
-
-	/**
 	 * Call the pending-site poll handler and capture its JSON response.
 	 *
 	 * @param Membership $membership Membership to poll.
@@ -167,26 +137,16 @@ class Membership_Manager_Test extends \WP_UnitTestCase {
 	 */
 	private function call_check_pending_site_created(Membership $membership): array {
 
-		$handler = $this->install_ajax_die_handler();
-		$manager = $this->get_manager_instance();
-
 		$_REQUEST['membership_hash'] = $membership->get_hash();
 
-		ob_start();
-
-		try {
+		$response = $this->capture_ajax_json_response(function () {
+			$manager = $this->get_manager_instance();
 			$manager->check_pending_site_created();
-		} catch (\WPAjaxDieContinueException $exception) {
-			// Expected: wp_send_json() terminates via wp_die() in AJAX context.
-			unset($exception);
-		}
-
-		$output = ob_get_clean();
+		});
 
 		unset($_REQUEST['membership_hash']);
-		$this->remove_ajax_die_handler($handler);
 
-		return json_decode($output, true);
+		return $response['decoded'];
 	}
 
 	// ========================================================================

--- a/tests/WP_Ultimo/Managers/Regression_Pending_Site_And_Subdomain_Test.php
+++ b/tests/WP_Ultimo/Managers/Regression_Pending_Site_And_Subdomain_Test.php
@@ -34,12 +34,15 @@ defined('ABSPATH') || exit;
 
 use WP_UnitTestCase;
 use WP_Ultimo\Models\Site;
+use WP_Ultimo\Tests\Ajax_JSON_Test_Trait;
 
 /**
  * Regression coverage for the pending-site stale-flag reset (BUG 4) and the
  * subdomain enqueue guard (BUG 5).
  */
 class Regression_Pending_Site_And_Subdomain_Test extends WP_UnitTestCase {
+
+	use Ajax_JSON_Test_Trait;
 
 	/**
 	 * Membership manager under test (BUG 4).
@@ -145,42 +148,6 @@ class Regression_Pending_Site_And_Subdomain_Test extends WP_UnitTestCase {
 		return $membership;
 	}
 
-	/**
-	 * Invoke an AJAX handler, capturing the JSON wp_send_json output.
-	 *
-	 * @param callable $ajax_handler The handler to run.
-	 * @return array The decoded JSON payload.
-	 */
-	private function capture_ajax_json(callable $ajax_handler): array {
-
-		add_filter('wp_doing_ajax', '__return_true');
-
-		$die_handler = function () {
-			return function ($message) {
-				throw new \WPAjaxDieContinueException(esc_html((string) $message));
-			};
-		};
-		add_filter('wp_die_ajax_handler', $die_handler, 1);
-
-		ob_start();
-
-		try {
-			$ajax_handler();
-		} catch (\WPAjaxDieContinueException $e) {
-			// wp_send_json() called wp_die() — expected.
-			unset($e);
-		}
-
-		$output = ob_get_clean();
-
-		remove_filter('wp_doing_ajax', '__return_true');
-		remove_filter('wp_die_ajax_handler', $die_handler, 1);
-
-		$decoded = json_decode($output, true);
-
-		return is_array($decoded) ? $decoded : [];
-	}
-
 	// =========================================================================
 	// BUG 4 — stale publishing flag unblocks the overlay
 	// Exercises: Membership_Manager::check_pending_site_created()
@@ -209,11 +176,12 @@ class Regression_Pending_Site_And_Subdomain_Test extends WP_UnitTestCase {
 		$_REQUEST['membership_hash'] = $membership->get_hash();
 		$_GET['membership_hash']     = $membership->get_hash();
 
-		$payload = $this->capture_ajax_json(
+		$response = $this->capture_ajax_json_response(
 			function () {
 				$this->membership_manager->check_pending_site_created();
 			}
 		);
+		$payload  = $response['decoded'];
 
 		unset($_REQUEST['membership_hash'], $_GET['membership_hash']);
 
@@ -249,11 +217,12 @@ class Regression_Pending_Site_And_Subdomain_Test extends WP_UnitTestCase {
 		$_REQUEST['membership_hash'] = $membership->get_hash();
 		$_GET['membership_hash']     = $membership->get_hash();
 
-		$payload = $this->capture_ajax_json(
+		$response = $this->capture_ajax_json_response(
 			function () {
 				$this->membership_manager->check_pending_site_created();
 			}
 		);
+		$payload  = $response['decoded'];
 
 		unset($_REQUEST['membership_hash'], $_GET['membership_hash']);
 

--- a/tests/WP_Ultimo/UI/Template_Switching_Element_Test.php
+++ b/tests/WP_Ultimo/UI/Template_Switching_Element_Test.php
@@ -14,6 +14,7 @@
 namespace WP_Ultimo\UI;
 
 use WP_UnitTestCase;
+use WP_Ultimo\Tests\Ajax_JSON_Test_Trait;
 
 /**
  * Test class for Template_Switching_Element AJAX flow.
@@ -21,6 +22,8 @@ use WP_UnitTestCase;
  * @group ajax
  */
 class Template_Switching_Element_Test extends WP_UnitTestCase {
+
+	use Ajax_JSON_Test_Trait;
 
 	/**
 	 * Set up.
@@ -59,61 +62,19 @@ class Template_Switching_Element_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Install AJAX die handler so wp_send_json_* don't kill PHPUnit.
-	 *
-	 * @return callable The installed handler.
-	 */
-	private function install_ajax_die_handler(): callable {
-
-		add_filter( 'wp_doing_ajax', '__return_true' );
-
-		$handler = function () {
-			return function ($message) {
-				throw new \WPAjaxDieContinueException( esc_html( (string) $message ) );
-			};
-		};
-
-		add_filter( 'wp_die_ajax_handler', $handler, 1 );
-
-		return $handler;
-	}
-
-	/**
-	 * Remove the AJAX die handler.
-	 *
-	 * @param callable $handler The handler returned by install_ajax_die_handler().
-	 */
-	private function remove_ajax_die_handler(callable $handler): void {
-
-		remove_filter( 'wp_doing_ajax', '__return_true' );
-		remove_filter( 'wp_die_ajax_handler', $handler, 1 );
-	}
-
-	/**
 	 * Call switch_template() inside an AJAX context, capturing JSON output.
 	 *
 	 * @return array{output: string, exception: bool}
 	 */
 	private function call_switch_template(): array {
 
-		$handler          = $this->install_ajax_die_handler();
-		$exception_caught = false;
-
-		ob_start();
-
-		try {
+		$response = $this->capture_ajax_json_response(function () {
 			Template_Switching_Element::get_instance()->switch_template();
-		} catch ( \WPAjaxDieContinueException $e ) {
-			$exception_caught = true;
-		}
-
-		$output = ob_get_clean();
-
-		$this->remove_ajax_die_handler( $handler );
+		});
 
 		return [
-			'output'    => $output,
-			'exception' => $exception_caught,
+			'output'    => $response['output'],
+			'exception' => $response['exception'],
 		];
 	}
 

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -86,6 +86,7 @@ require "{$_tests_dir}/includes/bootstrap.php";
 
 // Load test traits (not autoloaded since they don't end in Test.php).
 require_once __DIR__ . '/WP_Ultimo/Managers/Manager_Test_Trait.php';
+require_once __DIR__ . '/WP_Ultimo/Ajax_JSON_Test_Trait.php';
 
 /**
  * Minimal wc_get_order() stub for unit tests.


### PR DESCRIPTION
## Summary

Centralized AJAX JSON PHPUnit interception in a shared trait and updated pending-site/template-switching AJAX tests to execute wp_send_json paths under wp_doing_ajax with an AJAX wp_die handler.

## Files Changed

tests/WP_Ultimo/Ajax_JSON_Test_Trait.php,tests/WP_Ultimo/Managers/Membership_Manager_Test.php,tests/WP_Ultimo/Managers/Regression_Pending_Site_And_Subdomain_Test.php,tests/WP_Ultimo/UI/Template_Switching_Element_Test.php,tests/bootstrap.php

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** vendor/bin/phpcs tests/WP_Ultimo/Ajax_JSON_Test_Trait.php tests/bootstrap.php tests/WP_Ultimo/Managers/Membership_Manager_Test.php tests/WP_Ultimo/Managers/Regression_Pending_Site_And_Subdomain_Test.php tests/WP_Ultimo/UI/Template_Switching_Element_Test.php; vendor/bin/phpunit --filter PayPal_OAuth_Handler_Test; vendor/bin/phpunit --filter Gateway_Manager_Test; vendor/bin/phpunit --filter test_check_pending_site_created_invalidates_stale_pending_site_cache; vendor/bin/phpunit --filter Regression_Pending_Site_And_Subdomain_Test; vendor/bin/phpunit --filter Template_Switching_Element_Test. Note: vendor/bin/phpunit --filter Membership_Manager_Test is blocked locally by WordPress test schema corruption (missing wptests_sitemeta and missing spam/deleted columns on wptests_users), while the issue-specific membership AJAX method passes.

Resolves #1506


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.21.12 plugin for [OpenCode](https://opencode.ai) v1.17.9 with gpt-5.5 spent 17m and 163,068 tokens on this as a headless worker.