### PR TITLE
GH#1629: Expose tenant availability diagnostics

### DIFF
--- a/inc/managers/class-site-manager.php
+++ b/inc/managers/class-site-manager.php
@@ -168,7 +168,7 @@ class Site_Manager extends Base_Manager {
 						'public' => true,
 						'type'   => 'tool',
 					],
-					'annotations' => ['readOnlyHint' => true],
+					'annotations' => ['readonly' => true],
 				],
 			]
 		);
@@ -186,16 +186,20 @@ class Site_Manager extends Base_Manager {
 		$site           = false;
 		$mapped_domain  = false;
 		$requested_host = '';
+		$requested_path = '/';
 
 		if ( ! empty($input_data['site_id'])) {
 			$site = wu_get_site(absint($input_data['site_id']));
 		} elseif ( ! empty($input_data['domain'])) {
-			$requested_host = strtolower((string) wp_parse_url('https://' . preg_replace('#^https?://#i', '', trim($input_data['domain'])), PHP_URL_HOST));
+			$requested_url  = 'https://' . preg_replace('#^https?://#i', '', trim($input_data['domain']));
+			$requested_host = strtolower((string) wp_parse_url($requested_url, PHP_URL_HOST));
+			$requested_path = (string) wp_parse_url($requested_url, PHP_URL_PATH) ?: '/';
+			$requested_path = '/' . trim($requested_path, '/') . ('/' === $requested_path ? '' : '/');
 			$mapped_domain  = wu_get_domain_by_domain($requested_host);
 			$site           = $mapped_domain ? wu_get_site($mapped_domain->get_blog_id()) : false;
 
 			if ( ! $site) {
-				$blog_id = get_blog_id_from_url($requested_host, '/');
+				$blog_id = get_blog_id_from_url($requested_host, $requested_path);
 				$site    = $blog_id ? wu_get_site($blog_id) : false;
 			}
 		} else {

--- a/inc/managers/class-site-manager.php
+++ b/inc/managers/class-site-manager.php
@@ -139,7 +139,7 @@ class Site_Manager extends Base_Manager {
 
 		unset($ability_prefix);
 
-		if ('site' !== $model_name || $manager !== $this || wp_get_ability('multisite-ultimate/site-availability-diagnose')) {
+		if ('site' !== $model_name || $manager !== $this || wp_has_ability('multisite-ultimate/site-availability-diagnose')) {
 			return;
 		}
 

--- a/inc/managers/class-site-manager.php
+++ b/inc/managers/class-site-manager.php
@@ -154,15 +154,40 @@ class Site_Manager extends Base_Manager {
 				'input_schema'        => [
 					'type'                 => 'object',
 					'properties'           => [
-						'site_id' => [
+						'site_id'        => [
 							'type'    => 'integer',
 							'minimum' => 1,
 						],
-						'domain'  => ['type' => 'string'],
+						'domain'         => ['type' => 'string'],
+						'frontend_smoke' => [
+							'type'                 => 'object',
+							'properties'           => [
+								'dns'            => ['type' => 'string'],
+								'transport'      => ['type' => 'string'],
+								'effective_url'  => ['type' => 'string'],
+								'redirect_chain' => ['type' => 'array'],
+								'http_status'    => ['type' => 'integer'],
+								'title'          => ['type' => 'string'],
+								'body'           => ['type' => 'string'],
+							],
+							'additionalProperties' => false,
+						],
 					],
 					'additionalProperties' => false,
 				],
-				'output_schema'       => ['type' => 'object'],
+				'output_schema'       => [
+					'type'       => 'object',
+					'properties' => [
+						'site'                => ['type' => 'object'],
+						'targeting'           => ['type' => 'object'],
+						'domain_mapping'      => ['type' => ['object', 'null']],
+						'limitations'         => ['type' => 'object'],
+						'public_availability' => ['type' => 'object'],
+						'frontend_available'  => ['type' => 'boolean'],
+						'lock_reason'         => ['type' => 'string'],
+						'message'             => ['type' => 'string'],
+					],
+				],
 				'meta'                => [
 					'mcp'         => [
 						'public' => true,
@@ -191,7 +216,7 @@ class Site_Manager extends Base_Manager {
 		if ( ! empty($input_data['site_id'])) {
 			$site = wu_get_site(absint($input_data['site_id']));
 		} elseif ( ! empty($input_data['domain'])) {
-			$requested_url  = 'https://' . preg_replace('#^https?://#i', '', trim($input_data['domain']));
+			$requested_url  = 'https://' . preg_replace('#^https?://#i', '', sanitize_text_field($input_data['domain']));
 			$requested_host = strtolower((string) wp_parse_url($requested_url, PHP_URL_HOST));
 			$requested_path = (string) wp_parse_url($requested_url, PHP_URL_PATH) ?: '/';
 			$requested_path = '/' . trim($requested_path, '/') . ('/' === $requested_path ? '' : '/');
@@ -216,7 +241,7 @@ class Site_Manager extends Base_Manager {
 
 		$primary_domain = $site->get_primary_mapped_domain();
 		$domain         = $mapped_domain ?: $primary_domain;
-		$visits         = Visits_Manager::get_instance()->get_visit_lock_status($site);
+		$visits         = Visits_Manager::get_instance()->get_visit_lock_status($site, true);
 		$lock_reason    = 'none';
 
 		if ($site->is_deleted()) {
@@ -225,6 +250,12 @@ class Site_Manager extends Base_Manager {
 			$lock_reason = 'site_spam';
 		} elseif ($site->is_archived()) {
 			$lock_reason = 'site_archived';
+		} elseif ($mapped_domain && ! $mapped_domain->is_active()) {
+			$lock_reason = 'domain_inactive';
+		} elseif ($mapped_domain && ! $mapped_domain->is_primary_domain()) {
+			$lock_reason = 'domain_not_primary';
+		} elseif ($mapped_domain && 'done' !== $mapped_domain->get_stage()) {
+			$lock_reason = 'domain_stage_not_done';
 		} elseif ($visits['locked']) {
 			$lock_reason = 'visits_exceeded';
 		}
@@ -232,7 +263,7 @@ class Site_Manager extends Base_Manager {
 		$available = 'none' === $lock_reason;
 
 		return [
-			'site'               => [
+			'site'                => [
 				'blog_id'       => (int) $site->get_id(),
 				'domain'        => $site->get_domain(),
 				'path'          => $site->get_path(),
@@ -246,19 +277,52 @@ class Site_Manager extends Base_Manager {
 				'membership_id' => (int) $site->get_membership_id(),
 				'template_id'   => (int) $site->get_template_id(),
 			],
-			'domain_mapping'     => $domain ? [
+			'domain_mapping'      => $domain ? [
 				'domain'         => $domain->get_domain(),
 				'active'         => $domain->is_active(),
 				'primary_domain' => $domain->is_primary_domain(),
 				'secure'         => $domain->is_secure(),
 				'stage'          => $domain->get_stage(),
 			] : null,
-			'limitations'        => ['visits' => $visits],
-			'frontend_available' => $available,
-			'lock_reason'        => $lock_reason,
-			'message'            => $available
+			'targeting'           => [
+				'abspath'      => ABSPATH,
+				'home_url'     => get_home_url($site->get_id()),
+				'site_url'     => get_site_url($site->get_id()),
+				'blog_id'      => (int) $site->get_id(),
+				'request_host' => $requested_host ?: $site->get_domain(),
+			],
+			'limitations'         => ['visits' => $visits],
+			'public_availability' => $this->fingerprint_frontend_smoke($input_data['frontend_smoke'] ?? []),
+			'frontend_available'  => $available,
+			'lock_reason'         => $lock_reason,
+			'message'             => $available
 				? __('The site frontend is available.', 'ultimate-multisite')
 				: __('The site frontend is unavailable. Review the reported lock reason.', 'ultimate-multisite'),
+		];
+	}
+
+	/**
+	 * Normalize a caller-supplied frontend smoke result without making outbound requests.
+	 *
+	 * @since 2.15.0
+	 * @param array $smoke Frontend smoke result.
+	 * @return array
+	 */
+	public function fingerprint_frontend_smoke(array $smoke) {
+
+		$body        = isset($smoke['body']) ? sanitize_textarea_field($smoke['body']) : '';
+		$fingerprint = $body ? wp_html_excerpt(preg_replace('/\s+/', ' ', $body), 200, '&hellip;') : '';
+		$known_lock  = str_contains($body, 'This site is not available at this time.');
+
+		return [
+			'dns'              => sanitize_text_field($smoke['dns'] ?? 'not_checked'),
+			'transport'        => sanitize_text_field($smoke['transport'] ?? 'not_checked'),
+			'redirect_chain'   => array_map('esc_url_raw', (array) ($smoke['redirect_chain'] ?? [])),
+			'effective_url'    => esc_url_raw($smoke['effective_url'] ?? ''),
+			'http_status'      => absint($smoke['http_status'] ?? 0),
+			'title'            => sanitize_text_field($smoke['title'] ?? ''),
+			'body_fingerprint' => $fingerprint,
+			'known_lock'       => $known_lock ? 'visits_exceeded' : 'none',
 		];
 	}
 

--- a/inc/managers/class-site-manager.php
+++ b/inc/managers/class-site-manager.php
@@ -64,6 +64,8 @@ class Site_Manager extends Base_Manager {
 
 		$this->enable_mcp_abilities();
 
+		add_action('wu_mcp_abilities_registered', [$this, 'register_availability_diagnostic_ability'], 10, 3);
+
 		$this->enable_command_palette();
 
 		add_action('after_setup_theme', [$this, 'additional_thumbnail_sizes']);
@@ -122,6 +124,138 @@ class Site_Manager extends Base_Manager {
 
 		// Handle "go live" action requests from site admins.
 		add_action('wp', [$this, 'handle_go_live_action']);
+	}
+
+	/**
+	 * Register the authenticated site availability diagnostic ability.
+	 *
+	 * @since 2.15.0
+	 * @param string $ability_prefix Ability prefix.
+	 * @param string $model_name Model name.
+	 * @param object $manager Entity manager.
+	 * @return void
+	 */
+	public function register_availability_diagnostic_ability($ability_prefix, $model_name, $manager): void {
+
+		unset($ability_prefix);
+
+		if ('site' !== $model_name || $manager !== $this || wp_get_ability('multisite-ultimate/site-availability-diagnose')) {
+			return;
+		}
+
+		wp_register_ability(
+			'multisite-ultimate/site-availability-diagnose',
+			[
+				'label'               => __('Diagnose site availability', 'ultimate-multisite'),
+				'description'         => __('Resolve a tenant site and report authenticated, read-only frontend availability diagnostics.', 'ultimate-multisite'),
+				'category'            => 'ultimate-multisite',
+				'execute_callback'    => [$this, 'mcp_diagnose_site_availability'],
+				'permission_callback' => [$this, 'mcp_permission_callback'],
+				'input_schema'        => [
+					'type'                 => 'object',
+					'properties'           => [
+						'site_id' => [
+							'type'    => 'integer',
+							'minimum' => 1,
+						],
+						'domain'  => ['type' => 'string'],
+					],
+					'additionalProperties' => false,
+				],
+				'output_schema'       => ['type' => 'object'],
+				'meta'                => [
+					'mcp'         => [
+						'public' => true,
+						'type'   => 'tool',
+					],
+					'annotations' => ['readOnlyHint' => true],
+				],
+			]
+		);
+	}
+
+	/**
+	 * Diagnose why a tenant frontend is or is not available.
+	 *
+	 * @since 2.15.0
+	 * @param array $input_data Ability input data.
+	 * @return array|\WP_Error
+	 */
+	public function mcp_diagnose_site_availability(array $input_data) {
+
+		$site           = false;
+		$mapped_domain  = false;
+		$requested_host = '';
+
+		if ( ! empty($input_data['site_id'])) {
+			$site = wu_get_site(absint($input_data['site_id']));
+		} elseif ( ! empty($input_data['domain'])) {
+			$requested_host = strtolower((string) wp_parse_url('https://' . preg_replace('#^https?://#i', '', trim($input_data['domain'])), PHP_URL_HOST));
+			$mapped_domain  = wu_get_domain_by_domain($requested_host);
+			$site           = $mapped_domain ? wu_get_site($mapped_domain->get_blog_id()) : false;
+
+			if ( ! $site) {
+				$blog_id = get_blog_id_from_url($requested_host, '/');
+				$site    = $blog_id ? wu_get_site($blog_id) : false;
+			}
+		} else {
+			$site = wu_get_current_site();
+		}
+
+		if ( ! $site) {
+			return new \WP_Error('wu_site_not_found', __('No site could be resolved from the supplied input.', 'ultimate-multisite'), ['status' => 404]);
+		}
+
+		if ( ! $mapped_domain && $requested_host) {
+			$mapped_domain = wu_get_domain_by_domain($requested_host);
+		}
+
+		$primary_domain = $site->get_primary_mapped_domain();
+		$domain         = $mapped_domain ?: $primary_domain;
+		$visits         = Visits_Manager::get_instance()->get_visit_lock_status($site);
+		$lock_reason    = 'none';
+
+		if ($site->is_deleted()) {
+			$lock_reason = 'site_deleted';
+		} elseif ($site->is_spam()) {
+			$lock_reason = 'site_spam';
+		} elseif ($site->is_archived()) {
+			$lock_reason = 'site_archived';
+		} elseif ($visits['locked']) {
+			$lock_reason = 'visits_exceeded';
+		}
+
+		$available = 'none' === $lock_reason;
+
+		return [
+			'site'               => [
+				'blog_id'       => (int) $site->get_id(),
+				'domain'        => $site->get_domain(),
+				'path'          => $site->get_path(),
+				'public'        => (bool) $site->get_public(),
+				'archived'      => (bool) $site->is_archived(),
+				'spam'          => (bool) $site->is_spam(),
+				'deleted'       => (bool) $site->is_deleted(),
+				'mature'        => (bool) $site->is_mature(),
+				'type'          => $site->get_type(),
+				'customer_id'   => (int) $site->get_customer_id(),
+				'membership_id' => (int) $site->get_membership_id(),
+				'template_id'   => (int) $site->get_template_id(),
+			],
+			'domain_mapping'     => $domain ? [
+				'domain'         => $domain->get_domain(),
+				'active'         => $domain->is_active(),
+				'primary_domain' => $domain->is_primary_domain(),
+				'secure'         => $domain->is_secure(),
+				'stage'          => $domain->get_stage(),
+			] : null,
+			'limitations'        => ['visits' => $visits],
+			'frontend_available' => $available,
+			'lock_reason'        => $lock_reason,
+			'message'            => $available
+				? __('The site frontend is available.', 'ultimate-multisite')
+				: __('The site frontend is unavailable. Review the reported lock reason.', 'ultimate-multisite'),
+		];
 	}
 
 	/**

--- a/inc/managers/class-site-manager.php
+++ b/inc/managers/class-site-manager.php
@@ -165,7 +165,10 @@ class Site_Manager extends Base_Manager {
 								'dns'            => ['type' => 'string'],
 								'transport'      => ['type' => 'string'],
 								'effective_url'  => ['type' => 'string'],
-								'redirect_chain' => ['type' => 'array'],
+								'redirect_chain' => [
+									'type'  => 'array',
+									'items' => ['type' => 'string'],
+								],
 								'http_status'    => ['type' => 'integer'],
 								'title'          => ['type' => 'string'],
 								'body'           => ['type' => 'string'],
@@ -242,6 +245,7 @@ class Site_Manager extends Base_Manager {
 		$primary_domain = $site->get_primary_mapped_domain();
 		$domain         = $mapped_domain ?: $primary_domain;
 		$visits         = Visits_Manager::get_instance()->get_visit_lock_status($site, true);
+		$site_lock      = $this->evaluate_site_lock($site);
 		$lock_reason    = 'none';
 
 		if ($site->is_deleted()) {
@@ -256,6 +260,8 @@ class Site_Manager extends Base_Manager {
 			$lock_reason = 'domain_not_primary';
 		} elseif ($mapped_domain && 'done' !== $mapped_domain->get_stage()) {
 			$lock_reason = 'domain_stage_not_done';
+		} elseif ($site_lock['locked']) {
+			$lock_reason = $site_lock['reason'];
 		} elseif ($visits['locked']) {
 			$lock_reason = 'visits_exceeded';
 		}
@@ -310,6 +316,7 @@ class Site_Manager extends Base_Manager {
 	 */
 	public function fingerprint_frontend_smoke(array $smoke) {
 
+		$redirects   = array_filter((array) ($smoke['redirect_chain'] ?? []), 'is_string');
 		$body        = isset($smoke['body']) ? sanitize_textarea_field($smoke['body']) : '';
 		$fingerprint = $body ? wp_html_excerpt(preg_replace('/\s+/', ' ', $body), 200, '&hellip;') : '';
 		$known_lock  = str_contains($body, 'This site is not available at this time.');
@@ -317,12 +324,62 @@ class Site_Manager extends Base_Manager {
 		return [
 			'dns'              => sanitize_text_field($smoke['dns'] ?? 'not_checked'),
 			'transport'        => sanitize_text_field($smoke['transport'] ?? 'not_checked'),
-			'redirect_chain'   => array_map('esc_url_raw', (array) ($smoke['redirect_chain'] ?? [])),
+			'redirect_chain'   => array_map('esc_url_raw', $redirects),
 			'effective_url'    => esc_url_raw($smoke['effective_url'] ?? ''),
 			'http_status'      => absint($smoke['http_status'] ?? 0),
 			'title'            => sanitize_text_field($smoke['title'] ?? ''),
 			'body_fingerprint' => $fingerprint,
 			'known_lock'       => $known_lock ? 'visits_exceeded' : 'none',
+		];
+	}
+
+	/**
+	 * Evaluate site and membership states that block the public frontend.
+	 *
+	 * @since 2.15.0
+	 * @param \WP_Ultimo\Models\Site $site Site to inspect.
+	 * @return array{locked: bool, reason: string, use_block_page: bool}
+	 */
+	public function evaluate_site_lock($site) {
+
+		if ($site->is_keep_until_live()) {
+			return [
+				'locked'         => true,
+				'reason'         => 'demo_not_live',
+				'use_block_page' => false,
+			];
+		}
+
+		if ( ! $site->is_active()) {
+			return [
+				'locked'         => true,
+				'reason'         => 'site_inactive',
+				'use_block_page' => false,
+			];
+		}
+
+		$membership = $site->get_membership();
+		$status     = $membership ? $membership->get_status() : false;
+		$cancelled  = Membership_Status::CANCELLED === $status;
+		$inactive   = $status && ! $membership->is_active() && Membership_Status::TRIALING !== $status;
+
+		if ($cancelled || ($inactive && wu_get_setting('block_frontend', false))) {
+			$grace_period    = $cancelled ? 0 : (int) wu_get_setting('block_frontend_grace_period', 0);
+			$expiration_time = wu_date($membership->get_date_expiration())->getTimestamp() + $grace_period * DAY_IN_SECONDS;
+
+			if ($expiration_time < wu_date()->getTimestamp()) {
+				return [
+					'locked'         => true,
+					'reason'         => 'membership_inactive',
+					'use_block_page' => (bool) wu_get_setting('block_frontend', false),
+				];
+			}
+		}
+
+		return [
+			'locked'         => false,
+			'reason'         => 'none',
+			'use_block_page' => false,
 		];
 	}
 
@@ -606,11 +663,9 @@ class Site_Manager extends Base_Manager {
 			return;
 		}
 
-		$can_access = true;
-
-		$redirect_url = null;
-
-		$site = wu_get_current_site();
+		$site       = wu_get_current_site();
+		$site_lock  = $this->evaluate_site_lock($site);
+		$membership = $site->get_membership();
 
 		/*
 		 * Block frontend for keep-until-live demo sites.
@@ -620,7 +675,7 @@ class Site_Manager extends Base_Manager {
 		 * explicitly activates the site. Site administrators are allowed through
 		 * so they can preview their work.
 		 */
-		if ($site->is_keep_until_live()) {
+		if ('demo_not_live' === $site_lock['reason']) {
 			if (current_user_can('manage_options') || is_super_admin()) {
 				// Site admins can see the frontend — let them through.
 				return;
@@ -638,36 +693,7 @@ class Site_Manager extends Base_Manager {
 			);
 		}
 
-		if ( ! $site->is_active()) {
-			$can_access = false;
-		}
-
-		$membership = $site->get_membership();
-
-		$status = $membership ? $membership->get_status() : false;
-
-		$is_cancelled = Membership_Status::CANCELLED === $status;
-
-		$is_inactive = $status && ! $membership->is_active() && Membership_Status::TRIALING !== $status;
-
-		if ($is_cancelled || ($is_inactive && wu_get_setting('block_frontend', false))) {
-
-			// If membership is cancelled we do not add the grace period
-			$grace_period = Membership_Status::CANCELLED !== $status ? (int) wu_get_setting('block_frontend_grace_period', 0) : 0;
-
-			$expiration_time = wu_date($membership->get_date_expiration())->getTimestamp() + $grace_period * DAY_IN_SECONDS;
-
-			if ($expiration_time < wu_date()->getTimestamp()) {
-				$checkout_pages = \WP_Ultimo\Checkout\Checkout_Pages::get_instance();
-
-				// We only show the url field when block_frontend is true
-				$redirect_url = wu_get_setting('block_frontend', false) ? $checkout_pages->get_page_url('block_frontend') : false;
-
-				$can_access = false;
-			}
-		}
-
-		if (false === $can_access) {
+		if ($site_lock['locked']) {
 			/*
 			 * Allow plugins to provide a reactivation URL for blocked sites.
 			 *
@@ -690,7 +716,10 @@ class Site_Manager extends Base_Manager {
 				exit;
 			}
 
-			if ($redirect_url) {
+			if ($site_lock['use_block_page']) {
+				$checkout_pages = \WP_Ultimo\Checkout\Checkout_Pages::get_instance();
+				$redirect_url   = $checkout_pages->get_page_url('block_frontend');
+
 				wp_safe_redirect($redirect_url);
 
 				exit;

--- a/inc/managers/class-visits-manager.php
+++ b/inc/managers/class-visits-manager.php
@@ -83,7 +83,7 @@ class Visits_Manager {
 
 		$enabled = (bool) wu_get_setting('enable_visits_limiting', true);
 		$limit   = $enabled ? (int) $site->get_limitations()->visits->get_limit() : 0;
-		$count   = $enabled && ($limit > 0 || $force_count) ? (int) $site->get_visits_count() : 0;
+		$count   = $force_count || ($enabled && $limit > 0) ? (int) $site->get_visits_count() : 0;
 		$locked  = $enabled && $limit > 0 && $site->has_limitations() && $count > $limit;
 
 		return [

--- a/inc/managers/class-visits-manager.php
+++ b/inc/managers/class-visits-manager.php
@@ -75,14 +75,15 @@ class Visits_Manager {
 	 * authenticated availability diagnostics.
 	 *
 	 * @since 2.15.0
-	 * @param \WP_Ultimo\Models\Site $site Site to inspect.
+	 * @param \WP_Ultimo\Models\Site $site        Site to inspect.
+	 * @param bool                   $force_count Fetch the count for diagnostics even when visits are unlimited.
 	 * @return array{enabled: bool, limit: int, count: int, locked: bool}
 	 */
-	public function get_visit_lock_status($site) {
+	public function get_visit_lock_status($site, $force_count = false) {
 
 		$enabled = (bool) wu_get_setting('enable_visits_limiting', true);
 		$limit   = $enabled ? (int) $site->get_limitations()->visits->get_limit() : 0;
-		$count   = $enabled && $limit > 0 ? (int) $site->get_visits_count() : 0;
+		$count   = $enabled && ($limit > 0 || $force_count) ? (int) $site->get_visits_count() : 0;
 		$locked  = $enabled && $limit > 0 && $site->has_limitations() && $count > $limit;
 
 		return [

--- a/inc/managers/class-visits-manager.php
+++ b/inc/managers/class-visits-manager.php
@@ -61,16 +61,36 @@ class Visits_Manager {
 			return;
 		}
 
-		/*
-		 * Case unlimited visits
-		 */
-		if (empty($site->get_limitations()->visits->get_limit())) {
-			return;
-		}
+		$status = $this->get_visit_lock_status($site);
 
-		if ($site->has_limitations() && $site->get_visits_count() > $site->get_limitations()->visits->get_limit()) {
+		if ($status['locked']) {
 			wp_die(esc_html__('This site is not available at this time.', 'ultimate-multisite'), esc_html__('Not available', 'ultimate-multisite'), 503);
 		}
+	}
+
+	/**
+	 * Get the read-only visit lock status for a site.
+	 *
+	 * This is the canonical decision used by both frontend enforcement and
+	 * authenticated availability diagnostics.
+	 *
+	 * @since 2.15.0
+	 * @param \WP_Ultimo\Models\Site $site Site to inspect.
+	 * @return array{enabled: bool, limit: int, count: int, locked: bool}
+	 */
+	public function get_visit_lock_status($site) {
+
+		$enabled = (bool) wu_get_setting('enable_visits_limiting', true);
+		$limit   = $enabled ? (int) $site->get_limitations()->visits->get_limit() : 0;
+		$count   = $enabled && $limit > 0 ? (int) $site->get_visits_count() : 0;
+		$locked  = $enabled && $limit > 0 && $site->has_limitations() && $count > $limit;
+
+		return [
+			'enabled' => $enabled,
+			'limit'   => $limit,
+			'count'   => $count,
+			'locked'  => $locked,
+		];
 	}
 
 	/**

--- a/tests/WP_Ultimo/Managers/Site_Availability_Diagnostic_Test.php
+++ b/tests/WP_Ultimo/Managers/Site_Availability_Diagnostic_Test.php
@@ -1,0 +1,65 @@
+<?php
+/**
+ * Unit tests for tenant availability diagnostics.
+ *
+ * @package WP_Ultimo\Tests\Managers
+ */
+
+namespace WP_Ultimo\Tests\Managers;
+
+use WP_Ultimo\Managers\Site_Manager;
+
+class Site_Availability_Diagnostic_Test extends \WP_UnitTestCase {
+
+	/**
+	 * Test the availability diagnostic is registered as a read-only ability.
+	 */
+	public function test_registers_site_availability_diagnostic_ability(): void {
+		if ( ! function_exists('wp_get_ability')) {
+			$this->markTestSkipped('Abilities API is not available.');
+		}
+
+		$manager = Site_Manager::get_instance();
+
+		$this->setExpectedIncorrectUsage('wp_register_ability');
+		$manager->register_ability_category();
+		$manager->register_abilities();
+
+		$this->assertNotNull(wp_get_ability('multisite-ultimate/site-availability-diagnose'));
+	}
+
+	/**
+	 * Test mapped-domain lookup resolves the owning site without reporting a
+	 * visit lock when visit limiting is disabled.
+	 */
+	public function test_availability_diagnostic_resolves_mapped_domain(): void {
+		wu_save_setting('enable_visits_limiting', false);
+
+		$blog_id = self::factory()->blog->create();
+		$domain  = wu_create_domain(
+			[
+				'blog_id'        => $blog_id,
+				'domain'         => 'availability-' . wp_rand() . '.example.com',
+				'active'         => true,
+				'primary_domain' => true,
+				'secure'         => true,
+				'stage'          => 'done',
+			]
+		);
+
+		$this->assertNotWPError($domain);
+
+		$result = Site_Manager::get_instance()->mcp_diagnose_site_availability(['domain' => $domain->get_domain()]);
+
+		$this->assertNotWPError($result);
+		$this->assertSame($blog_id, $result['site']['blog_id']);
+		$this->assertSame($domain->get_domain(), $result['domain_mapping']['domain']);
+		$this->assertTrue($result['domain_mapping']['active']);
+		$this->assertTrue($result['domain_mapping']['primary_domain']);
+		$this->assertTrue($result['frontend_available']);
+		$this->assertSame('none', $result['lock_reason']);
+
+		$domain->delete();
+		wp_delete_site($blog_id);
+	}
+}

--- a/tests/WP_Ultimo/Managers/Site_Availability_Diagnostic_Test.php
+++ b/tests/WP_Ultimo/Managers/Site_Availability_Diagnostic_Test.php
@@ -36,6 +36,7 @@ class Site_Availability_Diagnostic_Test extends \WP_UnitTestCase {
 	 * visit lock when visit limiting is disabled.
 	 */
 	public function test_availability_diagnostic_resolves_mapped_domain(): void {
+		$original_setting = wu_get_setting('enable_visits_limiting', true);
 		wu_save_setting('enable_visits_limiting', false);
 
 		$blog_id = self::factory()->blog->create();
@@ -52,18 +53,21 @@ class Site_Availability_Diagnostic_Test extends \WP_UnitTestCase {
 
 		$this->assertNotWPError($domain);
 
-		$result = Site_Manager::get_instance()->mcp_diagnose_site_availability(['domain' => $domain->get_domain()]);
+		try {
+			$result = Site_Manager::get_instance()->mcp_diagnose_site_availability(['domain' => $domain->get_domain()]);
 
-		$this->assertNotWPError($result);
-		$this->assertSame($blog_id, $result['site']['blog_id']);
-		$this->assertSame($domain->get_domain(), $result['domain_mapping']['domain']);
-		$this->assertTrue($result['domain_mapping']['active']);
-		$this->assertTrue($result['domain_mapping']['primary_domain']);
-		$this->assertTrue($result['frontend_available']);
-		$this->assertSame('none', $result['lock_reason']);
-
-		$domain->delete();
-		wp_delete_site($blog_id);
+			$this->assertNotWPError($result);
+			$this->assertSame($blog_id, $result['site']['blog_id']);
+			$this->assertSame($domain->get_domain(), $result['domain_mapping']['domain']);
+			$this->assertTrue($result['domain_mapping']['active']);
+			$this->assertTrue($result['domain_mapping']['primary_domain']);
+			$this->assertTrue($result['frontend_available']);
+			$this->assertSame('none', $result['lock_reason']);
+		} finally {
+			wu_save_setting('enable_visits_limiting', $original_setting);
+			$domain->delete();
+			wp_delete_site($blog_id);
+		}
 	}
 
 	/**

--- a/tests/WP_Ultimo/Managers/Site_Availability_Diagnostic_Test.php
+++ b/tests/WP_Ultimo/Managers/Site_Availability_Diagnostic_Test.php
@@ -65,4 +65,24 @@ class Site_Availability_Diagnostic_Test extends \WP_UnitTestCase {
 		$domain->delete();
 		wp_delete_site($blog_id);
 	}
+
+	/**
+	 * Test the known frontend lock message is identified from a smoke fixture.
+	 */
+	public function test_frontend_smoke_fingerprints_known_lock_message(): void {
+		$result = Site_Manager::get_instance()->fingerprint_frontend_smoke(
+			[
+				'http_status' => 503,
+				'title'       => 'Not available',
+				'body'        => '<p>This site is not available at this time.</p>',
+			]
+		);
+
+		$this->assertSame(503, $result['http_status']);
+		$this->assertSame('Not available', $result['title']);
+		$this->assertStringContainsString('This site is not available at this time.', $result['body_fingerprint']);
+		$this->assertSame('visits_exceeded', $result['known_lock']);
+		$this->assertSame('not_checked', $result['dns']);
+		$this->assertSame('not_checked', $result['transport']);
+	}
 }

--- a/tests/WP_Ultimo/Managers/Site_Availability_Diagnostic_Test.php
+++ b/tests/WP_Ultimo/Managers/Site_Availability_Diagnostic_Test.php
@@ -25,7 +25,10 @@ class Site_Availability_Diagnostic_Test extends \WP_UnitTestCase {
 		$manager->register_ability_category();
 		$manager->register_abilities();
 
-		$this->assertNotNull(wp_get_ability('multisite-ultimate/site-availability-diagnose'));
+		$ability = wp_get_ability('multisite-ultimate/site-availability-diagnose');
+
+		$this->assertNotNull($ability);
+		$this->assertTrue($ability->get_meta_item('annotations')['readonly']);
 	}
 
 	/**

--- a/tests/WP_Ultimo/Managers/Visits_Manager_Test.php
+++ b/tests/WP_Ultimo/Managers/Visits_Manager_Test.php
@@ -29,6 +29,8 @@ class Visits_Manager_Test extends \WP_UnitTestCase {
 
 	public function test_maybe_lock_site_returns_service_unavailable_status(): void {
 
+		wu_save_setting('enable_visits_limiting', true);
+
 		$site = wu_create_site(
 			[
 				'title'       => 'Visits Limited Site',
@@ -106,6 +108,22 @@ class Visits_Manager_Test extends \WP_UnitTestCase {
 		wu_save_setting('enable_visits_limiting', false);
 
 		$site = $this->createMock(\WP_Ultimo\Models\Site::class);
+
+		$status = Visits_Manager::get_instance()->get_visit_lock_status($site);
+
+		$this->assertFalse($status['locked']);
+		$this->assertSame(0, $status['limit']);
+		$this->assertSame(0, $status['count']);
+	}
+
+	/**
+	 * Test enabled but unlimited visits never lock a site.
+	 */
+	public function test_get_visit_lock_status_ignores_unlimited_visits(): void {
+		wu_save_setting('enable_visits_limiting', true);
+
+		$site = $this->createMock(\WP_Ultimo\Models\Site::class);
+		$site->method('get_limitations')->willReturn(new \WP_Ultimo\Objects\Limitations(['visits' => ['limit' => 0]]));
 
 		$status = Visits_Manager::get_instance()->get_visit_lock_status($site);
 

--- a/tests/WP_Ultimo/Managers/Visits_Manager_Test.php
+++ b/tests/WP_Ultimo/Managers/Visits_Manager_Test.php
@@ -80,4 +80,37 @@ class Visits_Manager_Test extends \WP_UnitTestCase {
 		$this->assertSame('Not available', $die_args['title']);
 		$this->assertSame(503, $die_args['args']['response']);
 	}
+
+	/**
+	 * Test visit limits use the same strict exceeded decision as enforcement.
+	 */
+	public function test_get_visit_lock_status_reports_exceeded_limit(): void {
+		wu_save_setting('enable_visits_limiting', true);
+
+		$site = $this->createMock(\WP_Ultimo\Models\Site::class);
+		$site->method('get_limitations')->willReturn(new \WP_Ultimo\Objects\Limitations(['visits' => ['limit' => 2]]));
+		$site->method('get_visits_count')->willReturn(3);
+		$site->method('has_limitations')->willReturn(true);
+
+		$status = Visits_Manager::get_instance()->get_visit_lock_status($site);
+
+		$this->assertTrue($status['locked']);
+		$this->assertSame(2, $status['limit']);
+		$this->assertSame(3, $status['count']);
+	}
+
+	/**
+	 * Test disabled visit limiting never locks a site.
+	 */
+	public function test_get_visit_lock_status_ignores_disabled_visits(): void {
+		wu_save_setting('enable_visits_limiting', false);
+
+		$site = $this->createMock(\WP_Ultimo\Models\Site::class);
+
+		$status = Visits_Manager::get_instance()->get_visit_lock_status($site);
+
+		$this->assertFalse($status['locked']);
+		$this->assertSame(0, $status['limit']);
+		$this->assertSame(0, $status['count']);
+	}
 }

--- a/tests/WP_Ultimo/Managers/Visits_Manager_Test.php
+++ b/tests/WP_Ultimo/Managers/Visits_Manager_Test.php
@@ -117,6 +117,22 @@ class Visits_Manager_Test extends \WP_UnitTestCase {
 	}
 
 	/**
+	 * Test diagnostics can request the real count while limiting is disabled.
+	 */
+	public function test_get_visit_lock_status_forces_count_when_disabled(): void {
+		wu_save_setting('enable_visits_limiting', false);
+
+		$site = $this->createMock(\WP_Ultimo\Models\Site::class);
+		$site->method('get_visits_count')->willReturn(7);
+
+		$status = Visits_Manager::get_instance()->get_visit_lock_status($site, true);
+
+		$this->assertFalse($status['locked']);
+		$this->assertSame(0, $status['limit']);
+		$this->assertSame(7, $status['count']);
+	}
+
+	/**
 	 * Test enabled but unlimited visits never lock a site.
 	 */
 	public function test_get_visit_lock_status_ignores_unlimited_visits(): void {


### PR DESCRIPTION
## Summary

- Add an authenticated read-only tenant availability ability.
- Share visit-limit lock decisions with frontend enforcement.
- Resolve mapped domains and report tenant, targeting, domain, limitation, and optional frontend smoke diagnostics.
- Preserve the existing HTTP 503 frontend lock response.

## Runtime Testing

- Targeted PHPUnit: 11 tests, 34 assertions.
- PHPCS on all four changed files.
- PHPStan on both changed production files.

Resolves #1629

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.82 plugin for [OpenCode](https://opencode.ai) v1.17.18 with gpt-5.6-sol spent 6m and 114,894 tokens on this as a headless worker.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a read-only site availability diagnostic ability for assessing a site by ID or domain, including mapping resolution, access restrictions, visit-limit status, and whether the frontend is available.
  * Added frontend smoke fingerprinting to normalize known “not available” responses and surface consistent lock/diagnostic details.

* **Bug Fixes**
  * Improved visit-limit locking decisions by using a single canonical lock-status calculation, preventing false “locked” results for disabled or unlimited limits.
  * Updated frontend-block behavior to rely on the centralized site-lock evaluation.

* **Tests**
  * Added unit coverage for availability diagnostics, smoke fingerprinting, and visit-lock status behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->