### PR TITLE
test: cover wubox early click guard output

### DIFF
--- a/tests/WP_Ultimo/Scripts_Test.php
+++ b/tests/WP_Ultimo/Scripts_Test.php
@@ -291,6 +291,29 @@ class Scripts_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Test print_wubox_early_click_guard outputs the guard when wubox is enqueued.
+	 */
+	public function test_print_wubox_early_click_guard_outputs_script_when_wubox_enqueued(): void {
+
+		$force_wu_page = static fn() => true;
+
+		add_filter('wu_is_wu_page', $force_wu_page);
+
+		$this->scripts->register_default_scripts();
+		wp_enqueue_script('wubox');
+
+		ob_start();
+		$this->scripts->print_wubox_early_click_guard();
+		$output = ob_get_clean();
+
+		remove_filter('wu_is_wu_page', $force_wu_page);
+		wp_dequeue_script('wubox');
+
+		$this->assertStringContainsString('id="wu-wubox-early-click-guard"', $output);
+		$this->assertStringContainsString('window.__wuboxEarlyClicks=window.__wuboxEarlyClicks||[];', $output);
+	}
+
+	/**
 	 * Test register_default_scripts registers expected handles.
 	 */
 	public function test_register_default_scripts_registers_handles(): void {


### PR DESCRIPTION
## Summary

- Adds `Scripts_Test` coverage for the actual `print_wubox_early_click_guard()` output path.
- Forces the Ultimate Multisite page gate, enqueues `wubox`, captures the rendered head script, and asserts the guard ID and queue bootstrap are emitted.

## Testing

- `vendor/bin/phpunit --filter Scripts_Test`
- `vendor/bin/phpcs tests/WP_Ultimo/Scripts_Test.php`

Resolves #1597

<!-- MERGE_SUMMARY
Added test coverage for the wubox early click guard head output path by enqueuing `wubox` on a forced Ultimate Multisite page and asserting the rendered `<script id="wu-wubox-early-click-guard">` contains the guard bootstrap. Verified with `vendor/bin/phpunit --filter Scripts_Test` and `vendor/bin/phpcs tests/WP_Ultimo/Scripts_Test.php`.
-->


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.31.14 plugin for [OpenCode](https://opencode.ai) v1.17.12 with gpt-5.5 spent 5m and 109,803 tokens on this as a headless worker.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage for the early-click guard output when the relevant script is loaded.
  * Verifies the expected guard element and bootstrap snippet are rendered correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->