### PR TITLE
GH#1659: align checkout billing rule assignment

### DIFF
--- a/inc/checkout/class-checkout.php
+++ b/inc/checkout/class-checkout.php
@@ -2799,7 +2799,7 @@ class Checkout {
 			'billing_zip_code' => '',
 		];
 
-		$billing_rule_fields           = $this->checkout_form ? $this->checkout_form->get_all_fields() : $this->step['fields'];
+		$billing_rule_fields          = $this->checkout_form ? $this->checkout_form->get_all_fields() : $this->step['fields'];
 		$has_optional_billing_address = false;
 
 		foreach ($billing_rule_fields as $field_key => $field) {


### PR DESCRIPTION
## Summary

- Align the checkout billing-rule assignment with adjacent declarations.

## Verification

- `php -l inc/checkout/class-checkout.php`
- `vendor/bin/phpcs inc/checkout/class-checkout.php`
- `vendor/bin/phpstan analyse`
- `git diff --check`

Resolves #1659

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.165 plugin for [OpenCode](https://opencode.ai) v1.18.4


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved code formatting for checkout validation rules without changing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->