### PR TITLE
GH#1565: fix: guard symfony process minimum

### DIFF
--- a/inc/site-exporter/mu-migration/composer.json
+++ b/inc/site-exporter/mu-migration/composer.json
@@ -9,6 +9,9 @@
     "require": {
        "alchemy/zippy": "^1.0"
     },
+    "conflict": {
+        "symfony/process": "<5.4.51"
+    },
     "license": "MIT",
     "authors": [
         {

--- a/inc/site-exporter/mu-migration/composer.lock
+++ b/inc/site-exporter/mu-migration/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "9d8361deb77a1731c1b4788aa42df7c7",
+    "content-hash": "f0636f6966e06c1ce6b6ca7f0ffd87f8",
     "packages": [
         {
             "name": "alchemy/zippy",


### PR DESCRIPTION
## Summary

Added a Composer conflict guard in inc/site-exporter/mu-migration/composer.json to prevent symfony/process from resolving below 5.4.51 and regenerated the nested composer.lock content hash.

## Files Changed

inc/site-exporter/mu-migration/composer.json,inc/site-exporter/mu-migration/composer.lock

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** composer validate --strict && composer audit --locked --format=plain in inc/site-exporter/mu-migration passed. npm run check was attempted after composer install and npm install but is blocked by unrelated existing stylelint/PHPCS/PHPStan findings outside these files.

Resolves #1565


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.27.0 plugin for [OpenCode](https://opencode.ai) v1.17.11 with gpt-5.5 spent 8m and 81,995 tokens on this as a headless worker.