### PR TITLE
fix: copy temporary multisite tables

### DIFF
--- a/inc/duplication/data.php
+++ b/inc/duplication/data.php
@@ -110,6 +110,10 @@ if ( ! class_exists('MUCD_Data') ) {
 				$from_site_table = self::do_sql_query($sql_query, 'col');
 			}
 
+			if (empty($from_site_table)) {
+				$from_site_table = self::get_existing_blog_tables($from_site_id);
+			}
+
 			$tables_to_ignore = [
 				'actionscheduler_actions',
 				'actionscheduler_claims',
@@ -141,7 +145,7 @@ if ( ! class_exists('MUCD_Data') ) {
 				self::do_sql_query($create_statement_sql);
 
 				// Populate database with data from source table
-				self::do_sql_query('INSERT `' . $table_name . '` SELECT * FROM `' . $schema . '`.`' . $table . '`');
+				self::do_sql_query('INSERT `' . $table_name . '` SELECT * FROM `' . $table . '`');
 
 				$wpdb->get_results('SET foreign_key_checks = 1'); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
 			}
@@ -168,6 +172,41 @@ if ( ! class_exists('MUCD_Data') ) {
 			}
 
 			return $default_tables;
+		}
+
+		/**
+		 * Get source blog tables that exist on the current database connection.
+		 *
+		 * WordPress PHPUnit uses temporary per-blog tables for multisite fixtures.
+		 * Those tables can be described and copied in the current connection, but
+		 * they do not appear in INFORMATION_SCHEMA or SHOW TABLES. Falling back to
+		 * the canonical WordPress blog table list keeps duplication working in tests
+		 * while preserving the INFORMATION_SCHEMA path for production custom tables.
+		 *
+		 * @since 2.5.1
+		 *
+		 * @param int $site_id Source site ID.
+		 * @return array Existing source blog table names.
+		 */
+		private static function get_existing_blog_tables($site_id) {
+
+			global $wpdb;
+
+			$tables   = [];
+			$site_id  = (int) $site_id;
+			$blog_set = $wpdb->tables('blog', true, $site_id);
+
+			foreach ($blog_set as $table_name) {
+				$suppress_errors = $wpdb->suppress_errors();
+				$exists          = (bool) $wpdb->get_results('DESCRIBE `' . $table_name . '`'); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Table names cannot be bound and temporary PHPUnit tables are intentionally probed.
+				$wpdb->suppress_errors($suppress_errors);
+
+				if ($exists) {
+					$tables[] = $table_name;
+				}
+			}
+
+			return $tables;
 		}
 
 


### PR DESCRIPTION
## Summary

- Add a fallback table discovery path for multisite blog tables that are available on the current DB connection but absent from `INFORMATION_SCHEMA` / `SHOW TABLES`.
- Copy source tables without schema qualification so temporary PHPUnit multisite tables can be duplicated.
- Keeps the existing `INFORMATION_SCHEMA` discovery path for production/custom tables.

## Root cause

WordPress PHPUnit multisite fixtures can use temporary per-blog tables. They are `DESCRIBE`-able and copyable in the active connection, but are not listed by `INFORMATION_SCHEMA` or `SHOW TABLES`. `MUCD_Data::db_copy_tables()` therefore found no source tables, leaving duplicated sites with default content only and causing template-switching media/menu assertions to fail.

## Verification

- `vendor/bin/phpcs inc/duplication/data.php`
- `vendor/bin/phpstan analyse inc/duplication/data.php`
- `vendor/bin/phpunit --no-coverage --filter 'Main_Site_Promoter_Test|Site_Template_Switching_Image_Test|Site_Template_Switching_Menu_Test|Site_Duplicator'`
  - Result: `Tests: 81, Assertions: 275, Incomplete: 1`
- `vendor/bin/phpunit --no-coverage --log-junit <junit-output>`
  - Result: `Tests: 10014, Assertions: 27376, Skipped: 52, Incomplete: 1`


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.22.0 plugin for [OpenCode](https://opencode.ai) v1.17.9 with gpt-5.5


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed the duplication process to work reliably in edge cases where standard table detection methods fail, including testing environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->