### PR TITLE
fix: preserve admin targets after SSO denial

### DIFF
--- a/inc/sso/class-sso.php
+++ b/inc/sso/class-sso.php
@@ -617,7 +617,17 @@ class SSO {
 			exit;
 		}
 
-		$denial_url = add_query_arg('sso_verify', 'invalid', $broker_url);
+		$denial_args = [
+			'sso_verify' => 'invalid',
+		];
+
+		$redirect_to = $this->input('redirect_to', '');
+
+		if ( ! empty($redirect_to) && $this->is_admin_redirect_url($redirect_to)) {
+			$denial_args['redirect_to'] = $redirect_to;
+		}
+
+		$denial_url = add_query_arg($denial_args, $broker_url);
 
 		wp_safe_redirect($denial_url, 303, 'WP-Ultimo-SSO');
 		exit;
@@ -999,7 +1009,10 @@ class SSO {
 
 		if ( ! empty($return_url) ) {
 			$url = $this->add_cookie_less_sso_token($return_url, $user->ID);
-			return add_query_arg('redirect_to', $redirect_to, $url);
+
+			if ($return_url !== $url) {
+				return add_query_arg('redirect_to', $redirect_to, $url);
+			}
 		}
 
 		// Default: send to the subsite dashboard or main site admin.
@@ -1374,10 +1387,18 @@ class SSO {
 
 		if ($verify_code) {
 			if ('invalid' === $verify_code) {
-				setcookie('wu_sso_denied', '1', time() + 300, COOKIEPATH, COOKIE_DOMAIN);
+				if ( ! headers_sent()) {
+					setcookie('wu_sso_denied', '1', time() + 300, COOKIEPATH, COOKIE_DOMAIN);
+				}
+
 				$_COOKIE['wu_sso_denied'] = '1';
 
-				$return_url = $this->input('return_url', get_home_url());
+				$return_url  = $this->input('return_url', get_home_url());
+				$redirect_to = $this->input('redirect_to', '');
+
+				if ( ! empty($redirect_to) && $this->is_admin_redirect_url($redirect_to)) {
+					$return_url = wp_login_url($redirect_to, true);
+				}
 
 				wp_safe_redirect($return_url, 302, 'WP-Ultimo-SSO');
 

--- a/tests/WP_Ultimo/SSO/SSO_Coverage_Test.php
+++ b/tests/WP_Ultimo/SSO/SSO_Coverage_Test.php
@@ -71,6 +71,7 @@ class SSO_Coverage_Test extends \WP_UnitTestCase {
 		unset($_REQUEST['action']);
 		unset($_REQUEST['loggedout']);
 		unset($_REQUEST['return_url']);
+		unset($_REQUEST['redirect_to']);
 		unset($_COOKIE['wu_sso_denied']);
 
 		parent::tearDown();
@@ -331,7 +332,7 @@ class SSO_Coverage_Test extends \WP_UnitTestCase {
 		);
 
 		$this->assertStringContainsString(
-			"\$denial_url = add_query_arg('sso_verify', 'invalid', \$broker_url);",
+			'$denial_url = add_query_arg($denial_args, $broker_url);',
 			$source,
 			'handle_server() must append sso_verify=invalid to anonymous SSO grant redirects'
 		);
@@ -1609,7 +1610,7 @@ class SSO_Coverage_Test extends \WP_UnitTestCase {
 		);
 
 		$this->assertStringContainsString(
-			"'sso_verify', 'invalid'",
+			"'sso_verify' => 'invalid'",
 			$source,
 			'handle_server() must include sso_verify=invalid in anonymous denial redirects'
 		);
@@ -2080,6 +2081,50 @@ class SSO_Coverage_Test extends \WP_UnitTestCase {
 	}
 
 	/**
+	 * Test anonymous SSO denials preserve admin redirect targets for the broker.
+	 */
+	public function test_handle_server_anonymous_denial_preserves_admin_redirect_target(): void {
+		$sso = SSO::get_instance();
+
+		$redirect_to = 'https://customer.example.com/wp-admin/';
+
+		$_REQUEST['return_url']  = 'https://customer.example.com/';
+		$_REQUEST['redirect_to'] = $redirect_to;
+
+		$redirect_url = null;
+
+		add_filter(
+			'allowed_redirect_hosts',
+			function ($hosts) {
+				$hosts[] = 'customer.example.com';
+				return $hosts;
+			}
+		);
+
+		add_filter(
+			'wp_redirect',
+			function ($location) use (&$redirect_url) {
+				$redirect_url = $location;
+				throw new \RuntimeException('redirect_intercepted');
+			},
+			1
+		);
+
+		try {
+			$sso->handle_server('redirect');
+		} catch (\RuntimeException $e) {
+			$this->assertSame('redirect_intercepted', $e->getMessage());
+		}
+
+		unset($_REQUEST['return_url'], $_REQUEST['redirect_to']);
+
+		$this->assertNotNull($redirect_url, 'handle_server() must redirect anonymous SSO grant requests back to the broker');
+		$this->assertStringContainsString('sso_verify=invalid', $redirect_url);
+		$this->assertStringContainsString('redirect_to=', $redirect_url);
+		$this->assertStringContainsString('/wp-admin/', $redirect_url);
+	}
+
+	/**
 	 * Test handle_server does not attach anonymous sessions before redirecting.
 	 *
 	 * Uses wp_redirect filter to throw an exception before exit().
@@ -2221,6 +2266,56 @@ class SSO_Coverage_Test extends \WP_UnitTestCase {
 			$source,
 			'handle_broker() must call setcookie() for wu_sso_denied when sso_verify is invalid'
 		);
+	}
+
+	/**
+	 * Test invalid SSO verification from an admin request falls back to the login form.
+	 */
+	public function test_handle_broker_invalid_verify_redirects_admin_target_to_login(): void {
+		$subsite_id = self::factory()->blog->create();
+		switch_to_blog($subsite_id);
+
+		$sso = SSO::get_instance();
+
+		$mock_broker = $this->createMock(SSO_Broker::class);
+		$mock_broker->method('isAttached')->willReturn(false);
+
+		add_filter(
+			'wu_sso_get_broker',
+			function () use ($mock_broker) {
+				return $mock_broker;
+			}
+		);
+
+		$return_url   = home_url('/');
+		$redirect_to  = admin_url();
+		$redirect_url = null;
+
+		$_REQUEST['sso_verify']  = 'invalid';
+		$_REQUEST['return_url']  = $return_url;
+		$_REQUEST['redirect_to'] = $redirect_to;
+
+		add_filter(
+			'wp_redirect',
+			function ($location) use (&$redirect_url) {
+				$redirect_url = $location;
+				throw new \RuntimeException('redirect_intercepted');
+			},
+			1
+		);
+
+		try {
+			$sso->handle_broker('redirect');
+		} catch (\RuntimeException $e) {
+			$this->assertSame('redirect_intercepted', $e->getMessage());
+		}
+
+		restore_current_blog();
+
+		$this->assertNotNull($redirect_url, 'handle_broker() must redirect invalid admin SSO requests');
+		$this->assertStringContainsString('wp-login.php', $redirect_url);
+		$this->assertStringContainsString(rawurlencode($redirect_to), $redirect_url);
+		$this->assertStringNotContainsString($return_url . '?sso_verify=invalid', $redirect_url);
 	}
 
 	/**

--- a/tests/WP_Ultimo/SSO/SSO_Test.php
+++ b/tests/WP_Ultimo/SSO/SSO_Test.php
@@ -311,6 +311,25 @@ class SSO_Test extends \WP_UnitTestCase {
 	}
 
 	/**
+	 * Test same-domain SSO login redirects honour the requested admin URL directly.
+	 */
+	public function test_handle_login_redirect_uses_redirect_to_when_return_url_is_same_domain(): void {
+		$sso         = SSO::get_instance();
+		$user_id     = self::factory()->user->create();
+		$user        = get_user_by('id', $user_id);
+		$return_url  = home_url('/');
+		$redirect_to = admin_url();
+
+		$_REQUEST['return_url']  = $return_url;
+		$_REQUEST['redirect_to'] = $redirect_to;
+
+		$this->assertSame(
+			$redirect_to,
+			$sso->handle_login_redirect($redirect_to, $redirect_to, $user)
+		);
+	}
+
+	/**
 	 * Test broker /sso handoff URLs are not used as the post-token redirect target.
 	 */
 	public function test_get_sso_redirect_to_unwraps_broker_sso_handoff_redirect_to(): void {
@@ -1188,7 +1207,7 @@ class SSO_Test extends \WP_UnitTestCase {
 		// handle_broker can set wu_sso_denied on the broker domain
 		// and bounce the user back to their original page.
 		$this->assertMatchesRegularExpression(
-			'/add_query_arg\s*\(\s*[\'"]sso_verify[\'"]\s*,\s*[\'"]invalid[\'"]/s',
+			'/\$denial_args\s*=\s*\[.*?[\'"]sso_verify[\'"]\s*=>\s*[\'"]invalid[\'"].*?add_query_arg\s*\(\s*\$denial_args\s*,\s*\$broker_url\s*\)/s',
 			$body,
 			'handle_server() not-logged-in non-JSONP branch must append sso_verify=invalid to the broker URL so handle_broker can set wu_sso_denied and bounce the user back to the original page anonymously (instead of forcing wp-login.php).'
 		);


### PR DESCRIPTION
## Summary

- Preserve admin `redirect_to` targets when anonymous SSO grants are denied, so mapped-domain `/wp-admin/` requests fall back to the login form instead of the site homepage.
- Send invalid admin SSO verification responses to `wp_login_url( redirect_to, true )` while keeping public anonymous SSO denials on their original return URL.
- Avoid wrapping same-domain login redirects in an unnecessary SSO handoff when no cookie-less token is added.

## Verification

- Reproduced on the local multisite test site using a mapped/subdomain subsite: logged-out `/wp-admin/` redirected through SSO denial and ended at the subsite homepage before the fix.
- Verified patched flow: logged-out `/wp-admin/` now redirects to `wp-login.php?redirect_to=<mapped-subsite>/wp-admin/&reauth=1`; login POST returns `Location: <mapped-subsite>/wp-admin/`.
- `vendor/bin/phpcs inc/sso/class-sso.php tests/WP_Ultimo/SSO/SSO_Test.php tests/WP_Ultimo/SSO/SSO_Coverage_Test.php`
- `vendor/bin/phpunit --filter 'WP_Ultimo\\SSO\\SSO_Test|WP_Ultimo\\SSO\\SSO_Coverage_Test'`


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.25.0 plugin for [OpenCode](https://opencode.ai) v1.17.11 with gpt-5.5 spent 36m and 255,862 tokens on this with the user in an interactive session.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved SSO redirect handling so users are sent to the intended admin/login page when access is denied or verification fails.
  * Preserved destination URLs more reliably during login redirects, reducing unexpected returns to the home page.
  * Added safeguards to prevent redirect issues when response headers have already been sent.

* **Tests**
  * Expanded coverage for admin redirect flows and denial handling.
  * Updated existing checks to match the current redirect behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->