### PR TITLE
fix(stripe): use setup mode for trials

### DIFF
--- a/assets/js/gateways/stripe.js
+++ b/assets/js/gateways/stripe.js
@@ -229,10 +229,10 @@ const stripeElements = function (publicKey) {
 			return;
 		}
 
-		// Determine the correct mode based on order total
-		// Use 'payment' mode when there's an immediate charge, 'setup' for trials/$0
+		// Match the server-side intent selection: trials collect a card for
+		// off-session renewal with a SetupIntent, even when their renewal total is positive.
 		const orderTotal = form.order ? form.order.totals.total : 0;
-		const hasImmediateCharge = orderTotal > 0;
+		const hasImmediateCharge = orderTotal > 0 && ! form.order.has_trial;
 		const requiredMode = hasImmediateCharge ? 'payment' : 'setup';
 
 		// Convert amount to cents for Stripe (integer)


### PR DESCRIPTION
## Summary

- Use Stripe Payment Element setup mode when a checkout order has a trial.
- Keep payment mode for real immediate charges, matching the server-side PaymentIntent versus SetupIntent selection.

## Verification

- `npx eslint assets/js/gateways/stripe.js`
- `git diff --check`
- Local browser checkout: a trial with a $15 renewal total initialized the Payment Element in `setup` mode.

## Test limitation

- `vendor/bin/phpunit` is unavailable in the local dependency installation.

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.192 plugin for [OpenCode](https://opencode.ai) v1.18.5 with gpt-5.6-terra


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Stripe checkout handling for trial renewals.
  * Ensured payment details are collected using the appropriate flow when a renewal requires future billing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->