### PR TITLE
GH#1652: Prevent early documentation locale fatal

### DIFF
--- a/inc/class-documentation.php
+++ b/inc/class-documentation.php
@@ -26,7 +26,7 @@ class Documentation implements \WP_Ultimo\Interfaces\Singleton {
 	/**
 	 * Holds the links so we can retrieve them later
 	 *
-	 * @var array
+	 * @var array|null
 	 */
 	protected $links;
 
@@ -56,12 +56,30 @@ class Documentation implements \WP_Ultimo\Interfaces\Singleton {
 	];
 
 	/**
-	 * Set the default links.
+	 * Schedule the default links after WordPress finishes loading plugins.
 	 *
 	 * @since 2.0.0
 	 * @return void
 	 */
 	public function init(): void {
+
+		add_action('init', [$this, 'setup_links'], 0);
+	}
+
+	/**
+	 * Set the default links.
+	 *
+	 * The links are also initialized lazily for callers that request
+	 * documentation before the init hook runs.
+	 *
+	 * @since 2.15.0
+	 * @return void
+	 */
+	public function setup_links(): void {
+
+		if (is_array($this->links)) {
+			return;
+		}
 
 		$base = $this->get_docs_base_url();
 
@@ -105,7 +123,8 @@ class Documentation implements \WP_Ultimo\Interfaces\Singleton {
 		// Multiple Accounts
 		$links['multiple-accounts'] = $base . 'user-guide/configuration/customizing-your-registration-form';
 
-		$this->links = apply_filters('wu_documentation_links_list', $links);
+		$this->links = $links;
+		$this->links = apply_filters('wu_documentation_links_list', $this->links);
 	}
 
 	/**
@@ -118,7 +137,8 @@ class Documentation implements \WP_Ultimo\Interfaces\Singleton {
 
 		$base = 'https://ultimatemultisite.com/docs/';
 
-		$wp_locale = determine_locale();
+		$cookies_ready = defined('AUTH_COOKIE') && defined('SECURE_AUTH_COOKIE') && defined('LOGGED_IN_COOKIE');
+		$wp_locale     = $cookies_ready ? determine_locale() : get_locale();
 
 		// Try exact match first (e.g., pt_BR)
 		if (isset(self::$locale_map[ $wp_locale ])) {
@@ -159,6 +179,8 @@ class Documentation implements \WP_Ultimo\Interfaces\Singleton {
 	 */
 	public function get_link($slug, $return_default = true) {
 
+		$this->setup_links();
+
 		$default = $return_default ? $this->default_link : false;
 
 		$link = wu_get_isset($this->links, $slug, $default);
@@ -184,6 +206,8 @@ class Documentation implements \WP_Ultimo\Interfaces\Singleton {
 	 * @return void
 	 */
 	public function register_link($slug, $link): void {
+
+		$this->setup_links();
 
 		$this->links[ $slug ] = $link;
 	}

--- a/tests/WP_Ultimo/Functions/Documentation_Functions_Test.php
+++ b/tests/WP_Ultimo/Functions/Documentation_Functions_Test.php
@@ -14,6 +14,13 @@ use WP_UnitTestCase;
  */
 class Documentation_Functions_Test extends WP_UnitTestCase {
 
+	private function create_documentation_instance(): \WP_Ultimo\Documentation {
+
+		$reflection = new \ReflectionClass(\WP_Ultimo\Documentation::class);
+
+		return $reflection->newInstanceWithoutConstructor();
+	}
+
 	/**
 	 * Test wu_get_documentation_url returns string.
 	 */
@@ -33,5 +40,33 @@ class Documentation_Functions_Test extends WP_UnitTestCase {
 
 		// Returns false when slug not found and return_default is false.
 		$this->assertFalse($result);
+	}
+
+	public function test_documentation_setup_is_deferred_to_init(): void {
+
+		$documentation = $this->create_documentation_instance();
+
+		$documentation->init();
+
+		$this->assertSame(0, has_action('init', [$documentation, 'setup_links']));
+
+		remove_action('init', [$documentation, 'setup_links'], 0);
+	}
+
+	public function test_get_link_lazily_initializes_locale_aware_links(): void {
+
+		$documentation = $this->create_documentation_instance();
+		$locale_filter = static fn() => 'fr_FR';
+
+		add_filter('pre_determine_locale', $locale_filter);
+
+		try {
+			$this->assertSame(
+				'https://ultimatemultisite.com/docs/fr/',
+				$documentation->get_link('wp-ultimo-settings')
+			);
+		} finally {
+			remove_filter('pre_determine_locale', $locale_filter);
+		}
 	}
 }


### PR DESCRIPTION
## Summary

Defer documentation link construction until `init`, initialize lazily for legitimate early callers, and use the site locale until WordPress auth-cookie constants are available.

## Files Changed

- `inc/class-documentation.php`
- `tests/WP_Ultimo/Functions/Documentation_Functions_Test.php`

## Runtime Testing

- **Risk level:** Medium (early WordPress plugin bootstrap and locale selection)
- **Result:** Runtime verified with the official WP Umbrella 2.25.1 package.
- Before the fix, an authenticated WP Umbrella-style request returned HTTP 500 and logged `AUTH_COOKIE` as undefined through `Documentation::init()` and `determine_locale()`; HTTPS selects `SECURE_AUTH_COOKIE`, matching the report.
- With the fix, the same early-bootstrap conditions reached the WP Umbrella controller without an auth-cookie fatal. A controller validation response was returned instead.
- `Documentation_Functions_Test`: 4 tests and 4 assertions passed.
- PHPCS, PHP syntax checks, and targeted PHPStan passed.
- The full PHPUnit suite ran 10,083 tests with two unrelated existing site-exporter errors.
- Repository-wide PHPStan remains blocked by existing baseline findings; targeted analysis of the changed production file passed.

## Decisions

The suggested `init` deferral is combined with lazy initialization and a cookie-constant readiness fallback. This preserves documentation access for legitimate early callers without reintroducing the fatal path.

Resolves #1652

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.161 plugin for [OpenCode](https://opencode.ai) v1.18.4 with gpt-5.6-sol spent 2h 19m and 854,428 tokens on this with the user in an interactive session.
