### PR TITLE
test(sso): align cross-domain redirect expectation (#1625)

### DIFF
--- a/tests/WP_Ultimo/SSO/SSO_Test.php
+++ b/tests/WP_Ultimo/SSO/SSO_Test.php
@@ -368,9 +368,9 @@ class SSO_Test extends \WP_UnitTestCase {
 	}
 
 	/**
-	 * Test cross-domain return URLs default to the customer admin target.
+	 * Test cross-domain return URLs default to the customer root URL.
 	 */
-	public function test_get_sso_redirect_to_defaults_cross_domain_return_url_to_admin(): void {
+	public function test_get_sso_redirect_to_defaults_cross_domain_return_url_to_root(): void {
 		$sso        = SSO::get_instance();
 		$return_url = 'https://customer.example.com/';
 
@@ -378,7 +378,7 @@ class SSO_Test extends \WP_UnitTestCase {
 		$method->setAccessible(true);
 
 		$this->assertSame(
-			'https://customer.example.com/wp/wp-admin/',
+			'https://customer.example.com/',
 			$method->invoke($sso, $return_url)
 		);
 	}


### PR DESCRIPTION
## Summary

- update the cross-domain SSO redirect test to expect the normalized customer root URL
- rename the test and its description to document the corrected behavior
- preserve broker handoff expectations because explicit unwrapped targets are intentionally returned unchanged

## Testing

- `vendor/bin/phpcs tests/WP_Ultimo/SSO/SSO_Test.php`
- `php -l tests/WP_Ultimo/SSO/SSO_Test.php`
- Targeted PHPUnit was attempted but could not start because the WordPress test suite is not installed in this worker environment.

Resolves #1625
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.20 plugin for [OpenCode](https://opencode.ai) v1.17.18 with gpt-5.6-sol spent 2m and 60,643 tokens on this as a headless worker.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Cross-domain single sign-on redirects now default to the customer’s root site URL instead of the administration area.

* **Tests**
  * Updated coverage to verify the revised redirect behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->