### PR TITLE
fix(checkout): restore default template availability (#1637)

### DIFF
--- a/inc/limitations/class-limit-site-templates.php
+++ b/inc/limitations/class-limit-site-templates.php
@@ -204,18 +204,15 @@ class Limit_Site_Templates extends Limit {
 	 * @return array|false Array of available template IDs, or false when MODE_DEFAULT (unrestricted).
 	 */
 	public function get_available_site_templates() {
-
-		$limits = $this->get_limit();
-
 		/*
-		 * MODE_DEFAULT means "allow all templates" only when there is no explicit
-		 * template list. A merged plan can preserve its list while an addon with a
-		 * null/default template limitation contributes no restrictions; in that case
-		 * the list remains authoritative and must be returned for validation.
+		 * MODE_DEFAULT means "allow all templates" — no restriction.
+		 * Return false so callers that check is_array() treat this as unrestricted.
 		 */
-		if (self::MODE_DEFAULT === $this->mode && ! $limits) {
+		if (self::MODE_DEFAULT === $this->mode) {
 			return false;
 		}
+
+		$limits = $this->get_limit();
 
 		if ( ! $limits) {
 			return [];

--- a/inc/objects/class-limitations.php
+++ b/inc/objects/class-limitations.php
@@ -274,6 +274,14 @@ class Limitations implements \JsonSerializable {
 				continue;
 			}
 
+			if ( ! $override && is_array($results['site_templates'] ?? null) && is_array($limitation['site_templates'] ?? null) && 'default' !== ($results['site_templates']['mode'] ?? 'default') && 'default' === ($limitation['site_templates']['mode'] ?? 'default')) {
+				/*
+				 * The default site-template mode contributes no restriction. Do not let
+				 * an addon using it weaken a previously merged plan restriction.
+				 */
+				$limitation['site_templates']['mode'] = $results['site_templates']['mode'];
+			}
+
 			$this->merge_recursive($results, $limitation, ! $override);
 		}
 

--- a/tests/WP_Ultimo/Objects/Limitations_Test.php
+++ b/tests/WP_Ultimo/Objects/Limitations_Test.php
@@ -949,7 +949,7 @@ class Limitations_Test extends WP_UnitTestCase {
 			[
 				'site_templates' => [
 					'enabled' => true,
-					'mode'    => 'default',
+					'mode'    => 'choose_available_templates',
 					'limit'   => [
 						'2' => ['behavior' => 'available'],
 						'3' => ['behavior' => 'pre_selected'],

--- a/tests/WP_Ultimo/Objects/Limitations_Test.php
+++ b/tests/WP_Ultimo/Objects/Limitations_Test.php
@@ -1066,6 +1066,12 @@ class Limitations_Test extends WP_UnitTestCase {
 		$limits = $limits->merge($plan_data);
 		$limits = $limits->merge($addon_data);
 
+		$this->assertSame(
+			'choose_available_templates',
+			$limits->site_templates->get_mode(),
+			'A default-mode addon must not remove the plan template restriction.'
+		);
+
 		$available = $limits->site_templates->get_available_site_templates();
 
 		$this->assertContains(5, $available, 'Template 5 should be available');
@@ -1073,6 +1079,34 @@ class Limitations_Test extends WP_UnitTestCase {
 
 		// Disk space should be additive
 		$this->assertEquals(600, $limits->disk_space->get_limit(), 'Disk space should be summed');
+	}
+
+	/**
+	 * Regression test for issue #1637: default mode must allow all templates.
+	 *
+	 * Saved template data can remain after an administrator switches a product
+	 * back to the default mode. That stale list must not restrict checkout
+	 * template validation.
+	 */
+	public function test_default_template_mode_ignores_saved_template_list(): void {
+
+		$limitations = new Limitations(
+			[
+				'site_templates' => [
+					'enabled' => true,
+					'mode'    => 'default',
+					'limit'   => [
+						'123' => ['behavior' => 'available'],
+						'456' => ['behavior' => 'not_available'],
+					],
+				],
+			]
+		);
+
+		$this->assertFalse(
+			$limitations->site_templates->get_available_site_templates(),
+			'Default mode must return false so checkout validation treats all templates as available.'
+		);
 	}
 
 	/**


### PR DESCRIPTION
## Summary

- Restore default "Allow All Site Templates" behaviour even when saved template data remains.
- Preserve a plan’s template-selection restriction when a default-mode add-on is merged.
- Add focused regression coverage for both cases.

## Verification

- `vendor/bin/phpcs inc/objects/class-limitations.php inc/limitations/class-limit-site-templates.php tests/WP_Ultimo/Objects/Limitations_Test.php`
- `vendor/bin/phpstan analyse inc/objects/class-limitations.php inc/limitations/class-limit-site-templates.php`
- WordPress runtime template-limitation checks
- Browser smoke test against the local network dashboard with this worktree active

`vendor/bin/phpunit --filter WP_Ultimo\\Objects\\Limitations_Test` could not run because the local WordPress test library is not installed.

Resolves #1637

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.138 plugin for [OpenCode](https://opencode.ai) v1.18.3


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Preserved site template restrictions during checkout when combining plan and add-on settings.
  - Prevented default template settings from unintentionally removing existing plan restrictions.
  - Ensured default template mode ignores outdated saved template lists, allowing checkout validation to proceed correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->