### PR TITLE
test: pin checkout pre-flight session persistence

### DIFF
--- a/tests/WP_Ultimo/Checkout/Checkout_Test.php
+++ b/tests/WP_Ultimo/Checkout/Checkout_Test.php
@@ -636,6 +636,7 @@ class Checkout_Test extends WP_UnitTestCase {
 		$this->assertArrayNotHasKey('checkout_action', $saved);
 		$this->assertArrayNotHasKey('_wpnonce', $saved);
 		$this->assertSame('pre-flight@example.com', $saved['email_address']);
+		$this->assertSame('pre-flight@example.com', $signup['email_address']);
 		$this->assertSame('pre-flight@example.com', $signup['pre_selected']['email_address']);
 
 		$session->set('signup', []);


### PR DESCRIPTION
## Summary

- Adds the missing assertion that pre-flight checkout persistence writes `email_address` to the top-level `signup` session data.
- Keeps the existing `pre_selected` assertion so both persistence contracts are pinned.

Resolves #1617

## Testing

- `vendor/bin/phpcs tests/WP_Ultimo/Checkout/Checkout_Test.php`
- Targeted PHPUnit not run: `/tmp/wordpress-tests-lib/includes/bootstrap.php` is missing in this worker environment.

<!-- MERGE_SUMMARY -->
## Merge summary

Implemented the review follow-up by asserting `signup['email_address']` for pre-flight checkout persistence alongside the existing `signup['pre_selected']['email_address']` assertion.

Verification: `vendor/bin/phpcs tests/WP_Ultimo/Checkout/Checkout_Test.php` passed. Targeted PHPUnit was skipped because the WordPress test bootstrap is missing.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage to verify that the email address submitted during checkout pre-flight is preserved in the signup session.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->