### PR TITLE
fix(sso): cross-domain SSO redirect to hard-coded /wp/wp-admin/ creates a 404 loop that gets customers IP-banned

### DIFF
--- a/inc/sso/class-sso.php
+++ b/inc/sso/class-sso.php
@@ -1136,7 +1136,24 @@ class SSO {
 		$return_url = $unwrapped_return_url;
 
 		if ( ! empty($return_url) && $this->is_cross_domain_url($return_url) ) {
-			return esc_url_raw(rtrim($return_url, '/') . '/wp/wp-admin/');
+			/*
+			 * Send the user back to where they were (the return URL), not to a
+			 * hard-coded '/wp/wp-admin/' suffix. The suffix assumed a Bedrock-style
+			 * install; on standard installs it 404s, and the SSO snippet on the 404
+			 * page restarts the flow, appending one more '/wp/wp-admin/' per round
+			 * (site.com/wp/wp-admin/wp/wp-admin/...). A handful of fast 404s is
+			 * enough for security plugins with a 404 lockout (e.g. Defender) to ban
+			 * the customer's IP. Explicit admin intent still arrives through the
+			 * redirect_to branch above. Suffixes already stacked by previous
+			 * versions are collapsed so in-flight URLs self-heal.
+			 */
+			$clean_url = rtrim($return_url, '/');
+
+			while ( preg_match('#/(wp/)?wp-admin$#', $clean_url) ) {
+				$clean_url = rtrim(preg_replace('#/(wp/)?wp-admin$#', '', $clean_url), '/');
+			}
+
+			return esc_url_raw(trailingslashit($clean_url));
 		}
 
 		return esc_url_raw($redirect_to ?: admin_url());


### PR DESCRIPTION
## What happened (real production incident, 2026-07-10)

A brand-new customer on our network simply **visited her own mapped site while logged in**. The SSO flow redirected her to `https://hersite.com/wp/wp-admin/` - a path that only exists on Bedrock-style installs. On a standard install it 404s, and the SSO snippet rendered on the 404 page restarts the flow, appending one more `/wp/wp-admin/` per round:

```
hersite.com/wp/wp-admin/            -> 404
hersite.com/wp/wp-admin/wp/wp-admin/ -> 404
... (verified in access logs: path stacked x7, redirect_to x8)
```

She hit 10 404s in 23 seconds, **Defender's 404 lockout banned her IP for an hour**, and she cancelled her subscription 20 minutes after signing up. The site owner (network admin) got banned the same way while investigating.

## The bug

`SSO::get_sso_redirect_to()` (inc/sso/class-sso.php:1139):

```php
if ( ! empty($return_url) && $this->is_cross_domain_url($return_url) ) {
    return esc_url_raw(rtrim($return_url, '/') . '/wp/wp-admin/');
}
```

The hard-coded `/wp/wp-admin/` suffix assumes a Bedrock directory layout that standard WordPress installs don't have.

## The fix

Return the user to **where they were** (the cleaned `return_url`). Explicit admin intent still travels through the `redirect_to` branch above (untouched). Suffixes already stacked by previous versions are collapsed with a small loop, so URLs that are mid-flight when the fix ships self-heal instead of 404ing one last time.

1 file, +18/-1, validated with 4/4 unit-style tests via Reflection against a staging network plus the production incident URLs.

## Status on our side

Running patched in production (kursopro.com network) since 2026-07-10 - zero SSO 404 loops since. Given that any security plugin with a 404 lockout turns this loop into a **ban of your own paying customers**, we'd appreciate an urgent look. Related money-path fixes in the WooCommerce addon: Ultimate-Multisite/ultimate-multisite-woocommerce#118 and Ultimate-Multisite/ultimate-multisite-woocommerce#119.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved single sign-on redirects across domains by correctly normalizing administrator URLs.
  * Prevented duplicate or malformed administrative path segments in redirect destinations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->