### PR TITLE
fix(settings): preserve legacy false toggle values

### DIFF
--- a/inc/class-settings.php
+++ b/inc/class-settings.php
@@ -242,21 +242,20 @@ class Settings implements \WP_Ultimo\Interfaces\Singleton {
 			_doing_it_wrong(esc_html($setting), esc_html__('Dashes are no longer supported when registering a setting. You should change it to underscores in later versions.', 'ultimate-multisite'), '2.0.0');
 		}
 
+		$setting_exists = isset($settings[ $setting ]);
+
 		/*
-		 * Treat the literal string "false" as "not set" when reading a
-		 * setting. Earlier versions of the settings save flow could
-		 * persist the four-letter string "false" for any text field
-		 * that was empty when the user clicked Save (the Vue data-state
-		 * round-tripped a boolean false through v-model and back to
-		 * PHP as the string "false"). Recovering existing installs
-		 * without forcing a manual DB clean-up means treating that
-		 * sentinel as missing so the caller's default (or the field
-		 * default) takes precedence. The bug that produced these values
-		 * is fixed in add_field()'s value/display_value closures, so new
-		 * saves cannot reintroduce the string — this read-side guard
-		 * exists purely for already-corrupted databases.
+		 * Treat the literal string "false" as "not set" only for settings
+		 * whose fallback is text-like. Earlier versions could persist the
+		 * four-letter string "false" for empty text fields, but applying
+		 * that recovery to every setting changed legacy truthiness for
+		 * toggle/numeric values that already had the string saved.
 		 */
-		if (isset($settings[ $setting ]) && 'false' !== $settings[ $setting ]) {
+		if ($setting_exists && 'false' === $settings[ $setting ] && $this->should_treat_false_string_as_missing($setting, $default_value)) {
+			$setting_exists = false;
+		}
+
+		if ($setting_exists) {
 			$setting_value = $settings[ $setting ];
 		} elseif (false !== $default_value) {
 			$setting_value = $default_value;
@@ -266,6 +265,34 @@ class Settings implements \WP_Ultimo\Interfaces\Singleton {
 		}
 
 		return apply_filters('wu_get_setting', $setting_value, $setting, $default_value, $settings);
+	}
+
+	/**
+	 * Determines whether a saved literal "false" string should fall back.
+	 *
+	 * The string is a known corruption pattern for empty text fields, but it
+	 * must not be treated as missing for toggle/numeric defaults because older
+	 * versions exposed that saved value as truthy.
+	 *
+	 * @since 2.14.3
+	 *
+	 * @param string $setting       Settings name to inspect.
+	 * @param mixed  $default_value Default value passed to get_setting().
+	 * @return bool
+	 */
+	private function should_treat_false_string_as_missing($setting, $default_value): bool {
+
+		if (false !== $default_value) {
+			return is_string($default_value);
+		}
+
+		$defaults = static::get_setting_defaults();
+
+		if (array_key_exists($setting, $defaults)) {
+			return is_string($defaults[ $setting ]);
+		}
+
+		return true;
 	}
 
 	/**

--- a/inc/class-settings.php
+++ b/inc/class-settings.php
@@ -283,16 +283,32 @@ class Settings implements \WP_Ultimo\Interfaces\Singleton {
 	private function should_treat_false_string_as_missing($setting, $default_value): bool {
 
 		if (false !== $default_value) {
-			return is_string($default_value);
+			return $this->is_text_like_setting_default($default_value);
 		}
 
 		$defaults = static::get_setting_defaults();
 
 		if (array_key_exists($setting, $defaults)) {
-			return is_string($defaults[ $setting ]);
+			return $this->is_text_like_setting_default($defaults[ $setting ]);
 		}
 
 		return true;
+	}
+
+	/**
+	 * Determines whether a default value represents a text-like setting.
+	 *
+	 * Numeric strings are stored as strings for some settings, but should follow
+	 * numeric compatibility rules when recovering saved literal "false" values.
+	 *
+	 * @since 2.14.3
+	 *
+	 * @param mixed $default_value Default value to classify.
+	 * @return bool
+	 */
+	private function is_text_like_setting_default($default_value): bool {
+
+		return is_string($default_value) && ! is_numeric($default_value);
 	}
 
 	/**

--- a/tests/WP_Ultimo/Settings_Test.php
+++ b/tests/WP_Ultimo/Settings_Test.php
@@ -32,6 +32,7 @@ class Settings_Test extends WP_UnitTestCase {
 	public function tear_down() {
 		$this->settings->save_setting('allow_trial_without_payment_method', 0);
 		$this->settings->save_setting('company_name', '');
+		$this->settings->save_setting('precision', '2');
 
 		remove_all_filters('wu_get_setting');
 		remove_all_filters('wu_save_setting');
@@ -118,6 +119,12 @@ class Settings_Test extends WP_UnitTestCase {
 		$this->settings->save_setting('allow_trial_without_payment_method', 'false');
 
 		$this->assertSame('false', $this->settings->get_setting('allow_trial_without_payment_method'));
+	}
+
+	public function test_get_setting_preserves_literal_false_string_for_numeric_string_defaults() {
+		$this->settings->save_setting('precision', 'false');
+
+		$this->assertSame('false', $this->settings->get_setting('precision'));
 	}
 
 	public function test_save_setting_returns_boolean() {

--- a/tests/WP_Ultimo/Settings_Test.php
+++ b/tests/WP_Ultimo/Settings_Test.php
@@ -30,6 +30,9 @@ class Settings_Test extends WP_UnitTestCase {
 	}
 
 	public function tear_down() {
+		$this->settings->save_setting('allow_trial_without_payment_method', 0);
+		$this->settings->save_setting('company_name', '');
+
 		remove_all_filters('wu_get_setting');
 		remove_all_filters('wu_save_setting');
 		remove_all_filters('wu_settings_get_sections');
@@ -102,6 +105,19 @@ class Settings_Test extends WP_UnitTestCase {
 		$result = $this->settings->get_setting('totally_missing_setting_abc');
 		// Returns false or the default from get_setting_defaults
 		$this->assertNotNull($result);
+	}
+
+	public function test_get_setting_treats_literal_false_string_as_missing_for_text_defaults() {
+		$this->settings->save_setting('company_name', 'false');
+
+		$this->assertSame('', $this->settings->get_setting('company_name'));
+		$this->assertSame('', $this->settings->get_setting('company_name', ''));
+	}
+
+	public function test_get_setting_preserves_literal_false_string_for_toggle_defaults() {
+		$this->settings->save_setting('allow_trial_without_payment_method', 'false');
+
+		$this->assertSame('false', $this->settings->get_setting('allow_trial_without_payment_method'));
 	}
 
 	public function test_save_setting_returns_boolean() {

--- a/tests/unit/Cart_Should_Collect_Payment_Test.php
+++ b/tests/unit/Cart_Should_Collect_Payment_Test.php
@@ -204,4 +204,48 @@ class Cart_Should_Collect_Payment_Test extends WP_UnitTestCase {
 			'Documents the 2026-05-27 outage configuration: with allow_trial_without_payment_method ON, a trial cart skips payment collection and routes through the free gateway (which bypasses WooCommerce). If this ever changes, the change must be reviewed deliberately — this setting must stay OFF in production.'
 		);
 	}
+
+	/**
+	 * Legacy databases may have the setting saved as the literal string "false".
+	 *
+	 * Older releases exposed that non-empty string as truthy, which meant the
+	 * checkout skipped card collection for free trials. The settings recovery for
+	 * empty text fields must not silently flip that legacy checkout behaviour.
+	 *
+	 * @return void
+	 */
+	public function test_legacy_false_string_setting_keeps_trial_without_payment_method(): void {
+		wu_save_setting( self::TRIAL_SETTING, 'false' );
+
+		wp_set_current_user( 0 );
+
+		$product = wu_create_product(
+			[
+				'name'                => 'Trial Plan (legacy false string)',
+				'slug'                => 'trial-plan-legacy-false-' . uniqid(),
+				'amount'              => 19.99,
+				'type'                => 'plan',
+				'active'              => true,
+				'recurring'           => true,
+				'duration'            => 1,
+				'duration_unit'       => 'month',
+				'trial_duration'      => 14,
+				'trial_duration_unit' => 'day',
+			]
+		);
+
+		if ( is_wp_error( $product ) ) {
+			$this->markTestSkipped( 'Could not create product: ' . $product->get_error_message() );
+			return;
+		}
+
+		$cart = $this->build_cart_for_product( $product->get_id() );
+
+		$this->assertTrue( $cart->has_trial(), 'Sanity check: must be a trial cart for this branch.' );
+
+		$this->assertFalse(
+			$cart->should_collect_payment(),
+			'A saved literal string "false" must preserve legacy no-payment trial behaviour instead of forcing Stripe card collection after an update.'
+		);
+	}
 }


### PR DESCRIPTION
## Summary

- Preserve legacy saved `\"false\"` strings for toggle/numeric settings instead of treating them as missing.
- Keep the settings recovery for text fields that were previously corrupted to display `false`.
- Add regression coverage for the free-trial payment-method setting and settings fallback behavior.

## Root cause

A previous settings recovery change treated every saved literal `\"false\"` value as missing. For installs where `allow_trial_without_payment_method` had been saved as the string `\"false\"`, that changed checkout behavior after update: the value fell back to the default off state, so Stripe started asking for card details during free trials.

## Verification

- `vendor/bin/phpcs inc/class-settings.php tests/WP_Ultimo/Settings_Test.php tests/unit/Cart_Should_Collect_Payment_Test.php`
- `vendor/bin/phpunit --filter Settings_Test`
- `vendor/bin/phpunit --filter Cart_Should_Collect_Payment_Test`
- `vendor/bin/phpstan analyse inc/class-settings.php --memory-limit=512M`

---
<!-- aidevops:sig -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of saved settings containing the literal `"false"`.
  * Text-like settings now correctly treat the stored `"false"` as missing and fall back to defaults.
  * Toggle and numeric-like settings preserve legacy `"false"` behavior.
  * Trial carts configured to skip payment details continue to avoid requesting payment information.
* **Tests**
  * Added coverage for `"false"` handling across text, toggle, and numeric-like settings.
  * Added a regression test ensuring legacy trial-cart payment behavior remains unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->