### PR TITLE
fix(settings): show direct API keys after toggle

### DIFF
--- a/assets/js/vue-apps.js
+++ b/assets/js/vue-apps.js
@@ -147,6 +147,9 @@
 					if (Object.prototype.toString.call(value) === "[object Array]") {
 						return value.indexOf(this[ data ]) > -1;
 					}
+					if ([ "string", "number", "boolean" ].includes(typeof this[ data ]) && [ "string", "number", "boolean" ].includes(typeof value)) {
+						return String(this[ data ]) === String(value);
+					}
 					return this[ data ] === value;
 				},
 				open($event) {


### PR DESCRIPTION
## Summary

- Normalize scalar Vue settings values before evaluating field visibility requirements.
- Restore Stripe direct API-key inputs immediately after enabling the advanced toggle.

## Verification

- `eslint assets/js/vue-apps.js`
- Targeted scalar/array requirement regression assertion
- `vendor/bin/phpunit --filter Stripe_OAuth_Test`

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.191 plugin for [OpenCode](https://opencode.ai) v1.18.5 with gpt-5.6-terra


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved comparisons for string, number, and boolean values, ensuring equivalent primitive values are matched consistently.
  * Preserved strict comparison behavior for other value types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->