### PR TITLE
fix: update flatted lockfile

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7163,9 +7163,9 @@
       }
     },
     "node_modules/flatted": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.3.tgz",
-      "integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+      "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
       "dev": true,
       "license": "ISC"
     },


### PR DESCRIPTION
## Summary

- Updated `package-lock.json` so transitive `flatted` resolves to `3.4.2` for both `flat-cache` dependency paths.

## Testing

- `npm ls flatted --package-lock-only --depth=10` — resolves `flatted@3.4.2`
- Parsed `npm audit --json` — `flatted_in_audit=no`; audit total reduced to 27 existing non-flatted findings
- `npm run check` — blocked by pre-existing `assets/css/admin.css:43` Stylelint `CssSyntaxError` (`All rules have already been disabled`)

MERGE_SUMMARY: Updated the npm lockfile to resolve the transitive `flatted` dependency to the patched `3.4.2` release. Dependency-specific audit no longer reports `flatted`; the broader repo check remains blocked by existing unrelated lint debt in CSS.

Resolves #1547

<!-- aidevops:sig -->
