### PR TITLE
fix: preserve multi-step checkout account fields

### DIFF
--- a/inc/checkout/class-checkout.php
+++ b/inc/checkout/class-checkout.php
@@ -579,6 +579,14 @@ class Checkout {
 				wp_send_json_error($validation);
 			}
 
+			/*
+			 * Persist the validated step immediately. The front-end still performs a
+			 * native form submit to advance the browser to the next step, but relying on
+			 * that second request can lose first-step account fields before final AJAX
+			 * validation in some multi-step flows.
+			 */
+			$this->persist_current_step_to_session();
+
 			// Auto-save progress to draft payment
 			$this->save_draft_progress();
 
@@ -2989,26 +2997,7 @@ class Checkout {
 			* for later.
 			*/
 		} else {
-			/*
-			 * Cleans data and add it to the session.
-			 *
-			 * Here we remove the items that either
-			 * have checkout_ on their name or start
-			 * with an underscore.
-			 */
-			$to_save = array_filter($_POST, fn($item) => ! str_starts_with((string) $item, 'checkout_') && ! str_starts_with((string) $item, '_'), ARRAY_FILTER_USE_KEY); // phpcs:ignore WordPress.Security.NonceVerification
-
-			if (isset($to_save['pre-flight'])) {
-				unset($to_save['pre-flight']);
-				$this->session->add_values('signup', ['pre_selected' => $to_save]);
-			}
-
-			/*
-			 * Append the cleaned date to the
-			 * active session.
-			 */
-			$this->session->add_values('signup', $to_save);
-			$this->session->commit();
+			$this->persist_current_step_to_session();
 
 			/**
 			 * Whether we should advance to the next step.
@@ -3645,6 +3634,64 @@ class Checkout {
 			$payment->update_meta('checkout_session', $this->session->get());
 			$this->session->commit();
 		}
+	}
+
+	/**
+	 * Returns the current step values that should be stored in the signup session.
+	 *
+	 * Checkout control fields and private nonce fields are intentionally excluded
+	 * so only customer-entered checkout data is carried across steps.
+	 *
+	 * @since 2.6.0
+	 * @return array
+	 */
+	protected function get_current_step_session_values() {
+
+		return array_filter(
+			$_POST, // phpcs:ignore WordPress.Security.NonceVerification.Missing
+			fn($key) => ! str_starts_with((string) $key, 'checkout_') && ! str_starts_with((string) $key, '_'),
+			ARRAY_FILTER_USE_KEY
+		);
+	}
+
+	/**
+	 * Persists the current checkout step values in the signup session.
+	 *
+	 * This is used by both the AJAX validation pass and the subsequent native
+	 * step-advance POST. Saving during AJAX prevents first-step account fields
+	 * from being absent when a later step performs final AJAX validation.
+	 *
+	 * @since 2.6.0
+	 * @return array Values stored for the current step.
+	 */
+	protected function persist_current_step_to_session() {
+
+		if (null === $this->session) {
+			$this->session = wu_get_session('signup');
+		}
+
+		$to_save      = $this->get_current_step_session_values();
+		$needs_commit = false;
+
+		if (isset($to_save['pre-flight'])) {
+			unset($to_save['pre-flight']);
+
+			$this->session->add_values('signup', ['pre_selected' => $to_save]);
+
+			$needs_commit = true;
+		}
+
+		if ( ! empty($to_save)) {
+			$this->session->add_values('signup', $to_save);
+
+			$needs_commit = true;
+		}
+
+		if ($needs_commit) {
+			$this->session->commit();
+		}
+
+		return $to_save;
 	}
 
 	/**

--- a/tests/WP_Ultimo/Checkout/Checkout_Test.php
+++ b/tests/WP_Ultimo/Checkout/Checkout_Test.php
@@ -92,6 +92,32 @@ class Checkout_Test extends WP_UnitTestCase {
 		remove_filter('wu_cart_skip_initialization', [$this, 'set_cart_error']);
 		remove_filter('wu_cart_skip_initialization', '__return_true');
 
+		$checkout     = Checkout::get_instance();
+		$reflection   = new \ReflectionClass($checkout);
+		$session_prop = $this->get_session_prop($reflection);
+		$session      = $session_prop->getValue($checkout);
+
+		if ( ! $session instanceof \WP_Ultimo\Contracts\Session) {
+			$session = wu_get_session('signup');
+		}
+
+		$session->clear();
+		$session->destroy();
+		$session_prop->setValue($checkout, null);
+
+		unset(
+			$_COOKIE['wu_session_signup'],
+			$_COOKIE['wu_checkout_intent'],
+			$_REQUEST['checkout_action'],
+			$_REQUEST['checkout_form'],
+			$_REQUEST['payment'],
+			$_REQUEST['payment_id'],
+			$_REQUEST['pre-flight'],
+			$_REQUEST['resume_checkout'],
+			$_REQUEST['step'],
+			$_REQUEST['wu_form']
+		);
+
 		parent::tearDown();
 	}
 

--- a/tests/WP_Ultimo/Checkout/Checkout_Test.php
+++ b/tests/WP_Ultimo/Checkout/Checkout_Test.php
@@ -520,6 +520,63 @@ class Checkout_Test extends WP_UnitTestCase {
 		unset($_REQUEST['arr_key']);
 	}
 
+	/**
+	 * Test AJAX step persistence stores account fields for later steps.
+	 */
+	public function test_persist_current_step_to_session_saves_account_fields(): void {
+
+		$checkout   = Checkout::get_instance();
+		$reflection = new \ReflectionClass($checkout);
+
+		$this->ensure_session($checkout);
+
+		$session_prop = $this->get_session_prop($reflection);
+		$session      = $session_prop->getValue($checkout);
+
+		$session->set('signup', []);
+
+		$_POST['email_address']   = 'multi-step@example.com';
+		$_POST['username']        = 'multistepuser';
+		$_POST['password']        = 'strong-password';
+		$_POST['password_conf']   = 'strong-password';
+		$_POST['checkout_action'] = 'wu_checkout';
+		$_POST['checkout_step']   = 'account';
+		$_POST['_wpnonce']        = 'nonce';
+
+		$method = $reflection->getMethod('persist_current_step_to_session');
+
+		if (PHP_VERSION_ID < 80100) {
+			$method->setAccessible(true);
+		}
+
+		$saved  = $method->invoke($checkout);
+		$signup = $session->get('signup');
+
+		$this->assertSame('multi-step@example.com', $saved['email_address']);
+		$this->assertSame('multistepuser', $saved['username']);
+		$this->assertSame('strong-password', $saved['password']);
+		$this->assertSame('strong-password', $saved['password_conf']);
+		$this->assertSame('multi-step@example.com', $signup['email_address']);
+		$this->assertSame('multistepuser', $signup['username']);
+		$this->assertSame('strong-password', $signup['password']);
+		$this->assertSame('strong-password', $signup['password_conf']);
+		$this->assertArrayNotHasKey('checkout_action', $saved);
+		$this->assertArrayNotHasKey('checkout_step', $saved);
+		$this->assertArrayNotHasKey('_wpnonce', $saved);
+
+		$session->set('signup', []);
+
+		unset(
+			$_POST['email_address'],
+			$_POST['username'],
+			$_POST['password'],
+			$_POST['password_conf'],
+			$_POST['checkout_action'],
+			$_POST['checkout_step'],
+			$_POST['_wpnonce']
+		);
+	}
+
 	// -------------------------------------------------------------------------
 	// Step navigation — is_first_step
 	// -------------------------------------------------------------------------
@@ -2111,7 +2168,7 @@ class Checkout_Test extends WP_UnitTestCase {
 
 		$checkout->setup_checkout();
 
-		$this->assertEquals($user_id, $_REQUEST['user_id']);
+		$this->assertEquals($user_id, (int) wu_request('user_id'));
 
 		// Reset
 		$setup_prop->setValue($checkout, false);
@@ -3852,7 +3909,7 @@ class Checkout_Test extends WP_UnitTestCase {
 		$this->assertNull(
 			$result->get_date_expiration(),
 			'Free membership must have null date_expiration (lifetime). ' .
-			'Got: ' . var_export($result->get_date_expiration(), true)
+			'Got: ' . (string) $result->get_date_expiration()
 		);
 
 		// Consequently, the membership should be identified as lifetime
@@ -5247,7 +5304,7 @@ class Checkout_Test extends WP_UnitTestCase {
 	/**
 	 * Test login_customer_after_checkout uses wp_signon when a password is provided.
 	 *
-	 * wp_signon() internally fires wp_login on success.
+	 * The wp_signon() function internally fires wp_login on success.
 	 */
 	public function test_login_customer_after_checkout_with_password_fires_wp_login(): void {
 


### PR DESCRIPTION
## Summary

- Persist validated non-final checkout step values during the AJAX validation request.
- Reuse the same persistence helper for the existing native multi-step POST path.
- Add focused coverage for preserving `email_address`, `username`, `password`, and `password_conf` in the signup session.

## Reproduction and verification

Created a local 2-step checkout form at `http://wordpress.local:8080/aidevops-two-step-repro/`:

- Step 1: products, email, username, password
- Step 2: site title, site URL, order summary, payment, submit

Before the fix:

- Step 1 `wu_validate_form` AJAX returned `success: true`.
- Step 2 `wu_validate_form` AJAX, without reposting step-1 account fields, returned required-field errors for `email_address`, `username`, and `password`.

After the fix:

- The same two AJAX requests returned `success: true` on step 2.
- Checkout created the customer using the email and username submitted on step 1.

## Tests

- `php -l inc/checkout/class-checkout.php && php -l tests/WP_Ultimo/Checkout/Checkout_Test.php`
- `vendor/bin/phpcs inc/checkout/class-checkout.php tests/WP_Ultimo/Checkout/Checkout_Test.php`
- `vendor/bin/phpstan analyse inc/checkout/class-checkout.php tests/WP_Ultimo/Checkout/Checkout_Test.php --no-progress`
- `vendor/bin/phpunit --filter test_persist_current_step_to_session_saves_account_fields`
- `vendor/bin/phpunit --filter Checkout_Test`

Notes:

- PHPUnit passed with existing vendor/WordPress deprecation notices and 1 skipped test in `Checkout_Test`.
- Local dev plugin symlink and CAPTCHA add-on were restored after the manual HTTP verification.

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.2 plugin for [OpenCode](https://opencode.ai) v1.17.13


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Checkout progress now saves the information you’ve already entered immediately after each validated step, helping prevent data loss when continuing.
  * Saved interim step data is handled consistently, with checkout control fields excluded to keep progress storage clean.
* **Tests**
  * Added coverage to verify that only the expected user-entered fields are persisted, and improved checkout-related test setup/teardown to reduce cross-test interference.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->