### PR TITLE
perf: avoid public credential decryptions

### DIFF
--- a/inc/integrations/class-integration-registry.php
+++ b/inc/integrations/class-integration-registry.php
@@ -396,7 +396,7 @@ class Integration_Registry {
 	 */
 	public function register_admin_notices(): void {
 
-		if (\WP_Ultimo()->is_loaded() === false) {
+		if ( ! is_network_admin() || \WP_Ultimo()->is_loaded() === false) {
 			return;
 		}
 

--- a/inc/integrations/class-integration-registry.php
+++ b/inc/integrations/class-integration-registry.php
@@ -396,7 +396,7 @@ class Integration_Registry {
 	 */
 	public function register_admin_notices(): void {
 
-		if ( ! is_network_admin() || \WP_Ultimo()->is_loaded() === false) {
+		if ( ! is_network_admin() || false === \WP_Ultimo()->is_loaded()) {
 			return;
 		}
 

--- a/inc/integrations/class-integration.php
+++ b/inc/integrations/class-integration.php
@@ -324,6 +324,26 @@ class Integration {
 	}
 
 	/**
+	 * Determines whether a credential has been configured without decrypting it.
+	 *
+	 * This is intentionally limited to setup checks. Consumers that need the
+	 * credential value must continue to use get_credential().
+	 *
+	 * @since 2.5.0
+	 *
+	 * @param string $constant_name The credential constant name.
+	 * @return bool True when a constant or stored credential is present.
+	 */
+	private function has_credential(string $constant_name): bool {
+
+		if (defined($constant_name) && constant($constant_name)) {
+			return true;
+		}
+
+		return ! empty(get_network_option(null, 'wu_hosting_credential_' . $constant_name, ''));
+	}
+
+	/**
 	 * Saves credential values as encrypted network options.
 	 *
 	 * @since 2.5.0
@@ -371,7 +391,7 @@ class Integration {
 			$found     = false;
 
 			foreach ($constants as $name) {
-				if ($this->get_credential($name)) {
+				if ($this->has_credential($name)) {
 					$found = true;
 
 					break;
@@ -401,7 +421,7 @@ class Integration {
 			$found     = false;
 
 			foreach ($constants as $name) {
-				if ($this->get_credential($name)) {
+				if ($this->has_credential($name)) {
 					$found = true;
 
 					break;

--- a/tests/WP_Ultimo/Integrations/Integration_Test.php
+++ b/tests/WP_Ultimo/Integrations/Integration_Test.php
@@ -172,6 +172,22 @@ class Integration_Test extends WP_UnitTestCase {
 		$this->assertTrue($this->integration->is_setup());
 	}
 
+	public function test_is_setup_checks_stored_credential_presence_without_decrypting(): void {
+
+		update_network_option(
+			null,
+			'wu_hosting_credential_CONST_A',
+			'$wu_enc$eA=='
+		);
+		update_network_option(
+			null,
+			'wu_hosting_credential_CONST_B',
+			'$wu_enc$eA=='
+		);
+
+		$this->assertTrue($this->integration->is_setup());
+	}
+
 	public function test_is_setup_with_grouped_constants_accepts_either(): void {
 
 		$integration = new Integration('grouped', 'Grouped');


### PR DESCRIPTION
## Summary

- Avoid decrypting stored hosting credentials when evaluating integration setup.
- Restrict integration notices to network-admin requests.
- Cover setup checks with an invalid encrypted credential payload.

## Verification

- PHP syntax checks passed for the two source files and regression test.
- Git whitespace validation passed.
- Focused PHPUnit and PHPCS could not run because this linked worktree has no vendor directory.

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.156 plugin for [OpenCode](https://opencode.ai) v1.18.3


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved integration setup detection for configured credentials, including encrypted values.
  * Limited integration admin notices to the WordPress network admin area.
* **Tests**
  * Added coverage verifying integrations are recognized as configured without decrypting stored credentials.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->