### PR TITLE
test: keep installer table skips before fixtures

### DIFF
--- a/tests/WP_Ultimo/Installers/Default_Content_Installer_Test.php
+++ b/tests/WP_Ultimo/Installers/Default_Content_Installer_Test.php
@@ -8,6 +8,7 @@
 namespace WP_Ultimo\Tests\Installers;
 
 use WP_Ultimo\Installers\Default_Content_Installer;
+use WP_Ultimo\Loaders\Table_Loader;
 
 /**
  * Unit tests for Default_Content_Installer.
@@ -81,6 +82,15 @@ class Default_Content_Installer_Test extends \WP_UnitTestCase {
 		wu_save_setting( 'enable_custom_login_page', 0 );
 
 		parent::tearDown();
+	}
+
+	/**
+	 * Skips tests that need Ultimate Multisite database tables.
+	 */
+	protected function skip_unless_tables_installed(): void {
+		if ( ! Table_Loader::get_instance()->is_installed() ) {
+			$this->markTestSkipped( 'Requires installed Ultimate Multisite tables.' );
+		}
 	}
 
 	// -----------------------------------------------------------------------
@@ -197,9 +207,7 @@ class Default_Content_Installer_Test extends \WP_UnitTestCase {
 	 * Test done_creating_products returns true when plans exist.
 	 */
 	public function test_done_creating_products_true_when_plans_exist(): void {
-		if ( ! \WP_Ultimo\Loaders\Table_Loader::get_instance()->is_installed() ) {
-			$this->markTestSkipped( 'Requires installed Ultimate Multisite tables.' );
-		}
+		$this->skip_unless_tables_installed();
 
 		// Create a plan.
 		$product = wu_create_product( [
@@ -248,9 +256,7 @@ class Default_Content_Installer_Test extends \WP_UnitTestCase {
 	 * Test done_creating_checkout_forms returns true after creating a form.
 	 */
 	public function test_done_creating_checkout_forms_true_after_create(): void {
-		if ( ! \WP_Ultimo\Loaders\Table_Loader::get_instance()->is_installed() ) {
-			$this->markTestSkipped( 'Requires installed Ultimate Multisite tables.' );
-		}
+		$this->skip_unless_tables_installed();
 
 		$form = wu_create_checkout_form( [
 			'name' => 'Test Form',


### PR DESCRIPTION
## Summary

- Adds a shared `skip_unless_tables_installed()` helper for `Default_Content_Installer_Test`.
- Keeps table-installation skips as the first executable statement in the product and checkout-form fixture tests before any `wu_create_*()` calls.

Resolves #1526

## Testing

- `vendor/bin/phpunit --filter Default_Content_Installer_Test` (passes: 42 tests, 117 assertions, 1 skipped; existing PHP deprecation notices emitted)
- `vendor/bin/phpcs tests/WP_Ultimo/Installers/Default_Content_Installer_Test.php` (passes)

<!-- aidevops:sig -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Refactored test suite to centralize table installation verification logic into a dedicated helper method, eliminating code duplication and improving consistency across test cases.

* **Refactor**
  * Consolidated repeated inline verification checks across multiple tests into a single reusable utility method for better code clarity and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->