### PR TITLE
GH#1556: fix: update picomatch lockfile resolution

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10269,9 +10269,9 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -12252,9 +12252,9 @@
       }
     },
     "node_modules/tinyglobby/node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -108,6 +108,8 @@
     "js-yaml": "4.3.0",
     "minimatch@^3": "3.1.4",
     "minimatch@^9": "9.0.9",
+    "picomatch@^2": "2.3.2",
+    "picomatch@^4": "4.0.4",
     "postcss": "8.5.10"
   },
   "lint-staged": {


### PR DESCRIPTION
## Summary

Updated npm overrides so picomatch v2 resolves to 2.3.2 and the separate picomatch v4 path resolves to 4.0.4. Regenerated package-lock.json after rebasing onto origin/main so the existing postcss override is preserved.

## Files Changed

package-lock.json,package.json

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** npm install --package-lock-only; npm audit --audit-level=moderate (no picomatch entries remain; audit still reports unrelated ajv, brace-expansion, qs, shell-quote, simple-git, tmp, uuid, vue, and yaml advisories); npm run check (fails on pre-existing assets/css/admin.css:43 Stylelint needless-disable error unrelated to package manifests).

Resolves #1556


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.27.0 plugin for [OpenCode](https://opencode.ai) v1.17.11 with gpt-5.5 spent 9m and 86,462 tokens on this as a headless worker.