### PR TITLE
GH#1638: fix(sso): guard malformed cookie-less tokens

### DIFF
--- a/inc/sso/class-sso.php
+++ b/inc/sso/class-sso.php
@@ -390,6 +390,7 @@ class SSO {
 		if ($this->input($sso_path) && $this->input($sso_path) !== 'done') {
 			return true;
 		}
+
 		/*
 		 * A request that already carries a cookie-less SSO token must not kick
 		 * off a new SSO round-trip: handle_cookie_less_sso_token() (init:4) is
@@ -400,7 +401,9 @@ class SSO {
 		 * and /login/ (~2 rounds/sec observed in production access logs). This
 		 * mirrors the $sso_path short-circuit right above.
 		 */
-		if ('' !== (string) $this->input('wu_sso_token', '')) {
+		$wu_sso_token = $this->input('wu_sso_token', '');
+
+		if (is_string($wu_sso_token) && '' !== $wu_sso_token) {
 			return true;
 		}
 
@@ -1181,7 +1184,7 @@ class SSO {
 	public function handle_cookie_less_sso_token(): void {
 		$token = $this->input('wu_sso_token', '');
 
-		if ( empty($token) ) {
+		if ( ! is_string($token) || empty($token) ) {
 			return;
 		}
 

--- a/tests/WP_Ultimo/SSO/SSO_Extended_Test.php
+++ b/tests/WP_Ultimo/SSO/SSO_Extended_Test.php
@@ -51,7 +51,6 @@ class SSO_Extended_Test extends \WP_UnitTestCase {
 		remove_all_filters('wu_sso_logger');
 		remove_all_filters('wu_sso_server_request');
 		remove_all_filters('wu_sso_get_broker');
-		remove_all_filters('wu_is_same_domain');
 		remove_all_filters('mercator.sso.enabled');
 		remove_all_filters('allowed_http_origins');
 
@@ -64,7 +63,6 @@ class SSO_Extended_Test extends \WP_UnitTestCase {
 		unset($_REQUEST['wu_sso_token']);
 		unset($_REQUEST['action']);
 		unset($_REQUEST['loggedout']);
-		unset($_SERVER['REQUEST_URI']);
 		unset($_COOKIE['wu_sso_denied']);
 
 		parent::tearDown();
@@ -312,12 +310,17 @@ class SSO_Extended_Test extends \WP_UnitTestCase {
 
 	/**
 	 * Test handle_auth_redirect only short-circuits for string cookie-less tokens.
+	 *
+	 * The logged-in user prevents the fallback redirect branch from exiting after
+	 * the token guard falls through, while the old array-to-string guard would
+	 * still return true before reaching that branch.
 	 */
 	public function test_handle_auth_redirect_ignores_non_string_cookie_less_token(): void {
+		$user_id = self::factory()->user->create();
+		wp_set_current_user($user_id);
+
 		$_REQUEST['wu_sso_token'] = ['bad-token'];
 		$_SERVER['REQUEST_URI']   = '/wp-admin/customize.php?wu_sso_token[]=bad-token';
-
-		add_filter('wu_is_same_domain', '__return_true');
 
 		add_filter(
 			'wu_sso_get_broker',
@@ -328,10 +331,14 @@ class SSO_Extended_Test extends \WP_UnitTestCase {
 			}
 		);
 
-		$sso    = SSO::get_instance();
-		$result = $sso->handle_auth_redirect();
+		try {
+			$sso    = SSO::get_instance();
+			$result = $sso->handle_auth_redirect();
 
-		$this->assertNull($result);
+			$this->assertNull($result);
+		} finally {
+			wp_set_current_user(0);
+		}
 	}
 
 	/**

--- a/tests/WP_Ultimo/SSO/SSO_Extended_Test.php
+++ b/tests/WP_Ultimo/SSO/SSO_Extended_Test.php
@@ -50,6 +50,8 @@ class SSO_Extended_Test extends \WP_UnitTestCase {
 		remove_all_filters('wu_sso_get_url_path');
 		remove_all_filters('wu_sso_logger');
 		remove_all_filters('wu_sso_server_request');
+		remove_all_filters('wu_sso_get_broker');
+		remove_all_filters('wu_is_same_domain');
 		remove_all_filters('mercator.sso.enabled');
 		remove_all_filters('allowed_http_origins');
 
@@ -59,8 +61,10 @@ class SSO_Extended_Test extends \WP_UnitTestCase {
 		unset($_REQUEST['sso']);
 		unset($_REQUEST['sso-grant']);
 		unset($_REQUEST['sso_verify']);
+		unset($_REQUEST['wu_sso_token']);
 		unset($_REQUEST['action']);
 		unset($_REQUEST['loggedout']);
+		unset($_SERVER['REQUEST_URI']);
 		unset($_COOKIE['wu_sso_denied']);
 
 		parent::tearDown();
@@ -304,6 +308,42 @@ class SSO_Extended_Test extends \WP_UnitTestCase {
 
 		remove_all_filters('wu_sso_get_broker');
 		unset($_REQUEST['sso']);
+	}
+
+	/**
+	 * Test handle_auth_redirect only short-circuits for string cookie-less tokens.
+	 */
+	public function test_handle_auth_redirect_ignores_non_string_cookie_less_token(): void {
+		$_REQUEST['wu_sso_token'] = ['bad-token'];
+		$_SERVER['REQUEST_URI']   = '/wp-admin/customize.php?wu_sso_token[]=bad-token';
+
+		add_filter('wu_is_same_domain', '__return_true');
+
+		add_filter(
+			'wu_sso_get_broker',
+			function () {
+				$mock = $this->createMock(SSO_Broker::class);
+				$mock->method('is_must_redirect_call')->willReturn(false);
+				return $mock;
+			}
+		);
+
+		$sso    = SSO::get_instance();
+		$result = $sso->handle_auth_redirect();
+
+		$this->assertNull($result);
+	}
+
+	/**
+	 * Test malformed array cookie-less tokens do not reach string validation.
+	 */
+	public function test_handle_cookie_less_sso_token_ignores_non_string_token(): void {
+		$_REQUEST['wu_sso_token'] = ['bad-token'];
+
+		$sso = SSO::get_instance();
+		$sso->handle_cookie_less_sso_token();
+
+		$this->assertSame(0, get_current_user_id());
 	}
 
 	/**


### PR DESCRIPTION
## Summary

- Guard `wu_sso_token` auth-redirect bypasses so only non-empty string tokens short-circuit login redirects.
- Return early from cookie-less token consumption when the request supplies a non-string token value.
- Add regression coverage for array-style malformed token requests.

Resolves #1638

## Verification

- `php -l inc/sso/class-sso.php && php -l tests/WP_Ultimo/SSO/SSO_Extended_Test.php`
- `vendor/bin/phpcs inc/sso/class-sso.php tests/WP_Ultimo/SSO/SSO_Extended_Test.php`
- `git diff --check`
- Local smoke: `?wu_sso_token[]=bad` on mapped customizer now returns login redirect flow instead of HTTP 500.

## Notes

- `vendor/bin/phpunit --filter SSO_Extended_Test` could not run locally because `/tmp/wordpress-tests-lib/includes/functions.php` is not installed in this environment.

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.138 plugin for [OpenCode](https://opencode.ai) v1.18.3


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Hardened single sign-on handling so malformed cookie-less token inputs are safely ignored.
  * Prevented non-string token data from impacting authentication or altering the current user.

* **Tests**
  * Added unit coverage to ensure non-string (e.g., array) cookie-less tokens are ignored during authentication flows.
  * Improved test cleanup to avoid SSO token state leaking between test cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->