### PR TITLE
fix(setup): combine recommended plugin actions

### DIFF
--- a/assets/js/setup-wizard.js
+++ b/assets/js/setup-wizard.js
@@ -96,66 +96,113 @@
 					.find('.spinner').addClass('is-active').end()
 					.find('a.help').slideUp();
 
-				// Ajax request
-				$.ajax({
-					url: ajaxurl,
-					method: 'post',
-					data: {
-						action: wu_setup_settings.ajax_action || 'wu_setup_install',
-						installer: content,
-						'dry-run': wu_setup_settings.dry_run,
-						_wpnonce: wu_setup_settings.install_nonce,
-					},
-					success(data) {
+				/**
+				 * Move to the next selected installer row.
+				 */
+				function process_next_item() {
 
-						if (data.success === true) {
+					index++;
 
-							$item.find('td.status')
-								.attr('class', '')
-								.addClass('status wu-text-green-600')
-								.find('> span').html(wu_setup[ content ].success).end()
-								.find('.spinner').removeClass('is-active');
+					process_queue_item(queue.eq(index));
 
-							$item.removeAttr('data-content');
+				} // end process_next_item;
 
-							successes++;
+				/**
+				 * Display an installer error and continue processing the queue.
+				 *
+				 * @param {string} errorMessage The message to display.
+				 */
+				function show_error(errorMessage) {
 
-						} else {
+					$item.find('td.status')
+						.attr('class', '')
+						.addClass('status wu-text-red-400')
+						.find('> span').html(errorMessage).end()
+						.find('.spinner').removeClass('is-active').end()
+						.find('a.help').slideDown();
 
-							$item.find('td.status')
-								.attr('class', '')
-								.addClass('status wu-text-red-400')
-								.find('> span').html(data.data[ 0 ].message).end()
-								.find('.spinner').removeClass('is-active').end()
-								.find('a.help').slideDown();
+					process_next_item();
 
-						} // end if;
+				} // end show_error;
 
-						index++;
+				/**
+				 * Mark the current row complete after all of its actions succeed.
+				 */
+				function mark_complete() {
 
-						process_queue_item(queue.eq(index));
+					$item.find('td.status')
+						.attr('class', '')
+						.addClass('status wu-text-green-600')
+						.find('> span').html(wu_setup[ content ].success).end()
+						.find('.spinner').removeClass('is-active');
 
-					},
-					error(jqXHR) {
+					$item.removeAttr('data-content');
 
-						let errorMessage = wu_setup_settings.generic_error_message || 'An error occurred.';
+					successes++;
 
-						if (jqXHR.responseJSON && jqXHR.responseJSON.data && jqXHR.responseJSON.data[ 0 ]) {
-							errorMessage = jqXHR.responseJSON.data[ 0 ].message || errorMessage;
-						}
+					process_next_item();
 
-						$item.find('td.status')
-							.attr('class', '')
-							.addClass('status wu-text-red-400')
-							.find('> span').html(errorMessage).end()
-							.find('.spinner').removeClass('is-active').end()
-							.find('a.help').slideDown();
+				} // end mark_complete;
 
-						index++;
+				/**
+				 * Run one installer action for the current row.
+				 *
+				 * @param {string}   installer The installer action name.
+				 * @param {Function} onSuccess Callback after the action succeeds.
+				 */
+				function run_installer(installer, onSuccess) {
 
-						process_queue_item(queue.eq(index));
+					$.ajax({
+						url: ajaxurl,
+						method: 'post',
+						data: {
+							action: wu_setup_settings.ajax_action || 'wu_setup_install',
+							installer,
+							'dry-run': wu_setup_settings.dry_run,
+							_wpnonce: wu_setup_settings.install_nonce,
+						},
+						success(data) {
 
-					},
+							if (data.success === true) {
+
+								onSuccess();
+
+								return;
+
+							} // end if;
+
+							show_error(data.data[ 0 ].message);
+
+						},
+						error(jqXHR) {
+
+							let errorMessage = wu_setup_settings.generic_error_message || 'An error occurred.';
+
+							if (jqXHR.responseJSON && jqXHR.responseJSON.data && jqXHR.responseJSON.data[ 0 ]) {
+								errorMessage = jqXHR.responseJSON.data[ 0 ].message || errorMessage;
+							}
+
+							show_error(errorMessage);
+
+						},
+					});
+
+				} // end run_installer;
+
+				run_installer(content, function() {
+
+					if (wu_setup[ content ].activation) {
+
+						$item.find('td.status > span').html(wu_setup[ content ].activating);
+
+						run_installer(wu_setup[ content ].activation, mark_complete);
+
+						return;
+
+					} // end if;
+
+					mark_complete();
+
 				});
 
 			} // end process_queue_item;

--- a/inc/admin-pages/class-setup-wizard-admin-page.php
+++ b/inc/admin-pages/class-setup-wizard-admin-page.php
@@ -542,7 +542,7 @@ class Setup_Wizard_Admin_Page extends Wizard_Admin_Page {
 		// Recommended Plugins step (runs like other installer steps)
 		$sections['recommended-plugins'] = [
 			'title'        => __('Recommended Plugins', 'ultimate-multisite'),
-			'description'  => __('Optionally install helpful plugins. We will install them one by one and report progress.', 'ultimate-multisite'),
+			'description'  => __('Optionally install and activate helpful plugins. We will install and activate them one by one and report progress.', 'ultimate-multisite'),
 			'next_label'   => Recommended_Plugins_Installer::get_instance()->all_done() ? __('Go to the Next Step &rarr;', 'ultimate-multisite') : __('Install', 'ultimate-multisite'),
 			'disable_next' => true,
 			'fields'       => [

--- a/inc/installers/class-recommended-plugins-installer.php
+++ b/inc/installers/class-recommended-plugins-installer.php
@@ -165,7 +165,7 @@ class Recommended_Plugins_Installer extends Base_Installer {
 	}
 
 	/**
-	 * Determine if a plugin is active by slug.
+	 * Determine if a plugin is network active by slug.
 	 *
 	 * @since 2.0.0
 	 * @param string $plugin_slug Plugin slug (e.g. 'user-switching').
@@ -178,7 +178,7 @@ class Recommended_Plugins_Installer extends Base_Installer {
 			return false;
 		}
 
-		return is_plugin_active($plugin_file);
+		return is_plugin_active_for_network($plugin_file);
 	}
 
 	/**
@@ -276,13 +276,13 @@ class Recommended_Plugins_Installer extends Base_Installer {
 			return new \WP_Error('plugin-not-found', __('Plugin not found.', 'ultimate-multisite'));
 		}
 
-		// If already active, succeed early.
-		if (is_plugin_active($plugin_file)) {
+		// If already network active, succeed early.
+		if (is_plugin_active_for_network($plugin_file)) {
 			return true;
 		}
 
-		// Activate the plugin.
-		$result = activate_plugin($plugin_file);
+		// Activate the plugin across the network.
+		$result = activate_plugin($plugin_file, '', true);
 
 		if (is_wp_error($result)) {
 			return $result;

--- a/inc/installers/class-recommended-plugins-installer.php
+++ b/inc/installers/class-recommended-plugins-installer.php
@@ -43,23 +43,14 @@ class Recommended_Plugins_Installer extends Base_Installer {
 		// Recommended: User Switching (https://wordpress.org/plugins/user-switching/)
 		$user_switching_slug                               = 'user-switching';
 		$steps[ 'install_plugin_' . $user_switching_slug ] = [
-			'done'        => $this->is_plugin_installed($user_switching_slug),
+			'done'        => $this->is_plugin_active($user_switching_slug),
 			'title'       => __('User Switching', 'ultimate-multisite'),
 			'description' => __('Quickly switch between users for testing and support.', 'ultimate-multisite'),
 			'pending'     => __('Pending', 'ultimate-multisite'),
 			'installing'  => __('Installing User Switching...', 'ultimate-multisite'),
-			'success'     => __('Installed!', 'ultimate-multisite'),
-			'help'        => 'https://wordpress.org/plugins/user-switching/',
-			'checked'     => true,
-		];
-
-		$steps[ 'activate_plugin_' . $user_switching_slug ] = [
-			'done'        => $this->is_plugin_active($user_switching_slug),
-			'title'       => __('Activate User Switching', 'ultimate-multisite'),
-			'description' => __('Activate the User Switching plugin.', 'ultimate-multisite'),
-			'pending'     => __('Pending', 'ultimate-multisite'),
-			'installing'  => __('Activating User Switching...', 'ultimate-multisite'),
-			'success'     => __('Activated!', 'ultimate-multisite'),
+			'activation'  => 'activate_plugin_' . $user_switching_slug,
+			'activating'  => __('Activating User Switching...', 'ultimate-multisite'),
+			'success'     => __('Installed and activated!', 'ultimate-multisite'),
 			'help'        => 'https://wordpress.org/plugins/user-switching/',
 			'checked'     => true,
 		];
@@ -71,23 +62,14 @@ class Recommended_Plugins_Installer extends Base_Installer {
 		// Recommended for non-English networks: Superdav AI Language Packs.
 		$language_packs_slug                               = 'superdav-ai-language-packs';
 		$steps[ 'install_plugin_' . $language_packs_slug ] = [
-			'done'        => $this->is_plugin_installed($language_packs_slug),
+			'done'        => $this->is_plugin_active($language_packs_slug),
 			'title'       => __('AI Language Packs', 'ultimate-multisite'),
 			'description' => __('Add AI-powered language packs for plugin and theme translates, fully localize Ultimate Multisite and all community plugins.', 'ultimate-multisite'),
 			'pending'     => __('Pending', 'ultimate-multisite'),
 			'installing'  => __('Installing AI Language Packs...', 'ultimate-multisite'),
-			'success'     => __('Installed!', 'ultimate-multisite'),
-			'help'        => 'https://wordpress.org/plugins/superdav-ai-language-packs/',
-			'checked'     => $language_packs_is_checked,
-		];
-
-		$steps[ 'activate_plugin_' . $language_packs_slug ] = [
-			'done'        => $this->is_plugin_active($language_packs_slug),
-			'title'       => __('Activate Superdav AI Language Packs', 'ultimate-multisite'),
-			'description' => __('Activate Superdav AI Language Packs for your network.', 'ultimate-multisite'),
-			'pending'     => __('Pending', 'ultimate-multisite'),
-			'installing'  => __('Activating Superdav AI Language Packs...', 'ultimate-multisite'),
-			'success'     => __('Activated!', 'ultimate-multisite'),
+			'activation'  => 'activate_plugin_' . $language_packs_slug,
+			'activating'  => __('Activating AI Language Packs...', 'ultimate-multisite'),
+			'success'     => __('Installed and activated!', 'ultimate-multisite'),
 			'help'        => 'https://wordpress.org/plugins/superdav-ai-language-packs/',
 			'checked'     => $language_packs_is_checked,
 		];
@@ -95,23 +77,14 @@ class Recommended_Plugins_Installer extends Base_Installer {
 		// Optional: Superdav AI Agent.
 		$ai_agent_slug                               = 'superdav-ai-agent';
 		$steps[ 'install_plugin_' . $ai_agent_slug ] = [
-			'done'        => $this->is_plugin_installed($ai_agent_slug),
+			'done'        => $this->is_plugin_active($ai_agent_slug),
 			'title'       => __('SD AI Agent', 'ultimate-multisite'),
 			'description' => __('Use an AI Agent fully control all of WordPress. Create content, products, custom plugins and more. Like Claude code or Cursor running inside of wp-admin.', 'ultimate-multisite'),
 			'pending'     => __('Pending', 'ultimate-multisite'),
 			'installing'  => __('Installing Superdav AI Agent...', 'ultimate-multisite'),
-			'success'     => __('Installed!', 'ultimate-multisite'),
-			'help'        => 'https://wordpress.org/plugins/superdav-ai-agent/',
-			'checked'     => false,
-		];
-
-		$steps[ 'activate_plugin_' . $ai_agent_slug ] = [
-			'done'        => $this->is_plugin_active($ai_agent_slug),
-			'title'       => __('Activate SD AI Agent', 'ultimate-multisite'),
-			'description' => __('Activate SD AI Agent for your network.', 'ultimate-multisite'),
-			'pending'     => __('Pending', 'ultimate-multisite'),
-			'installing'  => __('Activating SD AI Agent...', 'ultimate-multisite'),
-			'success'     => __('Activated!', 'ultimate-multisite'),
+			'activation'  => 'activate_plugin_' . $ai_agent_slug,
+			'activating'  => __('Activating Superdav AI Agent...', 'ultimate-multisite'),
+			'success'     => __('Installed and activated!', 'ultimate-multisite'),
 			'help'        => 'https://wordpress.org/plugins/superdav-ai-agent/',
 			'checked'     => false,
 		];

--- a/tests/WP_Ultimo/Admin_Pages/Setup_Wizard_Admin_Page_Test.php
+++ b/tests/WP_Ultimo/Admin_Pages/Setup_Wizard_Admin_Page_Test.php
@@ -291,6 +291,15 @@ class Setup_Wizard_Admin_Page_Test extends WP_UnitTestCase {
 		$this->assertArrayHasKey('recommended-plugins', $this->page->get_sections());
 	}
 
+	public function test_recommended_plugins_description_covers_installation_and_activation(): void {
+		$sections = $this->page->get_sections();
+
+		$this->assertSame(
+			'Optionally install and activate helpful plugins. We will install and activate them one by one and report progress.',
+			$sections['recommended-plugins']['description']
+		);
+	}
+
 	public function test_welcome_section_has_required_keys(): void {
 		$sections = $this->page->get_sections();
 		$this->assertArrayHasKey('title', $sections['welcome']);

--- a/tests/WP_Ultimo/Installers/Recommended_Plugins_Installer_Test.php
+++ b/tests/WP_Ultimo/Installers/Recommended_Plugins_Installer_Test.php
@@ -41,16 +41,34 @@ class Recommended_Plugins_Installer_Test extends WP_UnitTestCase {
 		$steps = $this->get_steps_for_locale('pt_BR');
 
 		$this->assertTrue($steps['install_plugin_superdav-ai-language-packs']['checked']);
-		$this->assertTrue($steps['activate_plugin_superdav-ai-language-packs']['checked']);
 		$this->assertFalse($steps['install_plugin_superdav-ai-agent']['checked']);
-		$this->assertFalse($steps['activate_plugin_superdav-ai-agent']['checked']);
 	}
 
 	public function test_language_packs_are_not_selected_for_english_locales(): void {
 		$steps = $this->get_steps_for_locale('en_US');
 
 		$this->assertFalse($steps['install_plugin_superdav-ai-language-packs']['checked']);
-		$this->assertFalse($steps['activate_plugin_superdav-ai-language-packs']['checked']);
+	}
+
+	public function test_plugins_have_one_installation_row_with_an_activation_action(): void {
+		$steps = $this->get_steps_for_locale('en_US');
+
+		$this->assertSame(
+			[
+				'install_plugin_user-switching',
+				'install_plugin_superdav-ai-language-packs',
+				'install_plugin_superdav-ai-agent',
+			],
+			array_keys($steps)
+		);
+
+		foreach ($steps as $slug => $step) {
+			$plugin_slug = substr($slug, strlen('install_plugin_'));
+
+			$this->assertSame('activate_plugin_' . $plugin_slug, $step['activation']);
+			$this->assertNotEmpty($step['activating']);
+			$this->assertSame('Installed and activated!', $step['success']);
+		}
 	}
 
 	public function test_ai_plugin_descriptions_explain_their_purpose(): void {

--- a/tests/WP_Ultimo/Installers/Recommended_Plugins_Installer_Test.php
+++ b/tests/WP_Ultimo/Installers/Recommended_Plugins_Installer_Test.php
@@ -71,6 +71,41 @@ class Recommended_Plugins_Installer_Test extends WP_UnitTestCase {
 		}
 	}
 
+	public function test_activation_action_network_activates_a_locally_active_plugin(): void {
+		global $wp_filesystem;
+
+		require_once ABSPATH . 'wp-admin/includes/file.php';
+
+		$plugin_slug = 'recommended-plugin-network-activation-test';
+		$plugin_dir  = WP_PLUGIN_DIR . '/' . $plugin_slug;
+		$plugin_file = $plugin_slug . '/' . $plugin_slug . '.php';
+		$plugin_path = WP_PLUGIN_DIR . '/' . $plugin_file;
+
+		$this->assertTrue(WP_Filesystem());
+		$this->assertTrue(wp_mkdir_p($plugin_dir));
+		$this->assertTrue($wp_filesystem->put_contents($plugin_path, "<?php\n/* Plugin Name: Recommended Plugin Network Activation Test */\n"));
+
+		wp_clean_plugins_cache();
+
+		try {
+			$local_activation = activate_plugin($plugin_file, '', false, true);
+
+			$this->assertNotWPError($local_activation);
+			$this->assertTrue(is_plugin_active($plugin_file));
+			$this->assertFalse(is_plugin_active_for_network($plugin_file));
+
+			$result = Recommended_Plugins_Installer::get_instance()->handle(true, 'activate_plugin_' . $plugin_slug, $this);
+
+			$this->assertTrue($result);
+			$this->assertTrue(is_plugin_active_for_network($plugin_file));
+		} finally {
+			deactivate_plugins($plugin_file, true, true);
+			deactivate_plugins($plugin_file, true, false);
+			wp_clean_plugins_cache();
+			$wp_filesystem->delete($plugin_dir, true);
+		}
+	}
+
 	public function test_ai_plugin_descriptions_explain_their_purpose(): void {
 		$steps = $this->get_steps_for_locale('en_US');
 


### PR DESCRIPTION
## Summary

- show one selectable setup-wizard row per recommended plugin
- run activation automatically after each selected installation while reusing the row's status cell for progress
- update the wizard description and cover the combined install/activate metadata with tests

## Verification

- `vendor/bin/phpunit --filter 'Recommended_Plugins_Installer_Test|Setup_Wizard_Admin_Page_Test'`
- `vendor/bin/phpcs inc/admin-pages/class-setup-wizard-admin-page.php inc/installers/class-recommended-plugins-installer.php tests/WP_Ultimo/Admin_Pages/Setup_Wizard_Admin_Page_Test.php tests/WP_Ultimo/Installers/Recommended_Plugins_Installer_Test.php`
- `vendor/bin/phpstan analyse inc/admin-pages/class-setup-wizard-admin-page.php inc/installers/class-recommended-plugins-installer.php`
- `node_modules/.bin/eslint assets/js/setup-wizard.js`
- agent-browser: confirmed three plugin rows with no activation rows; selecting User Switching produced install then activate AJAX actions, status transitions through Installing and Activating, and network activation completed

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.188 plugin for [OpenCode](https://opencode.ai) v1.18.5 with gpt-5.6-sol spent 15m and 223,072 tokens on this with the user in an interactive session.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Recommended plugins are now installed and activated in a single wizard step, with “Installed and activated!” progress messaging.
  * Multi-step plugin setup now proceeds only after required activation completes successfully.

* **Bug Fixes**
  * Improved wizard queue handling and error/success state updates during plugin setup.
  * Activation now respects network-wide activation semantics when applicable.

* **Documentation**
  * Updated the setup wizard “Recommended Plugins” description to clarify sequential install-and-activate behavior.

* **Tests**
  * Updated and strengthened installer/admin-page tests for the new step logic and messaging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->