### PR TITLE
fix: reject blank screenshot captures

### DIFF
--- a/inc/helpers/class-screenshot.php
+++ b/inc/helpers/class-screenshot.php
@@ -264,8 +264,9 @@ class Screenshot {
 	/**
 	 * Checks whether an image body is blank or contains a single solid colour.
 	 *
-	 * A bounded grid is sampled so validation remains inexpensive for large
-	 * provider responses. Images that cannot be decoded are rejected.
+	 * The scan stops as soon as both visible and varied pixels are found, which
+	 * avoids rejecting mostly blank screenshots that contain real content.
+	 * Images that cannot be decoded are rejected.
 	 *
 	 * @since 2.14.2
 	 *
@@ -273,6 +274,12 @@ class Screenshot {
 	 * @return bool True when the image is unusable.
 	 */
 	private static function is_blank_image($body) {
+
+		$image_info = @getimagesizefromstring($body); // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged -- Invalid provider data is expected.
+
+		if (false === $image_info) {
+			return true;
+		}
 
 		if ( ! function_exists('imagecreatefromstring')) {
 			return false;
@@ -289,11 +296,9 @@ class Screenshot {
 		$first_color = null;
 		$is_solid    = true;
 		$transparent = true;
-		$x_step      = max(1, (int) floor($width / 20));
-		$y_step      = max(1, (int) floor($height / 20));
 
-		for ($y = 0; $y < $height; $y += $y_step) {
-			for ($x = 0; $x < $width; $x += $x_step) {
+		for ($y = 0; $y < $height; $y++) {
+			for ($x = 0; $x < $width; $x++) {
 				$color = imagecolorsforindex($image, imagecolorat($image, $x, $y));
 				$rgba  = [$color['red'], $color['green'], $color['blue'], $color['alpha']];
 
@@ -305,6 +310,12 @@ class Screenshot {
 
 				if ($color['alpha'] < 127) {
 					$transparent = false;
+				}
+
+				if ( ! $is_solid && ! $transparent) {
+					imagedestroy($image);
+
+					return false;
 				}
 			}
 		}

--- a/inc/helpers/class-screenshot.php
+++ b/inc/helpers/class-screenshot.php
@@ -177,7 +177,13 @@ class Screenshot {
 			return false;
 		}
 
-		$body = $response['body'];
+		$body = (string) wp_remote_retrieve_body($response);
+
+		if ('' === $body) {
+			wu_log_add('screenshot-generator', $log_prefix . __('Result is an empty screenshot; not saving.', 'ultimate-multisite'), LogLevel::ERROR);
+
+			return false;
+		}
 
 		/*
 		 * Detect image format from magic bytes.
@@ -192,6 +198,12 @@ class Screenshot {
 			return false;
 		}
 
+		if (self::is_blank_image($body)) {
+			wu_log_add('screenshot-generator', $log_prefix . __('Result is a blank or single-colour screenshot; not saving.', 'ultimate-multisite'), LogLevel::ERROR);
+
+			return false;
+		}
+
 		$upload = wp_upload_bits('screenshot-' . gmdate('Y-m-d-H-i-s') . '.' . $extension, null, $body);
 
 		if ( ! empty($upload['error'])) {
@@ -200,7 +212,18 @@ class Screenshot {
 			return false;
 		}
 
-		$file_path        = $upload['file'];
+		$file_path = $upload['file'];
+
+		if ( ! is_file($file_path) || 0 === filesize($file_path)) {
+			if (is_file($file_path)) {
+				wp_delete_file($file_path);
+			}
+
+			wu_log_add('screenshot-generator', $log_prefix . __('Uploaded screenshot is empty; not saving.', 'ultimate-multisite'), LogLevel::ERROR);
+
+			return false;
+		}
+
 		$file_name        = basename($file_path);
 		$file_type        = wp_check_filetype($file_name, null);
 		$attachment_title = sanitize_file_name(pathinfo($file_name, PATHINFO_FILENAME));
@@ -215,7 +238,14 @@ class Screenshot {
 		];
 
 		// Create the attachment
-		$attach_id = wp_insert_attachment($post_info, $file_path);
+		$attach_id = wp_insert_attachment($post_info, $file_path, 0, true);
+
+		if (is_wp_error($attach_id)) {
+			wp_delete_file($file_path);
+			wu_log_add('screenshot-generator', $log_prefix . $attach_id->get_error_message(), LogLevel::ERROR);
+
+			return false;
+		}
 
 		// Include image.php
 		require_once ABSPATH . 'wp-admin/includes/image.php';
@@ -229,5 +259,58 @@ class Screenshot {
 		wu_log_add('screenshot-generator', $log_prefix . __('Success!', 'ultimate-multisite'));
 
 		return $attach_id;
+	}
+
+	/**
+	 * Checks whether an image body is blank or contains a single solid colour.
+	 *
+	 * A bounded grid is sampled so validation remains inexpensive for large
+	 * provider responses. Images that cannot be decoded are rejected.
+	 *
+	 * @since 2.14.2
+	 *
+	 * @param string $body Raw image body.
+	 * @return bool True when the image is unusable.
+	 */
+	private static function is_blank_image($body) {
+
+		if ( ! function_exists('imagecreatefromstring')) {
+			return false;
+		}
+
+		$image = @imagecreatefromstring($body); // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged -- Invalid provider data is expected.
+
+		if (false === $image) {
+			return true;
+		}
+
+		$width       = imagesx($image);
+		$height      = imagesy($image);
+		$first_color = null;
+		$is_solid    = true;
+		$transparent = true;
+		$x_step      = max(1, (int) floor($width / 20));
+		$y_step      = max(1, (int) floor($height / 20));
+
+		for ($y = 0; $y < $height; $y += $y_step) {
+			for ($x = 0; $x < $width; $x += $x_step) {
+				$color = imagecolorsforindex($image, imagecolorat($image, $x, $y));
+				$rgba  = [$color['red'], $color['green'], $color['blue'], $color['alpha']];
+
+				if (null === $first_color) {
+					$first_color = $rgba;
+				} elseif ($first_color !== $rgba) {
+					$is_solid = false;
+				}
+
+				if ($color['alpha'] < 127) {
+					$transparent = false;
+				}
+			}
+		}
+
+		imagedestroy($image);
+
+		return $is_solid || $transparent;
 	}
 }

--- a/tests/WP_Ultimo/Helpers/Screenshot_Test.php
+++ b/tests/WP_Ultimo/Helpers/Screenshot_Test.php
@@ -31,11 +31,46 @@ class Screenshot_Test extends WP_UnitTestCase {
 	// ------------------------------------------------------------------
 
 	private function png_body() {
-		return "\x89\x50\x4e\x47\x0d\x0a\x1a\x0a" . str_repeat("\x00", 100);
+		$image = imagecreatetruecolor(10, 10);
+		imagefilledrectangle($image, 0, 0, 9, 9, imagecolorallocate($image, 20, 40, 60));
+		imagesetpixel($image, 5, 5, imagecolorallocate($image, 200, 180, 160));
+		ob_start();
+		imagepng($image);
+		$body = ob_get_clean();
+		imagedestroy($image);
+
+		return $body;
 	}
 
 	private function jpeg_body() {
-		return "\xFF\xD8\xFF\xE0\x00\x10JFIF\x00";
+		$image = imagecreatetruecolor(10, 10);
+		imagefilledrectangle($image, 0, 0, 9, 9, imagecolorallocate($image, 20, 40, 60));
+		imagesetpixel($image, 5, 5, imagecolorallocate($image, 200, 180, 160));
+		ob_start();
+		imagejpeg($image);
+		$body = ob_get_clean();
+		imagedestroy($image);
+
+		return $body;
+	}
+
+	private function solid_png_body($transparent = false) {
+		$image = imagecreatetruecolor(10, 10);
+
+		if ($transparent) {
+			imagesavealpha($image, true);
+			$color = imagecolorallocatealpha($image, 255, 255, 255, 127);
+		} else {
+			$color = imagecolorallocate($image, 255, 255, 255);
+		}
+
+		imagefilledrectangle($image, 0, 0, 9, 9, $color);
+		ob_start();
+		imagepng($image);
+		$body = ob_get_clean();
+		imagedestroy($image);
+
+		return $body;
 	}
 
 	// ------------------------------------------------------------------
@@ -161,6 +196,59 @@ class Screenshot_Test extends WP_UnitTestCase {
 
 		$result = Screenshot::save_image_from_url('https://example.com/test');
 		$this->assertFalse($result);
+	}
+
+	public function test_save_image_returns_false_for_empty_body() {
+		add_filter(
+			'pre_http_request',
+			function () {
+				return [
+					'response' => [
+						'code'    => 200,
+						'message' => 'OK',
+					],
+					'body'     => '',
+				];
+			}
+		);
+
+		$this->assertFalse(Screenshot::save_image_from_url('https://example.com/test'));
+	}
+
+	public function test_save_image_returns_false_for_all_white_png() {
+		$body = $this->solid_png_body();
+		add_filter(
+			'pre_http_request',
+			function () use ($body) {
+				return [
+					'response' => [
+						'code'    => 200,
+						'message' => 'OK',
+					],
+					'body'     => $body,
+				];
+			}
+		);
+
+		$this->assertFalse(Screenshot::save_image_from_url('https://example.com/test'));
+	}
+
+	public function test_save_image_returns_false_for_all_transparent_png() {
+		$body = $this->solid_png_body(true);
+		add_filter(
+			'pre_http_request',
+			function () use ($body) {
+				return [
+					'response' => [
+						'code'    => 200,
+						'message' => 'OK',
+					],
+					'body'     => $body,
+				];
+			}
+		);
+
+		$this->assertFalse(Screenshot::save_image_from_url('https://example.com/test'));
 	}
 
 	public function test_save_image_returns_false_on_http_error() {
@@ -313,6 +401,34 @@ class Screenshot_Test extends WP_UnitTestCase {
 
 		$this->assertIsInt($result, 'Expected fallback (thum.io) to succeed after Microlink failure.');
 		$this->assertSame(2, $call_count, 'Expected 2 HTTP calls: 1 Microlink (failed) + 1 thum.io.');
+	}
+
+	public function test_take_screenshot_falls_back_when_primary_is_blank() {
+		$call_count = 0;
+		$blank_body = $this->solid_png_body();
+		$valid_body = $this->png_body();
+
+		add_filter(
+			'pre_http_request',
+			function ($preempt, $args, $url) use (&$call_count, $blank_body, $valid_body) {
+				$call_count++;
+
+				return [
+					'response' => [
+						'code'    => 200,
+						'message' => 'OK',
+					],
+					'body'     => false !== strpos($url, 'microlink') ? $blank_body : $valid_body,
+				];
+			},
+			10,
+			3
+		);
+
+		$result = Screenshot::take_screenshot('example.com');
+
+		$this->assertIsInt($result);
+		$this->assertSame(2, $call_count);
 	}
 
 	public function test_take_screenshot_does_not_call_fallback_when_primary_succeeds() {


### PR DESCRIPTION
## Summary

- reject empty, malformed, all-transparent, and single-colour screenshot responses
- delete zero-byte uploads and files left by attachment insertion failures
- preserve fallback behavior when the primary provider returns a blank image
- add regression coverage for empty, white, transparent, valid, and fallback captures

## Testing

- `vendor/bin/phpunit --filter Screenshot_Test`
- `vendor/bin/phpcs inc/helpers/class-screenshot.php tests/WP_Ultimo/Helpers/Screenshot_Test.php`
- `vendor/bin/phpstan analyse inc/helpers/class-screenshot.php --no-progress`

Resolves #1622

---
<!-- aidevops:sig -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented blank, empty, transparent, or unusable screenshots from being uploaded.
  * Added validation to ensure uploaded screenshot files exist and contain data.
  * Improved fallback behavior when the primary screenshot source returns an invalid image.
  * Cleaned up invalid uploads when image processing or attachment creation fails.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->