### PR TITLE
fix(login): allow Cornerstone previews

### DIFF
--- a/inc/checkout/class-checkout-pages.php
+++ b/inc/checkout/class-checkout-pages.php
@@ -705,6 +705,7 @@ class Checkout_Pages {
 				'elementor-preview', // Elementor
 				'brizy-edit',        // Brizy
 				'brizy-edit-iframe', // Brizy
+				'cs_preview_state',  // Cornerstone
 			],
 			$custom_login_page,
 			$post,

--- a/tests/WP_Ultimo/Checkout/Checkout_Pages_Test.php
+++ b/tests/WP_Ultimo/Checkout/Checkout_Pages_Test.php
@@ -1996,6 +1996,30 @@ class Checkout_Pages_Test extends \WP_UnitTestCase {
 	}
 
 	/**
+	 * Test maybe_redirect_to_admin_panel allows Cornerstone preview requests.
+	 */
+	public function test_maybe_redirect_to_admin_panel_allows_cornerstone_preview(): void {
+
+		$user_id = self::factory()->user->create(['role' => 'subscriber']);
+		wp_set_current_user($user_id);
+
+		$login_page_id = self::factory()->post->create(['post_type' => 'page']);
+		wu_save_setting('default_login_page', $login_page_id);
+
+		global $post;
+		$post = get_post($login_page_id);
+
+		$_REQUEST['cs_preview_state'] = 'preview-state';
+
+		$this->pages->maybe_redirect_to_admin_panel();
+
+		unset($_REQUEST['cs_preview_state']);
+		wp_set_current_user(0);
+
+		$this->assertTrue(true);
+	}
+
+	/**
 	 * Test maybe_redirect_to_admin_panel exclusion list filter is applied.
 	 */
 	public function test_maybe_redirect_to_admin_panel_exclusion_filter(): void {


### PR DESCRIPTION
## Summary

- Exclude Cornerstone preview requests from the logged-in custom-login redirect.
- Cover the Cornerstone preview marker with a checkout-pages regression test.

## Verification

    vendor/bin/phpcs inc/checkout/class-checkout-pages.php tests/WP_Ultimo/Checkout/Checkout_Pages_Test.php
    vendor/bin/phpstan analyse inc/checkout/class-checkout-pages.php
    vendor/bin/phpunit --filter Checkout_Pages_Test

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.200 plugin for [OpenCode](https://opencode.ai) v1.18.9 with gpt-5.6-terra


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Cornerstone preview mode now remains accessible on the configured login page without being redirected to the admin panel.

- **Tests**
  - Added coverage to verify that login-page requests during Cornerstone preview complete without an unwanted redirect.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->