### PR TITLE
GH#1657: Pad autogenerated site names

### DIFF
--- a/inc/checkout/class-checkout.php
+++ b/inc/checkout/class-checkout.php
@@ -1578,7 +1578,7 @@ class Checkout {
 		 */
 		if (empty($site_url) || in_array($auto_generate_url, ['username', 'site_title'], true)) {
 			if ('username' === $auto_generate_url) {
-				$site_url   = $this->customer->get_username();
+				$site_url   = wu_generate_unique_site_url($this->customer->get_username(), $this->request_or_session('site_domain'));
 				$site_title = $site_title ?: $site_url;
 			} elseif ('site_title' === $auto_generate_url && $site_title) {
 				/*
@@ -2799,7 +2799,7 @@ class Checkout {
 			'billing_zip_code' => '',
 		];
 
-		$billing_rule_fields           = $this->checkout_form ? $this->checkout_form->get_all_fields() : $this->step['fields'];
+		$billing_rule_fields          = $this->checkout_form ? $this->checkout_form->get_all_fields() : $this->step['fields'];
 		$has_optional_billing_address = false;
 
 		foreach ($billing_rule_fields as $field_key => $field) {

--- a/inc/functions/site.php
+++ b/inc/functions/site.php
@@ -440,6 +440,17 @@ function wu_generate_site_url_from_title($site_title) {
 		// Ensure it starts with a letter (WordPress requirement)
 		$slug = 'site' . $slug;
 	}
+
+	/*
+	 * WordPress rejects network site names shorter than four characters.
+	 * Auto-generated usernames can legitimately be shorter (for example,
+	 * "me" from me@example.com), so pad generated slugs before checkout
+	 * validates or provisions the site.
+	 */
+	if (strlen($slug) < 4) {
+		$slug = str_pad($slug, 4, '0');
+	}
+
 	return $slug;
 }
 

--- a/tests/WP_Ultimo/Functions/Site_Functions_Extended_Test.php
+++ b/tests/WP_Ultimo/Functions/Site_Functions_Extended_Test.php
@@ -162,6 +162,17 @@ class Site_Functions_Extended_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Test wu_generate_site_url_from_title pads short slugs for WordPress.
+	 */
+	public function test_generate_site_url_from_title_pads_short_slug(): void {
+
+		$result = wu_generate_site_url_from_title('me');
+
+		$this->assertEquals('me00', $result);
+		$this->assertGreaterThanOrEqual(4, strlen($result));
+	}
+
+	/**
 	 * Test wu_generate_site_title_from_email with valid email.
 	 */
 	public function test_generate_site_title_from_email(): void {


### PR DESCRIPTION
## Summary

- Pad automatically generated site slugs to the WordPress four-character minimum.
- Generate username-derived checkout site URLs through the unique-slug helper.
- Add regression coverage for short generated slugs.

## Testing

- `php -l inc/functions/site.php`
- `php -l inc/checkout/class-checkout.php`
- `php -l tests/WP_Ultimo/Functions/Site_Functions_Extended_Test.php`
- Pre-commit PHPCS and PHPStan

## Runtime Testing

- Not run: the local WordPress test environment is unavailable (`/tmp/wordpress-tests-lib` and `../wordpress` are absent).

Resolves #1657

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.162 plugin for [OpenCode](https://opencode.ai) v1.18.4 with gpt-5.6-terra spent 6m and 142,263 tokens on this as a headless worker.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved automatically generated site URLs to ensure they are unique.
  * Short site names are now normalized to meet minimum hostname length requirements.
  * Prevented potential conflicts when creating sites from customer usernames or short titles.

* **Tests**
  * Added coverage for generating valid URLs from very short site titles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->