### PR TITLE
GH#1558: fix: update postcss lockfile resolution

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10315,9 +10315,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.6",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
-      "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
+      "version": "8.5.10",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.10.tgz",
+      "integrity": "sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==",
       "dev": true,
       "funding": [
         {

--- a/package.json
+++ b/package.json
@@ -107,7 +107,8 @@
     "glob": "^10.5.0",
     "js-yaml": "4.3.0",
     "minimatch@^3": "3.1.4",
-    "minimatch@^9": "9.0.9"
+    "minimatch@^9": "9.0.9",
+    "postcss": "8.5.10"
   },
   "lint-staged": {
     "assets/js/**/*.js": [


### PR DESCRIPTION
## Summary

Pinned postcss through npm overrides and refreshed package-lock.json so the resolved package is 8.5.10.

## Files Changed

package-lock.json,package.json

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** npm install --ignore-scripts; npm ls postcss; npm audit --json (postcss absent, unrelated existing alerts remain); npm run lint:js (fails on pre-existing JS lint violations); npm run lint:css (fails on pre-existing CSS lint violation); bash bin/check-env.sh (composer vendor missing)

Resolves #1558


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.27.0 plugin for [OpenCode](https://opencode.ai) v1.17.11 with gpt-5.5 spent 3m and 85,175 tokens on this as a headless worker.