### PR TITLE
fix: load site exporter in web requests

### DIFF
--- a/inc/site-exporter/class-site-exporter.php
+++ b/inc/site-exporter/class-site-exporter.php
@@ -3003,13 +3003,20 @@ final class Site_Exporter {
 
 		$base_path = wu_path('inc/site-exporter/mu-migration');
 
+		if (! class_exists('WP_CLI_Command') || ! class_exists('WP_CLI')) {
+			require_once $base_path . '/includes/wp-cli-polyfill.php';
+		}
+
 		require_once $base_path . '/includes/helpers.php';
-		require_once $base_path . '/includes/commands/class-mu-migration.php';
 		require_once $base_path . '/includes/commands/class-mu-migration-base.php';
 		require_once $base_path . '/includes/commands/class-mu-migration-export.php';
 		require_once $base_path . '/includes/commands/class-mu-migration-import.php';
 		require_once $base_path . '/includes/commands/class-mu-migration-posts.php';
 		require_once $base_path . '/includes/commands/class-mu-migration-users.php';
+
+		if (defined('WP_CLI') && WP_CLI) {
+			require_once $base_path . '/includes/commands/class-mu-migration.php';
+		}
 
 		if (file_exists($base_path . '/vendor/autoload.php')) {
 			require_once $base_path . '/vendor/autoload.php';

--- a/inc/site-exporter/class-site-exporter.php
+++ b/inc/site-exporter/class-site-exporter.php
@@ -2826,7 +2826,15 @@ final class Site_Exporter {
 
 		$start = microtime(true);
 
-		$command->all([$file_name], $args);
+		try {
+			$command->all([$file_name], $args);
+		} catch (\RuntimeException $exception) {
+			wu_exporter_delete_transient("wu_pending_site_import_{$hash}");
+
+			error_log($exception->getMessage()); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log -- Preserve import failure details for administrators instead of fataling in web/AJAX imports.
+
+			return false;
+		}
 
 		$time = microtime(true) - $start;
 

--- a/inc/site-exporter/mu-migration/includes/wp-cli-polyfill.php
+++ b/inc/site-exporter/mu-migration/includes/wp-cli-polyfill.php
@@ -1,0 +1,155 @@
+<?php
+/**
+ * Minimal WP-CLI polyfill for web/AJAX MU-Migration runs.
+ *
+ * @package TenUp\MU_Migration
+ */
+
+namespace {
+	if (! class_exists('WP_CLI_Command')) {
+		/**
+		 * Minimal command base class used when WP-CLI is not loaded.
+		 */
+		class WP_CLI_Command {
+
+			/**
+			 * Raise a command error.
+			 *
+			 * @param string $message Error message.
+			 * @return void
+			 */
+			public static function error($message): void {
+
+				throw new RuntimeException((string) $message);
+			}
+		}
+	}
+
+	if (! class_exists('WP_CLI')) {
+		/**
+		 * Minimal WP_CLI facade used by bundled MU-Migration command classes.
+		 */
+		class WP_CLI {
+
+			/**
+			 * No-op command registration outside WP-CLI.
+			 *
+			 * @return void
+			 */
+			public static function add_command(): void {
+
+				return;
+			}
+
+			/**
+			 * No-op informational output outside WP-CLI.
+			 *
+			 * @return void
+			 */
+			public static function line(): void {
+
+				return;
+			}
+
+			/**
+			 * No-op log output outside WP-CLI.
+			 *
+			 * @return void
+			 */
+			public static function log(): void {
+
+				return;
+			}
+
+			/**
+			 * No-op success output outside WP-CLI.
+			 *
+			 * @return void
+			 */
+			public static function success(): void {
+
+				return;
+			}
+
+			/**
+			 * No-op warning output outside WP-CLI.
+			 *
+			 * @return void
+			 */
+			public static function warning(): void {
+
+				return;
+			}
+
+			/**
+			 * Raise a command error outside WP-CLI.
+			 *
+			 * @param string $message Error message.
+			 * @return void
+			 */
+			public static function error($message): void {
+
+				throw new RuntimeException((string) $message);
+			}
+
+			/**
+			 * Minimal launch result outside WP-CLI.
+			 *
+			 * @return object
+			 */
+			public static function launch() {
+
+				return (object) [
+					'return_code' => 1,
+					'stdout'      => '',
+					'stderr'      => '',
+				];
+			}
+		}
+	}
+}
+
+namespace WP_CLI\Utils {
+	if (! function_exists(__NAMESPACE__ . '\\make_progress_bar')) {
+		/**
+		 * Return a no-op progress bar outside WP-CLI.
+		 *
+		 * @return object
+		 */
+		function make_progress_bar() {
+
+			return new class() {
+
+				/**
+				 * No-op display.
+				 *
+				 * @return void
+				 */
+				public function display(): void {
+
+					return;
+				}
+
+				/**
+				 * No-op tick.
+				 *
+				 * @return void
+				 */
+				public function tick(): void {
+
+					return;
+				}
+
+				/**
+				 * No-op finish.
+				 *
+				 * @return void
+				 */
+				public function finish(): void {
+
+					return;
+				}
+			};
+		}
+	}
+}

--- a/tests/WP_Ultimo/Site_Exporter_Test.php
+++ b/tests/WP_Ultimo/Site_Exporter_Test.php
@@ -325,6 +325,30 @@ class Site_Exporter_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Test site import command errors do not fatal in web context.
+	 */
+	public function test_handle_site_import_catches_wp_cli_polyfill_errors(): void {
+
+		$hash     = md5(uniqid('site-import-error-', true));
+		$zip_file = tempnam(sys_get_temp_dir(), 'wu_import_not_zip_');
+
+		if (false === $zip_file) {
+			$this->markTestSkipped('Unable to create temporary import fixture');
+		}
+
+		wu_exporter_set_transient("wu_pending_site_import_{$hash}", [$zip_file, [], $hash], 2 * HOUR_IN_SECONDS);
+
+		$this->pending_import_hashes[] = $hash;
+
+		try {
+			$this->assertFalse($this->exporter->handle_site_import(), 'Invalid imports should be handled gracefully without bubbling WP_CLI::error exceptions');
+			$this->assertEmpty(wu_exporter_get_pending_imports(), 'Failed imports should be removed from the pending queue');
+		} finally {
+			wp_delete_file($zip_file);
+		}
+	}
+
+	/**
 	 * Regression test for GH#1009 — circular dependency.
 	 *
 	 * The maybe_add_schedule() method must register wu_site_every_minute regardless of

--- a/tests/WP_Ultimo/Site_Exporter_Test.php
+++ b/tests/WP_Ultimo/Site_Exporter_Test.php
@@ -307,6 +307,24 @@ class Site_Exporter_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Test MU-Migration export command classes load without WP-CLI in web context.
+	 */
+	public function test_mu_migration_export_commands_load_without_wp_cli_runtime(): void {
+
+		$repo_root = dirname(__DIR__, 2);
+		$script    = 'require ' . wp_json_encode($repo_root . '/inc/site-exporter/mu-migration/includes/wp-cli-polyfill.php', JSON_UNESCAPED_SLASHES) . ';'
+			. 'require ' . wp_json_encode($repo_root . '/inc/site-exporter/mu-migration/includes/helpers.php', JSON_UNESCAPED_SLASHES) . ';'
+			. 'require ' . wp_json_encode($repo_root . '/inc/site-exporter/mu-migration/includes/commands/class-mu-migration-base.php', JSON_UNESCAPED_SLASHES) . ';'
+			. 'require ' . wp_json_encode($repo_root . '/inc/site-exporter/mu-migration/includes/commands/class-mu-migration-export.php', JSON_UNESCAPED_SLASHES) . ';'
+			. 'echo class_exists("TenUp\\\\MU_Migration\\\\Commands\\\\ExportCommand") ? "ok" : "missing";';
+
+		// phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.system_calls_shell_exec -- Regression test isolates a PHP process without WP-CLI runtime classes.
+		$output = shell_exec(escapeshellarg(PHP_BINARY) . ' -r ' . escapeshellarg($script));
+
+		$this->assertSame('ok', trim((string) $output), 'MU-Migration export classes must load in web/AJAX context without WP_CLI_Command');
+	}
+
+	/**
 	 * Regression test for GH#1009 — circular dependency.
 	 *
 	 * The maybe_add_schedule() method must register wu_site_every_minute regardless of


### PR DESCRIPTION
## Summary

- follow-up to #1540 for the web/AJAX export fatal reported after merge
- load a minimal WP-CLI polyfill before bundled MU-Migration command classes when `WP_CLI_Command` / `WP_CLI` are unavailable
- keep the CLI-only `mu-migration info` command loaded only during real WP-CLI requests
- add an isolated-process regression test proving MU-Migration export classes load without WP-CLI runtime classes

## Verification

- `vendor/bin/phpunit --filter 'Site_Exporter_Test|Site_Exporter_Round_Trip_Test|Site_Exporter_Import_Move_Test'`
- `vendor/bin/phpcs inc/site-exporter/class-site-exporter.php inc/site-exporter/mu-migration/includes/wp-cli-polyfill.php tests/WP_Ultimo/Site_Exporter_Test.php`
- `vendor/bin/phpstan analyse inc/site-exporter/class-site-exporter.php inc/site-exporter/mu-migration/includes/wp-cli-polyfill.php tests/WP_Ultimo/Site_Exporter_Test.php`

## Notes

The merged #1540 commit is in `main`, but the web/AJAX fatal fix was pushed afterward and did not land in `main`. This PR contains only that follow-up fix on top of current `main`.

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.22.1 plugin for [OpenCode](https://opencode.ai) v1.17.9 with gpt-5.5


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved site import/export behavior in non-WP-CLI (web/AJAX) contexts by adding lightweight WP-CLI compatibility stubs so export commands load reliably.
  * Added safer handling for runtime failures during site import, including clearing the pending-import marker and failing gracefully.
* **Tests**
  * Added a regression test to confirm MU-Migration export commands load correctly outside a WP-CLI session.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->