### PR TITLE
fix(mu-migration): web WP_CLI polyfill must not fatal third-party WP-CLI probes (2.14.0 full-site 500)

### DIFF
--- a/inc/site-exporter/mu-migration/includes/wp-cli-polyfill.php
+++ b/inc/site-exporter/mu-migration/includes/wp-cli-polyfill.php
@@ -105,6 +105,43 @@ namespace {
 					'stderr'      => '',
 				];
 			}
+
+			/**
+			 * Minimal runner stub outside WP-CLI.
+			 *
+			 * Third-party plugins probe `class_exists( 'WP_CLI' )` and then call
+			 * `WP_CLI::get_runner()` to decide whether a real CLI command is
+			 * running (e.g. WooCommerce Subscriptions' is_plugin_being_activated()
+			 * reads `WP_CLI::get_runner()->arguments`). Because this facade is
+			 * defined on web/AJAX requests, a missing get_runner() fatals the whole
+			 * request. Return a runner-like object whose `arguments` is an empty
+			 * list so those checks safely conclude no CLI command is running.
+			 *
+			 * @return object
+			 */
+			public static function get_runner() {
+
+				return (object) [
+					'arguments'      => [],
+					'assoc_args'     => [],
+					'runtime_config' => [],
+				];
+			}
+
+			/**
+			 * No-op fallback for any other static method a third-party plugin may
+			 * call once this facade is present. This facade only exists because the
+			 * real WP-CLI is not loaded, so an unknown method must never fatal a
+			 * web request.
+			 *
+			 * @param string $name      Method name.
+			 * @param array  $arguments Method arguments.
+			 * @return null
+			 */
+			public static function __callStatic($name, $arguments) {
+
+				return null;
+			}
 		}
 	}
 }

--- a/tests/WP_Ultimo/Site_Exporter/WP_CLI_Polyfill_Test.php
+++ b/tests/WP_Ultimo/Site_Exporter/WP_CLI_Polyfill_Test.php
@@ -1,0 +1,56 @@
+<?php
+/**
+ * Regression test for the MU-Migration WP-CLI polyfill on web/AJAX requests.
+ */
+
+namespace WP_Ultimo\Tests\Site_Exporter;
+
+use WP_UnitTestCase;
+
+/**
+ * @group site-exporter
+ * @group wp-cli-polyfill
+ */
+class WP_CLI_Polyfill_Test extends WP_UnitTestCase {
+
+	/**
+	 * The WP-CLI facade defined for web/AJAX MU-Migration runs must not fatal
+	 * third-party activation probes.
+	 *
+	 * WooCommerce Subscriptions (and other plugins) do:
+	 *
+	 *     if ( class_exists( 'WP_CLI' ) ) {
+	 *         $args = WP_CLI::get_runner()->arguments;
+	 *         ...
+	 *     }
+	 *
+	 * Once this facade is loaded on a normal web request, class_exists() becomes
+	 * true, so get_runner() must exist and return a runner-like object with a
+	 * countable `arguments` list. Without it, every front-end and admin request
+	 * fatals with "Call to undefined method WP_CLI::get_runner()" and the whole
+	 * site returns HTTP 500.
+	 *
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	public function test_polyfill_facade_is_web_safe_for_activation_probes(): void {
+
+		if (class_exists('WP_CLI', false) || (defined('WP_CLI') && WP_CLI)) {
+			$this->markTestSkipped('Real WP-CLI is loaded; the polyfill facade is not used.');
+		}
+
+		require dirname(__DIR__, 3) . '/inc/site-exporter/mu-migration/includes/wp-cli-polyfill.php';
+
+		$this->assertTrue(class_exists('WP_CLI', false), 'Polyfill must define the WP_CLI facade on web requests.');
+		$this->assertTrue(method_exists('WP_CLI', 'get_runner'), 'Facade must expose get_runner() so third-party probes do not fatal.');
+
+		$runner = \WP_CLI::get_runner();
+
+		$this->assertIsObject($runner, 'get_runner() must return a runner-like object.');
+		$this->assertTrue(is_countable($runner->arguments), 'get_runner()->arguments must be countable so activation probes short-circuit safely.');
+		$this->assertCount(0, $runner->arguments, 'No CLI command runs on a web request, so arguments is empty.');
+
+		// Any other unknown static method must be a no-op, never a fatal.
+		$this->assertNull(\WP_CLI::method_a_third_party_plugin_may_call());
+	}
+}


### PR DESCRIPTION
## Severity: full-site outage (HTTP 500 on every request) on 2.14.0 with WooCommerce Subscriptions

After updating the core to **2.14.0**, every front-end and admin request returns **HTTP 500**. The whole network is down — not a single page loads, including `wp-admin`, so the DB upgrade never even gets a chance to run.

## Root cause

`inc/site-exporter/class-site-exporter.php` (`load_dependencies()`) loads the MU-Migration WP-CLI polyfill on **web/AJAX** requests whenever WP-CLI is absent:

```php
if (! class_exists('WP_CLI_Command') || ! class_exists('WP_CLI')) {
    require_once $base_path . '/includes/wp-cli-polyfill.php';
}
```

`wp-cli-polyfill.php` then defines a global `WP_CLI` facade (`add_command`, `line`, `log`, `success`, `warning`, `error`, `launch`) — but **without `get_runner()`**.

Many plugins probe `class_exists('WP_CLI')` to decide whether a real CLI command is running. On web they now find the facade and call a method it lacks. WooCommerce Subscriptions does exactly this in `is_plugin_being_activated()`:

```php
if ( class_exists( WP_CLI::class ) ) {
    $args = WP_CLI::get_runner()->arguments;  // fatal: undefined method on the polyfill
    ...
}
```

That code runs on the **`init`** hook — i.e. on every request:

```
PHP Fatal error: Uncaught Error: Call to undefined method WP_CLI::get_runner()
  in woocommerce-subscriptions/includes/class-wc-subscriptions-plugin.php:410
  #0 WC_Subscriptions_Plugin->is_plugin_being_activated()
  #1 WC_Subscriptions_Plugin->init_apfs()   (init hook)
```

→ HTTP 500 on front-end **and** admin, for the entire network. Reproduced on a staging mirror of production (core 2.14.0, WooCommerce Subscriptions active); reverting the core to 2.13.1 restores the site immediately. 2.13.1 did not define a web-side `WP_CLI` facade, so this is a 2.14.0 regression introduced with the site-exporter / MU-Migration bundle.

## Fix

Make the polyfill facade defensive so it can never fatal a third-party probe:

- **`get_runner()`** returns a runner-like object with an empty, countable `arguments` list → WooCommerce Subscriptions' `is_countable($args)` / `count($args)` checks short-circuit to "no CLI command running", which is the correct answer on a web request.
- **`__callStatic()`** is a no-op fallback so any *other* unforeseen static call a plugin might make once the facade is present cannot fatal a web request either.

Additive only; it does not change behaviour under real WP-CLI, since the facade is defined solely when WP-CLI is absent.

## Test

`tests/WP_Ultimo/Site_Exporter/WP_CLI_Polyfill_Test.php` (runs in a separate process, skips when real WP-CLI is loaded) asserts the facade exposes `get_runner()` with a countable `arguments` list and that unknown static calls are no-ops. `php -l` clean on both files; please run the suite in CI.

## Note on a stronger fix

A more robust long-term change would be to **not define a global `WP_CLI` facade on web at all** — defining it makes *every* `class_exists('WP_CLI')` probe in the whole process believe a CLI run is active, which is the underlying trap here. Happy to follow up with that approach if you prefer; the defensive facade in this PR is the minimal change that stops the outage now.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility with plugins that check for WP-CLI during web or AJAX requests.
  * Prevented fatal errors when expected WP-CLI methods are unavailable.
  * Ensured web requests do not inadvertently execute command-line operations.

* **Tests**
  * Added regression coverage for safe WP-CLI detection and fallback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->