### PR TITLE
fix: remediate simple-git dependency alert

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2988,6 +2988,23 @@
       "hasInstallScript": true,
       "license": "Apache-2.0"
     },
+    "node_modules/@simple-git/args-pathspec": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@simple-git/args-pathspec/-/args-pathspec-1.0.3.tgz",
+      "integrity": "sha512-ngJMaHlsWDTfjyq9F3VIQ8b7NXbBLq5j9i5bJ6XLYtD6qlDXT7fdKY2KscWWUF8t18xx052Y/PUO1K1TRc9yKA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@simple-git/argv-parser": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@simple-git/argv-parser/-/argv-parser-1.1.1.tgz",
+      "integrity": "sha512-Q9lBcfQ+VQCpQqGJFHe5yooOS5hGdLFFbJ5R+R5aDsnkPCahtn1hSkMcORX65J2Z5lxSkD0lQorMsncuBQxYUw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@simple-git/args-pathspec": "^1.0.3"
+      }
+    },
     "node_modules/@sindresorhus/is": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-4.6.0.tgz",
@@ -11268,14 +11285,16 @@
       }
     },
     "node_modules/simple-git": {
-      "version": "3.28.0",
-      "resolved": "https://registry.npmjs.org/simple-git/-/simple-git-3.28.0.tgz",
-      "integrity": "sha512-Rs/vQRwsn1ILH1oBUy8NucJlXmnnLeLCfcvbSehkPzbv3wwoFWIdtfd6Ndo6ZPhlPsCZ60CPI4rxurnwAa+a2w==",
+      "version": "3.36.0",
+      "resolved": "https://registry.npmjs.org/simple-git/-/simple-git-3.36.0.tgz",
+      "integrity": "sha512-cGQjLjK8bxJw4QuYT7gxHw3/IouVESbhahSsHrX97MzCL1gu2u7oy38W6L2ZIGECEfIBG4BabsWDPjBxJENv9Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@kwsites/file-exists": "^1.1.1",
         "@kwsites/promise-deferred": "^1.1.1",
+        "@simple-git/args-pathspec": "^1.0.3",
+        "@simple-git/argv-parser": "^1.1.0",
         "debug": "^4.4.0"
       },
       "funding": {

--- a/package.json
+++ b/package.json
@@ -112,6 +112,7 @@
     "picomatch@^4": "4.0.4",
     "postcss": "8.5.10",
     "qs": "6.15.3",
+    "simple-git": "3.36.0",
     "shell-quote": "1.8.4"
   },
   "lint-staged": {


### PR DESCRIPTION
## Summary

- Added an npm override for `simple-git` at `3.36.0`.
- Refreshed `package-lock.json` so `@wordpress/env` resolves to the patched `simple-git` package and its current helper dependencies.

## Testing

- `npm install --package-lock-only`
- `npm audit --omit=optional` — `simple-git` is no longer reported; unrelated existing advisories remain for ajv, brace-expansion, tmp, uuid, vue, and yaml.
- `npm run check` — blocked by an existing Stylelint parser error in `assets/css/admin.css:43` (`All rules have already been disabled`).

Resolves #1563


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.27.0 plugin for [OpenCode](https://opencode.ai) v1.17.11 with gpt-5.5 spent 4m and 55,946 tokens on this as a headless worker.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated a dependency override to pin a Git integration package to a specific version for more consistent installs and builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->