### PR TITLE
fix(sso): admin auth-redirect preempts incoming cookie-less token - infinite customize.php <-> /login/ loop (site customizer down)

### DIFF
--- a/inc/sso/class-sso.php
+++ b/inc/sso/class-sso.php
@@ -390,6 +390,19 @@ class SSO {
 		if ($this->input($sso_path) && $this->input($sso_path) !== 'done') {
 			return true;
 		}
+		/*
+		 * A request that already carries a cookie-less SSO token must not kick
+		 * off a new SSO round-trip: handle_cookie_less_sso_token() (init:4) is
+		 * about to consume it and set the auth cookies. Without this
+		 * short-circuit, wp-admin URLs like customize.php?wu_sso_token=... are
+		 * redirected to the main /login/ BEFORE consumption, the main site mints
+		 * yet another token and the browser loops forever between customize.php
+		 * and /login/ (~2 rounds/sec observed in production access logs). This
+		 * mirrors the $sso_path short-circuit right above.
+		 */
+		if ('' !== (string) $this->input('wu_sso_token', '')) {
+			return true;
+		}
 
 		$should_skip_redirect = $this->get_isset($_COOKIE, 'wu_sso_denied', false);
 


### PR DESCRIPTION
## Real-world impact (kursopro.com, 2026-07-14)

The site **customizer opened through our panel was down for every subsite**. The embedding UI shows a generic error while the iframe silently loops. Access log (~2 rounds per second):

```
GET subsite/wp-admin/customize.php?wu_sso_token=VALID   -> 302
GET main/login/?sso=login&redirect_to=...customize.php  -> 303 (mints ANOTHER token)
GET subsite/wp-admin/customize.php?wu_sso_token=NEW     -> 302
... forever
```

## The bug

`handle_auth_redirect()` kicks off an SSO round-trip for any wp-admin request that is not logged in and not on the main domain. But when the request **already carries a valid `?wu_sso_token=`** (the cookie-less flow), the kick-off fires **before** `handle_cookie_less_sso_token()` (init:4) can consume it - so the token is never consumed, the main site mints another one, and the loop never converges. The `wu_sso_redirect_attempts` breaker only degrades it to a login form inside the iframe, which the embedding UI renders as an error.

Front-end URLs are unaffected (no kick-off there) - we verified a fresh token on `subsite/?wu_sso_token=...` consumes perfectly (auth cookies set), while the same flow on `wp-admin/customize.php` never even reaches the receiver (zero lines in the sso log, not even the already-used error for a burned token).

## The fix

Mirror the existing `$sso_path` short-circuit right above: when `wu_sso_token` is present in the current request, return `true` so the auth redirect is bypassed and the init:4 receiver consumes the token.

1 file, +13 lines (comment-heavy), no behavior change for requests without a token.

## Verified end-to-end in production

After deploying this patch: `customize.php?wu_sso_token=FRESH` -> 302 to the clean URL **with auth cookies set** -> following with cookies -> **HTTP 200, customizer opens**.

Related: #1624 (merged - thanks for the fast turnaround!), Ultimate-Multisite/ultimate-multisite-woocommerce#118, Ultimate-Multisite/ultimate-multisite-woocommerce#119.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue that could cause repeated SSO redirects when signing in without cookies.
  * Cookie-less SSO tokens are now processed correctly before starting another authentication flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->