### PR TITLE
fix(setup): initialize newsletter opt-in on fresh installs

### DIFF
--- a/inc/class-newsletter.php
+++ b/inc/class-newsletter.php
@@ -45,10 +45,10 @@ class Newsletter {
 			'general',
 			self::SETTING_FIELD_SLUG,
 			[
-				'title' => __('Signup for Ultimate Multisite Newsletter', 'ultimate-multisite'),
-				'desc'  => __('Be informed of new releases and all things related to running a WaaS Network.', 'ultimate-multisite'),
-				'type'  => 'toggle',
-				'value' => '1',
+				'title'   => __('Signup for Ultimate Multisite Newsletter', 'ultimate-multisite'),
+				'desc'    => __('Be informed of new releases and all things related to running a WaaS Network.', 'ultimate-multisite'),
+				'type'    => 'toggle',
+				'default' => '1',
 			],
 			45
 		);

--- a/inc/class-settings.php
+++ b/inc/class-settings.php
@@ -2149,6 +2149,7 @@ class Settings implements \WP_Ultimo\Interfaces\Singleton {
 			'thousand_separator'                 => ',',
 			'precision'                          => '2',
 			'enable_beta_updates'                => 0,
+			'newsletter_optin'                   => '1',
 
 			// Login & Registration
 			'enable_registration'                => 1,

--- a/tests/WP_Ultimo/Settings_Test.php
+++ b/tests/WP_Ultimo/Settings_Test.php
@@ -517,6 +517,22 @@ class Settings_Test extends WP_UnitTestCase {
 		$this->assertEquals('administrator', $all['default_role']);
 	}
 
+	public function test_get_all_with_defaults_includes_newsletter_optin_when_db_is_empty() {
+		// Simulate a fresh install with no saved settings.
+		wu_save_option(Settings::KEY, []);
+
+		$ref = new \ReflectionProperty(Settings::class, 'settings');
+		if (PHP_VERSION_ID < 80100) {
+			$ref->setAccessible(true);
+		}
+		$ref->setValue($this->settings, null);
+
+		$all = $this->settings->get_all_with_defaults();
+
+		$this->assertArrayHasKey('newsletter_optin', $all);
+		$this->assertSame('1', $all['newsletter_optin']);
+	}
+
 	public function test_get_all_with_defaults_preserves_saved_values() {
 		// When a value IS saved in the DB it must be preserved.
 		$this->settings->save_setting('default_role', 'editor');


### PR DESCRIPTION
## Summary

- Initialize the newsletter opt-in setting in fresh-install settings state.
- Preserve the existing opt-in default when the setup wizard saves settings.
- Add regression coverage for an empty configuration.

## Verification

- `vendor/bin/phpcs inc/class-newsletter.php inc/class-settings.php tests/WP_Ultimo/Settings_Test.php`
- `vendor/bin/phpunit --filter test_get_all_with_defaults_includes_newsletter_optin_when_db_is_empty`
- Pre-commit PHPStan

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.198 plugin for [OpenCode](https://opencode.ai) v1.18.5 with gpt-5.6-terra


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a default opt-in setting for newsletters.
  * The newsletter preference is enabled by default and remains configurable through its existing title and description.

* **Bug Fixes**
  * Ensured the newsletter setting is available even when no saved settings exist.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->