### PR TITLE
GH#1568: fix: remediate uuid dependency alert

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12752,13 +12752,17 @@
       "license": "MIT"
     },
     "node_modules/uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
+      "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
       "dev": true,
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
       "license": "MIT",
       "bin": {
-        "uuid": "dist/bin/uuid"
+        "uuid": "dist/esm/bin/uuid"
       }
     },
     "node_modules/v-money": {

--- a/package.json
+++ b/package.json
@@ -113,7 +113,8 @@
     "postcss": "8.5.10",
     "qs": "6.15.3",
     "simple-git": "3.36.0",
-    "shell-quote": "1.8.4"
+    "shell-quote": "1.8.4",
+    "uuid": "11.1.1"
   },
   "lint-staged": {
     "assets/js/**/*.js": [


### PR DESCRIPTION
## Summary

Added an npm override for uuid 11.1.1 and refreshed package-lock.json so the transitive @cypress/request resolution uses the patched uuid release.

## Files Changed

package-lock.json,package.json

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** npm ls uuid; npm audit --json check confirmed no uuid vulnerability entry; npm run quality (blocked by existing assets/css/admin.css:43 stylelint error unrelated to this dependency change).

Resolves #1568


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.27.0 plugin for [OpenCode](https://opencode.ai) v1.17.11 with gpt-5.5 spent 3m and 49,123 tokens on this as a headless worker.