### PR TITLE
GH#1648: Recommend AI plugins in setup wizard

### DIFF
--- a/inc/installers/class-recommended-plugins-installer.php
+++ b/inc/installers/class-recommended-plugins-installer.php
@@ -64,6 +64,54 @@ class Recommended_Plugins_Installer extends Base_Installer {
 			'checked'     => true,
 		];
 
+		$locale                    = function_exists('determine_locale') ? determine_locale() : get_locale();
+		$is_english_locale         = 'en' === $locale || str_starts_with($locale, 'en_') || str_starts_with($locale, 'en-');
+		$language_packs_is_checked = ! $is_english_locale;
+
+		// Recommended for non-English networks: Superdav AI Language Packs.
+		$language_packs_slug                               = 'superdav-ai-language-packs';
+		$steps[ 'install_plugin_' . $language_packs_slug ] = [
+			'done'        => $this->is_plugin_installed($language_packs_slug),
+			'title'       => __('Superdav AI Language Packs', 'ultimate-multisite'),
+			'description' => __('Add AI-powered language packs to translate your network.', 'ultimate-multisite'),
+			'pending'     => __('Pending', 'ultimate-multisite'),
+			'installing'  => __('Installing Superdav AI Language Packs...', 'ultimate-multisite'),
+			'success'     => __('Installed!', 'ultimate-multisite'),
+			'checked'     => $language_packs_is_checked,
+		];
+
+		$steps[ 'activate_plugin_' . $language_packs_slug ] = [
+			'done'        => $this->is_plugin_active($language_packs_slug),
+			'title'       => __('Activate Superdav AI Language Packs', 'ultimate-multisite'),
+			'description' => __('Activate Superdav AI Language Packs for your network.', 'ultimate-multisite'),
+			'pending'     => __('Pending', 'ultimate-multisite'),
+			'installing'  => __('Activating Superdav AI Language Packs...', 'ultimate-multisite'),
+			'success'     => __('Activated!', 'ultimate-multisite'),
+			'checked'     => $language_packs_is_checked,
+		];
+
+		// Optional: Superdav AI Agent.
+		$ai_agent_slug                               = 'superdav-ai-agent';
+		$steps[ 'install_plugin_' . $ai_agent_slug ] = [
+			'done'        => $this->is_plugin_installed($ai_agent_slug),
+			'title'       => __('Superdav AI Agent', 'ultimate-multisite'),
+			'description' => __('Use an AI assistant to help manage and support your network.', 'ultimate-multisite'),
+			'pending'     => __('Pending', 'ultimate-multisite'),
+			'installing'  => __('Installing Superdav AI Agent...', 'ultimate-multisite'),
+			'success'     => __('Installed!', 'ultimate-multisite'),
+			'checked'     => false,
+		];
+
+		$steps[ 'activate_plugin_' . $ai_agent_slug ] = [
+			'done'        => $this->is_plugin_active($ai_agent_slug),
+			'title'       => __('Activate Superdav AI Agent', 'ultimate-multisite'),
+			'description' => __('Activate Superdav AI Agent for your network.', 'ultimate-multisite'),
+			'pending'     => __('Pending', 'ultimate-multisite'),
+			'installing'  => __('Activating Superdav AI Agent...', 'ultimate-multisite'),
+			'success'     => __('Activated!', 'ultimate-multisite'),
+			'checked'     => false,
+		];
+
 		return $steps;
 	}
 

--- a/inc/installers/class-recommended-plugins-installer.php
+++ b/inc/installers/class-recommended-plugins-installer.php
@@ -72,11 +72,12 @@ class Recommended_Plugins_Installer extends Base_Installer {
 		$language_packs_slug                               = 'superdav-ai-language-packs';
 		$steps[ 'install_plugin_' . $language_packs_slug ] = [
 			'done'        => $this->is_plugin_installed($language_packs_slug),
-			'title'       => __('Superdav AI Language Packs', 'ultimate-multisite'),
-			'description' => __('Add AI-powered language packs to translate your network.', 'ultimate-multisite'),
+			'title'       => __('AI Language Packs', 'ultimate-multisite'),
+			'description' => __('Add AI-powered language packs for plugin and theme translates, fully localize Ultimate Multisite and all community plugins.', 'ultimate-multisite'),
 			'pending'     => __('Pending', 'ultimate-multisite'),
-			'installing'  => __('Installing Superdav AI Language Packs...', 'ultimate-multisite'),
+			'installing'  => __('Installing AI Language Packs...', 'ultimate-multisite'),
 			'success'     => __('Installed!', 'ultimate-multisite'),
+			'help'        => 'https://wordpress.org/plugins/superdav-ai-language-packs/',
 			'checked'     => $language_packs_is_checked,
 		];
 
@@ -87,6 +88,7 @@ class Recommended_Plugins_Installer extends Base_Installer {
 			'pending'     => __('Pending', 'ultimate-multisite'),
 			'installing'  => __('Activating Superdav AI Language Packs...', 'ultimate-multisite'),
 			'success'     => __('Activated!', 'ultimate-multisite'),
+			'help'        => 'https://wordpress.org/plugins/superdav-ai-language-packs/',
 			'checked'     => $language_packs_is_checked,
 		];
 
@@ -94,21 +96,23 @@ class Recommended_Plugins_Installer extends Base_Installer {
 		$ai_agent_slug                               = 'superdav-ai-agent';
 		$steps[ 'install_plugin_' . $ai_agent_slug ] = [
 			'done'        => $this->is_plugin_installed($ai_agent_slug),
-			'title'       => __('Superdav AI Agent', 'ultimate-multisite'),
-			'description' => __('Use an AI assistant to help manage and support your network.', 'ultimate-multisite'),
+			'title'       => __('SD AI Agent', 'ultimate-multisite'),
+			'description' => __('Use an AI Agent fully control all of WordPress. Create content, products, custom plugins and more. Like Claude code or Cursor running inside of wp-admin.', 'ultimate-multisite'),
 			'pending'     => __('Pending', 'ultimate-multisite'),
 			'installing'  => __('Installing Superdav AI Agent...', 'ultimate-multisite'),
 			'success'     => __('Installed!', 'ultimate-multisite'),
+			'help'        => 'https://wordpress.org/plugins/superdav-ai-agent/',
 			'checked'     => false,
 		];
 
 		$steps[ 'activate_plugin_' . $ai_agent_slug ] = [
 			'done'        => $this->is_plugin_active($ai_agent_slug),
-			'title'       => __('Activate Superdav AI Agent', 'ultimate-multisite'),
-			'description' => __('Activate Superdav AI Agent for your network.', 'ultimate-multisite'),
+			'title'       => __('Activate SD AI Agent', 'ultimate-multisite'),
+			'description' => __('Activate SD AI Agent for your network.', 'ultimate-multisite'),
 			'pending'     => __('Pending', 'ultimate-multisite'),
-			'installing'  => __('Activating Superdav AI Agent...', 'ultimate-multisite'),
+			'installing'  => __('Activating SD AI Agent...', 'ultimate-multisite'),
 			'success'     => __('Activated!', 'ultimate-multisite'),
+			'help'        => 'https://wordpress.org/plugins/superdav-ai-agent/',
 			'checked'     => false,
 		];
 

--- a/tests/WP_Ultimo/Installers/Recommended_Plugins_Installer_Test.php
+++ b/tests/WP_Ultimo/Installers/Recommended_Plugins_Installer_Test.php
@@ -56,7 +56,7 @@ class Recommended_Plugins_Installer_Test extends WP_UnitTestCase {
 	public function test_ai_plugin_descriptions_explain_their_purpose(): void {
 		$steps = $this->get_steps_for_locale('en_US');
 
-		$this->assertSame('Add AI-powered language packs to translate your network.', $steps['install_plugin_superdav-ai-language-packs']['description']);
-		$this->assertSame('Use an AI assistant to help manage and support your network.', $steps['install_plugin_superdav-ai-agent']['description']);
+		$this->assertSame('Add AI-powered language packs for plugin and theme translates, fully localize Ultimate Multisite and all community plugins.', $steps['install_plugin_superdav-ai-language-packs']['description']);
+		$this->assertSame('Use an AI Agent fully control all of WordPress. Create content, products, custom plugins and more. Like Claude code or Cursor running inside of wp-admin.', $steps['install_plugin_superdav-ai-agent']['description']);
 	}
 }

--- a/tests/WP_Ultimo/Installers/Recommended_Plugins_Installer_Test.php
+++ b/tests/WP_Ultimo/Installers/Recommended_Plugins_Installer_Test.php
@@ -1,0 +1,60 @@
+<?php
+/**
+ * Tests for Recommended_Plugins_Installer class.
+ *
+ * @package WP_Ultimo\Tests
+ */
+
+namespace WP_Ultimo\Installers;
+
+use WP_UnitTestCase;
+
+/**
+ * Test class for Recommended_Plugins_Installer.
+ */
+class Recommended_Plugins_Installer_Test extends WP_UnitTestCase {
+
+	/**
+	 * Gets the recommended plugin steps with a specific locale.
+	 *
+	 * @param string $locale The locale to use.
+	 * @return array
+	 */
+	private function get_steps_for_locale($locale): array {
+
+		$locale_filter = static function () use ($locale) {
+			return $locale;
+		};
+
+		add_filter('locale', $locale_filter);
+
+		try {
+			return Recommended_Plugins_Installer::get_instance()->get_steps();
+		} finally {
+			remove_filter('locale', $locale_filter);
+		}
+	}
+
+	public function test_language_packs_are_selected_for_non_english_locales(): void {
+		$steps = $this->get_steps_for_locale('pt_BR');
+
+		$this->assertTrue($steps['install_plugin_superdav-ai-language-packs']['checked']);
+		$this->assertTrue($steps['activate_plugin_superdav-ai-language-packs']['checked']);
+		$this->assertFalse($steps['install_plugin_superdav-ai-agent']['checked']);
+		$this->assertFalse($steps['activate_plugin_superdav-ai-agent']['checked']);
+	}
+
+	public function test_language_packs_are_not_selected_for_english_locales(): void {
+		$steps = $this->get_steps_for_locale('en_US');
+
+		$this->assertFalse($steps['install_plugin_superdav-ai-language-packs']['checked']);
+		$this->assertFalse($steps['activate_plugin_superdav-ai-language-packs']['checked']);
+	}
+
+	public function test_ai_plugin_descriptions_explain_their_purpose(): void {
+		$steps = $this->get_steps_for_locale('en_US');
+
+		$this->assertSame('Add AI-powered language packs to translate your network.', $steps['install_plugin_superdav-ai-language-packs']['description']);
+		$this->assertSame('Use an AI assistant to help manage and support your network.', $steps['install_plugin_superdav-ai-agent']['description']);
+	}
+}

--- a/tests/WP_Ultimo/Installers/Recommended_Plugins_Installer_Test.php
+++ b/tests/WP_Ultimo/Installers/Recommended_Plugins_Installer_Test.php
@@ -27,11 +27,13 @@ class Recommended_Plugins_Installer_Test extends WP_UnitTestCase {
 		};
 
 		add_filter('locale', $locale_filter);
+		add_filter('determine_locale', $locale_filter);
 
 		try {
 			return Recommended_Plugins_Installer::get_instance()->get_steps();
 		} finally {
 			remove_filter('locale', $locale_filter);
+			remove_filter('determine_locale', $locale_filter);
 		}
 	}
 


### PR DESCRIPTION
## Summary

- Recommend Superdav AI Language Packs in the setup wizard and select it by default for non-English locales.
- Offer Superdav AI Agent as an unselected optional install.
- Cover locale defaults and AI plugin descriptions with installer tests.

## Verification

- Passed: vendor/bin/phpcs inc/installers/class-recommended-plugins-installer.php tests/WP_Ultimo/Installers/Recommended_Plugins_Installer_Test.php
- Passed: vendor/bin/phpstan analyse inc/installers/class-recommended-plugins-installer.php --memory-limit=1G
- Passed: php -l inc/installers/class-recommended-plugins-installer.php and php -l tests/WP_Ultimo/Installers/Recommended_Plugins_Installer_Test.php
- Blocked: vendor/bin/phpunit --filter Recommended_Plugins_Installer_Test because the local WordPress test suite is absent at /tmp/wordpress-tests-lib.

Resolves #1648

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.148 plugin for [OpenCode](https://opencode.ai) v1.18.3 with gpt-5.6-terra spent 10m and 144,595 tokens on this with the user in an interactive session.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Updated the recommended plugin setup to include **Superdav AI Language Packs** with locale-based preselection (selected only for non-English locales; not selected for English).
  * Updated the recommended plugin setup to include **Superdav AI Agent**, with its install/activate steps left unselected by default.
* **Tests**
  * Added automated coverage to verify locale-based selection behavior and confirm the expected step descriptions for language packs and the AI agent.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->