### PR TITLE
Restore add-on product types in the product editor

### DIFF
--- a/inc/admin-pages/class-product-edit-admin-page.php
+++ b/inc/admin-pages/class-product-edit-admin-page.php
@@ -695,12 +695,14 @@ class Product_Edit_Admin_Page extends Edit_Admin_Page {
 	 */
 	protected function get_product_type_options() {
 
-		return [
-			Product_Type::PLAN    => __('Plan — Subscription tier that creates and manages customer sites.', 'ultimate-multisite'),
-			Product_Type::PACKAGE => __('Package — Add-on sold with plans to unlock extra features or resources.', 'ultimate-multisite'),
-			Product_Type::SERVICE => __('Service — Work or support customers can buy without creating a site.', 'ultimate-multisite'),
-			Product_Type::DEMO    => __('Demo — Temporary trial site for prospects to test before buying.', 'ultimate-multisite'),
-		];
+		$options = Product_Type::to_array();
+
+		$options[ Product_Type::PLAN ]    = __('Plan — Subscription tier that creates and manages customer sites.', 'ultimate-multisite');
+		$options[ Product_Type::PACKAGE ] = __('Package — Add-on sold with plans to unlock extra features or resources.', 'ultimate-multisite');
+		$options[ Product_Type::SERVICE ] = __('Service — Work or support customers can buy without creating a site.', 'ultimate-multisite');
+		$options[ Product_Type::DEMO ]    = __('Demo — Temporary trial site for prospects to test before buying.', 'ultimate-multisite');
+
+		return $options;
 	}
 
 	/**

--- a/inc/database/engine/class-enum.php
+++ b/inc/database/engine/class-enum.php
@@ -62,7 +62,7 @@ abstract class Enum {
 	 * Returns an array with values => labels.
 	 *
 	 * @since 2.0.0
-	 * @return void
+	 * @return array
 	 */
 	abstract protected function labels();
 
@@ -198,11 +198,15 @@ abstract class Enum {
 	 */
 	public static function to_array() {
 
-		static $instance;
+		static $instances = [];
 
-		if (null === $instance) {
-			$instance = new static();
+		$class_name = static::class;
+
+		if ( ! isset($instances[ $class_name ])) {
+			$instances[ $class_name ] = new static();
 		}
+
+		$instance = $instances[ $class_name ];
 
 		$hook = $instance::get_hook_name();
 

--- a/tests/WP_Ultimo/Admin_Pages/Product_Edit_Admin_Page_Test.php
+++ b/tests/WP_Ultimo/Admin_Pages/Product_Edit_Admin_Page_Test.php
@@ -9,6 +9,7 @@ namespace WP_Ultimo\Admin_Pages;
 
 use WP_UnitTestCase;
 use WP_Ultimo\Models\Product;
+use WP_Ultimo\Database\Payments\Payment_Status;
 use WP_Ultimo\Database\Products\Product_Type;
 use WP_Ultimo\Limitations\Limit_Site_Templates;
 
@@ -219,6 +220,9 @@ class Product_Edit_Admin_Page_Test extends WP_UnitTestCase {
 	 * Test product types registered by add-ons are available in the editor.
 	 */
 	public function test_product_type_options_include_addon_types(): void {
+		// Ensure another Enum::to_array() call cannot leak its cached instance.
+		Payment_Status::to_array();
+
 		$register_email_type = static function (array $types): array {
 			$types['email'] = 'Email — Mailbox plan that lets customers create and manage email accounts.';
 

--- a/tests/WP_Ultimo/Admin_Pages/Product_Edit_Admin_Page_Test.php
+++ b/tests/WP_Ultimo/Admin_Pages/Product_Edit_Admin_Page_Test.php
@@ -25,6 +25,15 @@ class Testable_Product_Edit_Admin_Page extends Product_Edit_Admin_Page {
 	public function public_get_product_option_sections(): array {
 		return $this->get_product_option_sections();
 	}
+
+	/**
+	 * Expose get_product_type_options as public.
+	 *
+	 * @return array
+	 */
+	public function public_get_product_type_options(): array {
+		return $this->get_product_type_options();
+	}
 }
 
 /**
@@ -204,6 +213,29 @@ class Product_Edit_Admin_Page_Test extends WP_UnitTestCase {
 
 		$this->assertIsString($title);
 		$this->assertEquals('Edit Product', $title);
+	}
+
+	/**
+	 * Test product types registered by add-ons are available in the editor.
+	 */
+	public function test_product_type_options_include_addon_types(): void {
+		$register_email_type = static function (array $types): array {
+			$types['email'] = 'Email';
+
+			return $types;
+		};
+
+		add_filter('wu_product_type_to_array', $register_email_type);
+
+		try {
+			$options = $this->page->public_get_product_type_options();
+		} finally {
+			remove_filter('wu_product_type_to_array', $register_email_type);
+		}
+
+		$this->assertArrayHasKey('email', $options);
+		$this->assertSame('Email', $options['email']);
+		$this->assertStringContainsString('Subscription tier', $options[ Product_Type::PLAN ]);
 	}
 
 	// -------------------------------------------------------------------------

--- a/tests/WP_Ultimo/Admin_Pages/Product_Edit_Admin_Page_Test.php
+++ b/tests/WP_Ultimo/Admin_Pages/Product_Edit_Admin_Page_Test.php
@@ -220,7 +220,7 @@ class Product_Edit_Admin_Page_Test extends WP_UnitTestCase {
 	 */
 	public function test_product_type_options_include_addon_types(): void {
 		$register_email_type = static function (array $types): array {
-			$types['email'] = 'Email';
+			$types['email'] = 'Email — Mailbox plan that lets customers create and manage email accounts.';
 
 			return $types;
 		};
@@ -234,7 +234,7 @@ class Product_Edit_Admin_Page_Test extends WP_UnitTestCase {
 		}
 
 		$this->assertArrayHasKey('email', $options);
-		$this->assertSame('Email', $options['email']);
+		$this->assertSame('Email — Mailbox plan that lets customers create and manage email accounts.', $options['email']);
 		$this->assertStringContainsString('Subscription tier', $options[ Product_Type::PLAN ]);
 	}
 

--- a/tests/WP_Ultimo/Admin_Pages/Product_Edit_Admin_Page_Test.php
+++ b/tests/WP_Ultimo/Admin_Pages/Product_Edit_Admin_Page_Test.php
@@ -223,22 +223,22 @@ class Product_Edit_Admin_Page_Test extends WP_UnitTestCase {
 		// Ensure another Enum::to_array() call cannot leak its cached instance.
 		Payment_Status::to_array();
 
-		$register_email_type = static function (array $types): array {
-			$types['email'] = 'Email — Mailbox plan that lets customers create and manage email accounts.';
+		$register_addon_type = static function (array $types): array {
+			$types['addon'] = 'Add-on Product';
 
 			return $types;
 		};
 
-		add_filter('wu_product_type_to_array', $register_email_type);
+		add_filter('wu_product_type_to_array', $register_addon_type);
 
 		try {
 			$options = $this->page->public_get_product_type_options();
 		} finally {
-			remove_filter('wu_product_type_to_array', $register_email_type);
+			remove_filter('wu_product_type_to_array', $register_addon_type);
 		}
 
-		$this->assertArrayHasKey('email', $options);
-		$this->assertSame('Email — Mailbox plan that lets customers create and manage email accounts.', $options['email']);
+		$this->assertArrayHasKey('addon', $options);
+		$this->assertSame('Add-on Product', $options['addon']);
 		$this->assertStringContainsString('Subscription tier', $options[ Product_Type::PLAN ]);
 	}
 


### PR DESCRIPTION
## Summary

- restore add-on product types in the product editor dropdown
- preserve the longer usage descriptions for the four core product types
- isolate `Enum::to_array()` caches by subclass so one enum cannot return another enum's labels
- add regression coverage for an add-on type after another enum has already been loaded

## Root cause

`Product_Edit_Admin_Page::get_product_type_options()` was changed in 2.13.2 to return a hard-coded list of Plan, Package, Service, and Demo. The product type enum remained extensible, but the editor no longer consumed its filtered labels.

There was also an order-dependent issue in `Enum::to_array()`: its inherited static local cached one instance shared by every enum subclass. For example, loading `Payment_Status::to_array()` first caused a later `Product_Type::to_array()` call to use the payment-status hook and labels. Add-on product filters then could not run reliably.

As a result, add-ons could register a valid product type that worked in the model layer while administrators had no way to select it. Ultimate Multisite: Emails 1.1.3 exposes this as a missing **Email** option.

The editor now starts with `Product_Type::to_array()` and replaces only the four core labels with their detailed descriptions. `Enum::to_array()` caches an instance per concrete enum class, so add-on labels remain stable regardless of call order.

## Validation

- PHP syntax and Git diff checks pass locally
- PHP_CodeSniffer passes for the changed product editor production file
- PHPStan passes for the changed product editor production file
- local call-order probe loads payment statuses first, then confirms product options contain `plan` and `email` but not payment status keys
- local WordPress validation returns `plan`, `package`, `service`, `demo`, and `email`
- local product sections include `email_settings`
- configured cPanel integration is available and its connection test succeeds
- transactional add-on test covers secondary membership creation, activation, provisioning, shortcode rendering, and rollback
- regression test covers a type registered by an add-on after another enum has initialized its cache

The local PHPUnit runner could not start because the WordPress test library is not installed in this checkout; the full matrix runs in CI.

Reproduced with WordPress 7.0.1, Ultimate Multisite 2.14.1, and Ultimate Multisite: Emails 1.1.3.

@superdav42
