### PR TITLE
fix: align baseline performance retry delay

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -240,6 +240,7 @@ jobs:
             echo "--- Baseline attempt $attempt/3 ---"
             if ! curl -sf --max-time 5 http://127.0.0.1:9400/ > /dev/null 2>&1; then
               echo "Server not responding — skipping"
+              [ "$attempt" -lt 3 ] && sleep 10
               continue
             fi
             if npm run test:performance; then


### PR DESCRIPTION
## Summary

- Added the guarded 10-second retry delay to the baseline performance server-not-responding path.
- Matched the existing PR branch performance retry behavior.

## Testing

- `git diff --check`
- `actionlint .github/workflows/tests.yml` not run: `actionlint` is not installed in this environment.

Resolves #1616

<!-- MERGE_SUMMARY -->
## Merge summary

Added the same guarded baseline performance retry delay already used by the PR performance loop, so transient server failures pause before retrying without delaying after the final attempt.

Verification: `git diff --check` passed; `actionlint` is unavailable in this environment.

<!-- aidevops:sig -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of baseline performance test runs by adding a brief wait between initial server readiness checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->