### PR TITLE
fix: normalize unsaved notable notes

### DIFF
--- a/inc/models/traits/trait-notable.php
+++ b/inc/models/traits/trait-notable.php
@@ -35,6 +35,12 @@ trait Notable {
 	public function get_notes() {
 
 		if (null === $this->notes) {
+			if ( ! $this->get_id()) {
+				$this->notes = [];
+
+				return $this->notes;
+			}
+
 			$this->notes = get_metadata($this->get_meta_data_table_name(), $this->get_id(), 'wu_note', false);
 		}
 

--- a/tests/WP_Ultimo/Models/Interfaces/Interface_Notable_Test.php
+++ b/tests/WP_Ultimo/Models/Interfaces/Interface_Notable_Test.php
@@ -62,16 +62,15 @@ class Interface_Notable_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Test get_notes returns array or empty for unsaved model.
+	 * Test get_notes returns an empty array for unsaved model.
 	 */
-	public function test_get_notes_returns_array_or_empty_for_unsaved(): void {
+	public function test_get_notes_returns_empty_array_for_unsaved(): void {
 
 		$customer = new Customer();
 
-		// Unsaved model — meta not available, should return null or empty.
 		$notes = $customer->get_notes();
 
-		$this->assertTrue(is_array($notes) || is_null($notes));
+		$this->assertSame([], $notes, 'Unsaved models have no meta row and should expose no notes.');
 	}
 
 	/**


### PR DESCRIPTION
## Summary

- Return an empty notes array for unsaved Notable models before metadata lookup.
- Tighten the Notable interface regression test to assert the intended empty-array contract.
- Verified the membership pending-site stale recovery failure listed in the issue is not currently reproducible; the focused membership suite passes.

Resolves #1512

## Testing

- `vendor/bin/phpunit --filter Interface_Notable_Test` — pass (9 tests, 12 assertions)
- `vendor/bin/phpunit --filter Membership_Test` — pass (119 tests, 223 assertions, 1 existing skipped test)
- `vendor/bin/phpcs inc/models/traits/trait-notable.php tests/WP_Ultimo/Models/Interfaces/Interface_Notable_Test.php` — pass
- `vendor/bin/phpstan analyse` — blocked by existing project-wide baseline errors (526 reported), including unrelated issues in `inc/duplication/functions.php`, `inc/external-cron/class-external-cron-manager.php`, `inc/models/class-base-model.php`, and others


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.21.12 plugin for [OpenCode](https://opencode.ai) v1.17.9 with gpt-5.5


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where retrieving notes for unsaved items could cause unexpected behavior; now consistently returns an empty array instead.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->