### PR TITLE
GH#1634: Address site availability review feedback

### DIFF
--- a/inc/managers/class-site-manager.php
+++ b/inc/managers/class-site-manager.php
@@ -720,9 +720,11 @@ class Site_Manager extends Base_Manager {
 				$checkout_pages = \WP_Ultimo\Checkout\Checkout_Pages::get_instance();
 				$redirect_url   = $checkout_pages->get_page_url('block_frontend');
 
-				wp_safe_redirect($redirect_url);
+				if ($redirect_url) {
+					wp_safe_redirect($redirect_url);
 
-				exit;
+					exit;
+				}
 			}
 
 			wp_die(

--- a/tests/WP_Ultimo/Managers/Site_Availability_Diagnostic_Test.php
+++ b/tests/WP_Ultimo/Managers/Site_Availability_Diagnostic_Test.php
@@ -5,11 +5,25 @@
  * @package WP_Ultimo\Tests\Managers
  */
 
-namespace WP_Ultimo\Tests\Managers;
+namespace WP_Ultimo\Managers;
 
-use WP_Ultimo\Managers\Site_Manager;
+use WP_Ultimo\Tests\Managers\Manager_Test_Trait;
 
 class Site_Availability_Diagnostic_Test extends \WP_UnitTestCase {
+
+	use Manager_Test_Trait;
+
+	protected function get_manager_class(): string {
+		return Site_Manager::class;
+	}
+
+	protected function get_expected_slug(): ?string {
+		return 'site';
+	}
+
+	protected function get_expected_model_class(): ?string {
+		return \WP_Ultimo\Models\Site::class;
+	}
 
 	/**
 	 * Test the availability diagnostic is registered as a read-only ability.


### PR DESCRIPTION
## Summary

- fall back to the locked-site message when no block page URL is configured
- align the availability diagnostic test namespace and shared manager assertions with project conventions

## Testing

- `php -l inc/managers/class-site-manager.php`
- `php -l tests/WP_Ultimo/Managers/Site_Availability_Diagnostic_Test.php`
- `vendor/bin/phpcs inc/managers/class-site-manager.php tests/WP_Ultimo/Managers/Site_Availability_Diagnostic_Test.php`
- `vendor/bin/phpstan analyse inc/managers/class-site-manager.php tests/WP_Ultimo/Managers/Site_Availability_Diagnostic_Test.php --no-progress`
- `vendor/bin/phpunit --filter Site_Availability_Diagnostic_Test` (7 tests, 21 assertions)
- `vendor/bin/phpunit --filter Site_Manager_Test` (226 tests, 408 assertions, 4 skipped)

## Runtime Testing

- Runtime-verified against the WordPress 7.0.1 multisite test environment

Resolves #1634

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.89 plugin for [OpenCode](https://opencode.ai) v1.17.18 with gpt-5.6-sol spent 3m and 92,375 tokens on this as a headless worker.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved site-lock handling when a frontend block-page URL is unavailable.
  * Sites now show the standard “Site not available” message instead of attempting an invalid redirect.

* **Tests**
  * Updated site availability tests to align with the current test structure while preserving existing coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->