### PR TITLE
GH#1645: Preserve standard handling for non-warning errors

### DIFF
--- a/tests/WP_Ultimo/UI/Magic_Link_Url_Element_Test.php
+++ b/tests/WP_Ultimo/UI/Magic_Link_Url_Element_Test.php
@@ -181,9 +181,11 @@ class Magic_Link_Url_Element_Test extends WP_UnitTestCase {
 			static function ($error_number, $error_message) use (&$warnings) {
 				if (E_WARNING === $error_number) {
 					$warnings[] = $error_message;
+
+					return true;
 				}
 
-				return true;
+				return false;
 			}
 		);
 


### PR DESCRIPTION
## Summary

- Handle only `E_WARNING` in the Magic Link generator regression test callback.
- Return `false` for every other error level so PHP standard error handling remains active.

## Verification

- `vendor/bin/phpcs tests/WP_Ultimo/UI/Magic_Link_Url_Element_Test.php`
- `WP_TESTS_DIR=<local-wordpress-tests-lib> vendor/bin/phpunit --filter Magic_Link_Url_Element_Test` (6 tests, 9 assertions)
- `php -l tests/WP_Ultimo/UI/Magic_Link_Url_Element_Test.php`

Resolves #1645

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.145 plugin for [OpenCode](https://opencode.ai) v1.18.3 with gpt-5.6-sol spent 3m and 90,439 tokens on this as a headless worker. Overall, 47m since this issue was created.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test error handling so only expected warnings are suppressed.
  * Unexpected PHP errors now propagate correctly, helping identify potential issues during validation.
  * No changes to end-user functionality or application behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->