### PR TITLE
fix(stripe): skip card validation for free trials

### DIFF
--- a/assets/js/gateways/stripe.js
+++ b/assets/js/gateways/stripe.js
@@ -13,6 +13,39 @@ let currentElementsMode = null;
 let currentElementsAmount = null;
 
 /**
+ * Check if the current checkout should collect Stripe details.
+ *
+ * @param {Object} checkout Checkout form instance.
+ * @return {boolean} True when Stripe should collect a new payment method.
+ */
+const shouldCollectStripePayment = function (checkout) {
+
+	return checkout &&
+		checkout.order &&
+		checkout.order.should_collect_payment &&
+		checkout.payment_method === 'add-new';
+};
+
+/**
+ * Unmount the current Payment Element instance.
+ */
+const resetStripeElements = function () {
+
+	if (paymentElement) {
+		try {
+			paymentElement.unmount();
+		} catch (error) {
+			// Silence
+		}
+	}
+
+	paymentElement = null;
+	elements = null;
+	currentElementsMode = null;
+	currentElementsAmount = null;
+};
+
+/**
  * Initialize Stripe and set up Payment Element.
  *
  * @param {string} publicKey Stripe publishable key.
@@ -29,7 +62,7 @@ const stripeElements = function (publicKey) {
 		'nextpress/wp-ultimo',
 		function (promises, checkout, gateway) {
 
-			if (gateway === 'stripe' && checkout.order.totals.total > 0) {
+			if (gateway === 'stripe' && shouldCollectStripePayment(checkout)) {
 
 				const paymentEl = document.getElementById('payment-element');
 
@@ -66,6 +99,11 @@ const stripeElements = function (publicKey) {
 		function (checkout, results) {
 
 			if (checkout.gateway !== 'stripe') {
+				return;
+			}
+
+			if (!checkout.order || !checkout.order.should_collect_payment) {
+				checkout.set_prevent_submission(false);
 				return;
 			}
 
@@ -131,17 +169,14 @@ const stripeElements = function (publicKey) {
 			form.set_prevent_submission(false);
 
 			// Destroy elements if switching away from Stripe
-			if (paymentElement) {
-				try {
-					paymentElement.unmount();
-				} catch (error) {
-					// Silence
-				}
-				paymentElement = null;
-				elements = null;
-				currentElementsMode = null;
-				currentElementsAmount = null;
-			}
+			resetStripeElements();
+
+			return;
+		}
+
+		if (!form.order || !form.order.should_collect_payment) {
+			form.set_prevent_submission(false);
+			resetStripeElements();
 
 			return;
 		}

--- a/assets/js/gateways/stripe.js
+++ b/assets/js/gateways/stripe.js
@@ -27,6 +27,25 @@ const shouldCollectStripePayment = function (checkout) {
 };
 
 /**
+ * Check if Stripe should confirm a previously saved payment method.
+ *
+ * @param {Object} checkout Checkout form instance.
+ * @return {boolean} True when using a saved Stripe payment method.
+ */
+const shouldConfirmSavedStripePayment = function (checkout) {
+
+	return checkout &&
+		checkout.order &&
+		checkout.order.should_collect_payment &&
+		checkout.payment_method &&
+		checkout.payment_method !== 'add-new' &&
+		(
+			checkout.order.totals.total > 0 ||
+			checkout.order.totals.recurring.total > 0
+		);
+};
+
+/**
  * Unmount the current Payment Element instance.
  */
 const resetStripeElements = function () {
@@ -43,6 +62,67 @@ const resetStripeElements = function () {
 	elements = null;
 	currentElementsMode = null;
 	currentElementsAmount = null;
+};
+
+/**
+ * Confirm a Stripe intent returned by the checkout endpoint.
+ *
+ * @param {Object}  checkout Checkout form instance.
+ * @param {Object}  results Checkout response payload.
+ * @param {boolean} useElements Whether to confirm through the Payment Element.
+ */
+const confirmStripeIntent = function (checkout, results, useElements) {
+
+	// Check if we received a client_secret from the server
+	if (!results.gateway.data.stripe_client_secret) {
+		checkout.set_prevent_submission(false);
+		return;
+	}
+
+	const clientSecret = results.gateway.data.stripe_client_secret;
+	const intentType = results.gateway.data.stripe_intent_type;
+
+	checkout.set_prevent_submission(false);
+
+	// Determine the confirmation method based on intent type
+	const confirmMethod = intentType === 'payment_intent'
+		? 'confirmPayment'
+		: 'confirmSetup';
+
+	const confirmParams = {
+		confirmParams: {
+			return_url: window.location.href,
+		},
+		redirect: 'if_required',
+	};
+
+	if (useElements) {
+		confirmParams.elements = elements;
+
+		// Only pass name and email — Stripe's Payment Element
+		// already collects country and postal code natively.
+		confirmParams.confirmParams.payment_method_data = {
+			billing_details: {
+				name: results.customer.display_name,
+				email: results.customer.user_email,
+			},
+		};
+	}
+
+	// Add clientSecret for confirmation
+	confirmParams.clientSecret = clientSecret;
+
+	_stripe[confirmMethod](confirmParams).then(function (result) {
+
+		if (result.error) {
+			wu_checkout_form.unblock();
+			wu_checkout_form.errors.push(result.error);
+		} else {
+			// Payment succeeded - resubmit form to complete checkout
+			wu_checkout_form.resubmit();
+		}
+
+	});
 };
 
 /**
@@ -102,8 +182,14 @@ const stripeElements = function (publicKey) {
 				return;
 			}
 
-			if (!checkout.order || !checkout.order.should_collect_payment) {
+			if (!shouldCollectStripePayment(checkout)) {
 				checkout.set_prevent_submission(false);
+				resetStripeElements();
+
+				if (shouldConfirmSavedStripePayment(checkout)) {
+					confirmStripeIntent(checkout, results, false);
+				}
+
 				return;
 			}
 
@@ -111,52 +197,7 @@ const stripeElements = function (publicKey) {
 				return;
 			}
 
-			// Check if we received a client_secret from the server
-			if (!results.gateway.data.stripe_client_secret) {
-				checkout.set_prevent_submission(false);
-				return;
-			}
-
-			const clientSecret = results.gateway.data.stripe_client_secret;
-			const intentType = results.gateway.data.stripe_intent_type;
-
-			checkout.set_prevent_submission(false);
-
-			// Determine the confirmation method based on intent type
-			const confirmMethod = intentType === 'payment_intent'
-				? 'confirmPayment'
-				: 'confirmSetup';
-
-			// Only pass name and email — Stripe's Payment Element
-			// already collects country and postal code natively.
-			const confirmParams = {
-				elements: elements,
-				confirmParams: {
-					return_url: window.location.href,
-					payment_method_data: {
-						billing_details: {
-							name: results.customer.display_name,
-							email: results.customer.user_email,
-						},
-					},
-				},
-				redirect: 'if_required',
-			};
-
-			// Add clientSecret for confirmation
-			confirmParams.clientSecret = clientSecret;
-
-			_stripe[confirmMethod](confirmParams).then(function (result) {
-
-				if (result.error) {
-					wu_checkout_form.unblock();
-					wu_checkout_form.errors.push(result.error);
-				} else {
-					// Payment succeeded - resubmit form to complete checkout
-					wu_checkout_form.resubmit();
-				}
-
-			});
+			confirmStripeIntent(checkout, results, true);
 		}
 	);
 
@@ -174,7 +215,7 @@ const stripeElements = function (publicKey) {
 			return;
 		}
 
-		if (!form.order || !form.order.should_collect_payment) {
+		if (!shouldCollectStripePayment(form)) {
 			form.set_prevent_submission(false);
 			resetStripeElements();
 
@@ -205,11 +246,7 @@ const stripeElements = function (publicKey) {
 
 		if (!needsReinit) {
 			// Already initialized with correct mode, just update prevent submission state
-			form.set_prevent_submission(
-				form.order &&
-				form.order.should_collect_payment &&
-				form.payment_method === 'add-new'
-			);
+			form.set_prevent_submission(shouldCollectStripePayment(form));
 			return;
 		}
 
@@ -275,11 +312,7 @@ const stripeElements = function (publicKey) {
 			});
 
 			// Set prevent submission until payment element is ready
-			form.set_prevent_submission(
-				form.order &&
-				form.order.should_collect_payment &&
-				form.payment_method === 'add-new'
-			);
+			form.set_prevent_submission(shouldCollectStripePayment(form));
 
 		} catch (error) {
 			// Log error but don't break the form


### PR DESCRIPTION
## Summary

- Follow-up to #1674 for the remaining frontend checkout path.
- Skip Stripe Payment Element validation and setup when the checkout order says payment collection is not required.
- Reset any mounted Stripe Elements when switching away from a payment-collecting Stripe state.

## Verification

- ./node_modules/.bin/eslint assets/js/gateways/stripe.js
- git diff --check
- Local browser checkout with a recurring free-trial product, allow_trial_without_payment_method stored as legacy false, and Stripe active reached the thank-you page without a card validation error.

## Notes

The PR build workflow runs npm run build, so the customer nightly.link ZIP generated from this PR should include regenerated minified assets for this Stripe JS change.

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.188 plugin for [OpenCode](https://opencode.ai) v1.18.5 with gpt-5.5


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Stripe payment handling during checkout, including correct teardown of the Payment Element.
  * Prevented requesting new payment details when payment collection isn’t required or when a previously saved method is being used.
  * Ensured Stripe payment fields are cleared appropriately when switching payment methods.
  * Improved checkout submission flow by avoiding blocked or incomplete submissions when Stripe details aren’t needed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->