### PR TITLE
fix: update fast-uri lockfile

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7025,9 +7025,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
-      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
       "dev": true,
       "funding": [
         {


### PR DESCRIPTION
## Summary

- Updated `package-lock.json` so `fast-uri` resolves to patched version `3.1.2`.
- Kept the change limited to npm lockfile resolution for the dependency alert.

## Verification

- `npm audit --json` parsed for `fast-uri`: no `fast-uri` vulnerability present.
- `node -e "const lock=require('./package-lock.json'); const fastUri=lock.packages['node_modules/fast-uri']; console.log('fast-uri', fastUri.version); if (fastUri.version !== '3.1.2') process.exit(1);"` -> `fast-uri 3.1.2`
- `npm run lint:js` attempted; fails on existing unrelated JS lint violations in tracked assets.
- `npm run lint:css` attempted; fails on existing unrelated `assets/css/admin.css` stylelint issue.

Resolves #1546

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.27.0 plugin for [OpenCode](https://opencode.ai) v1.17.11 with gpt-5.5 spent 6m and 55,009 tokens on this as a headless worker.
