### PR TITLE
fix(checkout): load custom CSS for block forms (#1666)

### DIFF
--- a/inc/ui/class-checkout-element.php
+++ b/inc/ui/class-checkout-element.php
@@ -366,7 +366,12 @@ class Checkout_Element extends Base_Element {
 	 * @return void
 	 */
 	public function register_scripts() {
-		$slug          = $this->get_pre_loaded_attribute('slug', $this->defaults()['slug']);
+		$slug = $this->get_pre_loaded_attribute('slug');
+
+		if (! $slug) {
+			$slug = $this->defaults()['slug'];
+		}
+
 		$checkout_form = wu_get_checkout_form_by_slug($slug);
 
 		if (! $checkout_form) {

--- a/inc/ui/class-checkout-element.php
+++ b/inc/ui/class-checkout-element.php
@@ -261,6 +261,24 @@ class Checkout_Element extends Base_Element {
 	}
 
 	/**
+	 * Retains the current block or shortcode attributes for script registration.
+	 *
+	 * Block templates can render without a post whose content contains the block,
+	 * so the early element scan cannot always preload the configured slug.
+	 *
+	 * @since 2.4.15
+	 *
+	 * @param array $atts Element attributes.
+	 * @return void
+	 */
+	public function display($atts) {
+
+		$this->pre_loaded_attributes = wp_parse_args($atts, $this->defaults());
+
+		parent::display($atts);
+	}
+
+	/**
 	 * Checks if we are on a thank you page.
 	 *
 	 * @since 2.0.0
@@ -348,7 +366,7 @@ class Checkout_Element extends Base_Element {
 	 * @return void
 	 */
 	public function register_scripts() {
-		$slug          = $this->get_pre_loaded_attribute('slug');
+		$slug          = $this->get_pre_loaded_attribute('slug', $this->defaults()['slug']);
 		$checkout_form = wu_get_checkout_form_by_slug($slug);
 
 		if (! $checkout_form) {

--- a/tests/WP_Ultimo/UI/Checkout_Element_Test.php
+++ b/tests/WP_Ultimo/UI/Checkout_Element_Test.php
@@ -69,9 +69,8 @@ class Checkout_Element_Test extends WP_UnitTestCase {
 
 		$this->assertNotWPError($form);
 
-		$property = new \ReflectionProperty($this->element, 'pre_loaded_attributes');
-
-		$property->setValue($this->element, false);
+		$property                       = new \ReflectionProperty($this->element, 'pre_loaded_attributes');
+		$original_pre_loaded_attributes = $property->getValue($this->element);
 
 		if ( ! wp_style_is('wu-checkout', 'registered')) {
 			wp_register_style('wu-checkout', false, [], 'test');
@@ -85,17 +84,74 @@ class Checkout_Element_Test extends WP_UnitTestCase {
 
 		add_filter('wu_checkout_skip_output', $skip_output);
 
-		$this->element->display(['slug' => $slug]);
+		try {
+			$property->setValue($this->element, false);
 
-		remove_filter('wu_checkout_skip_output', $skip_output);
+			$this->element->display(['slug' => $slug]);
 
-		$this->element->register_scripts();
+			$this->element->register_scripts();
 
-		$styles = wp_styles()->get_data('wu-checkout', 'after');
+			$styles = wp_styles()->get_data('wu-checkout', 'after');
 
-		$this->assertSame($slug, $this->element->get_pre_loaded_attribute('slug'));
-		$this->assertIsArray($styles);
-		$this->assertStringContainsString('.wu_checkout_form_' . $slug . ' .wu-custom-css-test', implode("\n", $styles));
+			$this->assertSame($slug, $this->element->get_pre_loaded_attribute('slug'));
+			$this->assertIsArray($styles);
+			$this->assertStringContainsString('.wu_checkout_form_' . $slug . ' .wu-custom-css-test', implode("\n", $styles));
+		} finally {
+			remove_filter('wu_checkout_skip_output', $skip_output);
+			$property->setValue($this->element, $original_pre_loaded_attributes);
+		}
+	}
+
+	/**
+	 * Test checkout scripts use the default form when attributes were not pre-loaded.
+	 */
+	public function test_register_scripts_uses_default_slug_without_pre_loaded_attributes(): void {
+		$custom_css = '.wu-default-custom-css-test { color: red; }';
+		$form       = wu_get_checkout_form_by_slug('main-form');
+		$old_css    = false;
+
+		if (! $form) {
+			$form = wu_create_checkout_form(
+				[
+					'name'       => 'Main Form',
+					'slug'       => 'main-form',
+					'custom_css' => $custom_css,
+				]
+			);
+		} else {
+			$old_css = $form->get_custom_css();
+			$form->set_custom_css($custom_css);
+			$form->save();
+		}
+
+		$this->assertNotWPError($form);
+
+		$property                       = new \ReflectionProperty($this->element, 'pre_loaded_attributes');
+		$original_pre_loaded_attributes = $property->getValue($this->element);
+
+		if ( ! wp_style_is('wu-checkout', 'registered')) {
+			wp_register_style('wu-checkout', false, [], 'test');
+		}
+
+		wp_enqueue_style('wu-checkout');
+
+		try {
+			$property->setValue($this->element, false);
+
+			$this->element->register_scripts();
+
+			$styles = wp_styles()->get_data('wu-checkout', 'after');
+
+			$this->assertIsArray($styles);
+			$this->assertStringContainsString('.wu_checkout_form_main-form .wu-default-custom-css-test', implode("\n", $styles));
+		} finally {
+			$property->setValue($this->element, $original_pre_loaded_attributes);
+
+			if (false !== $old_css) {
+				$form->set_custom_css($old_css);
+				$form->save();
+			}
+		}
 	}
 
 	/**

--- a/tests/WP_Ultimo/UI/Checkout_Element_Test.php
+++ b/tests/WP_Ultimo/UI/Checkout_Element_Test.php
@@ -55,6 +55,50 @@ class Checkout_Element_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Test block attributes remain available when checkout scripts are registered during rendering.
+	 */
+	public function test_display_retains_block_slug_for_late_script_registration(): void {
+		$slug = 'custom-css-form-' . wp_generate_uuid4();
+		$form = wu_create_checkout_form(
+			[
+				'name'       => 'Custom CSS Form',
+				'slug'       => $slug,
+				'custom_css' => '.wu-custom-css-test { color: red; }',
+			]
+		);
+
+		$this->assertNotWPError($form);
+
+		$property = new \ReflectionProperty($this->element, 'pre_loaded_attributes');
+
+		$property->setValue($this->element, false);
+
+		if ( ! wp_style_is('wu-checkout', 'registered')) {
+			wp_register_style('wu-checkout', false, [], 'test');
+		}
+
+		wp_enqueue_style('wu-checkout');
+
+		$skip_output = static function () {
+			return true;
+		};
+
+		add_filter('wu_checkout_skip_output', $skip_output);
+
+		$this->element->display(['slug' => $slug]);
+
+		remove_filter('wu_checkout_skip_output', $skip_output);
+
+		$this->element->register_scripts();
+
+		$styles = wp_styles()->get_data('wu-checkout', 'after');
+
+		$this->assertSame($slug, $this->element->get_pre_loaded_attribute('slug'));
+		$this->assertIsArray($styles);
+		$this->assertStringContainsString('.wu_checkout_form_' . $slug . ' .wu-custom-css-test', implode("\n", $styles));
+	}
+
+	/**
 	 * Test deferred output renders a cache-safe placeholder instead of live checkout markup.
 	 */
 	public function test_deferred_output_renders_placeholder_without_nocache_action(): void {


### PR DESCRIPTION
## Summary

- Preserve checkout block and shortcode attributes while rendering, including the configured form slug.
- Use that slug when compiling and attaching the form's scoped Custom CSS.
- Add regression coverage that creates a form with Custom CSS and verifies the generated inline style.

## Verification

- `vendor/bin/phpcs inc/ui/class-checkout-element.php tests/WP_Ultimo/UI/Checkout_Element_Test.php`
- `vendor/bin/phpstan analyse inc/ui/class-checkout-element.php`
- `vendor/bin/phpunit --filter Checkout_Element_Test`

## Known baseline failures

- `npm run check` stops at existing JavaScript lint errors in unrelated assets.
- `npm run stan` reports 526 existing errors outside the changed files.
- `npm run test` completes 10,124 tests with 2 existing Site Exporter errors and 1 existing discount-code assertion failure.

Resolves #1666

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.188 plugin for [OpenCode](https://opencode.ai) v1.18.5 with gpt-5.6-terra


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Checkout forms now retain their configured slug when assets are registered later.
  * Custom checkout styling is applied consistently to the correct form.

* **Tests**
  * Added coverage verifying slug retention and generated custom stylesheet behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->