### PR TITLE
fix: remediate shell-quote dependency alert

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11152,9 +11152,9 @@
       }
     },
     "node_modules/shell-quote": {
-      "version": "1.8.3",
-      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.3.tgz",
-      "integrity": "sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==",
+      "version": "1.8.4",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.4.tgz",
+      "integrity": "sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -111,7 +111,8 @@
     "picomatch@^2": "2.3.2",
     "picomatch@^4": "4.0.4",
     "postcss": "8.5.10",
-    "qs": "6.15.3"
+    "qs": "6.15.3",
+    "shell-quote": "1.8.4"
   },
   "lint-staged": {
     "assets/js/**/*.js": [


### PR DESCRIPTION
## Summary

- Add an npm override for `shell-quote` at `1.8.4`.
- Refresh `package-lock.json` so `npm-run-all` resolves to `shell-quote@1.8.4`.
- Preserve the existing dependency overrides already merged into `main`.

Resolves #1561

## Testing

- `npm install --package-lock-only --ignore-scripts`
- `npm install --ignore-scripts`
- `npm ls shell-quote` → `shell-quote@1.8.4 overridden`
- `npm audit --json` → `shell-quote` absent; unrelated existing audit findings remain
- `npm run lint:js` → fails on existing unrelated JS lint violations
- `npm run lint:css` → fails on existing unrelated CSS lint violation
- `npm run stan` → fails on existing unrelated PHPStan violations

<!-- MERGE_SUMMARY: Added a shell-quote override at 1.8.4 and refreshed package-lock so npm-run-all resolves to the patched shell-quote release. Verification confirmed shell-quote is absent from npm audit output; unrelated existing audit/lint/static-analysis findings remain. -->

<!-- aidevops:sig -->
