### PR TITLE
GH#1535: fix: resolve SSO session ArrayAccess deprecation

### DIFF
--- a/inc/sso/jasny/Broker/Session.php
+++ b/inc/sso/jasny/Broker/Session.php
@@ -41,7 +41,7 @@ class Session implements \ArrayAccess {
 	/**
 	 * @inheritDoc
 	 */
-	public function offsetGet($name) {
+	public function offsetGet(mixed $name): mixed {
 		return $_SESSION[ $name ] ?? null;
 	}
 

--- a/tests/WP_Ultimo/SSO/Admin_Bar_Magic_Links_Test.php
+++ b/tests/WP_Ultimo/SSO/Admin_Bar_Magic_Links_Test.php
@@ -51,6 +51,10 @@ class Admin_Bar_Magic_Links_Test extends WP_UnitTestCase {
 		// Ensure no user is logged in.
 		wp_set_current_user(0);
 
+		if ( ! class_exists('\WP_Admin_Bar') ) {
+			require_once ABSPATH . WPINC . '/class-wp-admin-bar.php';
+		}
+
 		$admin_bar = new \WP_Admin_Bar();
 		$this->magic_links->modify_my_sites_menu($admin_bar);
 

--- a/tests/WP_Ultimo/SSO/Magic_Link_Test.php
+++ b/tests/WP_Ultimo/SSO/Magic_Link_Test.php
@@ -226,9 +226,9 @@ class Magic_Link_Test extends \WP_UnitTestCase {
 
 		$fired = false;
 
-		add_action('wu_magic_link_invalid_token', function ($reason) use (&$fired) {
+		add_action('wu_magic_link_invalid_token', function () use (&$fired) {
 			$fired = true;
-		});
+		}, 10, 0);
 
 		$ref->invoke($instance, 'test reason');
 

--- a/tests/WP_Ultimo/SSO/Nav_Menu_Subsite_Links_Test.php
+++ b/tests/WP_Ultimo/SSO/Nav_Menu_Subsite_Links_Test.php
@@ -71,9 +71,9 @@ class Nav_Menu_Subsite_Links_Test extends WP_UnitTestCase {
 	 * Test filter_menu_item_urls passes through items unchanged when no subsite items.
 	 */
 	public function test_filter_menu_item_urls_passthrough(): void {
-		$item       = new \stdClass();
-		$item->ID   = 1;
-		$item->url  = 'https://example.com';
+		$item          = new \stdClass();
+		$item->ID      = 1;
+		$item->url     = 'https://example.com';
 		$item->classes = [];
 
 		$items  = [$item];

--- a/tests/WP_Ultimo/SSO/SSO_Test.php
+++ b/tests/WP_Ultimo/SSO/SSO_Test.php
@@ -972,6 +972,20 @@ class SSO_Test extends \WP_UnitTestCase {
 	// ------------------------------------------------------------------
 
 	/**
+	 * Test broker session array access reads stored values and returns null for missing keys.
+	 */
+	public function test_broker_session_array_access_reads_values_and_missing_keys(): void {
+		$session = new Jasny\Broker\Session();
+
+		$session['wu_sso_test_token'] = 'test-token';
+
+		$this->assertSame('test-token', $session['wu_sso_test_token']);
+		$this->assertNull($session['wu_sso_missing_token']);
+
+		unset($session['wu_sso_test_token']);
+	}
+
+	/**
 	 * Test session handler isActive returns false by default.
 	 */
 	public function test_session_handler_is_active_returns_false(): void {


### PR DESCRIPTION
## Summary

Updated the SSO Jasny Session offsetGet signature to match ArrayAccess on PHP 8.4, added array-access coverage for stored and missing session keys, and cleaned neighboring SSO test/bootstrap issues so the requested SSO verification can complete.

## Files Changed

inc/sso/jasny/Broker/Session.php,tests/WP_Ultimo/SSO/Admin_Bar_Magic_Links_Test.php,tests/WP_Ultimo/SSO/Magic_Link_Test.php,tests/WP_Ultimo/SSO/Nav_Menu_Subsite_Links_Test.php,tests/WP_Ultimo/SSO/SSO_Test.php

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** vendor/bin/phpunit --filter SSO; vendor/bin/phpcs inc/sso/jasny/Broker/Session.php tests/WP_Ultimo/SSO

Resolves #1535


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.22.0 plugin for [OpenCode](https://opencode.ai) v1.17.9 with gpt-5.5 spent 7m and 73,789 tokens on this as a headless worker.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test coverage and reliability for the Single Sign-On system, including comprehensive validation of session array access behavior, improved WordPress admin bar component handling in test environments, and better fixture setup for menu link testing.

* **Refactor**
  * Improved type safety in session handling implementation with enhanced method signatures for better code reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->