### PR TITLE
GH#1527: test: clarify persisted discount cleanup

### DIFF
--- a/tests/WP_Ultimo/Checkout/Cart_Addon_Pricing_Test.php
+++ b/tests/WP_Ultimo/Checkout/Cart_Addon_Pricing_Test.php
@@ -312,7 +312,7 @@ class Cart_Addon_Pricing_Test extends WP_UnitTestCase {
 		self::$membership->delete_meta(Membership::META_VERIFIED_PAYMENT_DISCOUNT);
 
 		$cleanup_saved = self::$membership->save();
-		$this->assertNotWPError($cleanup_saved);
+		$this->assertNotWPError($cleanup_saved, 'Discount metadata cleanup should be persisted.');
 	}
 
 	/**


### PR DESCRIPTION
## Summary

- Clarifies the addon pricing test assertion for persisted membership discount metadata cleanup.
- Keeps the existing cleanup save in place so reloaded memberships do not retain discount meta between tests.

## Testing

- `vendor/bin/phpcs tests/WP_Ultimo/Checkout/Cart_Addon_Pricing_Test.php`
- `vendor/bin/phpunit --filter Cart_Addon_Pricing_Test`

Resolves #1527

---
<!-- aidevops:sig -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test assertion messaging for more detailed failure diagnostics.

---

**Note:** This release contains no user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->