### PR TITLE
fix(emails): clarify free checkout notifications

### DIFF
--- a/inc/helpers/class-sender.php
+++ b/inc/helpers/class-sender.php
@@ -242,6 +242,19 @@ class Sender {
 			return $content;
 		}
 
+		/*
+		 * Allow templates to include a block only when the matching payload
+		 * value is truthy. This keeps a single transactional email template
+		 * useful for related outcomes, such as paid checkouts and free trials.
+		 */
+		$content = preg_replace_callback(
+			'/{{#([a-zA-Z0-9_]+)}}(.*?){{\/\1}}/s',
+			function ($matches) use ($payload) {
+				return ! empty($payload[ $matches[1] ]) ? $matches[2] : '';
+			},
+			$content
+		);
+
 		$match = [];
 
 		preg_match_all('/{{(.*?)}}/', $content, $match);

--- a/inc/managers/class-email-manager.php
+++ b/inc/managers/class-email-manager.php
@@ -161,7 +161,7 @@ class Email_Manager extends Base_Manager {
 			/*
 			 * Add the invoice attachment, if need be.
 			 */
-			if (wu_get_isset($payload, 'payment_id') && wu_get_setting('attach_invoice_pdf', true)) {
+			if (wu_get_isset($payload, 'payment_id') && wu_get_setting('attach_invoice_pdf', true) && (! isset($payload['payment_is_paid']) || $payload['payment_is_paid'])) {
 				$invoice_payment = wu_get_payment($payload['payment_id']);
 
 				if ($invoice_payment) {
@@ -391,28 +391,29 @@ class Email_Manager extends Base_Manager {
 	 */
 	public function register_all_default_system_emails(): void {
 		/*
-		 * Payment Successful - Admin
+		 * Checkout Completed - Admin
 		 */
 		$this->register_default_system_email(
 			[
 				'event'   => 'payment_received',
 				'slug'    => 'payment_received_admin',
 				'target'  => 'admin',
-				'title'   => __('You got a new payment!', 'ultimate-multisite'),
+				'title'   => '{{payment_email_admin_subject}}',
 				'content' => wu_get_template_contents('emails/admin/payment-received'),
 			]
 		);
 
 		/*
-		 * Payment Successful - Customer
+		 * Checkout Completed - Customer
 		 */
 		$this->register_default_system_email(
 			[
-				'event'   => 'payment_received',
-				'slug'    => 'payment_received_customer',
-				'target'  => 'customer',
-				'title'   => __('We got your payment!', 'ultimate-multisite'),
-				'content' => wu_get_template_contents('emails/customer/payment-received'),
+				'event'              => 'payment_received',
+				'slug'               => 'payment_received_customer',
+				'target'             => 'customer',
+				'title'              => '{{payment_email_customer_subject}}',
+				'content'            => wu_get_template_contents('emails/customer/payment-received'),
+				'send_copy_to_admin' => false,
 			]
 		);
 

--- a/inc/managers/class-payment-manager.php
+++ b/inc/managers/class-payment-manager.php
@@ -127,6 +127,93 @@ class Payment_Manager extends Base_Manager {
 			}
 		}
 
+		$has_trial = $membership && $membership->is_trialing();
+		$is_paid   = 0 < (float) $payment->get_total();
+
+		$payload['payment_is_paid']        = $is_paid;
+		$payload['payment_is_free_signup'] = ! $is_paid && ! $has_trial;
+		$payload['payment_is_trial']       = $has_trial;
+
+		if ($has_trial && $is_paid) {
+			$payload['payment_email_customer_subject'] = __('Payment confirmed - your trial has started', 'ultimate-multisite');
+			$payload['payment_email_customer_intro']   = sprintf(
+				/* translators: 1: payment total, 2: product names. */
+				__('Your payment of %1$s for %2$s was successful. Your trial is now active.', 'ultimate-multisite'),
+				$payload['payment_total'],
+				$payload['payment_product_names']
+			);
+			$payload['payment_email_admin_subject'] = sprintf(
+				/* translators: 1: payment total, 2: customer name. */
+				__('Payment received: %1$s from %2$s', 'ultimate-multisite'),
+				$payload['payment_total'],
+				$payload['customer_name']
+			);
+			$payload['payment_email_admin_intro'] = sprintf(
+				/* translators: 1: payment total, 2: customer name, 3: product names. */
+				__('Received %1$s from %2$s for %3$s. Their trial is now active.', 'ultimate-multisite'),
+				$payload['payment_total'],
+				$payload['customer_name'],
+				$payload['payment_product_names']
+			);
+		} elseif ($is_paid) {
+			$payload['payment_email_customer_subject'] = __('Payment confirmed', 'ultimate-multisite');
+			$payload['payment_email_customer_intro']   = sprintf(
+				/* translators: 1: payment total, 2: product names. */
+				__('Your payment of %1$s for %2$s was successful.', 'ultimate-multisite'),
+				$payload['payment_total'],
+				$payload['payment_product_names']
+			);
+			$payload['payment_email_admin_subject'] = sprintf(
+				/* translators: 1: payment total, 2: customer name. */
+				__('Payment received: %1$s from %2$s', 'ultimate-multisite'),
+				$payload['payment_total'],
+				$payload['customer_name']
+			);
+			$payload['payment_email_admin_intro'] = sprintf(
+				/* translators: 1: payment total, 2: customer name, 3: product names. */
+				__('Received %1$s from %2$s for %3$s.', 'ultimate-multisite'),
+				$payload['payment_total'],
+				$payload['customer_name'],
+				$payload['payment_product_names']
+			);
+		} elseif ($has_trial) {
+			$payload['payment_email_customer_subject'] = __('Your free trial has started', 'ultimate-multisite');
+			$payload['payment_email_customer_intro']   = sprintf(
+				/* translators: %s: product names. */
+				__('Your %s free trial is now active. You will not be charged today.', 'ultimate-multisite'),
+				$payload['payment_product_names']
+			);
+			$payload['payment_email_admin_subject'] = sprintf(
+				/* translators: %s: customer name. */
+				__('New trial started: %s', 'ultimate-multisite'),
+				$payload['customer_name']
+			);
+			$payload['payment_email_admin_intro'] = sprintf(
+				/* translators: 1: customer name, 2: product names. */
+				__('A free trial for %2$s has started for %1$s. No payment was collected today.', 'ultimate-multisite'),
+				$payload['customer_name'],
+				$payload['payment_product_names']
+			);
+		} else {
+			$payload['payment_email_customer_subject'] = __('Your free membership is active', 'ultimate-multisite');
+			$payload['payment_email_customer_intro']   = sprintf(
+				/* translators: %s: product names. */
+				__('Your free %s is now active. No payment was required.', 'ultimate-multisite'),
+				$payload['payment_product_names']
+			);
+			$payload['payment_email_admin_subject'] = sprintf(
+				/* translators: %s: customer name. */
+				__('New free membership: %s', 'ultimate-multisite'),
+				$payload['customer_name']
+			);
+			$payload['payment_email_admin_intro'] = sprintf(
+				/* translators: 1: customer name, 2: product names. */
+				__('A free membership for %2$s has been created for %1$s. No payment was collected.', 'ultimate-multisite'),
+				$payload['customer_name'],
+				$payload['payment_product_names']
+			);
+		}
+
 		wu_do_event('payment_received', $payload);
 	}
 

--- a/inc/managers/class-payment-manager.php
+++ b/inc/managers/class-payment-manager.php
@@ -127,8 +127,10 @@ class Payment_Manager extends Base_Manager {
 			}
 		}
 
-		$has_trial = $membership && $membership->is_trialing();
-		$is_paid   = 0 < (float) $payment->get_total();
+		$has_trial             = $membership && $membership->is_trialing();
+		$is_paid               = 0 < (float) $payment->get_total();
+		$customer_name         = wu_get_isset($payload, 'customer_name', '');
+		$payment_product_names = wu_get_isset($payload, 'payment_product_names', '');
 
 		$payload['payment_is_paid']        = $is_paid;
 		$payload['payment_is_free_signup'] = ! $is_paid && ! $has_trial;
@@ -140,20 +142,20 @@ class Payment_Manager extends Base_Manager {
 				/* translators: 1: payment total, 2: product names. */
 				__('Your payment of %1$s for %2$s was successful. Your trial is now active.', 'ultimate-multisite'),
 				$payload['payment_total'],
-				$payload['payment_product_names']
+				$payment_product_names
 			);
 			$payload['payment_email_admin_subject'] = sprintf(
 				/* translators: 1: payment total, 2: customer name. */
 				__('Payment received: %1$s from %2$s', 'ultimate-multisite'),
 				$payload['payment_total'],
-				$payload['customer_name']
+				$customer_name
 			);
 			$payload['payment_email_admin_intro'] = sprintf(
 				/* translators: 1: payment total, 2: customer name, 3: product names. */
 				__('Received %1$s from %2$s for %3$s. Their trial is now active.', 'ultimate-multisite'),
 				$payload['payment_total'],
-				$payload['customer_name'],
-				$payload['payment_product_names']
+				$customer_name,
+				$payment_product_names
 			);
 		} elseif ($is_paid) {
 			$payload['payment_email_customer_subject'] = __('Payment confirmed', 'ultimate-multisite');
@@ -161,56 +163,56 @@ class Payment_Manager extends Base_Manager {
 				/* translators: 1: payment total, 2: product names. */
 				__('Your payment of %1$s for %2$s was successful.', 'ultimate-multisite'),
 				$payload['payment_total'],
-				$payload['payment_product_names']
+				$payment_product_names
 			);
 			$payload['payment_email_admin_subject'] = sprintf(
 				/* translators: 1: payment total, 2: customer name. */
 				__('Payment received: %1$s from %2$s', 'ultimate-multisite'),
 				$payload['payment_total'],
-				$payload['customer_name']
+				$customer_name
 			);
 			$payload['payment_email_admin_intro'] = sprintf(
 				/* translators: 1: payment total, 2: customer name, 3: product names. */
 				__('Received %1$s from %2$s for %3$s.', 'ultimate-multisite'),
 				$payload['payment_total'],
-				$payload['customer_name'],
-				$payload['payment_product_names']
+				$customer_name,
+				$payment_product_names
 			);
 		} elseif ($has_trial) {
 			$payload['payment_email_customer_subject'] = __('Your free trial has started', 'ultimate-multisite');
 			$payload['payment_email_customer_intro']   = sprintf(
 				/* translators: %s: product names. */
 				__('Your %s free trial is now active. You will not be charged today.', 'ultimate-multisite'),
-				$payload['payment_product_names']
+				$payment_product_names
 			);
 			$payload['payment_email_admin_subject'] = sprintf(
 				/* translators: %s: customer name. */
 				__('New trial started: %s', 'ultimate-multisite'),
-				$payload['customer_name']
+				$customer_name
 			);
 			$payload['payment_email_admin_intro'] = sprintf(
 				/* translators: 1: customer name, 2: product names. */
 				__('A free trial for %2$s has started for %1$s. No payment was collected today.', 'ultimate-multisite'),
-				$payload['customer_name'],
-				$payload['payment_product_names']
+				$customer_name,
+				$payment_product_names
 			);
 		} else {
 			$payload['payment_email_customer_subject'] = __('Your free membership is active', 'ultimate-multisite');
 			$payload['payment_email_customer_intro']   = sprintf(
 				/* translators: %s: product names. */
 				__('Your free %s is now active. No payment was required.', 'ultimate-multisite'),
-				$payload['payment_product_names']
+				$payment_product_names
 			);
 			$payload['payment_email_admin_subject'] = sprintf(
 				/* translators: %s: customer name. */
 				__('New free membership: %s', 'ultimate-multisite'),
-				$payload['customer_name']
+				$customer_name
 			);
 			$payload['payment_email_admin_intro'] = sprintf(
 				/* translators: 1: customer name, 2: product names. */
 				__('A free membership for %2$s has been created for %1$s. No payment was collected.', 'ultimate-multisite'),
-				$payload['customer_name'],
-				$payload['payment_product_names']
+				$customer_name,
+				$payment_product_names
 			);
 		}
 

--- a/tests/WP_Ultimo/Helpers/Sender_Test.php
+++ b/tests/WP_Ultimo/Helpers/Sender_Test.php
@@ -157,6 +157,28 @@ class Sender_Test extends WP_UnitTestCase {
 		$this->assertStringContainsString('42', $result);
 	}
 
+	/**
+	 * Test process_shortcodes renders conditional blocks for truthy payload values.
+	 */
+	public function test_process_shortcodes_renders_truthy_conditional_blocks() {
+		$content = 'Hello {{#payment_is_paid}}payment received{{/payment_is_paid}}!';
+
+		$result = Sender::process_shortcodes($content, ['payment_is_paid' => true]);
+
+		$this->assertEquals('Hello payment received!', $result);
+	}
+
+	/**
+	 * Test process_shortcodes removes conditional blocks for false payload values.
+	 */
+	public function test_process_shortcodes_removes_false_conditional_blocks() {
+		$content = 'Hello {{#payment_is_paid}}payment received{{/payment_is_paid}}!';
+
+		$result = Sender::process_shortcodes($content, ['payment_is_paid' => false]);
+
+		$this->assertEquals('Hello !', $result);
+	}
+
 	// ------------------------------------------------------------------
 	// send_mail — BCC strategy regression coverage (#1195 / GDPR fix +
 	// recipient validation fix for the 'undisclosed-recipients:;'
@@ -242,6 +264,7 @@ class Sender_Test extends WP_UnitTestCase {
 	public function test_send_mail_returns_false_when_all_bcc_recipients_are_filtered_out() {
 		$wp_mail_called = false;
 		$callback       = function ($short_circuit, $atts) use (&$wp_mail_called) {
+			unset($short_circuit, $atts);
 			$wp_mail_called = true;
 			return true;
 		};
@@ -284,6 +307,7 @@ class Sender_Test extends WP_UnitTestCase {
 	 */
 	public function test_send_mail_catches_throwable_from_wp_mail() {
 		$callback = function ($short_circuit, $atts) {
+			unset($short_circuit, $atts);
 			throw new \RuntimeException( 'Simulated SMTP plugin failure' );
 		};
 		add_filter( 'pre_wp_mail', $callback, 10, 2 );

--- a/tests/WP_Ultimo/Managers/Email_Manager_Test.php
+++ b/tests/WP_Ultimo/Managers/Email_Manager_Test.php
@@ -93,6 +93,9 @@ class Email_Manager_Test extends \WP_UnitTestCase {
 		$this->assertArrayHasKey('payment_received_customer', $registered_emails);
 		$this->assertArrayHasKey('site_published_admin', $registered_emails);
 		$this->assertArrayHasKey('site_published_customer', $registered_emails);
+		$this->assertSame('{{payment_email_admin_subject}}', $registered_emails['payment_received_admin']['title']);
+		$this->assertSame('{{payment_email_customer_subject}}', $registered_emails['payment_received_customer']['title']);
+		$this->assertFalse($registered_emails['payment_received_customer']['send_copy_to_admin']);
 	}
 
 	/**

--- a/views/emails/admin/payment-received.php
+++ b/views/emails/admin/payment-received.php
@@ -1,126 +1,86 @@
 <?php
 /**
- * Payment Received Email Template
+ * Checkout Completed Email Template - Admin
  *
  * @since 2.0.0
  */
 defined('ABSPATH') || exit;
 ?>
 <p><?php esc_html_e('Hey there', 'ultimate-multisite'); ?></p>
-<?php // translators: %1$s: Customer name, %2$s: Customer email, %3$s: Customer user email, %4$s: Payment total. ?>
-<p><?php printf(esc_html__('We have great news! You received %1$s from %2$s (%3$s) for %4$s.', 'ultimate-multisite'), '{{payment_total}}', '{{customer_name}}', '{{customer_user_email}}', '{{payment_product_names}}'); ?></p>
+<p>{{payment_email_admin_intro}}</p>
 
-<p><a href="{{payment_invoice_url}}" style="text-decoration: none;" rel="nofollow"><?php esc_html_e('Download Invoice', 'ultimate-multisite'); ?></a></p>
+{{#payment_is_paid}}
+<p><a href="{{payment_invoice_url}}" style="text-decoration: none;" rel="nofollow"><?php esc_html_e('Download Receipt', 'ultimate-multisite'); ?></a></p>
 
-<h2><b><?php esc_html_e('Payment', 'ultimate-multisite'); ?></b></h2>
+<h2><b><?php esc_html_e('Payment Details', 'ultimate-multisite'); ?></b></h2>
 
 <table cellpadding="0" cellspacing="0" style="width: 100%; border-collapse: collapse;">
 	<tbody>
 	<tr>
 		<td style="text-align: right; width: 160px; padding: 8px; background: #f9f9f9; border: 1px solid #eee;"><b><?php esc_html_e('Products', 'ultimate-multisite'); ?></b></td>
-		<td style="padding: 8px; background: #fff; border: 1px solid #eee; border: 1px solid #eee;">
-		{{payment_product_names}}
-		</td>
+		<td style="padding: 8px; background: #fff; border: 1px solid #eee;">{{payment_product_names}}</td>
 	</tr>
 	<tr>
-		<td style="text-align: right; width: 160px; padding: 8px; background: #f9f9f9; border: 1px solid #eee;"><b><?php esc_html_e('Subtotal', 'ultimate-multisite'); ?></b></td>
-		<td style="padding: 8px; background: #fff; border: 1px solid #eee;">
-		{{payment_subtotal}}
-		</td>
+		<td style="text-align: right; width: 160px; padding: 8px; background: #f9f9f9; border: 1px solid #eee;"><b><?php esc_html_e('Amount Received', 'ultimate-multisite'); ?></b></td>
+		<td style="padding: 8px; background: #fff; border: 1px solid #eee;">{{payment_total}}</td>
 	</tr>
 	<tr>
-		<td style="text-align: right; width: 160px; padding: 8px; background: #f9f9f9; border: 1px solid #eee;"><b><?php esc_html_e('Tax', 'ultimate-multisite'); ?></b></td>
-		<td style="padding: 8px; background: #fff; border: 1px solid #eee;">
-		{{payment_tax_total}}
-		</td>
+		<td style="text-align: right; width: 160px; padding: 8px; background: #f9f9f9; border: 1px solid #eee;"><b><?php esc_html_e('Paid With', 'ultimate-multisite'); ?></b></td>
+		<td style="padding: 8px; background: #fff; border: 1px solid #eee;">{{payment_gateway}}</td>
 	</tr>
 	<tr>
-		<td style="text-align: right; width: 160px; padding: 8px; background: #f9f9f9; border: 1px solid #eee;"><b><?php esc_html_e('Total', 'ultimate-multisite'); ?></b></td>
-		<td style="padding: 8px; background: #fff; border: 1px solid #eee;">
-		{{payment_total}}
-		</td>
-	</tr>
-	<tr>
-		<td style="text-align: right; width: 160px; padding: 8px; background: #f9f9f9; border: 1px solid #eee;"><b><?php esc_html_e('Paid with', 'ultimate-multisite'); ?></b></td>
-		<td style="padding: 8px; background: #fdfdfd; border: 1px solid #eee;">{{payment_gateway}}</td>
-	</tr>
-	<tr>
-		<td style="text-align: right; width: 160px; padding: 8px; background: #f9f9f9; border: 1px solid #eee;"><b><?php esc_html_e('ID', 'ultimate-multisite'); ?></b></td>
-		<td style="padding: 8px; background: #fdfdfd; border: 1px solid #eee;">
-		<a href="{{payment_manage_url}}" style="text-decoration: none;" rel="nofollow">{{payment_id}}</a>
-		</td>
-	</tr>
-	<tr>
-		<td style="text-align: right; width: 160px; padding: 8px; background: #f9f9f9; border: 1px solid #eee;"><b><?php esc_html_e('Reference Code', 'ultimate-multisite'); ?></b></td>
-		<td style="padding: 8px; background: #fdfdfd; border: 1px solid #eee;">
-		<a href="{{payment_manage_url}}" style="text-decoration: none;" rel="nofollow">{{payment_reference_code}}</a>
-		</td>
-	</tr>
-	<tr>
-		<td style="text-align: right; width: 160px; padding: 8px; background: #f9f9f9; border: 1px solid #eee;"><b><?php esc_html_e('Processed at', 'ultimate-multisite'); ?></b></td>
-		<td style="padding: 8px; background: #fff; border: 1px solid #eee;">{{payment_date_created}}</td>
-	</tr>
-	<tr>
-		<td style="text-align: right; width: 160px; padding: 8px; background: #f9f9f9;"><b><?php esc_html_e('Invoice', 'ultimate-multisite'); ?></b></td>
-		<td style="padding: 8px; background: #fdfdfd; border: 1px solid #eee;">
-		<a href="{{payment_invoice_url}}" style="text-decoration: none;" rel="nofollow">
-			<?php esc_html_e('Download PDF', 'ultimate-multisite'); ?>
-		</a>
-		</td>
-	</tr>
-	<tr>
-		<td style="text-align: right; width: 160px; padding: 8px; background: #f9f9f9; border: 1px solid #eee;"><b><?php esc_html_e('Type', 'ultimate-multisite'); ?></b></td>
-		<td style="padding: 8px; background: #fff; border: 1px solid #eee;">Initial Payment</td>
-	</tr>
-	<tr>
-		<td style="text-align: right; width: 160px; padding: 8px; background: #f9f9f9; border: 1px solid #eee;"><b><?php esc_html_e('Admin Panel', 'ultimate-multisite'); ?></b></td>
-		<td style="padding: 8px; background: #fff; border: 1px solid #eee;">
-		<a href="{{payment_manage_url}}" style="text-decoration: none;" rel="nofollow"><?php esc_html_e('Go to Payment &rarr;', 'ultimate-multisite'); ?></a>
-		</td>
+		<td style="text-align: right; width: 160px; padding: 8px; background: #f9f9f9; border: 1px solid #eee;"><b><?php esc_html_e('Payment', 'ultimate-multisite'); ?></b></td>
+		<td style="padding: 8px; background: #fff; border: 1px solid #eee;"><a href="{{payment_manage_url}}" style="text-decoration: none;" rel="nofollow">{{payment_reference_code}}</a></td>
 	</tr>
 	</tbody>
 </table>
+{{/payment_is_paid}}
 
-<h2><b><?php esc_html_e('Membership', 'ultimate-multisite'); ?></b></h2>
+{{#payment_is_free_signup}}
+<h2><b><?php esc_html_e('Free Membership', 'ultimate-multisite'); ?></b></h2>
 
 <table cellpadding="0" cellspacing="0" style="width: 100%; border-collapse: collapse;">
 	<tbody>
 	<tr>
-		<td style="text-align: right; width: 160px; padding: 8px; background: #f9f9f9; border: 1px solid #eee;"><b><?php esc_html_e('Amount', 'ultimate-multisite'); ?></b></td>
-		<td style="padding: 8px; background: #fff; border: 1px solid #eee;">
-		{{membership_description}}
-		</td>
+		<td style="text-align: right; width: 160px; padding: 8px; background: #f9f9f9; border: 1px solid #eee;"><b><?php esc_html_e('Products', 'ultimate-multisite'); ?></b></td>
+		<td style="padding: 8px; background: #fff; border: 1px solid #eee;">{{payment_product_names}}</td>
 	</tr>
 	<tr>
-		<td style="text-align: right; width: 160px; padding: 8px; background: #f9f9f9; border: 1px solid #eee;"><b><?php esc_html_e('Initial Amount', 'ultimate-multisite'); ?></b></td>
-		<td style="padding: 8px; background: #fff; border: 1px solid #eee;">
-		{{membership_initial_amount}}
-		</td>
+		<td style="text-align: right; width: 160px; padding: 8px; background: #f9f9f9; border: 1px solid #eee;"><b><?php esc_html_e('Cost Today', 'ultimate-multisite'); ?></b></td>
+		<td style="padding: 8px; background: #fff; border: 1px solid #eee;"><?php esc_html_e('No payment collected', 'ultimate-multisite'); ?></td>
 	</tr>
 	<tr>
-		<td style="text-align: right; width: 160px; padding: 8px; background: #f9f9f9; border: 1px solid #eee;"><b><?php esc_html_e('ID', 'ultimate-multisite'); ?></b></td>
-		<td style="padding: 8px; background: #fdfdfd; border: 1px solid #eee;">
-		<a href="{{membership_manage_url}}" style="text-decoration: none;" rel="nofollow">{{membership_id}}</a>
-		</td>
-	</tr>
-	<tr>
-		<td style="text-align: right; width: 160px; padding: 8px; background: #f9f9f9; border: 1px solid #eee;"><b><?php esc_html_e('Reference Code', 'ultimate-multisite'); ?></b></td>
-		<td style="padding: 8px; background: #fdfdfd; border: 1px solid #eee;">
-		<a href="{{membership_manage_url}}" style="text-decoration: none;" rel="nofollow">{{membership_reference_code}}</a>
-		</td>
-	</tr>
-	<tr>
-		<td style="text-align: right; width: 160px; padding: 8px; background: #f9f9f9; border: 1px solid #eee;"><b><?php esc_html_e('Expiration', 'ultimate-multisite'); ?></b></td>
-		<td style="padding: 8px; background: #fff; border: 1px solid #eee;">{{membership_date_expiration}}</td>
-	</tr>
-	<tr>
-		<td style="text-align: right; width: 160px; padding: 8px; background: #f9f9f9; border: 1px solid #eee;"><b><?php esc_html_e('Admin Panel', 'ultimate-multisite'); ?></b></td>
-		<td style="padding: 8px; background: #fff; border: 1px solid #eee;">
-		<a href="{{membership_manage_url}}" style="text-decoration: none;" rel="nofollow"><?php esc_html_e('Go to Membership &rarr;', 'ultimate-multisite'); ?></a>
-		</td>
+		<td style="text-align: right; width: 160px; padding: 8px; background: #f9f9f9; border: 1px solid #eee;"><b><?php esc_html_e('Membership', 'ultimate-multisite'); ?></b></td>
+		<td style="padding: 8px; background: #fff; border: 1px solid #eee;"><a href="{{membership_manage_url}}" style="text-decoration: none;" rel="nofollow">{{membership_reference_code}}</a></td>
 	</tr>
 	</tbody>
 </table>
+{{/payment_is_free_signup}}
+
+{{#payment_is_trial}}
+<h2><b><?php esc_html_e('Trial Details', 'ultimate-multisite'); ?></b></h2>
+
+<table cellpadding="0" cellspacing="0" style="width: 100%; border-collapse: collapse;">
+	<tbody>
+	<tr>
+		<td style="text-align: right; width: 160px; padding: 8px; background: #f9f9f9; border: 1px solid #eee;"><b><?php esc_html_e('Products', 'ultimate-multisite'); ?></b></td>
+		<td style="padding: 8px; background: #fff; border: 1px solid #eee;">{{payment_product_names}}</td>
+	</tr>
+	<tr>
+		<td style="text-align: right; width: 160px; padding: 8px; background: #f9f9f9; border: 1px solid #eee;"><b><?php esc_html_e('Trial Ends', 'ultimate-multisite'); ?></b></td>
+		<td style="padding: 8px; background: #fff; border: 1px solid #eee;">{{membership_date_expiration}}</td>
+	</tr>
+	<tr>
+		<td style="text-align: right; width: 160px; padding: 8px; background: #f9f9f9; border: 1px solid #eee;"><b><?php esc_html_e('First Payment', 'ultimate-multisite'); ?></b></td>
+		<td style="padding: 8px; background: #fff; border: 1px solid #eee;">{{membership_description}}</td>
+	</tr>
+	<tr>
+		<td style="text-align: right; width: 160px; padding: 8px; background: #f9f9f9; border: 1px solid #eee;"><b><?php esc_html_e('Membership', 'ultimate-multisite'); ?></b></td>
+		<td style="padding: 8px; background: #fff; border: 1px solid #eee;"><a href="{{membership_manage_url}}" style="text-decoration: none;" rel="nofollow">{{membership_reference_code}}</a></td>
+	</tr>
+	</tbody>
+</table>
+{{/payment_is_trial}}
 
 <h2><b><?php esc_html_e('Customer', 'ultimate-multisite'); ?></b></h2>
 
@@ -128,32 +88,15 @@ defined('ABSPATH') || exit;
 	<tbody>
 	<tr>
 		<td style="text-align: right; width: 160px; padding: 8px; background: #f9f9f9; border: 1px solid #eee;"><b><?php esc_html_e('Customer', 'ultimate-multisite'); ?></b></td>
-		<td style="padding: 8px; background: #fff; border: 1px solid #eee;">
-		{{customer_avatar}}<br />
-		{{customer_name}}
-		</td>
+		<td style="padding: 8px; background: #fff; border: 1px solid #eee;">{{customer_name}}</td>
 	</tr>
 	<tr>
 		<td style="text-align: right; width: 160px; padding: 8px; background: #f9f9f9; border: 1px solid #eee;"><b><?php esc_html_e('Email Address', 'ultimate-multisite'); ?></b></td>
-		<td style="padding: 8px; background: #fff; border: 1px solid #eee;">
-		<a href="mailto:{{customer_user_email}}" style="text-decoration: none;" rel="nofollow">{{customer_user_email}}</a>
-		</td>
-	</tr>
-	<tr>
-		<td style="text-align: right; width: 160px; padding: 8px; background: #f9f9f9; border: 1px solid #eee;"><b><?php esc_html_e('ID', 'ultimate-multisite'); ?></b></td>
-		<td style="padding: 8px; background: #fdfdfd; border: 1px solid #eee;">
-		<a href="{{customer_manage_url}}" style="text-decoration: none;" rel="nofollow">{{customer_id}}</a>
-		</td>
-	</tr>
-	<tr>
-		<td style="text-align: right; width: 160px; padding: 8px; background: #f9f9f9; border: 1px solid #eee;"><b><?php esc_html_e('Billing Address', 'ultimate-multisite'); ?></b></td>
-		<td style="padding: 8px; background: #fdfdfd; border: 1px solid #eee;">{{customer_billing_address}}</td>
+		<td style="padding: 8px; background: #fff; border: 1px solid #eee;"><a href="mailto:{{customer_user_email}}" style="text-decoration: none;" rel="nofollow">{{customer_user_email}}</a></td>
 	</tr>
 	<tr>
 		<td style="text-align: right; width: 160px; padding: 8px; background: #f9f9f9; border: 1px solid #eee;"><b><?php esc_html_e('Admin Panel', 'ultimate-multisite'); ?></b></td>
-		<td style="padding: 8px; background: #fff; border: 1px solid #eee;">
-		<a href="{{customer_manage_url}}" style="text-decoration: none;" rel="nofollow"><?php esc_html_e('Go to Customer &rarr;', 'ultimate-multisite'); ?></a>
-		</td>
+		<td style="padding: 8px; background: #fff; border: 1px solid #eee;"><a href="{{customer_manage_url}}" style="text-decoration: none;" rel="nofollow"><?php esc_html_e('Go to Customer &rarr;', 'ultimate-multisite'); ?></a></td>
 	</tr>
 	</tbody>
 </table>

--- a/views/emails/customer/payment-received.php
+++ b/views/emails/customer/payment-received.php
@@ -8,54 +8,65 @@ defined('ABSPATH') || exit;
 ?>
 <?php // translators: %s: Customer Name ?>
 <p><?php printf(esc_html__('Hey %s,', 'ultimate-multisite'), '{{customer_name}}'); ?></p>
-<?php // translators: %1$s: payment amount. ?>
-<p><?php printf(esc_html__('We have great news! We successfully processed your payment of %1$s for %2$s.', 'ultimate-multisite'), '{{payment_total}}', '{{payment_product_names}}'); ?></p>
+<p>{{payment_email_customer_intro}}</p>
 
-<p><a href="{{payment_invoice_url}}" style="text-decoration: none;" rel="nofollow"><?php esc_html_e('Download Invoice', 'ultimate-multisite'); ?></a></p>
+{{#payment_is_paid}}
+<p><a href="{{payment_invoice_url}}" style="text-decoration: none;" rel="nofollow"><?php esc_html_e('Download Receipt', 'ultimate-multisite'); ?></a></p>
 
-<h2><b><?php esc_html_e('Payment', 'ultimate-multisite'); ?></b></h2>
+<h2><b><?php esc_html_e('Payment Details', 'ultimate-multisite'); ?></b></h2>
 
 <table cellpadding="0" cellspacing="0" style="width: 100%; border-collapse: collapse;">
 	<tbody>
 	<tr>
 		<td style="text-align: right; width: 160px; padding: 8px; background: #f9f9f9; border: 1px solid #eee;"><b><?php esc_html_e('Products', 'ultimate-multisite'); ?></b></td>
-		<td style="padding: 8px; background: #fff; border: 1px solid #eee; border: 1px solid #eee;">
-		{{payment_product_names}}
-		</td>
+		<td style="padding: 8px; background: #fff; border: 1px solid #eee;">{{payment_product_names}}</td>
 	</tr>
 	<tr>
-		<td style="text-align: right; width: 160px; padding: 8px; background: #f9f9f9; border: 1px solid #eee;"><b><?php esc_html_e('Subtotal', 'ultimate-multisite'); ?></b></td>
-		<td style="padding: 8px; background: #fff; border: 1px solid #eee;">
-		{{payment_subtotal}}
-		</td>
+		<td style="text-align: right; width: 160px; padding: 8px; background: #f9f9f9; border: 1px solid #eee;"><b><?php esc_html_e('Total Paid', 'ultimate-multisite'); ?></b></td>
+		<td style="padding: 8px; background: #fff; border: 1px solid #eee;">{{payment_total}}</td>
 	</tr>
 	<tr>
-		<td style="text-align: right; width: 160px; padding: 8px; background: #f9f9f9; border: 1px solid #eee;"><b><?php esc_html_e('Tax', 'ultimate-multisite'); ?></b></td>
-		<td style="padding: 8px; background: #fff; border: 1px solid #eee;">
-		{{payment_tax_total}}
-		</td>
-	</tr>
-	<tr>
-		<td style="text-align: right; width: 160px; padding: 8px; background: #f9f9f9; border: 1px solid #eee;"><b><?php esc_html_e('Total', 'ultimate-multisite'); ?></b></td>
-		<td style="padding: 8px; background: #fff; border: 1px solid #eee;">
-		{{payment_total}}
-		</td>
-	</tr>
-	<tr>
-		<td style="text-align: right; width: 160px; padding: 8px; background: #f9f9f9; border: 1px solid #eee;"><b><?php esc_html_e('Processed at', 'ultimate-multisite'); ?></b></td>
+		<td style="text-align: right; width: 160px; padding: 8px; background: #f9f9f9; border: 1px solid #eee;"><b><?php esc_html_e('Paid On', 'ultimate-multisite'); ?></b></td>
 		<td style="padding: 8px; background: #fff; border: 1px solid #eee;">{{payment_date_created}}</td>
-	</tr>
-	<tr>
-		<td style="text-align: right; width: 160px; padding: 8px; background: #f9f9f9;"><b><?php esc_html_e('Invoice', 'ultimate-multisite'); ?></b></td>
-		<td style="padding: 8px; background: #fdfdfd; border: 1px solid #eee;">
-		<a href="{{payment_invoice_url}}" style="text-decoration: none;" rel="nofollow">
-			<?php esc_html_e('Download PDF', 'ultimate-multisite'); ?>
-		</a>
-		</td>
-	</tr>
-	<tr>
-		<td style="text-align: right; width: 160px; padding: 8px; background: #f9f9f9; border: 1px solid #eee;"><b><?php esc_html_e('Type', 'ultimate-multisite'); ?></b></td>
-		<td style="padding: 8px; background: #fff; border: 1px solid #eee;">Initial Payment</td>
 	</tr>
 	</tbody>
 </table>
+{{/payment_is_paid}}
+
+{{#payment_is_free_signup}}
+<h2><b><?php esc_html_e('Membership Details', 'ultimate-multisite'); ?></b></h2>
+
+<table cellpadding="0" cellspacing="0" style="width: 100%; border-collapse: collapse;">
+	<tbody>
+	<tr>
+		<td style="text-align: right; width: 160px; padding: 8px; background: #f9f9f9; border: 1px solid #eee;"><b><?php esc_html_e('Products', 'ultimate-multisite'); ?></b></td>
+		<td style="padding: 8px; background: #fff; border: 1px solid #eee;">{{payment_product_names}}</td>
+	</tr>
+	<tr>
+		<td style="text-align: right; width: 160px; padding: 8px; background: #f9f9f9; border: 1px solid #eee;"><b><?php esc_html_e('Cost Today', 'ultimate-multisite'); ?></b></td>
+		<td style="padding: 8px; background: #fff; border: 1px solid #eee;"><?php esc_html_e('No payment required', 'ultimate-multisite'); ?></td>
+	</tr>
+	</tbody>
+</table>
+{{/payment_is_free_signup}}
+
+{{#payment_is_trial}}
+<h2><b><?php esc_html_e('Trial Details', 'ultimate-multisite'); ?></b></h2>
+
+<table cellpadding="0" cellspacing="0" style="width: 100%; border-collapse: collapse;">
+	<tbody>
+	<tr>
+		<td style="text-align: right; width: 160px; padding: 8px; background: #f9f9f9; border: 1px solid #eee;"><b><?php esc_html_e('Products', 'ultimate-multisite'); ?></b></td>
+		<td style="padding: 8px; background: #fff; border: 1px solid #eee;">{{payment_product_names}}</td>
+	</tr>
+	<tr>
+		<td style="text-align: right; width: 160px; padding: 8px; background: #f9f9f9; border: 1px solid #eee;"><b><?php esc_html_e('Trial Ends', 'ultimate-multisite'); ?></b></td>
+		<td style="padding: 8px; background: #fff; border: 1px solid #eee;">{{membership_date_expiration}}</td>
+	</tr>
+	<tr>
+		<td style="text-align: right; width: 160px; padding: 8px; background: #f9f9f9; border: 1px solid #eee;"><b><?php esc_html_e('First Payment', 'ultimate-multisite'); ?></b></td>
+		<td style="padding: 8px; background: #fff; border: 1px solid #eee;">{{membership_description}}</td>
+	</tr>
+	</tbody>
+</table>
+{{/payment_is_trial}}


### PR DESCRIPTION
## Summary

- Classify checkout notifications as paid, free membership, or trial outcomes.
- Use outcome-specific customer and admin subjects, copy, details, and receipt handling.
- Avoid sending the customer checkout email as an admin copy; keep the dedicated admin notification.
- Add conditional email-template blocks and focused coverage.

## Verification

- `vendor/bin/phpcs inc/helpers/class-sender.php inc/managers/class-payment-manager.php inc/managers/class-email-manager.php views/emails/customer/payment-received.php views/emails/admin/payment-received.php tests/WP_Ultimo/Helpers/Sender_Test.php tests/WP_Ultimo/Managers/Email_Manager_Test.php`
- `vendor/bin/phpstan analyse inc/helpers/class-sender.php inc/managers/class-email-manager.php inc/managers/class-payment-manager.php`
- `vendor/bin/phpunit --filter 'Sender_Test|Email_Manager_Test|Payment_Manager_Test'`

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.180 plugin for [OpenCode](https://opencode.ai) v1.18.4


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Payment-received email templates now render different sections based on whether the payment is paid, a free signup, or a trial.
  * Admin and customer payment-received subjects and introductions are now driven by configurable placeholders.
* **Bug Fixes**
  * Invoice PDFs are now attached only when the payment is eligible (includes required state/settings conditions).
  * Customer payment-received emails no longer include an unnecessary administrative copy, and the default subject metadata was updated.
* **Tests**
  * Added coverage for conditional shortcode block rendering and strengthened existing email manager assertions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->