### PR TITLE
fix: stabilize UI asset tests

### DIFF
--- a/assets/css/checkout-editor.css
+++ b/assets/css/checkout-editor.css
@@ -39,11 +39,8 @@
 }
 
 /* Mobile responsive styles for checkout form editor.
- * These rules are also injected via wp_add_inline_style() from
- * Checkout_Form_Edit_Admin_Page::register_scripts() so they ship to users
- * loading the minified stylesheet (production). Keep both copies in sync;
- * the inline copy is the authoritative one for end users until the next
- * release rebuilds checkout-editor.min.css. */
+ * Production users load the rebuilt checkout-editor.min.css, so keep these
+ * rules in source CSS only and do not duplicate them via wp_add_inline_style(). */
 @media screen and (max-width: 782px) {
 
   /* Stack the top header bar vertically */

--- a/inc/admin-pages/class-checkout-form-edit-admin-page.php
+++ b/inc/admin-pages/class-checkout-form-edit-admin-page.php
@@ -1358,42 +1358,6 @@ class Checkout_Form_Edit_Admin_Page extends Edit_Admin_Page {
 		wp_enqueue_script('wu-checkout-form-editor');
 
 		wp_enqueue_style('wu-checkout-form-editor', wu_get_asset('checkout-editor.css', 'css'), [], wu_get_version());
-
-		/*
-		 * Inline mobile rules. Shipped via wp_add_inline_style so they reach
-		 * users loading checkout-editor.min.css (which is regenerated only at
-		 * release time) without hand-editing the minified asset on feature
-		 * branches. Keep this block in sync with the @media block in
-		 * assets/css/checkout-editor.css.
-		 */
-		wp_add_inline_style(
-			'wu-checkout-form-editor',
-			'@media screen and (max-width:782px){'
-				. '#wu-checkout-editor-app .postbox>.wu-flex.wu-items-center{flex-direction:column;gap:8px}'
-				. '#wu-checkout-editor-app .postbox>.wu-flex.wu-items-center>div{width:100%!important;text-align:center}'
-				. '#wu-checkout-editor-app .postbox>.wu-flex.wu-items-center>div:last-child{text-align:center}'
-				. '#wu-checkout-editor-app .postbox>.wu-flex.wu-items-center>div ul{justify-content:center}'
-				. '#wu-checkout-editor-app .column-order{display:none!important}'
-				. '#wu-checkout-editor-app .column-move{display:none!important}'
-				. '#wu-checkout-editor-app tr.is-expanded td.column-type,'
-				. '#wu-checkout-editor-app tr.is-expanded td.column-slug,'
-				. '#wu-checkout-editor-app tr.is-expanded td.column-move{position:relative!important;display:block!important;width:auto!important;padding:6px 12px!important;text-align:left!important}'
-				. '#wu-checkout-editor-app tr.is-expanded td.column-type::before,'
-				. '#wu-checkout-editor-app tr.is-expanded td.column-slug::before,'
-				. '#wu-checkout-editor-app tr.is-expanded td.column-move::before{position:static!important;display:block!important;float:none!important;width:auto!important;padding:0 0 4px 0!important;overflow:visible!important;white-space:normal!important;text-overflow:clip!important;font-weight:600;text-align:left!important}'
-				. '#wu-checkout-editor-app tr.is-expanded td.column-move{display:none!important}'
-				. '#wu-checkout-editor-app .wu-bg-gray-100 ul{flex-direction:column;align-items:center}'
-				. '#wu-checkout-editor-app .wu-bg-gray-100 ul li{margin-left:0!important;margin-bottom:4px}'
-				// WUBox modal: cap width at 100vw and reset inline negative margins so the
-				// field-type selector and per-field edit forms fit phones. The same rule
-				// lives in assets/css/admin.css for the next release rebuild.
-				. '#WUB_window,#WUB_ajaxContent{width:100vw!important;max-width:100vw!important;height:100%!important;margin-top:0!important;margin-left:0!important;top:0!important;left:0!important;border-radius:0!important}'
-				// "Add new Field" tile grid: drop from 4 columns to 2 so labels like
-				// "PASSWORD", "TEMPLATES", "DOMAIN SELECTION" stay readable. The grid uses
-				// wu-w-1/4 (25%) which becomes ~24vw on phones — too narrow for label text.
-				. '#WUB_ajaxContent ul[data-wu-app="add_checkout_form_field"] .wu-w-1\/4{width:50%!important}'
-			. '}'
-		);
 	}
 
 	/**

--- a/tests/WP_Ultimo/UI/Tours_Test.php
+++ b/tests/WP_Ultimo/UI/Tours_Test.php
@@ -432,6 +432,10 @@ class Tours_Test extends WP_UnitTestCase {
 			wp_register_script('underscore', false, [], '1.0.0', false);
 		}
 
+		// Mirror the real admin lifecycle: assets are registered on admin_enqueue_scripts
+		// before enqueue_scripts() runs in the footer.
+		$instance->register_scripts();
+
 		// Inject a tour so enqueue_scripts() proceeds.
 		$reflection = new \ReflectionClass($instance);
 		$prop       = $reflection->getProperty('tours');

--- a/tests/unit/Checkout_Editor_Assets_Test.php
+++ b/tests/unit/Checkout_Editor_Assets_Test.php
@@ -3,7 +3,7 @@ use PHPUnit\Framework\TestCase;
 
 final class Checkout_Editor_Assets_Test extends TestCase {
 
-	public function test_checkout_editor_mobile_styles_stay_in_source_css_only(): void {
+	public function test_checkout_editor_mobile_styles_are_built_into_source_and_minified_css(): void {
 		$source_path = __DIR__ . '/../../assets/css/checkout-editor.css';
 		$min_path    = __DIR__ . '/../../assets/css/checkout-editor.min.css';
 
@@ -19,17 +19,20 @@ final class Checkout_Editor_Assets_Test extends TestCase {
 		$this->assertNotFalse($min_contents);
 
 		$this->assertStringContainsString('@media screen and (max-width: 782px)', $source_contents, 'Expected mobile checkout editor styles to remain in the source CSS');
-		$this->assertStringNotContainsString('@media screen and (max-width:782px)', $min_contents, 'Generated checkout-editor.min.css should not contain the manually inlined mobile styles from PR #1073');
-		$this->assertStringNotContainsString('flex-direction:column', $min_contents, 'Generated checkout-editor.min.css should remain at its pre-PR #1073 state on feature branches');
+		$this->assertStringContainsString('@media screen and (max-width:782px)', $min_contents, 'Expected rebuilt checkout-editor.min.css to include the mobile media query');
+		$this->assertStringContainsString('flex-direction:column', $min_contents, 'Expected rebuilt checkout-editor.min.css to include the mobile header stacking rule');
+		$this->assertStringContainsString('.column-order{display:none!important}', $min_contents, 'Expected rebuilt checkout-editor.min.css to hide the ORDER column on mobile');
+		$this->assertStringContainsString('tr.is-expanded td.column-slug', $min_contents, 'Expected rebuilt checkout-editor.min.css to fix the expanded-row SLUG cell layout');
+		$this->assertStringContainsString('#WUB_ajaxContent,#WUB_window{width:100vw', $min_contents, 'Expected rebuilt checkout-editor.min.css to cap the wubox modal at viewport width on mobile');
+		$this->assertStringContainsString('add_checkout_form_field', $min_contents, 'Expected rebuilt checkout-editor.min.css to scope the field-type grid rule to the add_checkout_form_field Vue app');
 	}
 
 	/**
-	 * Production users load checkout-editor.min.css, which is rebuilt only at
-	 * release time. To ship mobile fixes immediately we inject the @media
-	 * block via wp_add_inline_style() from the admin page class. Verify that
-	 * registration is wired up so the rules actually reach end users.
+	 * Production users load checkout-editor.min.css. Once the release asset has
+	 * been rebuilt with the mobile rules, the admin page must not also inject the
+	 * same @media block inline or users receive duplicate rules.
 	 */
-	public function test_checkout_editor_mobile_styles_are_injected_inline_for_min_css_users(): void {
+	public function test_checkout_editor_mobile_styles_are_not_duplicated_inline_after_min_css_rebuild(): void {
 		$admin_page_path = __DIR__ . '/../../inc/admin-pages/class-checkout-form-edit-admin-page.php';
 
 		$this->assertFileExists($admin_page_path, 'class-checkout-form-edit-admin-page.php does not exist');
@@ -38,40 +41,7 @@ final class Checkout_Editor_Assets_Test extends TestCase {
 		$admin_page_contents = file_get_contents($admin_page_path);
 		$this->assertNotFalse($admin_page_contents);
 
-		$this->assertStringContainsString(
-			"wp_add_inline_style(\n\t\t\t'wu-checkout-form-editor'",
-			$admin_page_contents,
-			'Expected register_scripts() to call wp_add_inline_style on wu-checkout-form-editor so mobile rules ship without rebuilding the .min.css'
-		);
-		$this->assertStringContainsString(
-			'@media screen and (max-width:782px)',
-			$admin_page_contents,
-			'Expected the inline style block to contain the mobile @media query so production users receive the mobile checkout editor fixes'
-		);
-		$this->assertStringContainsString(
-			'.column-order{display:none!important}',
-			$admin_page_contents,
-			'Expected the inline style block to hide the ORDER column on mobile'
-		);
-		$this->assertStringContainsString(
-			'tr.is-expanded td.column-slug',
-			$admin_page_contents,
-			'Expected the inline style block to fix the broken expanded-row layout (vertical 1-character text wrap) for the SLUG cell'
-		);
-		$this->assertStringContainsString(
-			'#WUB_window,#WUB_ajaxContent{width:100vw',
-			$admin_page_contents,
-			'Expected the inline style block to cap the wubox modal at viewport width on mobile so the "Add new Field" dialogue fits a phone'
-		);
-		$this->assertStringContainsString(
-			'add_checkout_form_field',
-			$admin_page_contents,
-			'Expected the inline style block to scope the field-type grid rule to the add_checkout_form_field Vue app'
-		);
-		$this->assertStringContainsString(
-			'.wu-w-1\/4{width:50%!important}',
-			$admin_page_contents,
-			'Expected the inline style block to drop the field-type tile grid from 4 columns to 2 on mobile so labels (PASSWORD, TEMPLATES, DOMAIN SELECTION) stay readable'
-		);
+		$this->assertStringNotContainsString('wp_add_inline_style', $admin_page_contents, 'Checkout editor mobile rules should come from checkout-editor.min.css, not a duplicate inline block');
+		$this->assertStringNotContainsString('@media screen and (max-width:782px)', $admin_page_contents, 'The mobile @media query should not be duplicated inline after the minified asset was rebuilt');
 	}
 }


### PR DESCRIPTION
## Summary

- Register tour assets in the direct enqueue test so the shepherd style assertion matches the real admin lifecycle.
- Treat the checkout editor minified CSS as rebuilt with the mobile rules and remove the now-duplicate inline mobile CSS injection.
- Update asset tests/comments to guard against regressing the rebuilt minified CSS or reintroducing duplicate inline rules.

Resolves #1511

## Verification

- `vendor/bin/phpunit --filter Checkout_Editor_Assets_Test`
- `vendor/bin/phpunit --filter Tours_Test`
- `vendor/bin/phpcs inc/admin-pages/class-checkout-form-edit-admin-page.php tests/WP_Ultimo/UI/Tours_Test.php tests/unit/Checkout_Editor_Assets_Test.php`
- `vendor/bin/phpstan analyse inc/admin-pages/class-checkout-form-edit-admin-page.php tests/WP_Ultimo/UI/Tours_Test.php tests/unit/Checkout_Editor_Assets_Test.php`
- `npx stylelint 'assets/css/checkout-editor.css' --ignore-pattern '*.min.css'`

## Notes

- `npm run lint:css -- assets/css/checkout-editor.css` was attempted, but the npm script still expands to all CSS files and fails on the pre-existing `assets/css/admin.css` stylelint disable issue. The changed stylesheet passed the direct `npx stylelint` command above.

<!-- aidevops:sig -->
