### PR TITLE
fix: guard template selection stale sites

### DIFF
--- a/inc/functions/site.php
+++ b/inc/functions/site.php
@@ -44,6 +44,44 @@ function wu_get_site($id) {
 }
 
 /**
+ * Normalizes a mixed site list to existing site model instances.
+ *
+ * @since 2.13.2
+ *
+ * @param array $sites List of site IDs or site model instances.
+ * @return \WP_Ultimo\Models\Site[]
+ */
+function wu_normalize_sites_list($sites) {
+
+	if ( ! is_array($sites)) {
+		return [];
+	}
+
+	$sites = array_map(
+		static function ($site) {
+
+			if ($site instanceof \WP_Ultimo\Models\Site) {
+				return $site;
+			}
+
+			if (is_scalar($site)) {
+				return wu_get_site((int) $site);
+			}
+
+			return false;
+		},
+		$sites
+	);
+
+	return array_values(
+		array_filter(
+			$sites,
+			static fn($site) => $site instanceof \WP_Ultimo\Models\Site
+		)
+	);
+}
+
+/**
  * Gets a site based on the hash.
  *
  * @since 2.0.0

--- a/inc/functions/site.php
+++ b/inc/functions/site.php
@@ -64,7 +64,10 @@ function wu_normalize_sites_list($sites) {
 				return $site;
 			}
 
-			if (is_scalar($site)) {
+			if (
+				(is_int($site) && 0 < $site)
+				|| (is_string($site) && 1 === preg_match('/^[1-9]\d*$/', $site))
+			) {
 				return wu_get_site((int) $site);
 			}
 

--- a/tests/WP_Ultimo/Checkout/Signup_Fields/Template_Selection_Field_Template_Render_Test.php
+++ b/tests/WP_Ultimo/Checkout/Signup_Fields/Template_Selection_Field_Template_Render_Test.php
@@ -1,0 +1,48 @@
+<?php
+/**
+ * Tests for template selection field template rendering.
+ *
+ * @package WP_Ultimo\Tests
+ */
+
+namespace WP_Ultimo\Checkout\Signup_Fields;
+
+use WP_UnitTestCase;
+use WP_Ultimo\Checkout\Signup_Fields\Field_Templates\Template_Selection\Clean_Template_Selection_Field_Template;
+use WP_Ultimo\Checkout\Signup_Fields\Field_Templates\Template_Selection\Legacy_Template_Selection_Field_Template;
+use WP_Ultimo\Checkout\Signup_Fields\Field_Templates\Template_Selection\Minimal_Template_Selection_Field_Template;
+
+/**
+ * Test class for template selection field template rendering.
+ */
+class Template_Selection_Field_Template_Render_Test extends WP_UnitTestCase {
+
+	/**
+	 * Test template selection views skip missing site IDs.
+	 */
+	public function test_template_selection_views_skip_missing_site_ids(): void {
+		$attributes = [
+			'sites'          => [
+				999999,
+			],
+			'name'           => 'template_selection',
+			'cols'           => 3,
+			'categories'     => [],
+			'customer_sites' => [],
+			'should_display' => true,
+		];
+
+		$templates = [
+			new Clean_Template_Selection_Field_Template(),
+			new Minimal_Template_Selection_Field_Template(),
+			new Legacy_Template_Selection_Field_Template(),
+		];
+
+		foreach ($templates as $template) {
+			$html = $template->render($attributes);
+
+			$this->assertIsString($html);
+			$this->assertStringNotContainsString('999999', $html);
+		}
+	}
+}

--- a/tests/WP_Ultimo/Functions/Site_Functions_Test.php
+++ b/tests/WP_Ultimo/Functions/Site_Functions_Test.php
@@ -173,6 +173,17 @@ class Site_Functions_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Test wu_normalize_sites_list filters missing sites.
+	 */
+	public function test_normalize_sites_list_filters_missing_sites(): void {
+		$sites = wu_normalize_sites_list([get_current_blog_id(), 999999, false]);
+
+		$this->assertCount(1, $sites);
+		$this->assertInstanceOf(\WP_Ultimo\Models\Site::class, $sites[0]);
+		$this->assertSame(get_current_blog_id(), $sites[0]->get_id());
+	}
+
+	/**
 	 * Test wu_get_site_by_hash with invalid hash returns false.
 	 */
 	public function test_get_site_by_hash_invalid(): void {

--- a/tests/WP_Ultimo/Functions/Site_Functions_Test.php
+++ b/tests/WP_Ultimo/Functions/Site_Functions_Test.php
@@ -184,6 +184,15 @@ class Site_Functions_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Test wu_normalize_sites_list rejects non-integer scalar site identifiers.
+	 */
+	public function test_normalize_sites_list_rejects_non_integer_scalar_site_ids(): void {
+		$sites = wu_normalize_sites_list([true, 1.5, '1.5', 'site-1', '0', 0, -1]);
+
+		$this->assertSame([], $sites);
+	}
+
+	/**
 	 * Test wu_get_site_by_hash with invalid hash returns false.
 	 */
 	public function test_get_site_by_hash_invalid(): void {

--- a/views/checkout/templates/template-selection/clean.php
+++ b/views/checkout/templates/template-selection/clean.php
@@ -26,7 +26,7 @@ if (isset($should_display) && ! $should_display) {
 	return;
 }
 
-$sites = array_map('wu_get_site', $sites ?? []);
+$sites = wu_normalize_sites_list($sites ?? []);
 
 $categories ??= [];
 

--- a/views/checkout/templates/template-selection/legacy.php
+++ b/views/checkout/templates/template-selection/legacy.php
@@ -25,7 +25,7 @@ if ( ! $should_display ) {
 	return;
 }
 /** @var \WP_Ultimo\Models\Site[] $sites */
-$sites = array_map('wu_get_site', $sites ?? []);
+$sites = wu_normalize_sites_list($sites ?? []);
 
 $categories ??= [];
 

--- a/views/checkout/templates/template-selection/minimal.php
+++ b/views/checkout/templates/template-selection/minimal.php
@@ -21,7 +21,7 @@ defined('ABSPATH') || exit;
 if ( ! $should_display) {
 	return;
 }
-$sites = array_map('wu_get_site', $sites ?? []);
+$sites = wu_normalize_sites_list($sites ?? []);
 
 $categories ??= [];
 


### PR DESCRIPTION
## Summary

- Normalize template-selection site inputs so stale/deleted site IDs are filtered before views call site model methods.
- Apply the guard to the clean, minimal, and legacy template-selection checkout views.
- Add regression coverage for missing template site IDs and the normalization helper.

## Verification

- `vendor/bin/phpunit --filter 'Site_Functions_Test|Template_Selection_Field_Template_Render_Test'`
- `vendor/bin/phpcs inc/functions/site.php views/checkout/templates/template-selection/clean.php views/checkout/templates/template-selection/minimal.php views/checkout/templates/template-selection/legacy.php tests/WP_Ultimo/Functions/Site_Functions_Test.php tests/WP_Ultimo/Checkout/Signup_Fields/Template_Selection_Field_Template_Render_Test.php`
- Pre-commit hook ran PHPCS and PHPStan on staged production PHP files.


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.22.0 plugin for [OpenCode](https://opencode.ai) v1.17.9 with gpt-5.5 spent 33m and 220,756 tokens on this with the user in an interactive session.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added site list normalization to consistently resolve provided site IDs into valid site objects.
* **Bug Fixes**
  * Improved checkout template selection so invalid or missing site references are skipped/ignored rather than rendered.
* **Tests**
  * Added PHPUnit coverage for site list normalization behavior and verified template rendering across clean, minimal, and legacy styles.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->