### PR TITLE
fix: remediate fast-uri dependency alert (#1545)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7025,9 +7025,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
-      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
       "dev": true,
       "funding": [
         {


### PR DESCRIPTION
## Summary

- Updated `package-lock.json` so `fast-uri` resolves to `3.1.2`, above the patched `3.1.1` minimum reported by GitHub.
- Kept the remediation scoped to the npm lockfile transitive dependency path.

## Testing

- `npm ls fast-uri` → confirms `fast-uri@3.1.2` via `stylelint > table > ajv`.
- `npm audit --json` parsed for `fast-uri` → no `fast-uri` vulnerability entry present.
- `npm run lint:js` attempted after `npm install`; fails on pre-existing unrelated JS lint issues.
- `npm run lint:css` attempted after `npm install`; fails on pre-existing unrelated CSS lint issue in `assets/css/admin.css`.

Resolves #1545

MERGE_SUMMARY: Updated the npm lockfile so the vulnerable transitive `fast-uri` resolution is replaced with `fast-uri@3.1.2`; verified via `npm ls fast-uri` and npm audit JSON that the package no longer appears as vulnerable. Broader JS/CSS lint gates remain blocked by unrelated pre-existing violations.

<!-- aidevops:sig -->
