### PR TITLE
GH#1631: Return HTTP 503 for visits-limit frontend lock

### DIFF
--- a/inc/managers/class-visits-manager.php
+++ b/inc/managers/class-visits-manager.php
@@ -40,7 +40,7 @@ class Visits_Manager {
 		 * Due to how caching plugins work, we need to count visits via ajax.
 		 * This adds the ajax endpoint that performs the counting.
 		 */
-		add_action('wp_ajax_nopriv_wu_count_visits', [$this, 'count_visits'], 10, 2);
+		add_action('wp_ajax_nopriv_wu_count_visits', [$this, 'count_visits']);
 
 		add_action('wp_enqueue_scripts', [$this, 'enqueue_visit_counter_script']);
 
@@ -69,7 +69,7 @@ class Visits_Manager {
 		}
 
 		if ($site->has_limitations() && $site->get_visits_count() > $site->get_limitations()->visits->get_limit()) {
-			wp_die(esc_html__('This site is not available at this time.', 'ultimate-multisite'), esc_html__('Not available', 'ultimate-multisite'), 404);
+			wp_die(esc_html__('This site is not available at this time.', 'ultimate-multisite'), esc_html__('Not available', 'ultimate-multisite'), 503);
 		}
 	}
 
@@ -105,17 +105,6 @@ class Visits_Manager {
 		 * Add a new visit.
 		 */
 		$visits_manager->add_visit();
-
-		/*
-		 * Checks against the limitations.
-		 */
-		if (false) {
-			Cache_Manager::get_instance()->flush_known_caches();
-
-			echo 'flushing caches';
-
-			die('2');
-		}
 
 		die('1');
 	}

--- a/tests/WP_Ultimo/Managers/Visits_Manager_Test.php
+++ b/tests/WP_Ultimo/Managers/Visits_Manager_Test.php
@@ -8,6 +8,8 @@
 namespace WP_Ultimo\Tests\Managers;
 
 use WP_Ultimo\Managers\Visits_Manager;
+use WP_Ultimo\Models\Site_Type;
+use WP_Ultimo\Objects\Visits;
 
 class Visits_Manager_Test extends \WP_UnitTestCase {
 
@@ -23,5 +25,59 @@ class Visits_Manager_Test extends \WP_UnitTestCase {
 
 	protected function get_expected_model_class(): ?string {
 		return null;
+	}
+
+	public function test_maybe_lock_site_returns_service_unavailable_status(): void {
+
+		$site = wu_create_site(
+			[
+				'title'       => 'Visits Limited Site',
+				'domain'      => 'visits-limited-' . wp_rand() . '.example.com',
+				'template_id' => 1,
+				'type'        => Site_Type::CUSTOMER_OWNED,
+			]
+		);
+
+		$this->assertNotWPError($site);
+
+		$site->update_meta(
+			'wu_limitations',
+			[
+				'visits' => [
+					'enabled' => true,
+					'limit'   => 1,
+				],
+			]
+		);
+
+		$visits = new Visits($site->get_id());
+		$visits->add_visit(2);
+
+		switch_to_blog($site->get_id());
+
+		$die_args = null;
+		$handler  = function () use (&$die_args) {
+			// phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed -- All arguments are captured for assertions below.
+			return function ($message, $title, $args) use (&$die_args) {
+				$die_args = compact('message', 'title', 'args');
+				// phpcs:ignore WordPress.Security.EscapeOutput.ExceptionNotEscaped -- Test die handler rethrows the raw wp_die message.
+				throw new \WPDieException((string) $message);
+			};
+		};
+
+		add_filter('wp_die_handler', $handler);
+
+		try {
+			Visits_Manager::get_instance()->maybe_lock_site();
+			$this->fail('Expected the visits-limited site to terminate through wp_die.');
+		} catch (\WPDieException $exception) {
+			$this->assertSame('This site is not available at this time.', $exception->getMessage());
+		} finally {
+			remove_filter('wp_die_handler', $handler);
+			restore_current_blog();
+		}
+
+		$this->assertSame('Not available', $die_args['title']);
+		$this->assertSame(503, $die_args['args']['response']);
 	}
 }

--- a/tests/WP_Ultimo/Managers/Visits_Manager_Test.php
+++ b/tests/WP_Ultimo/Managers/Visits_Manager_Test.php
@@ -8,7 +8,7 @@
 namespace WP_Ultimo\Tests\Managers;
 
 use WP_Ultimo\Managers\Visits_Manager;
-use WP_Ultimo\Models\Site_Type;
+use WP_Ultimo\Database\Sites\Site_Type;
 use WP_Ultimo\Objects\Visits;
 
 class Visits_Manager_Test extends \WP_UnitTestCase {


### PR DESCRIPTION
## Summary

- Return HTTP 503 Service Unavailable when a site exceeds its visits limit.
- Preserve the existing lock title and message.
- Add regression coverage for the response status and lock copy.
- Remove unreachable visits-counter code and correct its zero-argument hook registration.

## Testing

- `vendor/bin/phpcs inc/managers/class-visits-manager.php tests/WP_Ultimo/Managers/Visits_Manager_Test.php`
- `vendor/bin/phpstan analyse inc/managers/class-visits-manager.php tests/WP_Ultimo/Managers/Visits_Manager_Test.php --no-progress`
- Targeted PHPUnit attempted but unavailable because `wordpress-tests-lib` is absent in the worker environment.

## Runtime Testing

Self-assessed through the focused regression test; remote CI will execute the WordPress test suite.

Resolves #1631


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.79 plugin for [OpenCode](https://opencode.ai) v1.17.18 with gpt-5.6-sol spent 4m and 82,503 tokens on this as a headless worker.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Locked or visit-limited sites now return **503 Service Unavailable** instead of **404**, providing clearer temporary-unavailability messaging.
  - Visit counting no longer contains obsolete internal debugging behavior.
  - Unauthenticated visit-count requests are handled more reliably.
- **Tests**
  - Added coverage to confirm the correct `wp_die` message and **503** status for visit-limited, customer-owned sites.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->