### PR TITLE
GH#1554: fix: update minimatch lockfile resolution

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3372,13 +3372,13 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
-      "version": "9.0.3",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.3.tgz",
-      "integrity": "sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==",
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
-        "brace-expansion": "^2.0.1"
+        "brace-expansion": "^2.0.2"
       },
       "engines": {
         "node": ">=16 || 14 >=14.17"
@@ -9414,9 +9414,9 @@
       }
     },
     "node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.4.tgz",
+      "integrity": "sha512-twmL+S8+7yIsE9wsqgzU3E8/LumN3M3QELrBZ20OdmQ9jB2JvW5oZtBEmft84k/Gs5CG9mqtWc6Y9vW+JEzGxw==",
       "dev": true,
       "license": "ISC",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -105,7 +105,9 @@
   "overrides": {
     "@babel/core": "7.29.6",
     "glob": "^10.5.0",
-    "js-yaml": "4.3.0"
+    "js-yaml": "4.3.0",
+    "minimatch@^3": "3.1.4",
+    "minimatch@^9": "9.0.9"
   },
   "lint-staged": {
     "assets/js/**/*.js": [


### PR DESCRIPTION
## Summary

Added npm overrides for vulnerable minimatch 3.x and 9.x transitive ranges and regenerated package-lock.json so resolved minimatch entries use patched releases while preserving the js-yaml override from current main.

## Files Changed

package-lock.json,package.json

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** PASS: node audit assertion confirms no minimatch entry in npm audit --json; root minimatch resolves 3.1.4 and nested @typescript-eslint minimatch resolves 9.0.9; git diff --check HEAD~1..HEAD. FAIL: npm run lint:js fails on pre-existing unrelated assets/js lint errors (147 errors, 10 warnings).

Resolves #1554


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.27.0 plugin for [OpenCode](https://opencode.ai) v1.17.11 with gpt-5.5 spent 7m and 96,290 tokens on this as a headless worker.