### PR TITLE
GH#1667: cover mixed import queue cron cleanup

### DIFF
--- a/tests/WP_Ultimo/Site_Exporter_Test.php
+++ b/tests/WP_Ultimo/Site_Exporter_Test.php
@@ -437,6 +437,25 @@ class Site_Exporter_Test extends WP_UnitTestCase {
 
 		$this->assertFalse(wp_next_scheduled('wu_import_site'), 'Stale wu_import_site event must be cleared without pending imports');
 		$this->assertFalse(wp_next_scheduled('wu_import_network'), 'Stale wu_import_network event must be cleared without pending imports');
+
+		$this->add_pending_site_import();
+		wp_schedule_event(time() + 60, 'wu_site_every_minute', 'wu_import_site');
+		wp_schedule_event(time() + 60, 'wu_site_every_minute', 'wu_import_network');
+
+		$this->exporter->maybe_run_imports();
+
+		$this->assertNotFalse(wp_next_scheduled('wu_import_site'), 'Active wu_import_site event must remain scheduled with pending site imports');
+		$this->assertFalse(wp_next_scheduled('wu_import_network'), 'Stale wu_import_network event must be cleared without pending network imports');
+
+		$this->clear_import_cron_events();
+		$this->add_pending_network_import();
+		wp_schedule_event(time() + 60, 'wu_site_every_minute', 'wu_import_site');
+		wp_schedule_event(time() + 60, 'wu_site_every_minute', 'wu_import_network');
+
+		$this->exporter->maybe_run_imports();
+
+		$this->assertFalse(wp_next_scheduled('wu_import_site'), 'Stale wu_import_site event must be cleared without pending site imports');
+		$this->assertNotFalse(wp_next_scheduled('wu_import_network'), 'Active wu_import_network event must remain scheduled with pending network imports');
 	}
 
 	/**


### PR DESCRIPTION
## Summary

- Add mixed site/network import queue coverage for stale cron cleanup.
- Verify the active queue keeps its scheduled hook while the inactive queue stale hook is removed.

## Testing

- `php -l tests/WP_Ultimo/Site_Exporter_Test.php`
- `vendor/bin/phpcs tests/WP_Ultimo/Site_Exporter_Test.php`
- `vendor/bin/phpunit --filter 'WP_Ultimo\\Site_Exporter\\Site_Exporter_Test'`

## Runtime Testing

- Self-assessed: low-risk test-only change.

Resolves #1667

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.180 plugin for [OpenCode](https://opencode.ai) v1.18.4 with gpt-5.6-terra spent 2m and 50,001 tokens on this as a headless worker.
