### PR TITLE
GH#1598: fix: preserve duplication table copy safety

### DIFF
--- a/inc/duplication/data.php
+++ b/inc/duplication/data.php
@@ -192,7 +192,7 @@ if ( ! class_exists('MUCD_Data') ) {
 			 * @param int    $from_site_id    Source site ID.
 			 * @param int    $to_site_id      Target site ID.
 			 */
-			return (bool) apply_filters('mucd_should_copy_table', $copy, $table, $table_base_name, $from_site_id, $to_site_id);
+			return (bool) apply_filters('wu_mucd_should_copy_table', $copy, $table, $table_base_name, $from_site_id, $to_site_id);
 		}
 
 		/**
@@ -248,7 +248,7 @@ if ( ! class_exists('MUCD_Data') ) {
 			 *
 			 * @param array $runtime_tables Runtime-only table base names.
 			 */
-			$runtime_tables = (array) apply_filters('mucd_runtime_tables_to_ignore', $runtime_tables);
+			$runtime_tables = (array) apply_filters('wu_mucd_runtime_tables_to_ignore', $runtime_tables);
 
 			return in_array($table_base_name, $runtime_tables, true);
 		}
@@ -274,7 +274,7 @@ if ( ! class_exists('MUCD_Data') ) {
 				return false;
 			}
 
-			return 0 === self::get_table_row_count($table);
+			return ! self::table_has_rows($table);
 		}
 
 		/**
@@ -297,7 +297,7 @@ if ( ! class_exists('MUCD_Data') ) {
 			 * @param int  $from_site_id      Source site ID.
 			 * @param int  $to_site_id        Target site ID.
 			 */
-			return (bool) apply_filters('mucd_skip_empty_tables', true, $from_site_id, $to_site_id);
+			return (bool) apply_filters('wu_mucd_skip_empty_tables', true, $from_site_id, $to_site_id);
 		}
 
 		/**
@@ -330,24 +330,30 @@ if ( ! class_exists('MUCD_Data') ) {
 			 *
 			 * @param array $required_tables Required table base names.
 			 */
-			$required_tables = (array) apply_filters('mucd_required_tables_to_copy', $required_tables);
+			$required_tables = (array) apply_filters('wu_mucd_required_tables_to_copy', $required_tables);
 
 			return in_array($table_base_name, $required_tables, true);
 		}
 
 		/**
-		 * Count rows in a source table.
+		 * Check whether a source table has rows.
 		 *
 		 * @since 2.5.1
 		 *
 		 * @param string $table Full source table name.
-		 * @return int Source table row count.
+		 * @return bool Whether the source table has rows.
 		 */
-		private static function get_table_row_count($table) {
+		private static function table_has_rows($table) {
+			global $wpdb;
 
-			$count = self::do_sql_query('SELECT COUNT(*) FROM `' . $table . '`', 'var', false);
+			$wpdb->last_error = '';
+			$has_rows         = self::do_sql_query('SELECT 1 FROM `' . $table . '` LIMIT 1', 'var', false);
 
-			return (int) $count;
+			if ('' !== $wpdb->last_error) {
+				return true;
+			}
+
+			return null !== $has_rows;
 		}
 
 		/**

--- a/tests/WP_Ultimo/Duplication/MUCD_Data_Test.php
+++ b/tests/WP_Ultimo/Duplication/MUCD_Data_Test.php
@@ -713,7 +713,7 @@ class MUCD_Data_Test extends WP_UnitTestCase {
 		};
 
 		add_filter(
-			'mucd_should_copy_table',
+			'wu_mucd_should_copy_table',
 			$filter,
 			10,
 			3
@@ -724,8 +724,23 @@ class MUCD_Data_Test extends WP_UnitTestCase {
 				\MUCD_Data::should_copy_table($table, 'actionscheduler_actions', get_current_blog_id(), 123)
 			);
 		} finally {
-			remove_filter('mucd_should_copy_table', $filter, 10);
+			remove_filter('wu_mucd_should_copy_table', $filter, 10);
 		}
+	}
+
+	/**
+	 * Test empty-table checks fail open when the row probe errors.
+	 */
+	public function test_should_copy_table_keeps_optional_table_when_row_probe_errors() {
+		global $wpdb;
+
+		$table = $wpdb->get_blog_prefix() . 'wu_missing_optional_fixture';
+
+		$this->drop_table_selection_fixture($table);
+
+		$this->assertTrue(
+			\MUCD_Data::should_copy_table($table, 'wu_missing_optional_fixture', get_current_blog_id(), 123)
+		);
 	}
 
 	/**


### PR DESCRIPTION
## Summary

Renamed new duplication table-copy filters to the required wu_ prefix and replaced the empty-table COUNT query with a fail-open row-existence probe.

## Files Changed

inc/duplication/data.php,tests/WP_Ultimo/Duplication/MUCD_Data_Test.php

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** vendor/bin/phpunit --filter MUCD_Data_Test; vendor/bin/phpcs inc/duplication/data.php; vendor/bin/phpstan analyse --no-progress --error-format=table inc/duplication/data.php

Resolves #1598


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.31.14 plugin for [OpenCode](https://opencode.ai) v1.17.12 with gpt-5.5 spent 4m and 109,790 tokens on this as a headless worker.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved duplication behavior when checking whether optional tables should be copied.
  * Empty-table detection is now more reliable, reducing cases where tables are skipped incorrectly.
  * Added coverage for cases where a table check fails, helping ensure optional tables are still handled safely.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->