### PR TITLE
GH#1503: guard invalid site duplication source

### DIFF
--- a/inc/helpers/class-site-duplicator.php
+++ b/inc/helpers/class-site-duplicator.php
@@ -58,10 +58,17 @@ class Site_Duplicator {
 	 */
 	public static function duplicate_site($from_site_id, $title, $args = []) {
 
-		$args['from_site_id'] = $from_site_id;
-		$args['title']        = $title;
+		$from_site = get_site($from_site_id);
 
-		$duplicate_site = self::process_duplication($args);
+		if ( ! $from_site) {
+			// translators: %d is the source template site ID.
+			$duplicate_site = new \WP_Error('source_template_site_not_found', sprintf(__('Source template site %d not found. Cannot duplicate site.', 'ultimate-multisite'), $from_site_id));
+		} else {
+			$args['from_site_id'] = $from_site_id;
+			$args['title']        = $title;
+
+			$duplicate_site = self::process_duplication($args);
+		}
 
 		if (is_wp_error($duplicate_site)) {
 

--- a/tests/WP_Ultimo/Helpers/Site_Duplicator_Test.php
+++ b/tests/WP_Ultimo/Helpers/Site_Duplicator_Test.php
@@ -217,8 +217,8 @@ class Site_Duplicator_Test extends WP_UnitTestCase {
 
 		$result = Site_Duplicator::duplicate_site($invalid_site_id, 'New Site', $args);
 
-		// The result should be either a WP_Error or a failure case
-		$this->assertTrue(is_wp_error($result) || ! $result || is_int($result));
+		$this->assertInstanceOf(\WP_Error::class, $result);
+		$this->assertSame('source_template_site_not_found', $result->get_error_code());
 	}
 
 	/**


### PR DESCRIPTION
## Summary

- Salvages the narrow useful hardening from closed PR #1521 after #1503 was already resolved by #1520.
- Adds an explicit missing source-site guard in `Site_Duplicator::duplicate_site()` before lower-level duplication code touches source tables.
- Tightens the invalid source-site test to assert the specific `source_template_site_not_found` `WP_Error`.

## Verification

- `vendor/bin/phpunit --filter test_duplicate_invalid_source_site`
- `vendor/bin/phpunit --filter Site_Duplicator_Test`
- `vendor/bin/phpcs inc/helpers/class-site-duplicator.php tests/WP_Ultimo/Helpers/Site_Duplicator_Test.php`
- Pre-commit hook: PHPCS and PHPStan passed for staged PHP files

For #1503
Supersedes #1521

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.22.0 plugin for [OpenCode](https://opencode.ai) v1.17.9 with gpt-5.5 salvaged closed PR #1521 in a headless run.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved site duplication error handling by validating the source site exists before processing.
  * Users now receive clear, localized error messages when attempting to duplicate from an invalid source site.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->