### PR TITLE
fix: support main site export imports

### DIFF
--- a/inc/site-exporter/class-site-exporter.php
+++ b/inc/site-exporter/class-site-exporter.php
@@ -252,10 +252,9 @@ final class Site_Exporter {
 	/**
 	 * Add export action link to WordPress Sites page rows.
 	 *
-	 * In multisite, the main site is excluded from the network Sites list because
-	 * it is exported through the regular admin Tools > Export & Import page.
-	 * In single-site installs this filter is never called (the network Sites page
-	 * does not exist), so the guard is multisite-specific.
+	 * In multisite, both the main site and subsites can be exported from the
+	 * network Sites list. The main site cannot be promoted into itself, so the
+	 * promotion action is only added for subsites.
 	 *
 	 * @since 2.5.0
 	 *
@@ -264,12 +263,6 @@ final class Site_Exporter {
 	 * @return array
 	 */
 	public function add_wp_sites_row_actions(array $actions, int $blog_id): array {
-
-		// In multisite, skip the main site — it is exported from the regular admin
-		// Tools > Export & Import page to avoid confusion in the network admin.
-		if ( is_multisite() && is_main_site($blog_id) ) {
-			return $actions;
-		}
 
 		$export_url = add_query_arg(
 			[
@@ -285,6 +278,10 @@ final class Site_Exporter {
 			esc_url($export_url),
 			__('Export', 'ultimate-multisite')
 		);
+
+		if (is_main_site($blog_id)) {
+			return $actions;
+		}
 
 		$promote_url = add_query_arg(
 			[
@@ -338,11 +335,6 @@ final class Site_Exporter {
 		$exported = 0;
 
 		foreach ($blog_ids as $blog_id) {
-			// Skip main site
-			if (is_main_site($blog_id)) {
-				continue;
-			}
-
 			wu_exporter_export($blog_id, ['uploads' => true], true);
 			++$exported;
 		}

--- a/inc/site-exporter/mu-migration/includes/commands/class-mu-migration-import.php
+++ b/inc/site-exporter/mu-migration/includes/commands/class-mu-migration-import.php
@@ -306,41 +306,22 @@ class ImportCommand extends MUMigrationBase {
 			if ( ! empty($this->assoc_args['old_url']) && ! empty($this->assoc_args['new_url']) ) {
 				$this->log(__('Running search-replace', 'mu-migration'), $verbose);
 
-				$old_url = Helpers\parse_url_for_search_replace($this->assoc_args['old_url']);
-				$new_url = Helpers\parse_url_for_search_replace($this->assoc_args['new_url']);
+				$old_url         = Helpers\parse_url_for_search_replace($this->assoc_args['old_url']);
+				$new_url         = Helpers\parse_url_for_search_replace($this->assoc_args['new_url']);
+				$imported_tables = $this->get_imported_table_names($filename);
 
-				$search_replace = Helpers\launch_self(
-					'search-replace',
-					[
-						$old_url,
-						$new_url,
-					],
-					[],
-					false,
-					false,
-					['url' => $new_url]
-				);
-
-				if ( 0 === $search_replace ) {
-					$this->log(__('Search and Replace has been successfully executed', 'mu-migration'), $verbose);
-				}
-
-				$this->log(__('Running Search and Replace for uploads paths', 'mu-migration'), $verbose);
-
-				$from = $to = 'wp-content/uploads';
-
-				if ( isset($this->assoc_args['original_blog_id']) && $this->assoc_args['original_blog_id'] > 1 ) {
-					$from = 'wp-content/uploads/sites/' . (int) $this->assoc_args['original_blog_id'];
-				}
-
-				if ( $this->assoc_args['blog_id'] > 1 ) {
-					$to = 'wp-content/uploads/sites/' . (int) $this->assoc_args['blog_id'];
-				}
-
-				if ( $from && $to ) {
+				if ( empty($imported_tables) ) {
+					WP_CLI::warning(__('Could not determine imported tables; skipping search-replace to avoid changing unrelated network tables.', 'mu-migration'));
+				} else {
 					$search_replace = Helpers\launch_self(
 						'search-replace',
-						[$from , $to],
+						array_merge(
+							[
+								$old_url,
+								$new_url,
+							],
+							$imported_tables
+						),
 						[],
 						false,
 						false,
@@ -348,7 +329,34 @@ class ImportCommand extends MUMigrationBase {
 					);
 
 					if ( 0 === $search_replace ) {
-						$this->log(sprintf(__('Uploads paths have been successfully updated: %1$s -> %2$s', 'mu-migration'), $from, $to), $verbose);
+						$this->log(__('Search and Replace has been successfully executed', 'mu-migration'), $verbose);
+					}
+
+					$this->log(__('Running Search and Replace for uploads paths', 'mu-migration'), $verbose);
+
+					$from = $to = 'wp-content/uploads';
+
+					if ( isset($this->assoc_args['original_blog_id']) && $this->assoc_args['original_blog_id'] > 1 ) {
+						$from = 'wp-content/uploads/sites/' . (int) $this->assoc_args['original_blog_id'];
+					}
+
+					if ( $this->assoc_args['blog_id'] > 1 ) {
+						$to = 'wp-content/uploads/sites/' . (int) $this->assoc_args['blog_id'];
+					}
+
+					if ( $from && $to ) {
+						$search_replace = Helpers\launch_self(
+							'search-replace',
+							array_merge([$from, $to], $imported_tables),
+							[],
+							false,
+							false,
+							['url' => $new_url]
+						);
+
+						if ( 0 === $search_replace ) {
+							$this->log(sprintf(__('Uploads paths have been successfully updated: %1$s -> %2$s', 'mu-migration'), $from, $to), $verbose);
+						}
 					}
 				}
 			}
@@ -801,6 +809,33 @@ class ImportCommand extends MUMigrationBase {
 
 			rename($temp_filename, $filename);
 		}
+	}
+
+	/**
+	 * Get table names present in an imported SQL file.
+	 *
+	 * Used to scope WP-CLI search-replace to the newly imported site tables.
+	 * Without explicit table names, `wp search-replace` can scan every network
+	 * table and rewrite existing wp_blogs rows when importing a main-site export.
+	 *
+	 * @param string $filename SQL file path.
+	 * @return array<int,string>
+	 */
+	private function get_imported_table_names($filename) {
+
+		$contents = file_get_contents($filename);
+
+		if ( ! is_string($contents) || '' === $contents ) {
+			return [];
+		}
+
+		preg_match_all('/(?:CREATE TABLE(?: IF NOT EXISTS)?|INSERT INTO|LOCK TABLES)\s+`?([A-Za-z0-9_]+)`?/i', $contents, $matches);
+
+		if ( empty($matches[1]) ) {
+			return [];
+		}
+
+		return array_values(array_unique($matches[1]));
 	}
 
 	/**

--- a/inc/site-exporter/mu-migration/includes/commands/class-mu-migration-import.php
+++ b/inc/site-exporter/mu-migration/includes/commands/class-mu-migration-import.php
@@ -823,19 +823,23 @@ class ImportCommand extends MUMigrationBase {
 	 */
 	private function get_imported_table_names($filename) {
 
-		$contents = file_get_contents($filename);
+		$handle = fopen($filename, 'r');
 
-		if ( ! is_string($contents) || '' === $contents ) {
+		if ( false === $handle ) {
 			return [];
 		}
 
-		preg_match_all('/(?:CREATE TABLE(?: IF NOT EXISTS)?|INSERT INTO|LOCK TABLES)\s+`?([A-Za-z0-9_]+)`?/i', $contents, $matches);
+		$tables = [];
 
-		if ( empty($matches[1]) ) {
-			return [];
+		while ( false !== ($line = fgets($handle)) ) {
+			if ( preg_match('/^\s*(?:CREATE TABLE(?: IF NOT EXISTS)?|INSERT INTO|LOCK TABLES)\s+`?([A-Za-z0-9_]+)`?/i', $line, $matches) ) {
+				$tables[$matches[1]] = true;
+			}
 		}
 
-		return array_values(array_unique($matches[1]));
+		fclose($handle);
+
+		return array_keys($tables);
 	}
 
 	/**

--- a/tests/WP_Ultimo/Site_Exporter_Test.php
+++ b/tests/WP_Ultimo/Site_Exporter_Test.php
@@ -73,6 +73,36 @@ class Site_Exporter_Test extends WP_UnitTestCase {
 
 		$this->clear_pending_import_transients('site');
 		$this->clear_pending_import_transients('network');
+		$this->clear_pending_export_transients();
+	}
+
+	/**
+	 * Clear pending site export transients created by tests.
+	 */
+	private function clear_pending_export_transients(): void {
+
+		global $wpdb;
+
+		if (is_multisite()) {
+			$table      = "{$wpdb->base_prefix}sitemeta";
+			$key_column = 'meta_key';
+			$like       = $wpdb->esc_like('_site_transient_wu_pending_site_export_') . '%';
+		} else {
+			$table      = "{$wpdb->base_prefix}options";
+			$key_column = 'option_name';
+			$like       = $wpdb->esc_like('_transient_wu_pending_site_export_') . '%';
+		}
+
+		// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Table and column are selected from known WordPress schema names.
+		$keys = $wpdb->get_col($wpdb->prepare("SELECT {$key_column} FROM {$table} WHERE {$key_column} LIKE %s", $like));
+
+		foreach ($keys as $key) {
+			$transient = preg_replace('/^_(site_)?transient_/', '', $key);
+
+			if (is_string($transient)) {
+				wu_exporter_delete_transient($transient);
+			}
+		}
 	}
 
 	/**
@@ -190,6 +220,89 @@ class Site_Exporter_Test extends WP_UnitTestCase {
 	public function test_singleton_returns_same_instance(): void {
 
 		$this->assertSame(Site_Exporter::get_instance(), Site_Exporter::get_instance());
+	}
+
+	/**
+	 * Test that main-site rows expose export without offering self-promotion.
+	 */
+	public function test_wp_sites_row_actions_include_main_site_export(): void {
+
+		$actions = $this->exporter->add_wp_sites_row_actions([], get_main_site_id());
+
+		$this->assertArrayHasKey('export', $actions, 'The WordPress main site must be exportable from Network Admin > Sites');
+		$this->assertArrayNotHasKey('promote_main_site', $actions, 'The WordPress main site must not offer Promote to Main Site');
+	}
+
+	/**
+	 * Test that subsite rows still expose both export and main-site promotion.
+	 */
+	public function test_wp_sites_row_actions_include_subsite_export_and_promotion(): void {
+
+		$blog_id = self::factory()->blog->create(['path' => '/exportable-subsite/']);
+
+		$actions = $this->exporter->add_wp_sites_row_actions([], $blog_id);
+
+		$this->assertArrayHasKey('export', $actions, 'Subsites must remain exportable from Network Admin > Sites');
+		$this->assertArrayHasKey('promote_main_site', $actions, 'Subsites must still offer Promote to Main Site');
+	}
+
+	/**
+	 * Test that bulk exports include the main site instead of silently skipping it.
+	 */
+	public function test_wp_sites_bulk_export_includes_main_site(): void {
+
+		if (! function_exists('wu_enqueue_async_action')) {
+			$this->markTestSkipped('wu_enqueue_async_action is not available in this environment');
+		}
+
+		$redirect_url = $this->exporter->handle_wp_sites_bulk_action('', 'export', [get_main_site_id()]);
+		$pending      = wu_exporter_get_pending();
+
+		$this->assertStringContainsString('bulk_exported=1', $redirect_url);
+		$this->assertNotEmpty($pending, 'Bulk exporting the main site must create a pending site export');
+		$this->assertSame(get_main_site_id(), (int) $pending[0]->options[0]);
+	}
+
+	/**
+	 * Test imported table parsing used to scope WP-CLI search-replace.
+	 */
+	public function test_imported_table_names_are_extracted_from_sql(): void {
+
+		$this->exporter->load_dependencies();
+
+		$sql_file = tempnam(sys_get_temp_dir(), 'wu_import_tables_');
+
+		if (false === $sql_file) {
+			$this->markTestSkipped('Unable to create temporary SQL file');
+		}
+
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents -- Test fixture writes a local temporary SQL file.
+		file_put_contents(
+			$sql_file,
+			implode(
+				"\n",
+				[
+					'CREATE TABLE IF NOT EXISTS `wp_61_posts` (`ID` bigint);',
+					'INSERT INTO `wp_61_options` VALUES (1, "siteurl", "http://example.test", "yes");',
+					'LOCK TABLES `wp_61_postmeta` WRITE;',
+					'INSERT INTO `wp_61_posts` VALUES (1);',
+				]
+			)
+		);
+
+		try {
+			$command    = new \TenUp\MU_Migration\Commands\ImportCommand();
+			$reflection = new \ReflectionMethod($command, 'get_imported_table_names');
+			$reflection->setAccessible(true);
+
+			$this->assertSame(
+				['wp_61_posts', 'wp_61_options', 'wp_61_postmeta'],
+				$reflection->invoke($command, $sql_file),
+				'Importer search-replace must be scoped to tables present in the imported SQL file'
+			);
+		} finally {
+			wp_delete_file($sql_file);
+		}
 	}
 
 	/**

--- a/tests/WP_Ultimo/Site_Exporter_Test.php
+++ b/tests/WP_Ultimo/Site_Exporter_Test.php
@@ -285,6 +285,7 @@ class Site_Exporter_Test extends WP_UnitTestCase {
 					'CREATE TABLE IF NOT EXISTS `wp_61_posts` (`ID` bigint);',
 					'INSERT INTO `wp_61_options` VALUES (1, "siteurl", "http://example.test", "yes");',
 					'LOCK TABLES `wp_61_postmeta` WRITE;',
+					'INSERT INTO `wp_61_options` VALUES (2, "fixture", "text mentioning CREATE TABLE `wp_61_not_a_table`", "yes");',
 					'INSERT INTO `wp_61_posts` VALUES (1);',
 				]
 			)


### PR DESCRIPTION
## Summary

- expose main-site single-site export from Network Admin > Sites row and bulk actions
- keep "Promote to Main Site" hidden for the main site while preserving subsite promotion
- scope MU-Migration import search-replace to imported SQL tables so main-site imports do not rewrite existing network rows
- add regression tests for main-site export actions, bulk export queueing, and imported-table parsing

## Verification

- `vendor/bin/phpunit --filter 'Site_Exporter_Test|Site_Exporter_Round_Trip_Test|Site_Exporter_Import_Move_Test'`
- `vendor/bin/phpcs inc/site-exporter/class-site-exporter.php inc/site-exporter/mu-migration/includes/commands/class-mu-migration-import.php tests/WP_Ultimo/Site_Exporter_Test.php`
- `vendor/bin/phpstan analyse inc/site-exporter/class-site-exporter.php inc/site-exporter/mu-migration/includes/commands/class-mu-migration-import.php tests/WP_Ultimo/Site_Exporter_Test.php`
- Manual: fresh single-site install with only Ultimate Multisite active exposed Tools > Export & Import, exported `/tmp/opencode/um-single-site-export.zip`, imported into dev multisite as blog ID 60, and verified `Single Export Verification` page
- Manual: exported multisite main site to `/tmp/opencode/um-main-site-export.zip`, reimported after scoped search-replace fix as blog ID 62, verified `Main Site Export Verification` page, and confirmed existing network site URLs stayed intact

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.22.1 plugin for [OpenCode](https://opencode.ai) v1.17.9 with gpt-5.5


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * You can now export the main site from the network “Sites” list, including when exporting multiple sites at once.
  * The main site shows an **Export** action, while promotion to the main site is available only for subsites.

* **Bug Fixes**
  * URL search-and-replace during import is now limited to tables detected in the imported SQL, reducing unintended changes.
  * If no matching tables are detected, the URL update step is safely skipped with a warning.

* **Tests**
  * Added regression coverage for row actions, bulk export behavior, and imported SQL table detection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->