### PR TITLE
GH#1504: fix: stabilize customer panel site fixtures

### DIFF
--- a/inc/admin-pages/customer-panel/class-account-admin-page.php
+++ b/inc/admin-pages/customer-panel/class-account-admin-page.php
@@ -263,6 +263,7 @@ class Account_Admin_Page extends Base_Customer_Facing_Admin_Page {
 		wu_get_template(
 			'base/dash',
 			[
+				'page_title'        => $this->get_title(),
 				'screen'            => get_current_screen(),
 				'page'              => $this,
 				'has_full_position' => false,

--- a/inc/admin-pages/customer-panel/class-add-new-site-admin-page.php
+++ b/inc/admin-pages/customer-panel/class-add-new-site-admin-page.php
@@ -257,6 +257,7 @@ class Add_New_Site_Admin_Page extends Base_Customer_Facing_Admin_Page {
 		wu_get_template(
 			'base/dash',
 			[
+				'page_title'        => $this->get_title(),
 				'screen'            => get_current_screen(),
 				'page'              => $this,
 				'has_full_position' => false,

--- a/inc/admin-pages/customer-panel/class-my-sites-admin-page.php
+++ b/inc/admin-pages/customer-panel/class-my-sites-admin-page.php
@@ -280,6 +280,7 @@ class My_Sites_Admin_Page extends Base_Customer_Facing_Admin_Page {
 		wu_get_template(
 			'base/dash',
 			[
+				'page_title'        => $this->get_title(),
 				'screen'            => get_current_screen(),
 				'page'              => $this,
 				'has_full_position' => false,

--- a/inc/functions/site.php
+++ b/inc/functions/site.php
@@ -66,9 +66,9 @@ function wu_get_site_by_hash($hash) {
  *
  * @since 2.5.0
  *
- * @param string       $search      The search term.
- * @param array|false  $blog_id__in Optional array of blog IDs to restrict the search to.
- * @param int          $limit       Maximum number of IDs to return.
+ * @param string      $search      The search term.
+ * @param array|false $blog_id__in Optional array of blog IDs to restrict the search to.
+ * @param int         $limit       Maximum number of IDs to return.
  * @return int[]
  */
 function wu_get_sites_extra_ids_for_search($search, $blog_id__in = false, $limit = 100) {
@@ -230,6 +230,34 @@ function wu_create_site($site_data) {
 
 	$network_domain = $current_site->domain;
 
+	$existing_site_data = [];
+
+	if ( ! empty($site_data['blog_id'])) {
+		$existing_site = get_site((int) $site_data['blog_id']);
+
+		if ($existing_site) {
+			$details = get_blog_details((int) $site_data['blog_id']);
+
+			$existing_site_data = [
+				'site_id'      => (int) $existing_site->network_id,
+				'domain'       => $existing_site->domain,
+				'path'         => $existing_site->path,
+				'registered'   => $existing_site->registered,
+				'last_updated' => $existing_site->last_updated,
+				'public'       => (bool) $existing_site->public,
+				'archived'     => (bool) $existing_site->archived,
+				'mature'       => (bool) $existing_site->mature,
+				'spam'         => (bool) $existing_site->spam,
+				'deleted'      => (bool) $existing_site->deleted,
+				'lang_id'      => (int) $existing_site->lang_id,
+			];
+
+			if ($details && isset($details->blogname)) {
+				$existing_site_data['title'] = $details->blogname;
+			}
+		}
+	}
+
 	// Mode-aware domain/path normalisation. When the caller passes a path
 	// but no explicit domain (or only the network root domain) on a
 	// subdomain multisite install, the path is meaningless — WordPress
@@ -250,8 +278,8 @@ function wu_create_site($site_data) {
 	$domain_supplied           = '' !== $normalized_input_domain && $normalized_input_domain !== $normalized_network_domain;
 
 	if (is_multisite() && apply_filters('wu_is_subdomain_install', is_subdomain_install()) && $path_supplied && ! $domain_supplied) {
-		$raw_slug             = trim((string) $site_data['path'], '/');
-		$slug                 = sanitize_title_with_dashes(wu_clean($raw_slug));
+		$raw_slug = trim((string) $site_data['path'], '/');
+		$slug     = sanitize_title_with_dashes(wu_clean($raw_slug));
 
 		if ('' === $slug) {
 			return new \WP_Error(
@@ -260,23 +288,26 @@ function wu_create_site($site_data) {
 			);
 		}
 
-		$bare_network_domain  = preg_replace('/^www\./i', '', (string) $network_domain);
-		$site_data['domain']  = "{$slug}.{$bare_network_domain}";
-		$site_data['path']    = '/';
+		$bare_network_domain = preg_replace('/^www\./i', '', (string) $network_domain);
+		$site_data['domain'] = "{$slug}.{$bare_network_domain}";
+		$site_data['path']   = '/';
 	}
 
 	$site_data = wp_parse_args(
 		$site_data,
-		[
-			'domain'                => $network_domain,
-			'path'                  => '/',
-			'title'                 => false,
-			'type'                  => false,
-			'template_id'           => false,
-			'featured_image_id'     => 0,
-			'duplication_arguments' => false,
-			'public'                => true,
-		]
+		array_merge(
+			[
+				'domain'                => $network_domain,
+				'path'                  => '/',
+				'title'                 => false,
+				'type'                  => false,
+				'template_id'           => false,
+				'featured_image_id'     => 0,
+				'duplication_arguments' => false,
+				'public'                => true,
+			],
+			$existing_site_data
+		)
 	);
 
 	$site = new \WP_Ultimo\Models\Site($site_data);

--- a/tests/WP_Ultimo/Admin_Pages/Customer_Panel/Account_Admin_Page_Test.php
+++ b/tests/WP_Ultimo/Admin_Pages/Customer_Panel/Account_Admin_Page_Test.php
@@ -60,10 +60,12 @@ class Account_Admin_Page_Test extends WP_UnitTestCase {
 				$this->customer = wu_get_customer_by_user_id($user->ID);
 			}
 
-			if (!$this->customer || is_wp_error($this->customer)) {
+			if (! $this->customer || is_wp_error($this->customer)) {
 				$this->fail('Could not create test customer');
 			}
 		}
+
+		wp_set_current_user($this->customer->get_user_id());
 
 		// Create a membership.
 		$this->membership = wu_create_membership(
@@ -210,7 +212,7 @@ class Account_Admin_Page_Test extends WP_UnitTestCase {
 	// -------------------------------------------------------------------------
 
 	/**
-	 * get_title returns 'Account'.
+	 * Get_title returns 'Account'.
 	 */
 	public function test_get_title(): void {
 
@@ -225,7 +227,7 @@ class Account_Admin_Page_Test extends WP_UnitTestCase {
 	// -------------------------------------------------------------------------
 
 	/**
-	 * get_menu_title returns 'Account'.
+	 * Get_menu_title returns 'Account'.
 	 */
 	public function test_get_menu_title(): void {
 
@@ -240,7 +242,7 @@ class Account_Admin_Page_Test extends WP_UnitTestCase {
 	// -------------------------------------------------------------------------
 
 	/**
-	 * get_submenu_title returns 'Account'.
+	 * Get_submenu_title returns 'Account'.
 	 */
 	public function test_get_submenu_title(): void {
 
@@ -255,7 +257,7 @@ class Account_Admin_Page_Test extends WP_UnitTestCase {
 	// -------------------------------------------------------------------------
 
 	/**
-	 * page_loaded sets current_site and current_membership.
+	 * Page_loaded sets current_site and current_membership.
 	 */
 	public function test_page_loaded(): void {
 
@@ -277,7 +279,7 @@ class Account_Admin_Page_Test extends WP_UnitTestCase {
 	// -------------------------------------------------------------------------
 
 	/**
-	 * hooks() does not throw.
+	 * Hooks() does not throw.
 	 */
 	public function test_hooks_does_not_throw(): void {
 
@@ -291,7 +293,7 @@ class Account_Admin_Page_Test extends WP_UnitTestCase {
 	// -------------------------------------------------------------------------
 
 	/**
-	 * screen_options() does not throw.
+	 * Screen_options() does not throw.
 	 */
 	public function test_screen_options_does_not_throw(): void {
 
@@ -305,7 +307,7 @@ class Account_Admin_Page_Test extends WP_UnitTestCase {
 	// -------------------------------------------------------------------------
 
 	/**
-	 * register_widgets() does not throw when called with a valid screen.
+	 * Register_widgets() does not throw when called with a valid screen.
 	 */
 	public function test_register_widgets_does_not_throw(): void {
 
@@ -321,7 +323,7 @@ class Account_Admin_Page_Test extends WP_UnitTestCase {
 	// -------------------------------------------------------------------------
 
 	/**
-	 * output() renders without throwing.
+	 * Output() renders without throwing.
 	 */
 	public function test_output_renders(): void {
 
@@ -339,7 +341,7 @@ class Account_Admin_Page_Test extends WP_UnitTestCase {
 	// -------------------------------------------------------------------------
 
 	/**
-	 * add_notices() with no updated query param does nothing.
+	 * Add_notices() with no updated query param does nothing.
 	 */
 	public function test_add_notices_no_update_param(): void {
 
@@ -353,11 +355,12 @@ class Account_Admin_Page_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * add_notices() with payment_method update type adds notice.
+	 * Add_notices() with payment_method update type adds notice.
 	 */
 	public function test_add_notices_payment_method_update(): void {
 
-		$_GET['updated'] = 'payment_method';
+		$_GET['updated']     = 'payment_method';
+		$_REQUEST['updated'] = 'payment_method';
 
 		$reflection = new \ReflectionClass($this->page);
 		$method     = $reflection->getMethod('add_notices');
@@ -368,15 +371,16 @@ class Account_Admin_Page_Test extends WP_UnitTestCase {
 		$notices = \WP_Ultimo()->notices->get_notices('admin');
 		$this->assertNotEmpty($notices);
 
-		unset($_GET['updated']);
+		unset($_GET['updated'], $_REQUEST['updated']);
 	}
 
 	/**
-	 * add_notices() with generic update type adds notice.
+	 * Add_notices() with generic update type adds notice.
 	 */
 	public function test_add_notices_generic_update(): void {
 
-		$_GET['updated'] = 'profile';
+		$_GET['updated']     = 'profile';
+		$_REQUEST['updated'] = 'profile';
 
 		$reflection = new \ReflectionClass($this->page);
 		$method     = $reflection->getMethod('add_notices');
@@ -387,6 +391,6 @@ class Account_Admin_Page_Test extends WP_UnitTestCase {
 		$notices = \WP_Ultimo()->notices->get_notices('admin');
 		$this->assertNotEmpty($notices);
 
-		unset($_GET['updated']);
+		unset($_GET['updated'], $_REQUEST['updated']);
 	}
 }

--- a/tests/WP_Ultimo/Admin_Pages/Customer_Panel/Add_New_Site_Admin_Page_Test.php
+++ b/tests/WP_Ultimo/Admin_Pages/Customer_Panel/Add_New_Site_Admin_Page_Test.php
@@ -60,10 +60,12 @@ class Add_New_Site_Admin_Page_Test extends WP_UnitTestCase {
 				$this->customer = wu_get_customer_by_user_id($user->ID);
 			}
 
-			if (!$this->customer || is_wp_error($this->customer)) {
+			if (! $this->customer || is_wp_error($this->customer)) {
 				$this->fail('Could not create test customer');
 			}
 		}
+
+		wp_set_current_user($this->customer->get_user_id());
 
 		// Create a membership.
 		$this->membership = wu_create_membership(
@@ -234,7 +236,7 @@ class Add_New_Site_Admin_Page_Test extends WP_UnitTestCase {
 	// -------------------------------------------------------------------------
 
 	/**
-	 * get_title returns 'Add New Site'.
+	 * Get_title returns 'Add New Site'.
 	 */
 	public function test_get_title(): void {
 
@@ -249,7 +251,7 @@ class Add_New_Site_Admin_Page_Test extends WP_UnitTestCase {
 	// -------------------------------------------------------------------------
 
 	/**
-	 * get_menu_title returns 'Add New Site'.
+	 * Get_menu_title returns 'Add New Site'.
 	 */
 	public function test_get_menu_title(): void {
 
@@ -264,7 +266,7 @@ class Add_New_Site_Admin_Page_Test extends WP_UnitTestCase {
 	// -------------------------------------------------------------------------
 
 	/**
-	 * get_submenu_title returns 'Add New Site'.
+	 * Get_submenu_title returns 'Add New Site'.
 	 */
 	public function test_get_submenu_title(): void {
 
@@ -279,7 +281,7 @@ class Add_New_Site_Admin_Page_Test extends WP_UnitTestCase {
 	// -------------------------------------------------------------------------
 
 	/**
-	 * page_loaded sets customer.
+	 * Page_loaded sets customer.
 	 */
 	public function test_page_loaded(): void {
 
@@ -305,7 +307,7 @@ class Add_New_Site_Admin_Page_Test extends WP_UnitTestCase {
 	// -------------------------------------------------------------------------
 
 	/**
-	 * hooks() does not throw.
+	 * Hooks() does not throw.
 	 */
 	public function test_hooks_does_not_throw(): void {
 
@@ -319,7 +321,7 @@ class Add_New_Site_Admin_Page_Test extends WP_UnitTestCase {
 	// -------------------------------------------------------------------------
 
 	/**
-	 * force_screen_options() returns early when screen id doesn't match.
+	 * Force_screen_options() returns early when screen id doesn't match.
 	 */
 	public function test_force_screen_options_wrong_screen(): void {
 
@@ -331,7 +333,7 @@ class Add_New_Site_Admin_Page_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * force_screen_options() adds screen option when screen id matches.
+	 * Force_screen_options() adds screen option when screen id matches.
 	 */
 	public function test_force_screen_options_correct_screen(): void {
 
@@ -347,7 +349,7 @@ class Add_New_Site_Admin_Page_Test extends WP_UnitTestCase {
 	// -------------------------------------------------------------------------
 
 	/**
-	 * screen_options() does not throw.
+	 * Screen_options() does not throw.
 	 */
 	public function test_screen_options_does_not_throw(): void {
 
@@ -361,7 +363,7 @@ class Add_New_Site_Admin_Page_Test extends WP_UnitTestCase {
 	// -------------------------------------------------------------------------
 
 	/**
-	 * register_widgets() does not throw when called with a valid screen.
+	 * Register_widgets() does not throw when called with a valid screen.
 	 */
 	public function test_register_widgets_does_not_throw(): void {
 
@@ -377,7 +379,7 @@ class Add_New_Site_Admin_Page_Test extends WP_UnitTestCase {
 	// -------------------------------------------------------------------------
 
 	/**
-	 * output() renders without throwing.
+	 * Output() renders without throwing.
 	 */
 	public function test_output_renders(): void {
 

--- a/tests/WP_Ultimo/Admin_Pages/Customer_Panel/My_Sites_Admin_Page_Test.php
+++ b/tests/WP_Ultimo/Admin_Pages/Customer_Panel/My_Sites_Admin_Page_Test.php
@@ -60,10 +60,12 @@ class My_Sites_Admin_Page_Test extends WP_UnitTestCase {
 				$this->customer = wu_get_customer_by_user_id($user->ID);
 			}
 
-			if (!$this->customer || is_wp_error($this->customer)) {
+			if (! $this->customer || is_wp_error($this->customer)) {
 				$this->fail('Could not create test customer');
 			}
 		}
+
+		wp_set_current_user($this->customer->get_user_id());
 
 		// Create a membership.
 		$this->membership = wu_create_membership(
@@ -210,7 +212,7 @@ class My_Sites_Admin_Page_Test extends WP_UnitTestCase {
 	// -------------------------------------------------------------------------
 
 	/**
-	 * get_title returns 'My Sites'.
+	 * Get_title returns 'My Sites'.
 	 */
 	public function test_get_title(): void {
 
@@ -225,7 +227,7 @@ class My_Sites_Admin_Page_Test extends WP_UnitTestCase {
 	// -------------------------------------------------------------------------
 
 	/**
-	 * get_menu_title returns 'My Sites'.
+	 * Get_menu_title returns 'My Sites'.
 	 */
 	public function test_get_menu_title(): void {
 
@@ -240,7 +242,7 @@ class My_Sites_Admin_Page_Test extends WP_UnitTestCase {
 	// -------------------------------------------------------------------------
 
 	/**
-	 * get_submenu_title returns 'My Sites'.
+	 * Get_submenu_title returns 'My Sites'.
 	 */
 	public function test_get_submenu_title(): void {
 
@@ -255,7 +257,7 @@ class My_Sites_Admin_Page_Test extends WP_UnitTestCase {
 	// -------------------------------------------------------------------------
 
 	/**
-	 * page_loaded sets customer.
+	 * Page_loaded sets customer.
 	 */
 	public function test_page_loaded(): void {
 
@@ -281,7 +283,7 @@ class My_Sites_Admin_Page_Test extends WP_UnitTestCase {
 	// -------------------------------------------------------------------------
 
 	/**
-	 * hooks() does not throw.
+	 * Hooks() does not throw.
 	 */
 	public function test_hooks_does_not_throw(): void {
 
@@ -295,7 +297,7 @@ class My_Sites_Admin_Page_Test extends WP_UnitTestCase {
 	// -------------------------------------------------------------------------
 
 	/**
-	 * unset_default_my_sites_menu() does not throw.
+	 * Unset_default_my_sites_menu() does not throw.
 	 */
 	public function test_unset_default_my_sites_menu_does_not_throw(): void {
 
@@ -309,15 +311,22 @@ class My_Sites_Admin_Page_Test extends WP_UnitTestCase {
 	// -------------------------------------------------------------------------
 
 	/**
-	 * change_my_sites_link() returns early when my-sites node is empty.
+	 * Change_my_sites_link() returns early when my-sites node is empty.
 	 */
 	public function test_change_my_sites_link_no_node(): void {
 
-		global $wp_admin_bar;
+		$wp_admin_bar = new class() {
 
-		if (!$wp_admin_bar) {
-			$wp_admin_bar = new \WP_Admin_Bar();
-		}
+			public function get_node($id) {
+
+				return null;
+			}
+
+			public function add_node($node): void {
+
+				throw new \RuntimeException('add_node should not be called when the my-sites node is missing.');
+			}
+		};
 
 		$this->page->change_my_sites_link($wp_admin_bar);
 
@@ -329,7 +338,7 @@ class My_Sites_Admin_Page_Test extends WP_UnitTestCase {
 	// -------------------------------------------------------------------------
 
 	/**
-	 * force_screen_options() returns early when screen id doesn't match.
+	 * Force_screen_options() returns early when screen id doesn't match.
 	 */
 	public function test_force_screen_options_wrong_screen(): void {
 
@@ -341,7 +350,7 @@ class My_Sites_Admin_Page_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * force_screen_options() adds screen option when screen id matches.
+	 * Force_screen_options() adds screen option when screen id matches.
 	 */
 	public function test_force_screen_options_correct_screen(): void {
 
@@ -357,7 +366,7 @@ class My_Sites_Admin_Page_Test extends WP_UnitTestCase {
 	// -------------------------------------------------------------------------
 
 	/**
-	 * screen_options() does not throw.
+	 * Screen_options() does not throw.
 	 */
 	public function test_screen_options_does_not_throw(): void {
 
@@ -371,7 +380,7 @@ class My_Sites_Admin_Page_Test extends WP_UnitTestCase {
 	// -------------------------------------------------------------------------
 
 	/**
-	 * register_widgets() does not throw when called with a valid screen.
+	 * Register_widgets() does not throw when called with a valid screen.
 	 */
 	public function test_register_widgets_does_not_throw(): void {
 
@@ -387,7 +396,7 @@ class My_Sites_Admin_Page_Test extends WP_UnitTestCase {
 	// -------------------------------------------------------------------------
 
 	/**
-	 * output() renders without throwing.
+	 * Output() renders without throwing.
 	 */
 	public function test_output_renders(): void {
 

--- a/tests/WP_Ultimo/Functions/Site_Functions_Extended_Test.php
+++ b/tests/WP_Ultimo/Functions/Site_Functions_Extended_Test.php
@@ -319,4 +319,34 @@ class Site_Functions_Extended_Test extends WP_UnitTestCase {
 		$this->assertWPError($result);
 		$this->assertEquals('invalid_site_path', $result->get_error_code());
 	}
+
+	/**
+	 * Test wu_create_site preserves existing WordPress site URL data.
+	 */
+	public function test_create_site_with_existing_blog_id_uses_existing_domain_and_path(): void {
+
+		$blog_id = self::factory()->blog->create(
+			[
+				'title' => 'Existing Fixture Site',
+			]
+		);
+
+		$this->assertNotWPError($blog_id);
+
+		$wp_site = get_site($blog_id);
+
+		$this->assertInstanceOf(\WP_Site::class, $wp_site);
+
+		$site = wu_create_site(
+			[
+				'blog_id' => $blog_id,
+				'type'    => 'customer_owned',
+			]
+		);
+
+		$this->assertNotWPError($site);
+		$this->assertInstanceOf(\WP_Ultimo\Models\Site::class, $site);
+		$this->assertSame($wp_site->domain, $site->get_domain());
+		$this->assertSame($wp_site->path, $site->get_path());
+	}
 }


### PR DESCRIPTION
## Summary

Fixed wu_create_site() so an existing blog_id fixture preserves its WordPress domain/path data, passed customer-panel dash page titles to the shared view, and updated customer-panel tests to model an authenticated customer fixture.

## Files Changed

inc/admin-pages/customer-panel/class-account-admin-page.php,inc/admin-pages/customer-panel/class-add-new-site-admin-page.php,inc/admin-pages/customer-panel/class-my-sites-admin-page.php,inc/functions/site.php,tests/WP_Ultimo/Admin_Pages/Customer_Panel/Account_Admin_Page_Test.php,tests/WP_Ultimo/Admin_Pages/Customer_Panel/Add_New_Site_Admin_Page_Test.php,tests/WP_Ultimo/Admin_Pages/Customer_Panel/My_Sites_Admin_Page_Test.php,tests/WP_Ultimo/Functions/Site_Functions_Extended_Test.php

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** vendor/bin/phpunit --filter 'Account_Admin_Page_Test|Add_New_Site_Admin_Page_Test|My_Sites_Admin_Page_Test|test_create_site_with_existing_blog_id_uses_existing_domain_and_path'; vendor/bin/phpcs inc/functions/site.php inc/admin-pages/customer-panel/class-account-admin-page.php inc/admin-pages/customer-panel/class-add-new-site-admin-page.php inc/admin-pages/customer-panel/class-my-sites-admin-page.php tests/WP_Ultimo/Admin_Pages/Customer_Panel/Account_Admin_Page_Test.php tests/WP_Ultimo/Admin_Pages/Customer_Panel/Add_New_Site_Admin_Page_Test.php tests/WP_Ultimo/Admin_Pages/Customer_Panel/My_Sites_Admin_Page_Test.php tests/WP_Ultimo/Functions/Site_Functions_Extended_Test.php; pre-commit PHPStan

Resolves #1504


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.21.12 plugin for [OpenCode](https://opencode.ai) v1.17.9 with gpt-5.5 spent 23m and 350,797 tokens on this as a headless worker.