### PR TITLE
fix: address addon repository review followup

### DIFF
--- a/inc/class-addon-repository.php
+++ b/inc/class-addon-repository.php
@@ -56,7 +56,7 @@ class Addon_Repository {
 
 		$iv_length = openssl_cipher_iv_length('aes-256-cbc');
 
-		if (false === $iv_length || strlen($data) <= $iv_length) {
+		if (false === $iv_length || $iv_length >= strlen($data)) {
 			return '';
 		}
 

--- a/tests/WP_Ultimo/Addon_Repository_Test.php
+++ b/tests/WP_Ultimo/Addon_Repository_Test.php
@@ -260,8 +260,8 @@ class Addon_Repository_Test extends WP_UnitTestCase {
 		// Provide data with enough bytes for IV (16 bytes) + some cipher text
 		$fake_data = str_repeat('A', 32); // 16 bytes IV + 16 bytes cipher text
 		$result    = $method->invoke($this->repo, base64_encode($fake_data)); // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_encode
-		// Result will be empty string or decrypted string (likely empty since data is invalid)
-		$this->assertIsString($result);
+		// Malformed payloads should fail closed.
+		$this->assertSame('', $result);
 	}
 
 	public function test_decrypt_value_supports_current_release_archive_key() {


### PR DESCRIPTION
## Summary

- Keep the addon credential payload length comparison in Yoda form.
- Assert malformed addon credential payloads fail closed with an empty string.

## Testing

- `vendor/bin/phpcs inc/class-addon-repository.php tests/WP_Ultimo/Addon_Repository_Test.php`
- `vendor/bin/phpunit --filter Addon_Repository_Test`

Resolves #1602

---
<!-- aidevops:sig -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of malformed encrypted values so they now fail safely and return an empty result instead of exposing unexpected output.
  * Tightened validation during decryption to better detect invalid input and preserve existing behavior for valid data.
* **Tests**
  * Updated automated coverage to verify invalid encrypted input is handled securely.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->