### PR TITLE
fix(integrations): preserve DirectAdmin raw responses

### DIFF
--- a/inc/integrations/providers/directadmin/class-directadmin-integration.php
+++ b/inc/integrations/providers/directadmin/class-directadmin-integration.php
@@ -94,7 +94,9 @@ class DirectAdmin_Integration extends Integration {
 			return $response;
 		}
 
-		if (isset($response['raw']) && false !== stripos((string) $response['raw'], '<html')) {
+		$raw_response = $response['_raw_response'] ?? $response['raw'] ?? '';
+
+		if (false !== stripos((string) $raw_response, '<html')) {
 			return new \WP_Error('directadmin-login-test-failed', __('DirectAdmin returned the login page instead of an API response. Check the username and Login Key or password.', 'ultimate-multisite'));
 		}
 
@@ -297,7 +299,7 @@ class DirectAdmin_Integration extends Integration {
 			parse_str($body, $parsed);
 
 			if ( ! empty($parsed)) {
-				$parsed['raw'] = $body;
+				$parsed['_raw_response'] = $body;
 
 				return $parsed;
 			}

--- a/inc/integrations/providers/directadmin/class-directadmin-integration.php
+++ b/inc/integrations/providers/directadmin/class-directadmin-integration.php
@@ -297,6 +297,8 @@ class DirectAdmin_Integration extends Integration {
 			parse_str($body, $parsed);
 
 			if ( ! empty($parsed)) {
+				$parsed['raw'] = $body;
+
 				return $parsed;
 			}
 		}

--- a/tests/WP_Ultimo/Integrations/Providers/DirectAdmin/DirectAdmin_Integration_Test.php
+++ b/tests/WP_Ultimo/Integrations/Providers/DirectAdmin/DirectAdmin_Integration_Test.php
@@ -129,26 +129,25 @@ class DirectAdmin_Integration_Test extends WP_UnitTestCase {
 				}
 			);
 
-		add_filter(
-			'pre_http_request',
-			function () {
-				return [
-					'headers'  => [],
-					'body'     => '<html><body><input name="username" value="admin"></body></html>',
-					'response' => [
-						'code'    => 200,
-						'message' => 'OK',
-					],
-					'cookies'  => [],
-					'filename' => null,
-				];
-			}
-		);
+		$pre_http_request = function () {
+			return [
+				'headers'  => [],
+				'body'     => 'raw=server-value&error=0&message=<html><body><input name="username" value="admin"></body></html>',
+				'response' => [
+					'code'    => 200,
+					'message' => 'OK',
+				],
+				'cookies'  => [],
+				'filename' => null,
+			];
+		};
+
+		add_filter('pre_http_request', $pre_http_request);
 
 		try {
 			$result = $integration->test_connection();
 		} finally {
-			remove_all_filters('pre_http_request');
+			remove_filter('pre_http_request', $pre_http_request);
 		}
 
 		$this->assertInstanceOf(\WP_Error::class, $result);

--- a/tests/WP_Ultimo/Integrations/Providers/DirectAdmin/DirectAdmin_Integration_Test.php
+++ b/tests/WP_Ultimo/Integrations/Providers/DirectAdmin/DirectAdmin_Integration_Test.php
@@ -110,6 +110,51 @@ class DirectAdmin_Integration_Test extends WP_UnitTestCase {
 		$this->assertSame('directadmin-login-test-failed', $result->get_error_code());
 	}
 
+	public function test_test_connection_detects_url_encoded_login_page_response(): void {
+
+		$integration = $this->getMockBuilder(DirectAdmin_Integration::class)
+			->onlyMethods(['get_credential'])
+			->getMock();
+
+		$integration->method('get_credential')
+			->willReturnCallback(
+				function (string $key) {
+					$credentials = [
+						'WU_DIRECTADMIN_HOST'      => 'server.example.com',
+						'WU_DIRECTADMIN_USERNAME'  => 'admin',
+						'WU_DIRECTADMIN_API_TOKEN' => 'login-key',
+					];
+
+					return $credentials[ $key ] ?? '';
+				}
+			);
+
+		add_filter(
+			'pre_http_request',
+			function () {
+				return [
+					'headers'  => [],
+					'body'     => '<html><body><input name="username" value="admin"></body></html>',
+					'response' => [
+						'code'    => 200,
+						'message' => 'OK',
+					],
+					'cookies'  => [],
+					'filename' => null,
+				];
+			}
+		);
+
+		try {
+			$result = $integration->test_connection();
+		} finally {
+			remove_all_filters('pre_http_request');
+		}
+
+		$this->assertInstanceOf(\WP_Error::class, $result);
+		$this->assertSame('directadmin-login-test-failed', $result->get_error_code());
+	}
+
 	public function test_directadmin_api_request_returns_error_when_host_missing(): void {
 
 		$integration = $this->getMockBuilder(DirectAdmin_Integration::class)


### PR DESCRIPTION
## Summary

- Preserve the original DirectAdmin response body after URL-form parsing.
- Detect HTML login pages that contain form attributes during connection tests.

## Testing

- vendor/bin/phpunit --filter DirectAdmin_Integration_Test
- vendor/bin/phpcs changed DirectAdmin integration files

Resolves #1665


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.180 plugin for [OpenCode](https://opencode.ai) v1.18.4 with gpt-5.6-terra spent 14m and 83,127 tokens on this as a headless worker.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved DirectAdmin connection validation to correctly identify URL-encoded login page responses as failed authentication attempts.
  * Preserved the original DirectAdmin response details when processing non-JSON responses, improving diagnostic information for connection issues.

* **Tests**
  * Added coverage to verify that login page responses produce the expected connection error.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->