### PR TITLE
fix: preserve same-domain SSO with ports

### DIFF
--- a/inc/functions/domain.php
+++ b/inc/functions/domain.php
@@ -161,6 +161,45 @@ function wu_with_sso($url) {
 }
 
 /**
+ * Normalizes a domain or URL for host comparisons.
+ *
+ * WordPress stores multisite domain values as host names, but local
+ * development domains may include a port (for example,
+ * local.test:8080). wp_parse_url( ..., PHP_URL_HOST ) drops that
+ * port from the current request URL, which makes same-origin admin requests
+ * look like mapped-domain requests and triggers an unnecessary SSO handoff.
+ *
+ * @since 2.0.11
+ *
+ * @param string $domain Domain or URL to normalize.
+ * @return string Normalized host, including the port when present.
+ */
+function wu_normalize_domain_for_comparison($domain) {
+
+	$domain = strtolower(trim((string) $domain));
+
+	if ('' === $domain) {
+		return '';
+	}
+
+	$url = false === strpos($domain, '://') ? 'http://' . ltrim($domain, '/') : $domain;
+
+	$parsed_url = wp_parse_url($url);
+
+	if (empty($parsed_url['host'])) {
+		return $domain;
+	}
+
+	$normalized_domain = strtolower((string) $parsed_url['host']);
+
+	if (isset($parsed_url['port'])) {
+		$normalized_domain .= ':' . absint($parsed_url['port']);
+	}
+
+	return $normalized_domain;
+}
+
+/**
  * Compares the current domain to the main network domain.
  *
  * @since 2.0.11
@@ -170,5 +209,9 @@ function wu_is_same_domain() {
 
 	global $current_blog, $current_site;
 
-	return wp_parse_url(wu_get_current_url(), PHP_URL_HOST) === $current_blog->domain && $current_blog->domain === $current_site->domain;
+	$current_domain = wu_normalize_domain_for_comparison(wu_get_current_url());
+	$blog_domain    = wu_normalize_domain_for_comparison($current_blog->domain ?? '');
+	$site_domain    = wu_normalize_domain_for_comparison($current_site->domain ?? '');
+
+	return $current_domain === $blog_domain && $blog_domain === $site_domain;
 }

--- a/tests/WP_Ultimo/Functions/Domain_Functions_Test.php
+++ b/tests/WP_Ultimo/Functions/Domain_Functions_Test.php
@@ -98,6 +98,47 @@ class Domain_Functions_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Test wu_is_same_domain handles multisite domains with ports.
+	 */
+	public function test_wu_is_same_domain_handles_domains_with_ports(): void {
+
+		global $current_blog, $current_site;
+
+		$original_blog_domain = $current_blog->domain;
+		$original_site_domain = $current_site->domain;
+		$original_http_host   = isset($_SERVER['HTTP_HOST']) ? sanitize_text_field(wp_unslash($_SERVER['HTTP_HOST'])) : null;
+		$original_request_uri = isset($_SERVER['REQUEST_URI']) ? sanitize_url(wp_unslash($_SERVER['REQUEST_URI'])) : null;
+
+		$current_blog->domain   = 'local.test:8080';
+		$current_site->domain   = 'local.test:8080';
+		$_SERVER['HTTP_HOST']   = 'local.test:8080';
+		$_SERVER['REQUEST_URI'] = '/wp-admin/';
+
+		try {
+			$this->assertTrue(wu_is_same_domain());
+
+			$_SERVER['HTTP_HOST'] = 'local.test:9090';
+
+			$this->assertFalse(wu_is_same_domain());
+		} finally {
+			$current_blog->domain = $original_blog_domain;
+			$current_site->domain = $original_site_domain;
+
+			if (null === $original_http_host) {
+				unset($_SERVER['HTTP_HOST']);
+			} else {
+				$_SERVER['HTTP_HOST'] = $original_http_host;
+			}
+
+			if (null === $original_request_uri) {
+				unset($_SERVER['REQUEST_URI']);
+			} else {
+				$_SERVER['REQUEST_URI'] = $original_request_uri;
+			}
+		}
+	}
+
+	/**
 	 * Test wu_restore_original_url returns string.
 	 */
 	public function test_wu_restore_original_url_returns_string(): void {


### PR DESCRIPTION
## Summary

- Normalize domain comparisons in `wu_is_same_domain()` so local multisite domains with ports remain same-domain.
- Preserve SSO redirects for true mapped/cross-domain hosts while avoiding the unauthenticated same-origin `/wp-admin/` SSO handoff.
- Add regression coverage for matching and mismatched request ports.

## Verification

- `vendor/bin/phpcs inc/functions/domain.php tests/WP_Ultimo/Functions/Domain_Functions_Test.php`
- `vendor/bin/phpunit --filter Domain_Functions_Test`
- `git diff --check`

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.22.1 plugin for [OpenCode](https://opencode.ai) v1.17.9 with gpt-5.5


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved domain matching so URLs and domains are compared correctly even when a port number is included.
  * Fixed an issue where domain checks could fail for multisite setups using hostnames with ports.
* **Tests**
  * Added coverage for domain comparisons involving port-based hostnames to help prevent regressions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->