### PR TITLE
fix: guard wubox clicks before scripts load

### DIFF
--- a/inc/class-scripts.php
+++ b/inc/class-scripts.php
@@ -37,6 +37,8 @@ class Scripts {
 
 		add_action('admin_enqueue_scripts', [$this, 'enqueue_default_admin_scripts']);
 
+		add_action('admin_head', [$this, 'print_wubox_early_click_guard'], 1);
+
 		add_action('wp_ajax_wu_toggle_container', [$this, 'update_use_container']);
 
 		add_filter('admin_body_class', [$this, 'add_body_class_container_boxed']);
@@ -299,19 +301,7 @@ class Scripts {
 		 */
 		wp_add_inline_script(
 			'wubox',
-			"(function(){
-				window.__wuboxEarlyClicks=[];
-				window.__wuboxEarlyClickHandler=function(e){
-					if(window.__wuboxReady)return;
-					var t=e.target.closest('.wubox');
-					if(!t)return;
-					e.preventDefault();
-					e.stopPropagation();
-					t.style.cursor='wait';
-					window.__wuboxEarlyClicks.push(t);
-				};
-				document.addEventListener('click',window.__wuboxEarlyClickHandler,true);
-			})();",
+			$this->get_wubox_early_click_guard_script(),
 			'before'
 		);
 
@@ -468,6 +458,54 @@ class Scripts {
 
 		// Password toggle for AJAX-loaded modals (e.g., Add Customer).
 		wp_enqueue_script('wu-password-toggle');
+	}
+
+	/**
+	 * Prints the early wubox click guard in the document head.
+	 *
+	 * Wubox itself is printed in the footer, so links/buttons rendered earlier in
+	 * the admin page can navigate to their AJAX URL before the footer inline script
+	 * runs. Printing the capture listener in the head closes that race for all
+	 * modal form triggers that use the shared `.wubox` class.
+	 *
+	 * @since 2.6.3
+	 * @return void
+	 */
+	public function print_wubox_early_click_guard(): void {
+
+		if ( ! wu_is_wu_page() || ! wp_script_is('wubox', 'enqueued')) {
+			return;
+		}
+
+		printf(
+			"\n<script id=\"wu-wubox-early-click-guard\">\n%s\n</script>\n",
+			$this->get_wubox_early_click_guard_script() // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Static JavaScript, no user input.
+		);
+	}
+
+	/**
+	 * Returns the idempotent early wubox click guard script.
+	 *
+	 * @since 2.6.3
+	 * @return string
+	 */
+	protected function get_wubox_early_click_guard_script(): string {
+
+		return "(function(){
+	window.__wuboxEarlyClicks=window.__wuboxEarlyClicks||[];
+	if(window.__wuboxEarlyClickHandler)return;
+	window.__wuboxEarlyClickHandler=function(e){
+		if(window.__wuboxReady)return;
+		var t=e.target&&e.target.closest?e.target.closest('.wubox'):null;
+		if(!t)return;
+		e.preventDefault();
+		e.stopPropagation();
+		if(e.stopImmediatePropagation)e.stopImmediatePropagation();
+		t.style.cursor='wait';
+		window.__wuboxEarlyClicks.push(t);
+	};
+	document.addEventListener('click',window.__wuboxEarlyClickHandler,true);
+})();";
 	}
 
 	/**

--- a/tests/WP_Ultimo/Scripts_Test.php
+++ b/tests/WP_Ultimo/Scripts_Test.php
@@ -252,7 +252,42 @@ class Scripts_Test extends WP_UnitTestCase {
 		$this->assertNotFalse(has_action('init', [$this->scripts, 'register_default_styles']));
 		$this->assertNotFalse(has_action('admin_enqueue_scripts', [$this->scripts, 'enqueue_default_admin_styles']));
 		$this->assertNotFalse(has_action('admin_enqueue_scripts', [$this->scripts, 'enqueue_default_admin_scripts']));
+		$this->assertNotFalse(has_action('admin_head', [$this->scripts, 'print_wubox_early_click_guard']));
 		$this->assertNotFalse(has_filter('admin_body_class', [$this->scripts, 'add_body_class_container_boxed']));
+	}
+
+	/**
+	 * Test the wubox early click guard preserves queued clicks.
+	 */
+	public function test_wubox_early_click_guard_is_idempotent_and_preserves_queue(): void {
+
+		$reflection = new \ReflectionClass($this->scripts);
+		$method     = $reflection->getMethod('get_wubox_early_click_guard_script');
+
+		if (PHP_VERSION_ID < 80100) {
+			$method->setAccessible(true);
+		}
+
+		$script = $method->invoke($this->scripts);
+
+		$this->assertStringContainsString('window.__wuboxEarlyClicks=window.__wuboxEarlyClicks||[];', $script);
+		$this->assertStringContainsString('if(window.__wuboxEarlyClickHandler)return;', $script);
+		$this->assertStringContainsString("e.target.closest('.wubox')", $script);
+		$this->assertStringContainsString("document.addEventListener('click',window.__wuboxEarlyClickHandler,true);", $script);
+	}
+
+	/**
+	 * Test register_default_scripts attaches the same early click guard to wubox.
+	 */
+	public function test_register_default_scripts_attaches_wubox_early_click_guard(): void {
+
+		$this->scripts->register_default_scripts();
+
+		$before = wp_scripts()->get_data('wubox', 'before');
+
+		$this->assertIsArray($before);
+		$this->assertNotEmpty($before);
+		$this->assertStringContainsString('window.__wuboxEarlyClicks=window.__wuboxEarlyClicks||[];', implode("\n", $before));
 	}
 
 	/**


### PR DESCRIPTION
## Summary

- Print an idempotent `.wubox` early-click guard in `admin_head` when wubox is enqueued so modal form links cannot navigate to raw AJAX URLs before footer scripts load.
- Reuse the same guard for the footer inline script and preserve previously queued clicks.
- Add `Scripts_Test` coverage for the new hook and guard contents.

## Verification

- `vendor/bin/phpcs inc/class-scripts.php tests/WP_Ultimo/Scripts_Test.php`
- `vendor/bin/phpunit --filter Scripts_Test`
- Browser repro with a `.wubox` Add Domain AJAX href: without guard the click navigated to `admin-ajax.php?action=wu_form_display&form=add_new_domain`; with guard the URL stayed put and one click was queued.

## Notes

- The fix applies to all modal/form triggers using the shared `.wubox` class, not only the domains page.


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.31.0 plugin for [OpenCode](https://opencode.ai) v1.17.12 with gpt-5.5 spent 1h 30m and 469,237 tokens on this with the user in an interactive session.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved responsiveness when clicking “wubox” elements by capturing clicks earlier, helping prevent missed or delayed interactions on relevant admin pages.
  * Reduced duplicate click handling, making the behavior more reliable and consistent.
  
* **Refactor**
  * Updated how the click-handling logic is assembled internally to keep the behavior centralized and easier to maintain.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->