### PR TITLE
feat(integrations): add DirectAdmin host provider

### DIFF
--- a/assets/img/hosts/directadmin.svg
+++ b/assets/img/hosts/directadmin.svg
@@ -1,0 +1,7 @@
+<svg width="64" height="64" viewBox="0 0 64 64" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="directadmin-title">
+  <title id="directadmin-title">DirectAdmin</title>
+  <rect width="64" height="64" rx="14" fill="#1F6FB2"/>
+  <path d="M17 17H35C43.2843 17 50 23.7157 50 32C50 40.2843 43.2843 47 35 47H17V17Z" fill="white"/>
+  <path d="M27 27H35C37.7614 27 40 29.2386 40 32C40 34.7614 37.7614 37 35 37H27V27Z" fill="#1F6FB2"/>
+  <path d="M14 49L29 15H38L23 49H14Z" fill="#EC2027"/>
+</svg>

--- a/inc/integrations/class-integration-registry.php
+++ b/inc/integrations/class-integration-registry.php
@@ -123,6 +123,7 @@ class Integration_Registry {
 		$this->register(new Providers\Cloudways\Cloudways_Integration());
 		$this->register(new Providers\RunCloud\RunCloud_Integration());
 		$this->register(new Providers\CPanel\CPanel_Integration());
+		$this->register(new Providers\DirectAdmin\DirectAdmin_Integration());
 		$this->register(new Providers\ServerPilot\ServerPilot_Integration());
 		$this->register(new Providers\GridPane\GridPane_Integration());
 		$this->register(new Providers\Cloudflare\Cloudflare_Integration());
@@ -175,6 +176,7 @@ class Integration_Registry {
 		$this->add_capability('cloudways', new Providers\Cloudways\Cloudways_Domain_Mapping());
 		$this->add_capability('runcloud', new Providers\RunCloud\RunCloud_Domain_Mapping());
 		$this->add_capability('cpanel', new Providers\CPanel\CPanel_Domain_Mapping());
+		$this->add_capability('directadmin', new Providers\DirectAdmin\DirectAdmin_Domain_Mapping());
 		$this->add_capability('serverpilot', new Providers\ServerPilot\ServerPilot_Domain_Mapping());
 		$this->add_capability('gridpane', new Providers\GridPane\GridPane_Domain_Mapping());
 		$this->add_capability('cloudflare', new Providers\Cloudflare\Cloudflare_Domain_Mapping());

--- a/inc/integrations/providers/directadmin/class-directadmin-domain-mapping.php
+++ b/inc/integrations/providers/directadmin/class-directadmin-domain-mapping.php
@@ -1,0 +1,295 @@
+<?php
+/**
+ * DirectAdmin Domain Mapping Capability.
+ *
+ * @package WP_Ultimo
+ * @subpackage Integrations/Providers/DirectAdmin
+ * @since 2.5.1
+ */
+
+namespace WP_Ultimo\Integrations\Providers\DirectAdmin;
+
+use Psr\Log\LogLevel;
+use WP_Ultimo\Integrations\Base_Capability_Module;
+use WP_Ultimo\Integrations\Capabilities\Domain_Mapping_Capability;
+
+// Exit if accessed directly.
+defined('ABSPATH') || exit;
+
+/**
+ * DirectAdmin domain mapping capability module.
+ *
+ * Adds mapped domains as DirectAdmin domain pointer aliases to the configured
+ * base domain so they resolve to the same WordPress multisite document root.
+ *
+ * @since 2.5.1
+ */
+class DirectAdmin_Domain_Mapping extends Base_Capability_Module implements Domain_Mapping_Capability {
+
+	/**
+	 * Supported features.
+	 *
+	 * @since 2.5.1
+	 * @var array
+	 */
+	protected array $supported_features = ['autossl'];
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function get_capability_id(): string {
+
+		return 'domain-mapping';
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function get_title(): string {
+
+		return __('Domain Mapping', 'ultimate-multisite');
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function get_explainer_lines(): array {
+
+		$explainer_lines = [
+			'will'     => [
+				'send_domains' => __('Add domain pointer aliases in DirectAdmin whenever a new domain mapping gets created on your network', 'ultimate-multisite'),
+				'autossl'      => __('Rely on DirectAdmin SSL automation to issue certificates for aliases when Let\'s Encrypt or Auto SSL is enabled on the DirectAdmin account', 'ultimate-multisite'),
+			],
+			'will_not' => [
+				'dns'      => __('Modify registrar or external DNS records for customer domains', 'ultimate-multisite'),
+				'register' => __('Register new domains', 'ultimate-multisite'),
+				'email'    => __('Create DirectAdmin email accounts or mailboxes', 'ultimate-multisite'),
+				'docroot'  => __('Create separate document roots for mapped domains', 'ultimate-multisite'),
+			],
+		];
+
+		if (is_subdomain_install()) {
+			$explainer_lines['will']['send_sub_domains'] = __('Add DirectAdmin domain pointer aliases for new subdomain sites so they use the same WordPress document root', 'ultimate-multisite');
+		}
+
+		return $explainer_lines;
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function register_hooks(): void {
+
+		add_action('wu_add_domain', [$this, 'on_add_domain'], 10, 2);
+		add_action('wu_remove_domain', [$this, 'on_remove_domain'], 10, 2);
+		add_action('wu_add_subdomain', [$this, 'on_add_subdomain'], 10, 2);
+		add_action('wu_remove_subdomain', [$this, 'on_remove_subdomain'], 10, 2);
+	}
+
+	/**
+	 * Called when a new domain is mapped.
+	 *
+	 * @since 2.5.1
+	 *
+	 * @param string $domain  The domain name being mapped.
+	 * @param int    $site_id ID of the site receiving the mapping.
+	 * @return void
+	 */
+	public function on_add_domain(string $domain, int $site_id): void {
+
+		$this->add_pointer($domain);
+
+		if (! str_starts_with($domain, 'www.') && \WP_Ultimo\Managers\Domain_Manager::get_instance()->should_create_www_subdomain($domain)) {
+			$this->add_pointer('www.' . $domain);
+		}
+	}
+
+	/**
+	 * Called when a mapped domain is removed.
+	 *
+	 * @since 2.5.1
+	 *
+	 * @param string $domain  The domain name being removed.
+	 * @param int    $site_id ID of the site.
+	 * @return void
+	 */
+	public function on_remove_domain(string $domain, int $site_id): void {
+
+		$this->delete_pointer($domain);
+
+		if (! str_starts_with($domain, 'www.')) {
+			$this->delete_pointer('www.' . $domain);
+		}
+	}
+
+	/**
+	 * Called when a new subdomain site is added.
+	 *
+	 * @since 2.5.1
+	 *
+	 * @param string $subdomain The subdomain being added.
+	 * @param int    $site_id   ID of the site.
+	 * @return void
+	 */
+	public function on_add_subdomain(string $subdomain, int $site_id): void {
+
+		$this->add_pointer($subdomain);
+	}
+
+	/**
+	 * Called when a subdomain site is removed.
+	 *
+	 * @since 2.5.1
+	 *
+	 * @param string $subdomain The subdomain being removed.
+	 * @param int    $site_id   ID of the site.
+	 * @return void
+	 */
+	public function on_remove_subdomain(string $subdomain, int $site_id): void {
+
+		$this->delete_pointer($subdomain);
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function test_connection() {
+
+		return $this->get_directadmin()->test_connection();
+	}
+
+	/**
+	 * Gets the parent DirectAdmin integration for API calls.
+	 *
+	 * @since 2.5.1
+	 * @return DirectAdmin_Integration
+	 */
+	private function get_directadmin(): DirectAdmin_Integration {
+
+		/** @var DirectAdmin_Integration */
+		return $this->get_integration();
+	}
+
+	/**
+	 * Adds a DirectAdmin domain pointer alias.
+	 *
+	 * @since 2.5.1
+	 *
+	 * @param string $domain Domain pointer hostname.
+	 * @return void
+	 */
+	private function add_pointer(string $domain): void {
+
+		$base_domain = $this->get_base_domain();
+		$domain      = $this->normalize_hostname($domain);
+
+		if (empty($base_domain) || empty($domain)) {
+			wu_log_add('integration-directadmin', __('Missing DirectAdmin base domain or mapped domain; cannot add domain pointer.', 'ultimate-multisite'), LogLevel::ERROR);
+
+			return;
+		}
+
+		$this->log_response(
+			sprintf(
+				/* translators: %s: domain pointer hostname. */
+				__('Add domain pointer %s', 'ultimate-multisite'),
+				$domain
+			),
+			$this->get_directadmin()->directadmin_api_request(
+				'/CMD_API_DOMAIN_POINTER',
+				'POST',
+				[
+					'domain' => $base_domain,
+					'action' => 'add',
+					'from'   => $domain,
+					'alias'  => 'yes',
+				]
+			)
+		);
+	}
+
+	/**
+	 * Deletes a DirectAdmin domain pointer alias.
+	 *
+	 * @since 2.5.1
+	 *
+	 * @param string $domain Domain pointer hostname.
+	 * @return void
+	 */
+	private function delete_pointer(string $domain): void {
+
+		$base_domain = $this->get_base_domain();
+		$domain      = $this->normalize_hostname($domain);
+
+		if (empty($base_domain) || empty($domain)) {
+			wu_log_add('integration-directadmin', __('Missing DirectAdmin base domain or mapped domain; cannot delete domain pointer.', 'ultimate-multisite'), LogLevel::ERROR);
+
+			return;
+		}
+
+		$this->log_response(
+			sprintf(
+				/* translators: %s: domain pointer hostname. */
+				__('Delete domain pointer %s', 'ultimate-multisite'),
+				$domain
+			),
+			$this->get_directadmin()->directadmin_api_request(
+				'/CMD_API_DOMAIN_POINTER',
+				'POST',
+				[
+					'domain'  => $base_domain,
+					'action'  => 'delete',
+					'select0' => $domain,
+				]
+			)
+		);
+	}
+
+	/**
+	 * Returns the configured DirectAdmin base domain.
+	 *
+	 * @since 2.5.1
+	 * @return string
+	 */
+	private function get_base_domain(): string {
+
+		return $this->normalize_hostname($this->get_directadmin()->get_credential('WU_DIRECTADMIN_DOMAIN'));
+	}
+
+	/**
+	 * Normalizes hostnames received from domain mapping hooks.
+	 *
+	 * @since 2.5.1
+	 *
+	 * @param string $hostname Hostname.
+	 * @return string
+	 */
+	private function normalize_hostname(string $hostname): string {
+
+		$hostname = preg_replace('#^https?://#i', '', $hostname);
+		$hostname = preg_replace('#/.*$#', '', (string) $hostname);
+		$hostname = strtolower(trim((string) $hostname, " \t\n\r\0\x0B."));
+
+		return $hostname;
+	}
+
+	/**
+	 * Log an API response with a contextual label.
+	 *
+	 * @since 2.5.1
+	 *
+	 * @param string          $action_label Descriptive label for the action.
+	 * @param array|\WP_Error $response     The API response.
+	 * @return void
+	 */
+	protected function log_response(string $action_label, $response): void {
+
+		if (is_wp_error($response)) {
+			wu_log_add('integration-directadmin', sprintf('[%s] %s', $action_label, $response->get_error_message()), LogLevel::ERROR);
+
+			return;
+		}
+
+		wu_log_add('integration-directadmin', sprintf('[%s] %s', $action_label, wp_json_encode($response)));
+	}
+}

--- a/inc/integrations/providers/directadmin/class-directadmin-integration.php
+++ b/inc/integrations/providers/directadmin/class-directadmin-integration.php
@@ -1,0 +1,351 @@
+<?php
+/**
+ * DirectAdmin Integration.
+ *
+ * Provides API access to DirectAdmin's legacy CMD_API endpoints for domain
+ * pointer and subdomain management.
+ *
+ * @package WP_Ultimo
+ * @subpackage Integrations/Providers/DirectAdmin
+ * @since 2.5.1
+ */
+
+namespace WP_Ultimo\Integrations\Providers\DirectAdmin;
+
+use WP_Ultimo\Integrations\Integration;
+
+// Exit if accessed directly.
+defined('ABSPATH') || exit;
+
+/**
+ * DirectAdmin integration provider.
+ *
+ * Uses DirectAdmin's documented legacy CMD_API interface. Authentication is
+ * HTTP Basic Auth where the password value should preferably be a DirectAdmin
+ * Login Key.
+ *
+ * @since 2.5.1
+ */
+class DirectAdmin_Integration extends Integration {
+
+	/**
+	 * Default DirectAdmin HTTPS port.
+	 *
+	 * @since 2.5.1
+	 * @var string
+	 */
+	private const DEFAULT_PORT = '2222';
+
+	/**
+	 * User-Agent header sent with API requests.
+	 *
+	 * @since 2.5.1
+	 * @var string
+	 */
+	private const USER_AGENT = 'UltimateMultisite-DirectAdmin-Integration/1.0';
+
+	/**
+	 * Constructor.
+	 *
+	 * @since 2.5.1
+	 */
+	public function __construct() {
+
+		parent::__construct('directadmin', 'DirectAdmin');
+
+		$this->set_logo(function_exists('wu_get_asset') ? wu_get_asset('directadmin.svg', 'img/hosts') : '');
+		$this->set_tutorial_link('https://docs.directadmin.com/developer/api/');
+		$this->set_constants(
+			[
+				'WU_DIRECTADMIN_HOST',
+				'WU_DIRECTADMIN_USERNAME',
+				['WU_DIRECTADMIN_API_TOKEN', 'WU_DIRECTADMIN_PASSWORD'],
+				'WU_DIRECTADMIN_DOMAIN',
+			]
+		);
+		$this->set_optional_constants(['WU_DIRECTADMIN_PORT']);
+		$this->set_supports(['autossl']);
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function get_description(): string {
+
+		return __('Integrates with DirectAdmin to add and remove domain pointer aliases automatically when domains are mapped or removed.', 'ultimate-multisite');
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function detect(): bool {
+
+		return (bool) ($this->get_credential('WU_DIRECTADMIN_HOST') && $this->get_credential('WU_DIRECTADMIN_USERNAME'));
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function test_connection() {
+
+		$response = $this->directadmin_api_request('/CMD_API_LOGIN_TEST');
+
+		if (is_wp_error($response)) {
+			return $response;
+		}
+
+		if (isset($response['raw']) && false !== stripos((string) $response['raw'], '<html')) {
+			return new \WP_Error('directadmin-login-test-failed', __('DirectAdmin returned the login page instead of an API response. Check the username and Login Key or password.', 'ultimate-multisite'));
+		}
+
+		return true;
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function get_fields(): array {
+
+		return [
+			'WU_DIRECTADMIN_HOST'      => [
+				'title'       => __('DirectAdmin Host', 'ultimate-multisite'),
+				'desc'        => __('The hostname or IP address of your DirectAdmin server. Do not include the protocol or port.', 'ultimate-multisite'),
+				'placeholder' => __('e.g. server.example.com', 'ultimate-multisite'),
+			],
+			'WU_DIRECTADMIN_PORT'      => [
+				'title'       => __('DirectAdmin Port', 'ultimate-multisite'),
+				'desc'        => __('The HTTPS port DirectAdmin listens on. Defaults to 2222.', 'ultimate-multisite'),
+				'placeholder' => __('2222', 'ultimate-multisite'),
+				'value'       => self::DEFAULT_PORT,
+			],
+			'WU_DIRECTADMIN_USERNAME'  => [
+				'title'       => __('DirectAdmin Username', 'ultimate-multisite'),
+				'desc'        => __('The DirectAdmin account username. Admins and resellers can use the DirectAdmin impersonation format, such as admin|customer.', 'ultimate-multisite'),
+				'placeholder' => __('e.g. admin|customer or customer', 'ultimate-multisite'),
+			],
+			'WU_DIRECTADMIN_API_TOKEN' => [
+				'type'        => 'password',
+				'html_attr'   => [
+					'autocomplete' => 'new-password',
+				],
+				'title'       => __('DirectAdmin Login Key (Recommended)', 'ultimate-multisite'),
+				'desc'        => __('Create a DirectAdmin Login Key and use it here instead of the account password. It is sent as the password part of HTTP Basic authentication.', 'ultimate-multisite'),
+				'placeholder' => __('Your DirectAdmin Login Key', 'ultimate-multisite'),
+			],
+			'WU_DIRECTADMIN_PASSWORD'  => [
+				'type'        => 'password',
+				'html_attr'   => [
+					'autocomplete' => 'new-password',
+				],
+				'title'       => __('DirectAdmin Password (Alternative)', 'ultimate-multisite'),
+				'desc'        => __('Only required when you are not using a Login Key.', 'ultimate-multisite'),
+				'placeholder' => __('Your DirectAdmin password', 'ultimate-multisite'),
+			],
+			'WU_DIRECTADMIN_DOMAIN'    => [
+				'title'       => __('Base Domain', 'ultimate-multisite'),
+				'desc'        => __('The DirectAdmin domain that serves this WordPress multisite. Mapped domains will be added as alias pointers to this domain.', 'ultimate-multisite'),
+				'placeholder' => __('e.g. network.example.com', 'ultimate-multisite'),
+			],
+		];
+	}
+
+	/**
+	 * Renders the wizard instructions partial.
+	 *
+	 * @since 2.5.1
+	 * @return void
+	 */
+	public function get_instructions(): void {
+
+		wu_get_template('wizards/host-integrations/directadmin-instructions');
+	}
+
+	/**
+	 * Sends an authenticated request to a DirectAdmin CMD_API endpoint.
+	 *
+	 * @since 2.5.1
+	 *
+	 * @param string $endpoint DirectAdmin endpoint path, e.g. /CMD_API_DOMAIN_POINTER.
+	 * @param string $method   HTTP method.
+	 * @param array  $data     Form/query parameters.
+	 * @return array|\WP_Error
+	 */
+	public function directadmin_api_request(string $endpoint, string $method = 'GET', array $data = []) {
+
+		$host = $this->normalize_host($this->get_credential('WU_DIRECTADMIN_HOST'));
+
+		if (empty($host)) {
+			return new \WP_Error('directadmin-no-host', __('DirectAdmin host is not configured.', 'ultimate-multisite'));
+		}
+
+		$username   = $this->get_credential('WU_DIRECTADMIN_USERNAME');
+		$api_token  = $this->get_credential('WU_DIRECTADMIN_API_TOKEN');
+		$password   = $this->get_credential('WU_DIRECTADMIN_PASSWORD');
+		$credential = $api_token ?: $password;
+
+		if (empty($username) || empty($credential)) {
+			return new \WP_Error('directadmin-no-auth', __('DirectAdmin username and Login Key or password are required.', 'ultimate-multisite'));
+		}
+
+		if ('' === $endpoint || '/' !== $endpoint[0]) {
+			$endpoint = '/' . $endpoint;
+		}
+
+		$method = strtoupper($method);
+		$port   = $this->get_credential('WU_DIRECTADMIN_PORT') ?: self::DEFAULT_PORT;
+		$url    = sprintf('https://%1$s:%2$s%3$s', $host, $port, $endpoint);
+
+		$args = [
+			'method'  => $method,
+			'timeout' => 45,
+			'headers' => [
+				'Accept'        => 'application/json, text/plain, */*',
+				'Content-Type'  => 'application/x-www-form-urlencoded',
+				'User-Agent'    => self::USER_AGENT,
+				// phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_encode
+				'Authorization' => 'Basic ' . base64_encode($username . ':' . $credential),
+			],
+		];
+
+		if ('GET' === $method) {
+			if ( ! empty($data)) {
+				$url = add_query_arg($data, $url);
+			}
+		} else {
+			$args['body'] = $data;
+		}
+
+		$response = wp_remote_request($url, $args);
+
+		if (is_wp_error($response)) {
+			return $response;
+		}
+
+		$status_code = (int) wp_remote_retrieve_response_code($response);
+		$body        = wp_remote_retrieve_body($response);
+
+		if (200 > $status_code || 300 <= $status_code) {
+			return new \WP_Error(
+				'directadmin-http-error',
+				sprintf(
+					/* translators: 1: HTTP status code, 2: response body. */
+					__('DirectAdmin API error (%1$d): %2$s', 'ultimate-multisite'),
+					$status_code,
+					(string) $body
+				),
+				[
+					'status' => $status_code,
+					'body'   => $body,
+				]
+			);
+		}
+
+		$decoded = $this->decode_directadmin_response((string) $body);
+
+		if ($this->is_directadmin_error($decoded)) {
+			return new \WP_Error(
+				'directadmin-api-error',
+				$this->get_directadmin_error_message($decoded),
+				$decoded
+			);
+		}
+
+		return $decoded;
+	}
+
+	/**
+	 * Normalizes a host field submitted by users.
+	 *
+	 * @since 2.5.1
+	 *
+	 * @param string $host Hostname submitted in settings.
+	 * @return string
+	 */
+	private function normalize_host(string $host): string {
+
+		$host = preg_replace('#^https?://#i', '', $host);
+		$host = rtrim((string) $host, "; \t\n\r\0\x0B/");
+		$host = preg_replace('#:\d+$#', '', $host);
+
+		return (string) $host;
+	}
+
+	/**
+	 * Decodes DirectAdmin response bodies.
+	 *
+	 * @since 2.5.1
+	 *
+	 * @param string $body Raw response body.
+	 * @return array
+	 */
+	private function decode_directadmin_response(string $body): array {
+
+		$body = trim($body);
+
+		if ('' === $body) {
+			return ['success' => true];
+		}
+
+		$decoded = json_decode($body, true);
+
+		if (JSON_ERROR_NONE === json_last_error() && is_array($decoded)) {
+			return $decoded;
+		}
+
+		if (str_contains($body, '=') || str_contains($body, '&')) {
+			$parsed = [];
+			parse_str($body, $parsed);
+
+			if ( ! empty($parsed)) {
+				return $parsed;
+			}
+		}
+
+		$lines = array_values(array_filter(preg_split('/\R/', $body) ?: []));
+
+		if ( ! empty($lines)) {
+			return [
+				'list' => $lines,
+				'raw'  => $body,
+			];
+		}
+
+		return ['raw' => $body];
+	}
+
+	/**
+	 * Checks if a decoded DirectAdmin payload signals an error.
+	 *
+	 * @since 2.5.1
+	 *
+	 * @param array $decoded Decoded DirectAdmin response.
+	 * @return bool
+	 */
+	private function is_directadmin_error(array $decoded): bool {
+
+		if ( ! array_key_exists('error', $decoded)) {
+			return false;
+		}
+
+		return ! in_array((string) $decoded['error'], ['', '0', 'false'], true);
+	}
+
+	/**
+	 * Extracts a human-readable DirectAdmin error message.
+	 *
+	 * @since 2.5.1
+	 *
+	 * @param array $decoded Decoded DirectAdmin response.
+	 * @return string
+	 */
+	private function get_directadmin_error_message(array $decoded): string {
+
+		foreach (['details', 'text', 'message', 'error'] as $key) {
+			if (isset($decoded[ $key ]) && is_scalar($decoded[ $key ])) {
+				return (string) $decoded[ $key ];
+			}
+		}
+
+		return __('Unknown DirectAdmin API error.', 'ultimate-multisite');
+	}
+}

--- a/tests/WP_Ultimo/Integrations/Integration_Registry_Test.php
+++ b/tests/WP_Ultimo/Integrations/Integration_Registry_Test.php
@@ -30,6 +30,7 @@ class Integration_Registry_Test extends WP_UnitTestCase {
 		$this->assertNotNull($this->registry->get('cloudways'));
 		$this->assertNotNull($this->registry->get('runcloud'));
 		$this->assertNotNull($this->registry->get('cpanel'));
+		$this->assertNotNull($this->registry->get('directadmin'));
 		$this->assertNotNull($this->registry->get('serverpilot'));
 		$this->assertNotNull($this->registry->get('gridpane'));
 		$this->assertNotNull($this->registry->get('cloudflare'));
@@ -61,6 +62,7 @@ class Integration_Registry_Test extends WP_UnitTestCase {
 			'cloudways',
 			'runcloud',
 			'cpanel',
+			'directadmin',
 			'serverpilot',
 			'gridpane',
 			'cloudflare',

--- a/tests/WP_Ultimo/Integrations/Providers/DirectAdmin/DirectAdmin_Domain_Mapping_Test.php
+++ b/tests/WP_Ultimo/Integrations/Providers/DirectAdmin/DirectAdmin_Domain_Mapping_Test.php
@@ -1,0 +1,163 @@
+<?php
+
+namespace WP_Ultimo\Integrations\Providers\DirectAdmin;
+
+use WP_UnitTestCase;
+
+class DirectAdmin_Domain_Mapping_Test extends WP_UnitTestCase {
+
+	private DirectAdmin_Domain_Mapping $module;
+	private DirectAdmin_Integration $integration;
+
+	public function setUp(): void {
+
+		parent::setUp();
+
+		$this->integration = $this->getMockBuilder(DirectAdmin_Integration::class)
+			->onlyMethods(['directadmin_api_request', 'get_credential', 'test_connection'])
+			->getMock();
+
+		$this->integration->method('get_credential')
+			->willReturnCallback(function (string $key) {
+				$map = [
+					'WU_DIRECTADMIN_DOMAIN' => 'mysite.com',
+				];
+
+				return $map[ $key ] ?? '';
+			});
+
+		$this->module = new DirectAdmin_Domain_Mapping();
+		$this->module->set_integration($this->integration);
+	}
+
+	public function test_get_capability_id(): void {
+
+		$this->assertSame('domain-mapping', $this->module->get_capability_id());
+	}
+
+	public function test_get_title_is_non_empty(): void {
+
+		$this->assertNotEmpty($this->module->get_title());
+	}
+
+	public function test_supports_autossl(): void {
+
+		$this->assertTrue($this->module->supports('autossl'));
+	}
+
+	public function test_get_explainer_lines_has_will_and_will_not_keys(): void {
+
+		$lines = $this->module->get_explainer_lines();
+
+		$this->assertArrayHasKey('will', $lines);
+		$this->assertNotEmpty($lines['will']);
+		$this->assertArrayHasKey('will_not', $lines);
+	}
+
+	public function test_register_hooks_adds_all_domain_actions(): void {
+
+		$this->module->register_hooks();
+
+		$this->assertIsInt(has_action('wu_add_domain', [$this->module, 'on_add_domain']));
+		$this->assertIsInt(has_action('wu_remove_domain', [$this->module, 'on_remove_domain']));
+		$this->assertIsInt(has_action('wu_add_subdomain', [$this->module, 'on_add_subdomain']));
+		$this->assertIsInt(has_action('wu_remove_subdomain', [$this->module, 'on_remove_subdomain']));
+	}
+
+	public function test_on_add_domain_calls_domain_pointer_add(): void {
+
+		$this->integration->expects($this->atLeast(1))
+			->method('directadmin_api_request')
+			->willReturnCallback(function (string $endpoint, string $method, array $data) {
+				$this->assertSame('/CMD_API_DOMAIN_POINTER', $endpoint);
+				$this->assertSame('POST', $method);
+				$this->assertSame('mysite.com', $data['domain']);
+				$this->assertSame('add', $data['action']);
+				$this->assertContains($data['from'], ['example.com', 'www.example.com']);
+				$this->assertSame('yes', $data['alias']);
+
+				return ['error' => '0'];
+			});
+
+		$this->module->on_add_domain('example.com', 1);
+	}
+
+	public function test_on_add_domain_skips_when_base_domain_missing(): void {
+
+		$integration = $this->getMockBuilder(DirectAdmin_Integration::class)
+			->onlyMethods(['directadmin_api_request', 'get_credential'])
+			->getMock();
+
+		$integration->method('get_credential')->willReturn('');
+
+		$integration->expects($this->never())
+			->method('directadmin_api_request');
+
+		$module = new DirectAdmin_Domain_Mapping();
+		$module->set_integration($integration);
+		$module->on_add_domain('example.com', 1);
+	}
+
+	public function test_on_remove_domain_calls_domain_pointer_delete(): void {
+
+		$this->integration->expects($this->atLeast(1))
+			->method('directadmin_api_request')
+			->willReturnCallback(function (string $endpoint, string $method, array $data) {
+				$this->assertSame('/CMD_API_DOMAIN_POINTER', $endpoint);
+				$this->assertSame('POST', $method);
+				$this->assertSame('mysite.com', $data['domain']);
+				$this->assertSame('delete', $data['action']);
+				$this->assertContains($data['select0'], ['example.com', 'www.example.com']);
+
+				return ['error' => '0'];
+			});
+
+		$this->module->on_remove_domain('example.com', 1);
+	}
+
+	public function test_on_add_subdomain_calls_domain_pointer_add(): void {
+
+		$this->integration->expects($this->once())
+			->method('directadmin_api_request')
+			->with(
+				'/CMD_API_DOMAIN_POINTER',
+				'POST',
+				$this->callback(function (array $data) {
+					return 'mysite.com' === $data['domain']
+						&& 'add' === $data['action']
+						&& 'sub.mysite.com' === $data['from']
+						&& 'yes' === $data['alias'];
+				})
+			)
+			->willReturn(['error' => '0']);
+
+		$this->module->on_add_subdomain('sub.mysite.com', 1);
+	}
+
+	public function test_on_remove_subdomain_calls_domain_pointer_delete(): void {
+
+		$this->integration->expects($this->once())
+			->method('directadmin_api_request')
+			->with(
+				'/CMD_API_DOMAIN_POINTER',
+				'POST',
+				$this->callback(function (array $data) {
+					return 'mysite.com' === $data['domain']
+						&& 'delete' === $data['action']
+						&& 'sub.mysite.com' === $data['select0'];
+				})
+			)
+			->willReturn(['error' => '0']);
+
+		$this->module->on_remove_subdomain('sub.mysite.com', 1);
+	}
+
+	public function test_test_connection_delegates_to_integration(): void {
+
+		$this->integration->expects($this->once())
+			->method('test_connection')
+			->willReturn(true);
+
+		$this->assertTrue($this->module->test_connection());
+	}
+}

--- a/tests/WP_Ultimo/Integrations/Providers/DirectAdmin/DirectAdmin_Integration_Test.php
+++ b/tests/WP_Ultimo/Integrations/Providers/DirectAdmin/DirectAdmin_Integration_Test.php
@@ -1,0 +1,126 @@
+<?php
+
+namespace WP_Ultimo\Integrations\Providers\DirectAdmin;
+
+use WP_UnitTestCase;
+
+class DirectAdmin_Integration_Test extends WP_UnitTestCase {
+
+	public function test_constructor_sets_id_and_title(): void {
+
+		$integration = new DirectAdmin_Integration();
+
+		$this->assertSame('directadmin', $integration->get_id());
+		$this->assertSame('DirectAdmin', $integration->get_title());
+	}
+
+	public function test_constructor_declares_required_constants(): void {
+
+		$integration = new DirectAdmin_Integration();
+		$constants   = $integration->get_constants();
+
+		$this->assertContains('WU_DIRECTADMIN_HOST', $constants);
+		$this->assertContains('WU_DIRECTADMIN_USERNAME', $constants);
+		$this->assertContains('WU_DIRECTADMIN_DOMAIN', $constants);
+		$this->assertContains(['WU_DIRECTADMIN_API_TOKEN', 'WU_DIRECTADMIN_PASSWORD'], $constants);
+	}
+
+	public function test_constructor_declares_autossl_support(): void {
+
+		$integration = new DirectAdmin_Integration();
+
+		$this->assertContains('autossl', $integration->get_supports());
+		$this->assertTrue($integration->supports('autossl'));
+	}
+
+	public function test_get_fields_returns_directadmin_credentials(): void {
+
+		$integration = new DirectAdmin_Integration();
+		$fields      = $integration->get_fields();
+
+		$this->assertArrayHasKey('WU_DIRECTADMIN_HOST', $fields);
+		$this->assertArrayHasKey('WU_DIRECTADMIN_PORT', $fields);
+		$this->assertArrayHasKey('WU_DIRECTADMIN_USERNAME', $fields);
+		$this->assertArrayHasKey('WU_DIRECTADMIN_API_TOKEN', $fields);
+		$this->assertArrayHasKey('WU_DIRECTADMIN_PASSWORD', $fields);
+		$this->assertArrayHasKey('WU_DIRECTADMIN_DOMAIN', $fields);
+		$this->assertSame('password', $fields['WU_DIRECTADMIN_API_TOKEN']['type']);
+	}
+
+	public function test_detect_returns_true_when_host_and_username_are_set(): void {
+
+		$integration = $this->getMockBuilder(DirectAdmin_Integration::class)
+			->onlyMethods(['get_credential'])
+			->getMock();
+
+		$integration->method('get_credential')
+			->willReturnCallback(function (string $key) {
+				$map = [
+					'WU_DIRECTADMIN_HOST'     => 'server.example.com',
+					'WU_DIRECTADMIN_USERNAME' => 'admin|customer',
+				];
+
+				return $map[ $key ] ?? '';
+			});
+
+		$this->assertTrue($integration->detect());
+	}
+
+	public function test_detect_returns_false_when_credentials_are_missing(): void {
+
+		$integration = $this->getMockBuilder(DirectAdmin_Integration::class)
+			->onlyMethods(['get_credential'])
+			->getMock();
+
+		$integration->method('get_credential')->willReturn('');
+
+		$this->assertFalse($integration->detect());
+	}
+
+	public function test_test_connection_calls_login_test_endpoint(): void {
+
+		$integration = $this->getMockBuilder(DirectAdmin_Integration::class)
+			->onlyMethods(['directadmin_api_request'])
+			->getMock();
+
+		$integration->expects($this->once())
+			->method('directadmin_api_request')
+			->with('/CMD_API_LOGIN_TEST')
+			->willReturn([
+				'error' => '0',
+				'text'  => 'Login OK',
+			]);
+
+		$this->assertTrue($integration->test_connection());
+	}
+
+	public function test_test_connection_returns_error_for_login_page_response(): void {
+
+		$integration = $this->getMockBuilder(DirectAdmin_Integration::class)
+			->onlyMethods(['directadmin_api_request'])
+			->getMock();
+
+		$integration->method('directadmin_api_request')->willReturn([
+			'raw' => '<html><body>DirectAdmin Login</body></html>',
+		]);
+
+		$result = $integration->test_connection();
+
+		$this->assertInstanceOf(\WP_Error::class, $result);
+		$this->assertSame('directadmin-login-test-failed', $result->get_error_code());
+	}
+
+	public function test_directadmin_api_request_returns_error_when_host_missing(): void {
+
+		$integration = $this->getMockBuilder(DirectAdmin_Integration::class)
+			->onlyMethods(['get_credential'])
+			->getMock();
+
+		$integration->method('get_credential')->willReturn('');
+
+		$result = $integration->directadmin_api_request('/CMD_API_LOGIN_TEST');
+
+		$this->assertInstanceOf(\WP_Error::class, $result);
+		$this->assertSame('directadmin-no-host', $result->get_error_code());
+	}
+}

--- a/tests/WP_Ultimo/Integrations/Providers/Provider_Integration_Test.php
+++ b/tests/WP_Ultimo/Integrations/Providers/Provider_Integration_Test.php
@@ -122,6 +122,7 @@ class Provider_Integration_Test extends WP_UnitTestCase {
 			'cloudways'   => ['cloudways'],
 			'runcloud'    => ['runcloud'],
 			'cpanel'      => ['cpanel'],
+			'directadmin' => ['directadmin'],
 			'serverpilot' => ['serverpilot'],
 			'gridpane'    => ['gridpane'],
 			'cloudflare'  => ['cloudflare'],

--- a/views/wizards/host-integrations/directadmin-instructions.php
+++ b/views/wizards/host-integrations/directadmin-instructions.php
@@ -1,0 +1,60 @@
+<?php
+/**
+ * DirectAdmin integration instructions view.
+ *
+ * @package WP_Ultimo
+ * @subpackage Views/Wizards/Host_Integrations
+ * @since 2.5.1
+ */
+defined('ABSPATH') || exit;
+?>
+<h1>
+	<?php esc_html_e('Instructions', 'ultimate-multisite'); ?>
+</h1>
+
+<p class="wu-text-lg wu-text-gray-600 wu-my-4 wu-mb-6">
+	<?php esc_html_e('You will need DirectAdmin API access, preferably using a Login Key, and the base DirectAdmin domain that serves this WordPress multisite.', 'ultimate-multisite'); ?>
+</p>
+
+<p class="wu-text-sm wu-bg-blue-100 wu-p-4 wu-text-blue-600 wu-rounded">
+	<strong><?php esc_html_e('What this integration uses:', 'ultimate-multisite'); ?></strong><br>
+	<?php esc_html_e('Ultimate Multisite talks to DirectAdmin over its documented CMD_API endpoints and creates domain pointer aliases. Domain pointers keep mapped domains on the same document root as your main multisite install.', 'ultimate-multisite'); ?>
+</p>
+
+<h3 class="wu-m-0 wu-py-4 wu-text-lg" id="step-1-create-login-key">
+	<?php esc_html_e('Step 1 — Create a DirectAdmin Login Key', 'ultimate-multisite'); ?>
+</h3>
+
+<ol class="wu-text-sm wu-list-decimal wu-pl-6 wu-space-y-2">
+	<li><?php esc_html_e('Log in to DirectAdmin as the user that owns the WordPress multisite domain, or as an admin/reseller that can impersonate that user.', 'ultimate-multisite'); ?></li>
+	<li><?php esc_html_e('Open the Login Keys screen and create a key named something recognisable, such as “Ultimate Multisite”.', 'ultimate-multisite'); ?></li>
+	<li><?php esc_html_e('Allow the key to use the domain pointer API for the account. If your DirectAdmin version does not expose granular permissions, use the standard account key permissions and restrict by expiry/IP where possible.', 'ultimate-multisite'); ?></li>
+	<li><?php esc_html_e('Copy the generated key immediately. Use it in the Login Key field on the next step instead of your DirectAdmin password.', 'ultimate-multisite'); ?></li>
+</ol>
+
+<h3 class="wu-m-0 wu-py-4 wu-text-lg" id="step-2-confirm-base-domain">
+	<?php esc_html_e('Step 2 — Confirm the base domain', 'ultimate-multisite'); ?>
+</h3>
+
+<p class="wu-text-sm">
+	<?php esc_html_e('The base domain is the DirectAdmin domain that currently serves your WordPress multisite. New customer domains will be added as alias pointers to this domain, not as separate sites or separate document roots.', 'ultimate-multisite'); ?>
+</p>
+
+<ul class="wu-text-sm wu-list-disc wu-pl-6 wu-space-y-2">
+	<li><?php esc_html_e('For a normal installation, this is your network domain, such as network.example.com.', 'ultimate-multisite'); ?></li>
+	<li><?php esc_html_e('If you authenticate as an admin or reseller for another account, use DirectAdmin’s username impersonation format in the username field, such as admin|customer.', 'ultimate-multisite'); ?></li>
+	<li><?php esc_html_e('Keep wildcard DNS or customer DNS pointed at the same server; this integration does not change external DNS records.', 'ultimate-multisite'); ?></li>
+</ul>
+
+<h3 class="wu-m-0 wu-py-4 wu-text-lg" id="step-3-ssl">
+	<?php esc_html_e('Step 3 — SSL expectations', 'ultimate-multisite'); ?>
+</h3>
+
+<p class="wu-text-sm">
+	<?php esc_html_e('DirectAdmin can issue certificates for aliases when Let’s Encrypt or Auto SSL is enabled for the account. After the pointer is created, make sure DirectAdmin’s SSL automation includes domain pointers for the base domain.', 'ultimate-multisite'); ?>
+</p>
+
+<p class="wu-text-sm wu-bg-yellow-100 wu-p-4 wu-text-yellow-700 wu-rounded wu-mt-4">
+	<strong><?php esc_html_e('Important:', 'ultimate-multisite'); ?></strong><br>
+	<?php esc_html_e('Customer domains still need DNS records pointing to this server before DirectAdmin can validate SSL and before WordPress can serve the mapped domain.', 'ultimate-multisite'); ?>
+</p>


### PR DESCRIPTION
## Summary

- Add a DirectAdmin hosting integration using DirectAdmin CMD_API domain pointer aliases.
- Register the provider and domain-mapping capability in the integration registry.
- Add setup wizard instructions, a host logo, and DirectAdmin-focused unit coverage.

## Implementation notes

- Uses `CMD_API_LOGIN_TEST` to validate credentials.
- Uses `CMD_API_DOMAIN_POINTER` with `action=add`, `from=<mapped-domain>`, and `alias=yes` to attach mapped domains to the configured base domain.
- Uses `CMD_API_DOMAIN_POINTER` with `action=delete` and `select0=<mapped-domain>` for removal.
- Subdomain events use domain pointer aliases so tenant hostnames continue to serve the multisite document root.

## Verification

- `php -l` on changed PHP files: pass.
- `vendor/bin/phpcs` on changed files: pass.
- Pre-commit PHPCS and PHPStan on staged PHP files: pass.
- `vendor/bin/phpunit --filter DirectAdmin`: blocked locally because the WordPress test suite is not installed; this PR is opened so CI can run the unit tests.

---
<!-- aidevops:sig -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added DirectAdmin integration support for connecting and managing credentials.
  * Added automatic domain and subdomain mapping through DirectAdmin domain pointers.
  * Added connection testing and SSL automation support.
  * Added setup instructions for Login Keys, base domains, and SSL configuration.
* **Tests**
  * Added coverage for DirectAdmin connection, credential validation, and domain-mapping behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->