### PR TITLE
GH#1566: fix: pin symfony yaml patched dependency

### DIFF
--- a/inc/site-exporter/mu-migration/composer.json
+++ b/inc/site-exporter/mu-migration/composer.json
@@ -20,6 +20,7 @@
     "files": [ "mu-migration.php" ]
   },
     "require-dev": {
-        "behat/behat": "^3.32"
+        "behat/behat": "^3.32",
+        "symfony/yaml": "^7.4"
     }
 }

--- a/inc/site-exporter/mu-migration/composer.lock
+++ b/inc/site-exporter/mu-migration/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "e0b9dd9722c2b01cf1e3608b8a5d13fc",
+    "content-hash": "9d8361deb77a1731c1b4788aa42df7c7",
     "packages": [
         {
             "name": "alchemy/zippy",


### PR DESCRIPTION
## Summary

Pinned the vendored MU Migration dev dependency to Symfony YAML ^7.4 and regenerated the lock metadata so GitHub dependency scanning has an explicit patched floor while retaining the locked v7.4.13 package.

## Files Changed

inc/site-exporter/mu-migration/composer.json,inc/site-exporter/mu-migration/composer.lock

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** bash bin/check-env.sh; composer --working-dir=inc/site-exporter/mu-migration validate --no-check-publish --strict; composer --working-dir=inc/site-exporter/mu-migration audit --locked --format=plain; vendor/bin/phpcs inc/site-exporter/mu-migration/composer.json

Resolves #1566


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.27.0 plugin for [OpenCode](https://opencode.ai) v1.17.11 with gpt-5.5 spent 4m and 53,610 tokens on this as a headless worker.