### PR TITLE
test: stabilize SSO regression coverage

### DIFF
--- a/tests/WP_Ultimo/SSO/SSO_Coverage_Test.php
+++ b/tests/WP_Ultimo/SSO/SSO_Coverage_Test.php
@@ -1241,34 +1241,74 @@ class SSO_Coverage_Test extends \WP_UnitTestCase {
 	 * Test get_sso_action detects SSO path in REQUEST_URI.
 	 */
 	public function test_get_sso_action_detects_sso_path_in_request_uri(): void {
+		unset($_REQUEST['sso'], $_REQUEST['sso-grant'], $_REQUEST['sso_verify']);
+
+		$previous_request_uri = $_SERVER['REQUEST_URI'] ?? null; // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized,WordPress.Security.ValidatedSanitizedInput.MissingUnslash -- Test restores the exact previous server global.
+		$previous_http_host   = $_SERVER['HTTP_HOST'] ?? null; // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized,WordPress.Security.ValidatedSanitizedInput.MissingUnslash -- Test restores the exact previous server global.
+
 		$_SERVER['REQUEST_URI'] = '/sso';
+		$_SERVER['HTTP_HOST']   = 'example.org';
 
-		$sso = SSO::get_instance();
+		try {
+			$sso = SSO::get_instance();
 
-		$ref    = new \ReflectionClass($sso);
-		$method = $ref->getMethod('get_sso_action');
-		$method->setAccessible(true);
+			$ref    = new \ReflectionClass($sso);
+			$method = $ref->getMethod('get_sso_action');
+			$method->setAccessible(true);
 
-		$result = $method->invoke($sso);
+			$result = $method->invoke($sso);
 
-		$this->assertSame('/sso', $result);
+			$this->assertSame('/sso', $result);
+		} finally {
+			if (null === $previous_request_uri) {
+				unset($_SERVER['REQUEST_URI']);
+			} else {
+				$_SERVER['REQUEST_URI'] = $previous_request_uri;
+			}
+
+			if (null === $previous_http_host) {
+				unset($_SERVER['HTTP_HOST']);
+			} else {
+				$_SERVER['HTTP_HOST'] = $previous_http_host;
+			}
+		}
 	}
 
 	/**
 	 * Test get_sso_action detects sso-grant path in REQUEST_URI.
 	 */
 	public function test_get_sso_action_detects_sso_grant_path_in_request_uri(): void {
+		unset($_REQUEST['sso'], $_REQUEST['sso-grant'], $_REQUEST['sso_verify']);
+
+		$previous_request_uri = $_SERVER['REQUEST_URI'] ?? null; // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized,WordPress.Security.ValidatedSanitizedInput.MissingUnslash -- Test restores the exact previous server global.
+		$previous_http_host   = $_SERVER['HTTP_HOST'] ?? null; // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized,WordPress.Security.ValidatedSanitizedInput.MissingUnslash -- Test restores the exact previous server global.
+
 		$_SERVER['REQUEST_URI'] = '/sso-grant';
+		$_SERVER['HTTP_HOST']   = 'example.org';
 
-		$sso = SSO::get_instance();
+		try {
+			$sso = SSO::get_instance();
 
-		$ref    = new \ReflectionClass($sso);
-		$method = $ref->getMethod('get_sso_action');
-		$method->setAccessible(true);
+			$ref    = new \ReflectionClass($sso);
+			$method = $ref->getMethod('get_sso_action');
+			$method->setAccessible(true);
 
-		$result = $method->invoke($sso);
+			$result = $method->invoke($sso);
 
-		$this->assertSame('/sso-grant', $result);
+			$this->assertSame('/sso-grant', $result);
+		} finally {
+			if (null === $previous_request_uri) {
+				unset($_SERVER['REQUEST_URI']);
+			} else {
+				$_SERVER['REQUEST_URI'] = $previous_request_uri;
+			}
+
+			if (null === $previous_http_host) {
+				unset($_SERVER['HTTP_HOST']);
+			} else {
+				$_SERVER['HTTP_HOST'] = $previous_http_host;
+			}
+		}
 	}
 
 	// ------------------------------------------------------------------

--- a/tests/WP_Ultimo/SSO/SSO_Extended_Test.php
+++ b/tests/WP_Ultimo/SSO/SSO_Extended_Test.php
@@ -1557,8 +1557,9 @@ class SSO_Extended_Test extends \WP_UnitTestCase {
 		$sso    = SSO::get_instance();
 		$result = $sso->get_setting('enable_sso', true);
 
-		// Default is true, so this should return true.
-		$this->assertTrue($result);
+		// WordPress stores checkbox-like settings as scalars such as '1';
+		// SSO treats enable_sso via normal option truthiness.
+		$this->assertTrue(wu_string_to_bool($result));
 	}
 
 	// ------------------------------------------------------------------

--- a/tests/WP_Ultimo/SSO/SSO_Test.php
+++ b/tests/WP_Ultimo/SSO/SSO_Test.php
@@ -7,6 +7,8 @@
 
 namespace WP_Ultimo\SSO;
 
+// phpcs:disable WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents -- Tests inspect local source files.
+
 /**
  * Unit tests for SSO class.
  *
@@ -1178,9 +1180,9 @@ class SSO_Test extends \WP_UnitTestCase {
 		);
 
 		$this->assertMatchesRegularExpression(
-			'/wp_safe_redirect\s*\(\s*\$denial_url\s*,\s*302\s*,\s*[\'"]WP-Ultimo-SSO[\'"]\s*\)\s*;\s*exit\s*;/s',
+			'/wp_safe_redirect\s*\(\s*\$denial_url\s*,\s*303\s*,\s*[\'"]WP-Ultimo-SSO[\'"]\s*\)\s*;\s*exit\s*;/s',
 			$body,
-			'handle_server() not-logged-in non-JSONP branch must call wp_safe_redirect( $denial_url, 302, \'WP-Ultimo-SSO\' ); exit; after building the denial URL.'
+			'handle_server() not-logged-in non-JSONP branch must call wp_safe_redirect( $denial_url, 303, \'WP-Ultimo-SSO\' ); exit; after building the denial URL.'
 		);
 
 		// Must NOT force wp-login.php on anonymous visitors — broker


### PR DESCRIPTION
## Summary

- Isolates SSO request-path tests from leaked `$_REQUEST` values and missing `HTTP_HOST` state.
- Documents that `enable_sso` may be stored as a WordPress scalar while still evaluating truthy for SSO.
- Aligns the anonymous non-JSONP denial-flow assertion with the existing production 303 redirect.

## Testing

- `vendor/bin/phpunit --filter SSO_Coverage_Test`
- `vendor/bin/phpunit --filter SSO_Extended_Test`
- `vendor/bin/phpunit --filter SSO_Test`
- `vendor/bin/phpcs tests/WP_Ultimo/SSO/SSO_Coverage_Test.php tests/WP_Ultimo/SSO/SSO_Extended_Test.php tests/WP_Ultimo/SSO/SSO_Test.php`

Resolves #1509


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.21.12 plugin for [OpenCode](https://opencode.ai) v1.17.9 with gpt-5.5 spent 16m and 159,061 tokens on this as a headless worker.
