### PR TITLE
GH#1650: Harden malformed SSO request handling

### DIFF
--- a/inc/sso/class-sso.php
+++ b/inc/sso/class-sso.php
@@ -145,7 +145,9 @@ class SSO {
 	 * @return mixed
 	 */
 	public function input($key, $default_content = false) {
-		return wu_request($key, $default_content);
+		$value = wu_request($key, $default_content);
+
+		return is_array($value) ? $default_content : $value;
 	}
 
 	/**
@@ -403,7 +405,7 @@ class SSO {
 		 */
 		$wu_sso_token = $this->input('wu_sso_token', '');
 
-		if (is_string($wu_sso_token) && '' !== $wu_sso_token) {
+		if (is_string($wu_sso_token) && ! empty($wu_sso_token)) {
 			return true;
 		}
 

--- a/tests/WP_Ultimo/SSO/SSO_Extended_Test.php
+++ b/tests/WP_Ultimo/SSO/SSO_Extended_Test.php
@@ -342,6 +342,35 @@ class SSO_Extended_Test extends \WP_UnitTestCase {
 	}
 
 	/**
+	 * Test zero-like cookie-less tokens do not bypass the auth redirect.
+	 */
+	public function test_handle_auth_redirect_ignores_zero_cookie_less_token(): void {
+		$user_id = self::factory()->user->create();
+		wp_set_current_user($user_id);
+
+		$_REQUEST['wu_sso_token'] = '0';
+		$_SERVER['REQUEST_URI']   = '/wp-admin/customize.php?wu_sso_token=0';
+
+		add_filter(
+			'wu_sso_get_broker',
+			function () {
+				$mock = $this->createMock(SSO_Broker::class);
+				$mock->method('is_must_redirect_call')->willReturn(false);
+				return $mock;
+			}
+		);
+
+		try {
+			$sso    = SSO::get_instance();
+			$result = $sso->handle_auth_redirect();
+
+			$this->assertNull($result);
+		} finally {
+			wp_set_current_user(0);
+		}
+	}
+
+	/**
 	 * Test malformed array cookie-less tokens do not reach string validation.
 	 */
 	public function test_handle_cookie_less_sso_token_ignores_non_string_token(): void {
@@ -860,6 +889,20 @@ class SSO_Extended_Test extends \WP_UnitTestCase {
 		$result = $sso->input('nonexistent_key', 'fallback');
 
 		$this->assertSame('fallback', $result);
+	}
+
+	/**
+	 * Test input rejects array values before they reach typed SSO handlers.
+	 */
+	public function test_input_returns_default_for_array_value(): void {
+		$_REQUEST['test_key'] = ['unexpected'];
+
+		$sso    = SSO::get_instance();
+		$result = $sso->input('test_key', 'fallback');
+
+		$this->assertSame('fallback', $result);
+
+		unset($_REQUEST['test_key']);
 	}
 
 	// ------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- reject array-valued request parameters at the shared SSO input boundary
- prevent the zero-like cookie-less token from bypassing the normal admin authentication redirect
- add regressions for malformed arrays and the `wu_sso_token=0` case

## Testing

- `vendor/bin/phpunit --filter SSO_Extended_Test` (88 tests, 110 assertions)
- `vendor/bin/phpcs inc/sso/class-sso.php tests/WP_Ultimo/SSO/SSO_Extended_Test.php`
- `vendor/bin/phpstan analyse inc/sso/class-sso.php tests/WP_Ultimo/SSO/SSO_Extended_Test.php --no-progress`
- PHP syntax checks for both changed files

## Runtime Testing

Runtime-verified through the WordPress multisite PHPUnit environment on PHP 8.4.21. The targeted suite exercises the authentication redirect and shared request-input behavior.

Resolves #1650
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.152 plugin for [OpenCode](https://opencode.ai) v1.18.3 with gpt-5.6-sol spent 5m and 131,732 tokens on this as a headless worker.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved SSO request handling by rejecting array-valued inputs and using the configured default instead.
  * Corrected cookie-less SSO token validation so zero-like values do not trigger an unintended authentication redirect.
* **Tests**
  * Added coverage for invalid request input values and zero-like SSO tokens.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->