### PR TITLE
perf: optimize template table copy

### DIFF
--- a/inc/duplication/data.php
+++ b/inc/duplication/data.php
@@ -114,17 +114,10 @@ if ( ! class_exists('MUCD_Data') ) {
 				$from_site_table = self::get_existing_blog_tables($from_site_id);
 			}
 
-			$tables_to_ignore = [
-				'actionscheduler_actions',
-				'actionscheduler_claims',
-				'actionscheduler_groups',
-				'actionscheduler_logs',
-			];
-
 			foreach ($from_site_table as $table) {
 				$table_base_name = substr((string) $table, $from_site_prefix_length);
 
-				if (in_array($table_base_name, $tables_to_ignore, true)) {
+				if ( ! self::should_copy_table($table, $table_base_name, $from_site_id, $to_site_id)) {
 					continue;
 				}
 
@@ -154,6 +147,207 @@ if ( ! class_exists('MUCD_Data') ) {
 			self::db_restore_data($to_site_id, $saved_options);
 
 			return $saved_options;
+		}
+
+		/**
+		 * Determine whether a source table should be copied to the duplicated site.
+		 *
+		 * Runtime-only tables are skipped by default because queues, logs, caches,
+		 * analytics, and sessions are regenerated on the destination site. Empty
+		 * optional/custom tables are also skipped to avoid spending most of the
+		 * duplication time cloning schemas with no template data. WordPress core
+		 * content/config tables are always copied because wpmu_create_blog() creates
+		 * destination defaults that must be replaced with template values.
+		 *
+		 * @since 2.5.1
+		 *
+		 * @param string $table           Full source table name.
+		 * @param string $table_base_name Source table name without blog prefix.
+		 * @param int    $from_site_id    Source site ID.
+		 * @param int    $to_site_id      Target site ID.
+		 * @return bool Whether the table should be copied.
+		 */
+		public static function should_copy_table($table, $table_base_name, $from_site_id, $to_site_id) {
+
+			$copy = true;
+
+			if (self::is_runtime_table($table_base_name)) {
+				$copy = false;
+			} elseif (self::should_skip_empty_table($table, $table_base_name, $from_site_id, $to_site_id)) {
+				$copy = false;
+			}
+
+			/**
+			 * Filter whether a source table should be copied during site duplication.
+			 *
+			 * Returning true forces a table to be copied; returning false skips it.
+			 * This preserves extension control over custom table duplication while
+			 * keeping the default path optimized for empty/runtime template tables.
+			 *
+			 * @since 2.5.1
+			 *
+			 * @param bool   $copy            Whether the table should be copied.
+			 * @param string $table           Full source table name.
+			 * @param string $table_base_name Source table name without blog prefix.
+			 * @param int    $from_site_id    Source site ID.
+			 * @param int    $to_site_id      Target site ID.
+			 */
+			return (bool) apply_filters('mucd_should_copy_table', $copy, $table, $table_base_name, $from_site_id, $to_site_id);
+		}
+
+		/**
+		 * Check whether a source table is runtime-only data that should not be cloned.
+		 *
+		 * @since 2.5.1
+		 *
+		 * @param string $table_base_name Source table name without blog prefix.
+		 * @return bool Whether the table is runtime-only.
+		 */
+		public static function is_runtime_table($table_base_name) {
+
+			$runtime_tables = [
+				'actionscheduler_actions',
+				'actionscheduler_claims',
+				'actionscheduler_groups',
+				'actionscheduler_logs',
+				'blc_filters',
+				'blc_instances',
+				'blc_links',
+				'blc_synch',
+				'ewwwio_images',
+				'icl_background_task',
+				'icl_translate_job',
+				'icl_translation_batches',
+				'litespeed_avatar',
+				'litespeed_img_optm',
+				'litespeed_img_optming',
+				'litespeed_url',
+				'litespeed_url_file',
+				'quform_entries',
+				'quform_entry_data',
+				'quform_entry_entry_labels',
+				'quform_entry_labels',
+				'redirection_404',
+				'redirection_logs',
+				'woocommerce_api_keys',
+				'woocommerce_downloadable_product_permissions',
+				'woocommerce_log',
+				'woocommerce_sessions',
+				'yoast_indexable',
+				'yoast_indexable_hierarchy',
+				'yoast_migrations',
+				'yoast_primary_term',
+				'yoast_seo_links',
+				'yoast_seo_meta',
+			];
+
+			/**
+			 * Filter runtime-only table base names skipped during site duplication.
+			 *
+			 * @since 2.5.1
+			 *
+			 * @param array $runtime_tables Runtime-only table base names.
+			 */
+			$runtime_tables = (array) apply_filters('mucd_runtime_tables_to_ignore', $runtime_tables);
+
+			return in_array($table_base_name, $runtime_tables, true);
+		}
+
+		/**
+		 * Determine whether an empty source table can be skipped.
+		 *
+		 * @since 2.5.1
+		 *
+		 * @param string $table           Full source table name.
+		 * @param string $table_base_name Source table name without blog prefix.
+		 * @param int    $from_site_id    Source site ID.
+		 * @param int    $to_site_id      Target site ID.
+		 * @return bool Whether the table should be skipped because it is empty.
+		 */
+		private static function should_skip_empty_table($table, $table_base_name, $from_site_id, $to_site_id) {
+
+			if ( ! self::skip_empty_tables($from_site_id, $to_site_id)) {
+				return false;
+			}
+
+			if (self::is_required_table($table_base_name)) {
+				return false;
+			}
+
+			return 0 === self::get_table_row_count($table);
+		}
+
+		/**
+		 * Check whether empty optional/custom tables should be skipped.
+		 *
+		 * @since 2.5.1
+		 *
+		 * @param int $from_site_id Source site ID.
+		 * @param int $to_site_id   Target site ID.
+		 * @return bool Whether empty optional/custom tables should be skipped.
+		 */
+		private static function skip_empty_tables($from_site_id, $to_site_id) {
+
+			/**
+			 * Filter whether empty optional/custom source tables are skipped.
+			 *
+			 * @since 2.5.1
+			 *
+			 * @param bool $skip_empty_tables Whether to skip empty optional tables.
+			 * @param int  $from_site_id      Source site ID.
+			 * @param int  $to_site_id        Target site ID.
+			 */
+			return (bool) apply_filters('mucd_skip_empty_tables', true, $from_site_id, $to_site_id);
+		}
+
+		/**
+		 * Check whether a table is required for a faithful template clone.
+		 *
+		 * @since 2.5.1
+		 *
+		 * @param string $table_base_name Source table name without blog prefix.
+		 * @return bool Whether the table should be copied even when empty.
+		 */
+		private static function is_required_table($table_base_name) {
+
+			$required_tables = [
+				'commentmeta',
+				'comments',
+				'links',
+				'options',
+				'postmeta',
+				'posts',
+				'term_relationships',
+				'term_taxonomy',
+				'termmeta',
+				'terms',
+			];
+
+			/**
+			 * Filter required table base names copied even when empty.
+			 *
+			 * @since 2.5.1
+			 *
+			 * @param array $required_tables Required table base names.
+			 */
+			$required_tables = (array) apply_filters('mucd_required_tables_to_copy', $required_tables);
+
+			return in_array($table_base_name, $required_tables, true);
+		}
+
+		/**
+		 * Count rows in a source table.
+		 *
+		 * @since 2.5.1
+		 *
+		 * @param string $table Full source table name.
+		 * @return int Source table row count.
+		 */
+		private static function get_table_row_count($table) {
+
+			$count = self::do_sql_query('SELECT COUNT(*) FROM `' . $table . '`', 'var', false);
+
+			return (int) $count;
 		}
 
 		/**

--- a/tests/WP_Ultimo/Duplication/MUCD_Data_Test.php
+++ b/tests/WP_Ultimo/Duplication/MUCD_Data_Test.php
@@ -630,6 +630,131 @@ class MUCD_Data_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Test runtime-only tables are excluded from template copies by default.
+	 */
+	public function test_should_copy_table_skips_runtime_tables() {
+		global $wpdb;
+
+		$table = $wpdb->get_blog_prefix() . 'actionscheduler_actions';
+
+		$this->assertFalse(
+			\MUCD_Data::should_copy_table($table, 'actionscheduler_actions', get_current_blog_id(), 123)
+		);
+	}
+
+	/**
+	 * Test empty optional template tables are skipped by default.
+	 */
+	public function test_should_copy_table_skips_empty_optional_tables() {
+		global $wpdb;
+
+		$table = $wpdb->get_blog_prefix() . 'wu_empty_runtime_fixture';
+
+		$this->create_table_selection_fixture($table);
+
+		try {
+			$this->assertFalse(
+				\MUCD_Data::should_copy_table($table, 'wu_empty_runtime_fixture', get_current_blog_id(), 123)
+			);
+		} finally {
+			$this->drop_table_selection_fixture($table);
+		}
+	}
+
+	/**
+	 * Test non-empty optional template tables are still copied.
+	 */
+	public function test_should_copy_table_keeps_non_empty_optional_tables() {
+		global $wpdb;
+
+		$table = $wpdb->get_blog_prefix() . 'wu_non_empty_fixture';
+
+		$this->create_table_selection_fixture($table);
+		$wpdb->insert( // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Test fixture insert.
+			$table,
+			['value' => 'copy-me'],
+			['%s']
+		);
+
+		try {
+			$this->assertTrue(
+				\MUCD_Data::should_copy_table($table, 'wu_non_empty_fixture', get_current_blog_id(), 123)
+			);
+		} finally {
+			$this->drop_table_selection_fixture($table);
+		}
+	}
+
+	/**
+	 * Test required WordPress tables are copied even when empty.
+	 */
+	public function test_should_copy_table_keeps_required_tables_even_when_empty() {
+		global $wpdb;
+
+		$this->assertTrue(
+			\MUCD_Data::should_copy_table($wpdb->comments, 'comments', get_current_blog_id(), 123)
+		);
+	}
+
+	/**
+	 * Test filters can force-copy a table skipped by default.
+	 */
+	public function test_should_copy_table_filter_can_force_copy() {
+		global $wpdb;
+
+		$table = $wpdb->get_blog_prefix() . 'actionscheduler_actions';
+
+		$filter = function ($copy, $source_table, $table_base_name) use ($table) {
+			if ($table === $source_table && 'actionscheduler_actions' === $table_base_name) {
+				return true;
+			}
+
+			return $copy;
+		};
+
+		add_filter(
+			'mucd_should_copy_table',
+			$filter,
+			10,
+			3
+		);
+
+		try {
+			$this->assertTrue(
+				\MUCD_Data::should_copy_table($table, 'actionscheduler_actions', get_current_blog_id(), 123)
+			);
+		} finally {
+			remove_filter('mucd_should_copy_table', $filter, 10);
+		}
+	}
+
+	/**
+	 * Create a temporary table used by table-selection tests.
+	 *
+	 * @param string $table Table name.
+	 */
+	private function create_table_selection_fixture($table): void {
+		global $wpdb;
+
+		$this->drop_table_selection_fixture($table);
+
+		$wpdb->query( // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Test fixture table name cannot be bound.
+			"CREATE TABLE `{$table}` (id bigint(20) unsigned NOT NULL AUTO_INCREMENT, value varchar(20) NOT NULL DEFAULT '', PRIMARY KEY  (id))"
+		);
+	}
+
+	/**
+	 * Drop a temporary table used by table-selection tests.
+	 *
+	 * @param string $table Table name.
+	 */
+	private function drop_table_selection_fixture($table): void {
+		global $wpdb;
+
+		$wpdb->query("DROP TABLE IF EXISTS `{$table}`"); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Test fixture table name cannot be bound.
+	}
+
+	/**
 	 * Test that serialized boolean false (b:0;) is handled correctly.
 	 *
 	 * Ensures the unserialize safety check doesn't treat legitimate


### PR DESCRIPTION
## Summary

- Optimizes template-table selection in `MUCD_Data::db_copy_tables()`.
- Skips runtime-only tables such as queues/logs/caches/sessions by default.
- Skips empty optional/custom template tables while preserving required WordPress content/config tables.
- Adds filters for runtime deny-list, required table allow-list, empty-table skipping, and final per-table copy decisions.
- Adds targeted `MUCD_Data` regression tests for runtime, empty optional, non-empty optional, required, and forced-copy behavior.

Closes #1350

## Testing

- `composer install`
- `vendor/bin/phpcs inc/duplication/data.php`
- `vendor/bin/phpstan analyse inc/duplication/data.php`
- `vendor/bin/phpunit --filter MUCD_Data_Test`


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.29.41 plugin for [OpenCode](https://opencode.ai) v1.17.11 with gpt-5.5 spent 10m and 84,233 tokens on this with the user in an interactive session.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved table-copy behavior during duplication to better decide which tables should be included.
  * Added support for skipping runtime-only tables and empty optional tables, while still keeping required tables.

* **Bug Fixes**
  * Reduced unnecessary copying of irrelevant or empty tables during site duplication.
  * Added filter-based control so table-copy decisions can be overridden when needed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->