### PR TITLE
fix(checkout): relax optional billing address rules

### DIFF
--- a/inc/checkout/class-checkout.php
+++ b/inc/checkout/class-checkout.php
@@ -2799,7 +2799,8 @@ class Checkout {
 			'billing_zip_code' => '',
 		];
 
-		$billing_rule_fields = $this->checkout_form ? $this->checkout_form->get_all_fields() : $this->step['fields'];
+		$billing_rule_fields           = $this->checkout_form ? $this->checkout_form->get_all_fields() : $this->step['fields'];
+		$has_optional_billing_address = false;
 
 		foreach ($billing_rule_fields as $field_key => $field) {
 			if ( ! is_array($field)) {
@@ -2808,8 +2809,24 @@ class Checkout {
 
 			$field_id = wu_get_isset($field, 'id', is_string($field_key) ? $field_key : '');
 
+			/*
+			 * Checkout_Form::get_all_fields() returns the configured composite
+			 * field, rather than the billing_country and billing_zip_code fields
+			 * generated when it is rendered.
+			 */
+			if ('billing_address' === $field_id && ! wu_get_isset($field, 'required')) {
+				$has_optional_billing_address = true;
+				continue;
+			}
+
 			if (isset($optional_billing_rules[ $field_id ]) && ! wu_get_isset($field, 'required')) {
 				$validation_rules[ $field_id ] = $optional_billing_rules[ $field_id ];
+			}
+		}
+
+		if ($has_optional_billing_address) {
+			foreach ($optional_billing_rules as $field_id => $rule) {
+				$validation_rules[ $field_id ] = $rule;
 			}
 		}
 

--- a/tests/WP_Ultimo/Checkout/Checkout_Test.php
+++ b/tests/WP_Ultimo/Checkout/Checkout_Test.php
@@ -1787,7 +1787,7 @@ class Checkout_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Test optional billing fields on earlier checkout steps relax final validation.
+	 * Test an optional billing address element on an earlier step relaxes final validation.
 	 */
 	public function test_get_validation_rules_relaxes_optional_billing_address_fields_from_all_steps(): void {
 
@@ -1800,12 +1800,10 @@ class Checkout_Test extends WP_UnitTestCase {
 					'name'   => 'Billing Step',
 					'fields' => [
 						[
-							'id'   => 'billing_country',
-							'type' => 'select',
-						],
-						[
-							'id'   => 'billing_zip_code',
-							'type' => 'text',
+							'id'              => 'billing_address',
+							'type'            => 'billing_address',
+							'required'        => false,
+							'zip_and_country' => '1',
 						],
 					],
 				],
@@ -1832,17 +1830,15 @@ class Checkout_Test extends WP_UnitTestCase {
 
 		unset($_REQUEST['pre-flight'], $_REQUEST['checkout_form']);
 
-		$_REQUEST['billing_country']  = 'US';
-		$_REQUEST['billing_zip_code'] = '';
-		$_REQUEST['user_id']          = self::$customer->get_user_id();
+		$_REQUEST['user_id'] = self::$customer->get_user_id();
 
 		$rules = $checkout->get_validation_rules();
 
-		$this->assertSame('country', $rules['billing_country']);
+		$this->assertSame('', $rules['billing_country']);
 		$this->assertSame('', $rules['billing_zip_code']);
 		$this->assertTrue($checkout->validate($rules));
 
-		unset($_REQUEST['billing_country'], $_REQUEST['billing_zip_code'], $_REQUEST['user_id']);
+		unset($_REQUEST['user_id']);
 
 		$checkout->checkout_form = null;
 	}


### PR DESCRIPTION
## Summary

- detect optional `billing_address` composite fields while building checkout validation rules
- relax Country and ZIP validation when the composite field is hidden and empty
- cover an earlier-step optional billing-address configuration that is returned unexpanded by `Checkout_Form::get_all_fields()`

## Verification

- `php -l inc/checkout/class-checkout.php`
- `php -l tests/WP_Ultimo/Checkout/Checkout_Test.php`
- `git diff --check`

`bash bin/check-env.sh` confirms the local PHPUnit environment is unavailable because Composer dependencies, the WordPress development install, and the WordPress test suite are absent.

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.161 plugin for [OpenCode](https://opencode.ai) v1.18.4


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved checkout validation for optional billing addresses.
  * Billing country and postal code are no longer incorrectly required when included through an optional composite billing address field.

* **Tests**
  * Updated checkout validation coverage for optional billing address configurations, including combined postal code and country fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->