### PR TITLE
fix: clear stale import cron events

### DIFF
--- a/inc/site-exporter/class-site-exporter.php
+++ b/inc/site-exporter/class-site-exporter.php
@@ -2600,12 +2600,20 @@ final class Site_Exporter {
 	 */
 	public function maybe_run_imports(): void {
 
-		if (wu_exporter_get_pending_imports() && ! wp_next_scheduled('wu_import_site')) {
+		$pending_site_imports = wu_exporter_get_pending_imports();
+
+		if ($pending_site_imports && ! wp_next_scheduled('wu_import_site')) {
 			wp_schedule_event(time() + 10, 'wu_site_every_minute', 'wu_import_site');
+		} elseif (! $pending_site_imports && wp_next_scheduled('wu_import_site')) {
+			wp_clear_scheduled_hook('wu_import_site');
 		}
 
-		if (wu_exporter_get_pending_network_imports() && ! wp_next_scheduled('wu_import_network')) {
+		$pending_network_imports = wu_exporter_get_pending_network_imports();
+
+		if ($pending_network_imports && ! wp_next_scheduled('wu_import_network')) {
 			wp_schedule_event(time() + 10, 'wu_site_every_minute', 'wu_import_network');
+		} elseif (! $pending_network_imports && wp_next_scheduled('wu_import_network')) {
+			wp_clear_scheduled_hook('wu_import_network');
 		}
 	}
 

--- a/tests/WP_Ultimo/Site_Exporter_Test.php
+++ b/tests/WP_Ultimo/Site_Exporter_Test.php
@@ -421,6 +421,25 @@ class Site_Exporter_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Test that maybe_run_imports clears stale import events when no imports are pending.
+	 */
+	public function test_maybe_run_imports_clears_stale_events_without_pending_imports(): void {
+
+		wp_schedule_event(time() + 60, 'wu_site_every_minute', 'wu_import_site');
+		wp_schedule_event(time() + 60, 'wu_site_every_minute', 'wu_import_network');
+
+		$this->assertNotFalse(wp_next_scheduled('wu_import_site'), 'Test requires a stale site import event');
+		$this->assertNotFalse(wp_next_scheduled('wu_import_network'), 'Test requires a stale network import event');
+		$this->assertEmpty(wu_exporter_get_pending_imports(), 'Test requires no pending site imports');
+		$this->assertEmpty(wu_exporter_get_pending_network_imports(), 'Test requires no pending network imports');
+
+		$this->exporter->maybe_run_imports();
+
+		$this->assertFalse(wp_next_scheduled('wu_import_site'), 'Stale wu_import_site event must be cleared without pending imports');
+		$this->assertFalse(wp_next_scheduled('wu_import_network'), 'Stale wu_import_network event must be cleared without pending imports');
+	}
+
+	/**
 	 * Test that maybe_run_imports schedules the wu_import_site event when a site import is pending.
 	 */
 	public function test_maybe_run_imports_schedules_site_event_when_site_import_is_pending(): void {


### PR DESCRIPTION
## Summary

- clear stale `wu_import_site` cron events when no site imports are pending
- clear stale `wu_import_network` cron events when no network imports are pending
- add a regression test for stale import cron event cleanup

## Verification

- `php -l inc/site-exporter/class-site-exporter.php`
- `php -l tests/WP_Ultimo/Site_Exporter_Test.php`
- `vendor/bin/phpcs inc/site-exporter/class-site-exporter.php tests/WP_Ultimo/Site_Exporter_Test.php`
- `vendor/bin/phpunit --filter Site_Exporter_Test`

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.179 plugin for [OpenCode](https://opencode.ai) v1.18.4


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented obsolete site and network import schedules from running when no imports are pending.
  * Improved scheduling so site and network import tasks are independently managed.

* **Tests**
  * Added coverage to verify stale import schedules are removed when their queues are empty.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->