### PR TITLE
feat(admin): surface recent log errors

### DIFF
--- a/inc/class-admin-notices.php
+++ b/inc/class-admin-notices.php
@@ -114,7 +114,7 @@ class Admin_Notices implements \WP_Ultimo\Interfaces\Singleton {
 		 * @param array  $notices List of notices for that particular panel.
 		 * @param array  $all_notices List of notices added, segregated by panel.
 		 * @param string $panel Panel to retrieve the notices.
-		 * @param string $filter If the dismissable notices have been filtered out.
+		 * @param bool   $filter If the dismissable notices have been filtered out.
 		 * @param array  $dismissed_messages List of dismissed notice keys.
 		* @return array
 		 */
@@ -163,6 +163,8 @@ class Admin_Notices implements \WP_Ultimo\Interfaces\Singleton {
 
 		$panel = $this->get_current_panel();
 
+		$this->maybe_add_recent_error_notice($panel);
+
 		$notices = $this->get_notices($panel);
 
 		wu_get_template(
@@ -170,6 +172,57 @@ class Admin_Notices implements \WP_Ultimo\Interfaces\Singleton {
 			[
 				'notices' => $notices,
 				'nonce'   => wp_create_nonce('wu-dismiss-admin-notice'),
+			]
+		);
+	}
+
+	/**
+	 * Adds a dismissible notice for the latest recent error log entry.
+	 *
+	 * @since 2.14.3
+	 *
+	 * @param string $panel Current admin panel.
+	 * @return void
+	 */
+	private function maybe_add_recent_error_notice(string $panel): void {
+
+		if ('network-admin' !== $panel || ! current_user_can('manage_network')) {
+			return;
+		}
+
+		$page = sanitize_key(wu_request('page'));
+
+		if ('ultimate-multisite' !== $page && ! str_starts_with($page, 'wp-ultimo')) {
+			return;
+		}
+
+		$error = Logger::get_recent_error();
+
+		if ( ! $error) {
+			return;
+		}
+
+		$handle    = $error['handle'] ?? __('unknown', 'ultimate-multisite');
+		$message   = $error['message'] ?? __('No details available.', 'ultimate-multisite');
+		$timestamp = (int) ($error['timestamp'] ?? 0);
+
+		$notice = sprintf(
+			/* translators: 1: Log handle, 2: error message. */
+			__('A recent Ultimate Multisite error was logged in %1$s: %2$s', 'ultimate-multisite'),
+			esc_html($handle . '.log'),
+			esc_html($message)
+		);
+
+		$this->add(
+			$notice,
+			'error',
+			'network-admin',
+			'wu-recent-error-log-' . $timestamp,
+			[
+				'view-logs' => [
+					'title' => __('View Logs', 'ultimate-multisite'),
+					'url'   => wu_network_admin_url('wp-ultimo-view-logs'),
+				],
 			]
 		);
 	}

--- a/inc/class-admin-notices.php
+++ b/inc/class-admin-notices.php
@@ -205,6 +205,9 @@ class Admin_Notices implements \WP_Ultimo\Interfaces\Singleton {
 		$handle    = $error['handle'] ?? __('unknown', 'ultimate-multisite');
 		$message   = $error['message'] ?? __('No details available.', 'ultimate-multisite');
 		$timestamp = (int) ($error['timestamp'] ?? 0);
+		$level     = $error['level'] ?? '';
+
+		$dismissible_key = 'wu-recent-error-log-' . md5(wp_json_encode([$timestamp, $handle, $message, $level]));
 
 		$notice = sprintf(
 			/* translators: 1: Log handle, 2: error message. */
@@ -217,7 +220,7 @@ class Admin_Notices implements \WP_Ultimo\Interfaces\Singleton {
 			$notice,
 			'error',
 			'network-admin',
-			'wu-recent-error-log-' . $timestamp,
+			$dismissible_key,
 			[
 				'view-logs' => [
 					'title' => __('View Logs', 'ultimate-multisite'),

--- a/inc/class-logger.php
+++ b/inc/class-logger.php
@@ -27,6 +27,22 @@ class Logger extends AbstractLogger {
 	use \WP_Ultimo\Traits\Singleton;
 
 	/**
+	 * Site option that stores the latest error-level log entry.
+	 *
+	 * @since 2.14.3
+	 * @var string
+	 */
+	private const RECENT_ERROR_OPTION = 'wu_recent_error_log_entry';
+
+	/**
+	 * How long an error log entry should be considered recent.
+	 *
+	 * @since 2.14.3
+	 * @var int
+	 */
+	private const RECENT_ERROR_TTL = DAY_IN_SECONDS;
+
+	/**
 	 * Holds the log file path.
 	 *
 	 * @since 2.1
@@ -109,7 +125,60 @@ class Logger extends AbstractLogger {
 
 		$instance->log($log_level, $message);
 
+		self::maybe_store_recent_error($handle, (string) $message, $log_level);
+
 		do_action('wu_log_add', $handle, $message, $log_level);
+	}
+
+	/**
+	 * Stores the latest error-level log entry for admin notices.
+	 *
+	 * @since 2.14.3
+	 *
+	 * @param string $handle    Name of the log file written to.
+	 * @param string $message   Log message written.
+	 * @param string $log_level PSR-3 log level.
+	 * @return void
+	 */
+	private static function maybe_store_recent_error(string $handle, string $message, string $log_level): void {
+
+		if ( ! in_array($log_level, [LogLevel::EMERGENCY, LogLevel::ALERT, LogLevel::CRITICAL, LogLevel::ERROR], true)) {
+			return;
+		}
+
+		$message = wp_strip_all_tags($message);
+
+		update_site_option(
+			self::RECENT_ERROR_OPTION,
+			[
+				'handle'    => sanitize_key($handle),
+				'message'   => substr($message, 0, 300),
+				'level'     => $log_level,
+				'timestamp' => time(),
+			]
+		);
+	}
+
+	/**
+	 * Returns the latest recent error-level log entry.
+	 *
+	 * @since 2.14.3
+	 *
+	 * @return array|false Latest error entry, or false when none is recent.
+	 */
+	public static function get_recent_error() {
+
+		$entry = get_site_option(self::RECENT_ERROR_OPTION, false);
+
+		if ( ! is_array($entry) || empty($entry['timestamp'])) {
+			return false;
+		}
+
+		if ((int) $entry['timestamp'] < time() - self::RECENT_ERROR_TTL) {
+			return false;
+		}
+
+		return $entry;
 	}
 
 	/**

--- a/inc/duplication/data.php
+++ b/inc/duplication/data.php
@@ -811,7 +811,11 @@ if ( ! class_exists('MUCD_Data') ) {
 			}
 
 			if ('' !== $wpdb->last_error) {
-				self::sql_error($sql_query, $wpdb->last_error);
+				$last_error = $wpdb->last_error;
+
+				self::sql_error($sql_query, $last_error);
+
+				$wpdb->last_error = $last_error;
 			}
 
 			$wpdb->suppress_errors(false);

--- a/tests/WP_Ultimo/Admin_Notices_Test.php
+++ b/tests/WP_Ultimo/Admin_Notices_Test.php
@@ -46,6 +46,17 @@ class Admin_Notices_Test extends \WP_UnitTestCase {
 	}
 
 	/**
+	 * Clean up the shared recent-error notice state.
+	 */
+	public function tear_down(): void {
+
+		unset($_REQUEST['page']);
+		delete_site_option('wu_recent_error_log_entry');
+
+		parent::tear_down();
+	}
+
+	/**
 	 * Test singleton instance.
 	 */
 	public function test_singleton_instance(): void {
@@ -310,8 +321,55 @@ class Admin_Notices_Test extends \WP_UnitTestCase {
 		$this->assertSame('error', $notice['type']);
 		$this->assertStringContainsString('integration-hostinger.log', $notice['message']);
 		$this->assertArrayHasKey('view-logs', $notice['actions']);
+	}
 
-		unset($_REQUEST['page']);
-		delete_site_option('wu_recent_error_log_entry');
+	/**
+	 * Test recent error notices logged within the same second are independently dismissible.
+	 */
+	public function test_recent_error_notices_with_same_timestamp_have_unique_dismissible_keys(): void {
+
+		$user_id = self::factory()->user->create(['role' => 'administrator']);
+		grant_super_admin($user_id);
+		wp_set_current_user($user_id);
+
+		$_REQUEST['page'] = 'wp-ultimo-events';
+
+		$reflection = new \ReflectionClass($this->notices);
+		$method     = $reflection->getMethod('maybe_add_recent_error_notice');
+
+		if (PHP_VERSION_ID < 80100) {
+			$method->setAccessible(true);
+		}
+
+		$timestamp = time();
+
+		update_site_option(
+			'wu_recent_error_log_entry',
+			[
+				'handle'    => 'integration-hostinger',
+				'message'   => 'First API failure',
+				'level'     => \Psr\Log\LogLevel::ERROR,
+				'timestamp' => $timestamp,
+			]
+		);
+
+		$method->invoke($this->notices, 'network-admin');
+
+		update_site_option(
+			'wu_recent_error_log_entry',
+			[
+				'handle'    => 'integration-hostinger',
+				'message'   => 'Second API failure',
+				'level'     => \Psr\Log\LogLevel::ERROR,
+				'timestamp' => $timestamp,
+			]
+		);
+
+		$method->invoke($this->notices, 'network-admin');
+
+		$notices = $this->notices->get_notices('network-admin', false);
+
+		$this->assertCount(2, $notices);
+		$this->assertCount(2, array_unique(array_column($notices, 'dismissible_key')));
 	}
 }

--- a/tests/WP_Ultimo/Admin_Notices_Test.php
+++ b/tests/WP_Ultimo/Admin_Notices_Test.php
@@ -272,4 +272,46 @@ class Admin_Notices_Test extends \WP_UnitTestCase {
 
 		remove_all_filters('wu_admin_notices');
 	}
+
+	/**
+	 * Test recent error log notice is added on Ultimate Multisite network pages.
+	 */
+	public function test_recent_error_notice_added_on_ultimate_multisite_network_page(): void {
+
+		$user_id = self::factory()->user->create(['role' => 'administrator']);
+		grant_super_admin($user_id);
+		wp_set_current_user($user_id);
+
+		$_REQUEST['page'] = 'wp-ultimo-events';
+
+		update_site_option(
+			'wu_recent_error_log_entry',
+			[
+				'handle'    => 'integration-hostinger',
+				'message'   => 'Hostinger API failed',
+				'level'     => \Psr\Log\LogLevel::ERROR,
+				'timestamp' => time(),
+			]
+		);
+
+		$reflection = new \ReflectionClass($this->notices);
+		$method     = $reflection->getMethod('maybe_add_recent_error_notice');
+
+		if (PHP_VERSION_ID < 80100) {
+			$method->setAccessible(true);
+		}
+
+		$method->invoke($this->notices, 'network-admin');
+
+		$notices = $this->notices->get_notices('network-admin', false);
+		$notice  = reset($notices);
+
+		$this->assertCount(1, $notices);
+		$this->assertSame('error', $notice['type']);
+		$this->assertStringContainsString('integration-hostinger.log', $notice['message']);
+		$this->assertArrayHasKey('view-logs', $notice['actions']);
+
+		unset($_REQUEST['page']);
+		delete_site_option('wu_recent_error_log_entry');
+	}
 }

--- a/tests/WP_Ultimo/Logger_Recent_Error_Test.php
+++ b/tests/WP_Ultimo/Logger_Recent_Error_Test.php
@@ -1,0 +1,72 @@
+<?php
+/**
+ * Test recent error tracking for Logger.
+ *
+ * @package WP_Ultimo
+ * @subpackage Tests
+ */
+
+namespace WP_Ultimo\Tests;
+
+use Psr\Log\LogLevel;
+use WP_Ultimo\Logger;
+
+/**
+ * Test recent error tracking for Logger.
+ */
+class Logger_Recent_Error_Test extends \WP_UnitTestCase {
+
+	/**
+	 * Clean the recent error marker before each test.
+	 */
+	public function set_up(): void {
+
+		parent::set_up();
+
+		delete_site_option('wu_recent_error_log_entry');
+		wu_save_setting('error_logging_level', 'all');
+	}
+
+	/**
+	 * Clean the recent error marker after each test.
+	 */
+	public function tear_down(): void {
+
+		delete_site_option('wu_recent_error_log_entry');
+
+		parent::tear_down();
+	}
+
+	/**
+	 * Error-level log entries update the recent error marker.
+	 */
+	public function test_add_error_updates_recent_error_marker(): void {
+
+		$handle = 'test_recent_error_' . uniqid();
+
+		Logger::add($handle, 'Most recent error message', LogLevel::ERROR);
+
+		$entry = Logger::get_recent_error();
+
+		$this->assertIsArray($entry);
+		$this->assertSame(sanitize_key($handle), $entry['handle']);
+		$this->assertSame('Most recent error message', $entry['message']);
+		$this->assertSame(LogLevel::ERROR, $entry['level']);
+
+		Logger::clear($handle);
+	}
+
+	/**
+	 * Non-error log entries do not update the recent error marker.
+	 */
+	public function test_add_info_does_not_update_recent_error_marker(): void {
+
+		$handle = 'test_recent_info_' . uniqid();
+
+		Logger::add($handle, 'Informational message', LogLevel::INFO);
+
+		$this->assertFalse(Logger::get_recent_error());
+
+		Logger::clear($handle);
+	}
+}

--- a/tests/WP_Ultimo/Logger_Recent_Error_Test.php
+++ b/tests/WP_Ultimo/Logger_Recent_Error_Test.php
@@ -17,11 +17,20 @@ use WP_Ultimo\Logger;
 class Logger_Recent_Error_Test extends \WP_UnitTestCase {
 
 	/**
+	 * The error logging level before each test.
+	 *
+	 * @var string
+	 */
+	private $error_logging_level;
+
+	/**
 	 * Clean the recent error marker before each test.
 	 */
 	public function set_up(): void {
 
 		parent::set_up();
+
+		$this->error_logging_level = wu_get_setting('error_logging_level', 'default');
 
 		delete_site_option('wu_recent_error_log_entry');
 		wu_save_setting('error_logging_level', 'all');
@@ -33,6 +42,7 @@ class Logger_Recent_Error_Test extends \WP_UnitTestCase {
 	public function tear_down(): void {
 
 		delete_site_option('wu_recent_error_log_entry');
+		wu_save_setting('error_logging_level', $this->error_logging_level);
 
 		parent::tear_down();
 	}

--- a/views/ui/branding/footer.php
+++ b/views/ui/branding/footer.php
@@ -47,6 +47,11 @@ defined('ABSPATH') || exit;
 			<?php esc_html_e('Job Queue', 'ultimate-multisite'); ?>
 		</a>
 		</li>
+		<li class="wu-inline-block wu-mx-1">
+		<a href="<?php echo esc_attr(wu_network_admin_url('wp-ultimo-view-logs')); ?>" class="wu-text-gray-500 hover:wu-text-gray-600">
+			<?php esc_html_e('View Logs', 'ultimate-multisite'); ?>
+		</a>
+		</li>
 
 	<?php endif; ?>
 


### PR DESCRIPTION
## Summary

- Add a View Logs footer link after Job Queue on Ultimate Multisite admin pages.
- Track the latest recent error-level log entry when writing logs, without scanning log files.
- Show one dismissible Ultimate Multisite network-admin notice for the latest recent logged error, with a View Logs action.

## Verification

- php -l on modified PHP files
- vendor/bin/phpcs inc/class-logger.php inc/class-admin-notices.php views/ui/branding/footer.php tests/WP_Ultimo/Admin_Notices_Test.php tests/WP_Ultimo/Logger_Recent_Error_Test.php
- vendor/bin/phpstan analyse inc/class-admin-notices.php inc/class-logger.php --no-progress
- git diff --check

## Notes

- vendor/bin/phpunit --filter Logger_Recent_Error_Test|Admin_Notices_Test could not run locally because /tmp/wordpress-tests-lib/includes/functions.php is missing.

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.170 plugin for [OpenCode](https://opencode.ai) v1.18.4


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added dismissible “recent error” alerts on relevant network administration pages, including a **View Logs** action.
  * Added a **View Logs** link to the administration footer.
  * Recent error details are retained briefly for administrator visibility.
* **Bug Fixes**
  * Informational log entries no longer trigger recent-error alerts.
  * Fixed dismissal behavior so multiple errors with the same timestamp generate unique dismissal keys.
* **Tests**
  * Added/expanded automated coverage for recent-error logging and admin notice rendering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->