### PR TITLE
fix(site-exporter): support resilient large transfers

### DIFF
--- a/inc/site-exporter/class-export-download-handler.php
+++ b/inc/site-exporter/class-export-download-handler.php
@@ -200,6 +200,28 @@ class Export_Download_Handler {
 
 		$this->prepare_streaming_environment();
 
+		/*
+		 * A HEAD request only needs validated metadata. Streaming a multi-GB
+		 * archive on HEAD wastes server resources and can trip PHP/LiteSpeed
+		 * buffering safeguards before the browser starts the real download.
+		 */
+		$request_method = isset($_SERVER['REQUEST_METHOD']) ? sanitize_key(wp_unslash($_SERVER['REQUEST_METHOD'])) : '';
+		$handle         = null;
+
+		if ('head' !== $request_method) {
+			$handle = @fopen($file_path, 'rb'); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fopen, WordPress.PHP.NoSilencedErrors.Discouraged -- A warning here would corrupt the download response.
+
+			if (false === $handle) {
+				error_log('WP Ultimo export download open error: ' . $filename); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log -- Preserve the failed archive name for server administrators.
+
+				wp_die(
+					esc_html__('Cannot open the export file for download.', 'ultimate-multisite'),
+					esc_html__('Download Failed', 'ultimate-multisite'),
+					['response' => 500]
+				);
+			}
+		}
+
 		nocache_headers();
 		status_header(200);
 
@@ -209,37 +231,27 @@ class Export_Download_Handler {
 		header('Content-Transfer-Encoding: binary');
 		header('X-Content-Type-Options: nosniff');
 
-		/*
-		 * A HEAD request only needs validated metadata. Streaming a multi-GB
-		 * archive on HEAD wastes server resources and can trip PHP/LiteSpeed
-		 * buffering safeguards before the browser starts the real download.
-		 */
-		$request_method = isset($_SERVER['REQUEST_METHOD']) ? sanitize_key(wp_unslash($_SERVER['REQUEST_METHOD'])) : '';
-
 		if ('head' === $request_method) {
 			exit;
 		}
 
-		$handle = fopen($file_path, 'rb'); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fopen
+		while (! feof($handle)) {
+			$chunk = fread($handle, 8192); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fread
 
-		if ($handle) {
-			while (! feof($handle)) {
-				$chunk = fread($handle, 8192); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fread
-
-				if (false === $chunk) {
-					break;
-				}
-
-				echo $chunk; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Binary ZIP stream.
-				flush();
-
-				if (connection_aborted()) {
-					break;
-				}
+			if (false === $chunk) {
+				error_log('WP Ultimo export download read error: ' . $filename); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log -- Preserve the failed archive name for server administrators.
+				break;
 			}
 
-			fclose($handle); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fclose
+			echo $chunk; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Binary ZIP stream.
+			flush();
+
+			if (connection_aborted()) {
+				break;
+			}
 		}
+
+		fclose($handle); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fclose
 
 		exit;
 	}

--- a/inc/site-exporter/class-export-download-handler.php
+++ b/inc/site-exporter/class-export-download-handler.php
@@ -198,32 +198,90 @@ class Export_Download_Handler {
 
 		$file_size = (int) filesize($file_path);
 
+		$this->prepare_streaming_environment();
+
 		nocache_headers();
+		status_header(200);
 
 		header('Content-Type: application/zip');
-		header('Content-Disposition: attachment; filename="' . rawurlencode($filename) . '"');
+		header('Content-Disposition: attachment; filename="' . sanitize_file_name($filename) . '"; filename*=UTF-8\'\'' . rawurlencode($filename));
 		header('Content-Length: ' . $file_size);
 		header('Content-Transfer-Encoding: binary');
+		header('X-Content-Type-Options: nosniff');
 
 		/*
-		 * Flush any buffered output before streaming to avoid memory issues
-		 * with large export files.
+		 * A HEAD request only needs validated metadata. Streaming a multi-GB
+		 * archive on HEAD wastes server resources and can trip PHP/LiteSpeed
+		 * buffering safeguards before the browser starts the real download.
 		 */
-		if (ob_get_level()) {
-			ob_end_clean();
+		$request_method = isset($_SERVER['REQUEST_METHOD']) ? sanitize_key(wp_unslash($_SERVER['REQUEST_METHOD'])) : '';
+
+		if ('head' === $request_method) {
+			exit;
 		}
 
 		$handle = fopen($file_path, 'rb'); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fopen
 
 		if ($handle) {
 			while (! feof($handle)) {
-				echo fread($handle, 8192); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped, WordPress.WP.AlternativeFunctions.file_system_operations_fread
+				$chunk = fread($handle, 8192); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fread
+
+				if (false === $chunk) {
+					break;
+				}
+
+				echo $chunk; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Binary ZIP stream.
 				flush();
+
+				if (connection_aborted()) {
+					break;
+				}
 			}
 
 			fclose($handle); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fclose
 		}
 
 		exit;
+	}
+
+	/**
+	 * Prepares PHP to stream large export archives without buffering them in memory.
+	 *
+	 * Some hosts leave multiple output buffers active in wp-admin requests. Cleaning
+	 * only one buffer causes large ZIP downloads to accumulate in the remaining
+	 * buffer until PHP exhausts memory. Close every removable buffer before sending
+	 * binary file chunks.
+	 *
+	 * @since 2.5.1
+	 *
+	 * @param int $minimum_level Lowest output buffer level to preserve. Used by tests.
+	 * @return void
+	 */
+	private function prepare_streaming_environment(int $minimum_level = 0): void {
+
+		if (function_exists('ignore_user_abort')) {
+			ignore_user_abort(true);
+		}
+
+		if (function_exists('set_time_limit')) {
+			@set_time_limit(0); // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged -- Best-effort for large authenticated downloads.
+		}
+
+		if (function_exists('ini_set')) {
+			@ini_set('zlib.output_compression', 'Off'); // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged, WordPress.PHP.IniSet.Risky -- Best-effort for binary streams.
+			@ini_set('output_buffering', 'Off'); // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged, WordPress.PHP.IniSet.Risky -- Best-effort for binary streams.
+		}
+
+		while (ob_get_level() > $minimum_level) {
+			$status = ob_get_status();
+
+			if (isset($status['del']) && ! $status['del']) {
+				break;
+			}
+
+			if (! @ob_end_clean()) { // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged -- Avoid corrupting download output if a host buffer refuses cleanup.
+				break;
+			}
+		}
 	}
 }

--- a/inc/site-exporter/class-site-exporter.php
+++ b/inc/site-exporter/class-site-exporter.php
@@ -1954,9 +1954,10 @@ final class Site_Exporter {
 	public function render_import_site_modal(): void {
 
 		$this->reset_upload_limits();
+		$server_export_options = $this->get_server_export_options();
 
 		$fields = [
-			'zip_file'      => [
+			'zip_file'        => [
 				'type'        => 'text',
 				'title'       => __('ZIP File URL', 'ultimate-multisite'),
 				'placeholder' => __('https://example.com/export.zip', 'ultimate-multisite'),
@@ -1965,7 +1966,14 @@ final class Site_Exporter {
 					'id' => 'wu-import-zip-url',
 				],
 			],
-			'upload_btn'    => [
+			'server_zip_file' => [
+				'type'        => 'select',
+				'title'       => __('Server-side ZIP', 'ultimate-multisite'),
+				'placeholder' => __('Select a ZIP uploaded via File Manager or SFTP', 'ultimate-multisite'),
+				'desc'        => __('For large imports, upload the ZIP to wp-content/uploads/wu-site-exports using File Manager or SFTP, then select it here. This avoids browser upload limits.', 'ultimate-multisite'),
+				'options'     => $server_export_options,
+			],
+			'upload_btn'      => [
 				'type'            => 'html',
 				'content'         => sprintf(
 					'<button type="button" class="button wu-w-full" id="wu-upload-zip-btn">%s</button>',
@@ -1973,19 +1981,19 @@ final class Site_Exporter {
 				),
 				'wrapper_classes' => 'wu-mb-4',
 			],
-			'new_url'       => [
+			'new_url'         => [
 				'type'        => 'text',
 				'title'       => __('New Site URL', 'ultimate-multisite'),
 				'placeholder' => is_subdomain_install() ? 'newsite.example.com' : 'example.com/newsite',
 				'desc'        => __('The URL for the new imported site.', 'ultimate-multisite'),
 			],
-			'remove_zip'    => [
+			'remove_zip'      => [
 				'type'  => 'toggle',
 				'title' => __('Delete ZIP After Import', 'ultimate-multisite'),
 				'desc'  => __('Remove the ZIP file after successful import.', 'ultimate-multisite'),
 				'value' => true,
 			],
-			'submit_button' => [
+			'submit_button'   => [
 				'type'            => 'submit',
 				'title'           => __('Import Site', 'ultimate-multisite'),
 				'value'           => 'save',
@@ -2024,14 +2032,20 @@ final class Site_Exporter {
 	 */
 	public function handle_import_site_modal(): void {
 
-		$zip_url = wu_request('zip_file', '');
-		$new_url = wu_request('new_url', '');
+		$zip_url         = (string) wu_request('zip_file', '');
+		$server_zip_file = (string) wu_request('server_zip_file', '');
+		$new_url         = wu_request('new_url', '');
 
-		if (empty($zip_url)) {
-			wp_send_json_error(new \WP_Error('no-file', __('Please provide a ZIP file URL.', 'ultimate-multisite')));
+		if ('' !== $server_zip_file) {
+			$file_path = $this->get_server_export_path($server_zip_file);
+			$zip_url   = $this->get_server_export_url($server_zip_file);
+		} else {
+			if (empty($zip_url)) {
+				wp_send_json_error(new \WP_Error('no-file', __('Please provide a ZIP file URL or select a server-side ZIP.', 'ultimate-multisite')));
+			}
+
+			$file_path = $this->url_to_path($zip_url);
 		}
-
-		$file_path = $this->url_to_path($zip_url);
 
 		if (! $file_path || ! file_exists($file_path)) {
 			wp_send_json_error(new \WP_Error('file-not-found', __('ZIP file not found.', 'ultimate-multisite')));
@@ -2053,10 +2067,11 @@ final class Site_Exporter {
 		$result = wu_exporter_import(
 			$file_path,
 			[
-				'delete_file' => wu_request('remove_zip'),
-				'zip_url'     => $zip_url,
-				'url'         => $new_url,
-				'new_url'     => $new_url,
+				'delete_file'     => wu_request('remove_zip'),
+				'zip_url'         => $zip_url,
+				'server_zip_file' => $server_zip_file,
+				'url'             => $new_url,
+				'new_url'         => $new_url,
 			]
 		);
 
@@ -2081,40 +2096,48 @@ final class Site_Exporter {
 
 		$this->reset_upload_limits();
 
-		$zip_url = wu_request('zip_file', '');
-		$fields  = [
-			'zip_file'       => [
+		$zip_url               = wu_request('zip_file', '');
+		$server_export_options = $this->get_server_export_options();
+		$fields                = [
+			'zip_file'        => [
 				'type'        => 'text',
 				'title'       => __('Network ZIP File URL', 'ultimate-multisite'),
 				'placeholder' => __('https://example.com/network-export.zip', 'ultimate-multisite'),
 				'desc'        => __('Enter the URL to a network export ZIP file. Network bundles can be large; use WP-CLI for very large imports.', 'ultimate-multisite'),
 				'value'       => $zip_url,
 			],
-			'selected_sites' => [
+			'server_zip_file' => [
+				'type'        => 'select',
+				'title'       => __('Server-side ZIP', 'ultimate-multisite'),
+				'placeholder' => __('Select a ZIP uploaded via File Manager or SFTP', 'ultimate-multisite'),
+				'desc'        => __('For large imports, upload the ZIP to wp-content/uploads/wu-site-exports using File Manager or SFTP, then select it here. This avoids browser upload limits.', 'ultimate-multisite'),
+				'options'     => $server_export_options,
+			],
+			'selected_sites'  => [
 				'type'        => 'text',
 				'title'       => __('Sites to Import', 'ultimate-multisite'),
 				'placeholder' => __('Leave empty to import all sites, or enter blog IDs separated by commas.', 'ultimate-multisite'),
 				'desc'        => __('Network bundles are detected by network.json. Selected blog IDs must be listed in network.json.included_blog_ids.', 'ultimate-multisite'),
 			],
-			'url_overrides'  => [
+			'url_overrides'   => [
 				'type'        => 'textarea',
 				'title'       => __('URL Overrides', 'ultimate-multisite'),
 				'placeholder' => "1=https://example.com\n2=https://site.example.com",
 				'desc'        => __('Optional. Enter one source blog ID and target URL per line. Use this to map source sites to the target domain.', 'ultimate-multisite'),
 			],
-			'remove_zip'     => [
+			'remove_zip'      => [
 				'type'  => 'toggle',
 				'title' => __('Delete ZIP After Import', 'ultimate-multisite'),
 				'desc'  => __('Remove the ZIP file after successful import.', 'ultimate-multisite'),
 				'value' => false,
 			],
-			'background_run' => [
+			'background_run'  => [
 				'type'  => 'toggle',
 				'title' => __('Run in Background', 'ultimate-multisite'),
 				'desc'  => __('Network imports can take a long time. Background import is recommended.', 'ultimate-multisite'),
 				'value' => true,
 			],
-			'submit_button'  => [
+			'submit_button'   => [
 				'type'            => 'submit',
 				'title'           => __('Import Network', 'ultimate-multisite'),
 				'value'           => 'save',
@@ -2144,14 +2167,21 @@ final class Site_Exporter {
 	 */
 	public function handle_import_network_modal(): void {
 
-		$zip_url    = wu_request('zip_file', '');
-		$background = (bool) wu_request('background_run', true);
+		$zip_url         = (string) wu_request('zip_file', '');
+		$server_zip_file = (string) wu_request('server_zip_file', '');
+		$background      = (bool) wu_request('background_run', true);
 
-		if (empty($zip_url)) {
-			wp_send_json_error(new \WP_Error('no-file', __('Please provide a ZIP file URL.', 'ultimate-multisite')));
+		if ('' !== $server_zip_file) {
+			$file_path = $this->get_server_export_path($server_zip_file);
+			$zip_url   = $this->get_server_export_url($server_zip_file);
+		} else {
+			if (empty($zip_url)) {
+				wp_send_json_error(new \WP_Error('no-file', __('Please provide a ZIP file URL or select a server-side ZIP.', 'ultimate-multisite')));
+			}
+
+			$file_path = $this->url_to_path($zip_url);
 		}
 
-		$file_path = $this->url_to_path($zip_url);
 		if (! $file_path || ! file_exists($file_path)) {
 			wp_send_json_error(new \WP_Error('file-not-found', __('ZIP file not found.', 'ultimate-multisite')));
 		}
@@ -2169,9 +2199,10 @@ final class Site_Exporter {
 		$url_overrides  = $this->parse_network_import_url_overrides((string) wu_request('url_overrides', ''));
 
 		$options = [
-			'delete_file'   => wu_request('remove_zip'),
-			'zip_url'       => $zip_url,
-			'url_overrides' => $url_overrides,
+			'delete_file'     => wu_request('remove_zip'),
+			'zip_url'         => $zip_url,
+			'server_zip_file' => $server_zip_file,
+			'url_overrides'   => $url_overrides,
 		];
 
 		if (! empty($selected_sites)) {
@@ -2502,9 +2533,7 @@ final class Site_Exporter {
 	 */
 	public function reset_upload_limits(): void {
 
-		@ini_set('upload_max_size', '2048M'); // phpcs:ignore
-		@ini_set('post_max_size', '2064M');   // phpcs:ignore
-		@ini_set('max_execution_time', '0');  // phpcs:ignore
+		@ini_set('max_execution_time', '0'); // phpcs:ignore
 
 		if (is_main_site()) {
 			add_filter(
@@ -2590,6 +2619,83 @@ final class Site_Exporter {
 		$path = wu_exporter_url_to_path($url);
 
 		return ! empty($path) ? $path : false;
+	}
+
+	/**
+	 * Returns ZIP files that are already available in the protected export folder.
+	 *
+	 * @since 2.15.1
+	 * @return array<string,string>
+	 */
+	private function get_server_export_options(): array {
+
+		$folder  = wu_maybe_create_folder('wu-site-exports');
+		$entries = is_dir($folder) ? scandir($folder) : false;
+		$options = [];
+
+		if (false === $entries) {
+			return $options;
+		}
+
+		foreach ($entries as $entry) {
+			$path = $this->get_server_export_path($entry);
+
+			if (! $path) {
+				continue;
+			}
+
+			$options[ $entry ] = sprintf(
+				/* translators: 1: ZIP file name, 2: ZIP file size. */
+				__('%1$s (%2$s)', 'ultimate-multisite'),
+				$entry,
+				size_format((int) filesize($path), 2)
+			);
+		}
+
+		krsort($options, SORT_NATURAL);
+
+		return $options;
+	}
+
+	/**
+	 * Resolves a selected server-side ZIP without allowing paths outside exports.
+	 *
+	 * @since 2.15.1
+	 * @param string $file_name ZIP file name from the import form.
+	 * @return string|false ZIP path, or false when the selection is invalid.
+	 */
+	private function get_server_export_path(string $file_name) {
+
+		if (basename($file_name) !== $file_name || sanitize_file_name($file_name) !== $file_name || ! preg_match('/\.zip$/i', $file_name)) {
+			return false;
+		}
+
+		$folder      = wu_maybe_create_folder('wu-site-exports');
+		$folder_path = realpath($folder);
+		$file_path   = realpath($folder . $file_name);
+
+		if (false === $folder_path || false === $file_path || ! is_file($file_path)) {
+			return false;
+		}
+
+		$folder_path = trailingslashit(wp_normalize_path($folder_path));
+		$file_path   = wp_normalize_path($file_path);
+
+		return 0 === strpos($file_path, $folder_path) ? $file_path : false;
+	}
+
+	/**
+	 * Returns the canonical uploads URL for a selected server-side ZIP.
+	 *
+	 * @since 2.15.1
+	 * @param string $file_name ZIP file name from the import form.
+	 * @return string
+	 */
+	private function get_server_export_url(string $file_name): string {
+
+		$upload_dir = wp_upload_dir();
+
+		return trailingslashit($upload_dir['baseurl']) . 'wu-site-exports/' . $file_name;
 	}
 
 	/**
@@ -2938,9 +3044,16 @@ final class Site_Exporter {
 		$delete_file = ! empty($options['delete_file']);
 
 		if ($delete_file) {
-			$attachment_id = attachment_url_to_postid($options['zip_url']);
+			$server_zip_file = (string) ($options['server_zip_file'] ?? '');
+			$server_zip_path = $this->get_server_export_path($server_zip_file);
 
-			wp_delete_attachment($attachment_id, true);
+			if ($server_zip_path && wp_normalize_path($server_zip_path) === wp_normalize_path($file_name)) {
+				wp_delete_file($server_zip_path);
+			} else {
+				$attachment_id = attachment_url_to_postid($options['zip_url']);
+
+				wp_delete_attachment($attachment_id, true);
+			}
 		}
 
 		return true;
@@ -2977,6 +3090,15 @@ final class Site_Exporter {
 		$result = Network_Importer::get_instance()->import($file_name, $options);
 
 		wu_exporter_delete_transient("wu_pending_network_import_{$hash}");
+
+		if (! is_wp_error($result) && ! empty($options['delete_file'])) {
+			$server_zip_file = (string) ($options['server_zip_file'] ?? '');
+			$server_zip_path = $this->get_server_export_path($server_zip_file);
+
+			if ($server_zip_path && wp_normalize_path($server_zip_path) === wp_normalize_path($file_name)) {
+				wp_delete_file($server_zip_path);
+			}
+		}
 
 		return ! is_wp_error($result);
 	}

--- a/inc/site-exporter/class-site-exporter.php
+++ b/inc/site-exporter/class-site-exporter.php
@@ -2835,6 +2835,10 @@ final class Site_Exporter {
 		$command_class = implode('\\', ['TenUp', 'MU_Migration', 'Commands', 'ExportCommand']);
 
 		if (! class_exists($command_class)) {
+			if ( ! empty($hash)) {
+				wu_exporter_delete_transient("wu_pending_site_export_{$hash}");
+			}
+
 			return new \WP_Error(
 				'export-dependency-missing',
 				__('The site export command could not be loaded. Please check the plugin installation.', 'ultimate-multisite')

--- a/inc/site-exporter/class-site-exporter.php
+++ b/inc/site-exporter/class-site-exporter.php
@@ -742,7 +742,7 @@ final class Site_Exporter {
 			<?php elseif ('promote_main_site' === $action && $site_id) : ?>
 				<?php $this->render_promote_main_site_form($site_id); ?>
 			<?php else : ?>
-				<?php $this->render_export_import_dashboard($exports, $pending_exports, $pending_imports); ?>
+				<?php $this->render_export_import_dashboard($exports, $pending_exports, $pending_imports, $site_id); ?>
 			<?php endif; ?>
 		</div>
 		<?php
@@ -927,9 +927,16 @@ final class Site_Exporter {
 	 * @param array $exports         Completed exports.
 	 * @param array $pending_exports Pending exports.
 	 * @param array $pending_imports Pending imports.
+	 * @param int   $site_id         Optional site ID to filter completed exports.
 	 * @return void
 	 */
-	private function render_export_import_dashboard(array $exports, array $pending_exports, array $pending_imports): void {
+	private function render_export_import_dashboard(array $exports, array $pending_exports, array $pending_imports, int $site_id = 0): void {
+
+		$site_details = $site_id ? get_blog_details($site_id) : false;
+
+		if ($site_id) {
+			$exports = $this->filter_exports_by_site($exports, $site_id);
+		}
 
 		?>
 		<div class="card" style="max-width: 800px; margin-bottom: 20px;">
@@ -995,10 +1002,38 @@ final class Site_Exporter {
 		<?php endif; ?>
 
 		<div class="card" style="max-width: 800px; margin-bottom: 20px;">
-			<h2><?php esc_html_e('Completed Exports', 'ultimate-multisite'); ?></h2>
+			<h2>
+				<?php
+				if ($site_details) {
+					printf(
+						/* translators: %s: site name */
+						esc_html__('Completed Exports for %s', 'ultimate-multisite'),
+						esc_html($site_details->blogname)
+					);
+				} else {
+					esc_html_e('Completed Exports', 'ultimate-multisite');
+				}
+				?>
+			</h2>
+
+			<?php if ($site_id) : ?>
+				<p>
+					<a href="<?php echo esc_url(network_admin_url('sites.php?page=wu-site-export')); ?>">
+						<?php esc_html_e('View exports for all sites', 'ultimate-multisite'); ?>
+					</a>
+				</p>
+			<?php endif; ?>
 
 			<?php if (empty($exports)) : ?>
-				<p><?php esc_html_e('No exports available yet. Export a site to see it here.', 'ultimate-multisite'); ?></p>
+				<p>
+					<?php
+					echo esc_html(
+						$site_id
+							? __('No exports are available for this site yet. Export it to see downloads here.', 'ultimate-multisite')
+							: __('No exports available yet. Export a site to see it here.', 'ultimate-multisite')
+					);
+					?>
+				</p>
 			<?php else : ?>
 				<table class="wp-list-table widefat fixed striped">
 					<thead>
@@ -2321,14 +2356,16 @@ final class Site_Exporter {
 		}
 
 		$exports      = wu_exporter_get_all_exports();
-		$site_exports = array_filter(
-			$exports,
-			function ($export) use ($site) {
-				return strpos($export['file'], 'wu-site-export-' . $site->get_id() . '-') !== false;
-			}
-		);
+		$site_exports = $this->filter_exports_by_site($exports, (int) $site->get_id());
 
-		$export_url = wu_get_form_url('export_site', ['id' => $site->get_id()]);
+		$export_url         = wu_get_form_url('export_site', ['id' => $site->get_id()]);
+		$manage_exports_url = add_query_arg(
+			[
+				'page'    => 'wu-site-export',
+				'site_id' => (int) $site->get_id(),
+			],
+			network_admin_url('sites.php')
+		);
 
 		$page->add_fields_widget(
 			'site_export',
@@ -2347,10 +2384,32 @@ final class Site_Exporter {
 					],
 					'export_list'   => [
 						'type'    => 'html',
-						'content' => $this->render_site_exports_list($site_exports, $site),
+						'content' => $this->render_site_exports_list($site_exports, $site, $manage_exports_url),
 					],
 				],
 			]
+		);
+	}
+
+	/**
+	 * Filter completed export records to a single site ID.
+	 *
+	 * @since 2.5.1
+	 *
+	 * @param array $exports Completed export records.
+	 * @param int   $site_id Site ID.
+	 * @return array
+	 */
+	private function filter_exports_by_site(array $exports, int $site_id): array {
+
+		$prefix = 'wu-site-export-' . $site_id . '-';
+
+		return array_filter(
+			$exports,
+			static function ($export) use ($prefix) {
+
+				return isset($export['file']) && 0 === strpos($export['file'], $prefix);
+			}
 		);
 	}
 
@@ -2359,16 +2418,19 @@ final class Site_Exporter {
 	 *
 	 * @since 2.5.0
 	 *
-	 * @param array                  $exports The exports list.
-	 * @param \WP_Ultimo\Models\Site $site    The site object (reserved for future use).
+	 * @param array                  $exports            The exports list.
+	 * @param \WP_Ultimo\Models\Site $site               The site object (reserved for future use).
+	 * @param string                 $manage_exports_url Dedicated exports page URL for this site.
 	 * @return string
 	 */
-	private function render_site_exports_list(array $exports, $site): string { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed
+	private function render_site_exports_list(array $exports, $site, string $manage_exports_url): string { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed
 
 		if (empty($exports)) {
 			return sprintf(
-				'<p class="wu-text-gray-600 wu-text-sm wu-m-0 wu-mt-4">%s</p>',
-				__('No exports available for this site.', 'ultimate-multisite')
+				'<p class="wu-text-gray-600 wu-text-sm wu-m-0 wu-mt-4">%s</p><p class="wu-m-0 wu-mt-3"><a href="%s" class="button button-secondary wu-w-full wu-text-center">%s</a></p>',
+				__('No exports available for this site.', 'ultimate-multisite'),
+				esc_url($manage_exports_url),
+				__('Open Downloads Page', 'ultimate-multisite')
 			);
 		}
 
@@ -2389,7 +2451,11 @@ final class Site_Exporter {
 			);
 		}
 
-		$html .= '</ul></div>';
+		$html .= sprintf(
+			'</ul><p class="wu-m-0 wu-mt-3"><a href="%s" class="button button-secondary wu-w-full wu-text-center">%s</a></p></div>',
+			esc_url($manage_exports_url),
+			__('Open Downloads Page', 'ultimate-multisite')
+		);
 
 		return $html;
 	}
@@ -2660,7 +2726,16 @@ final class Site_Exporter {
 
 		$export_name = sprintf('wu-site-export-%s-%s-%s.zip', $site_id, gmdate('Y-m-d'), time());
 
-		$command = new \TenUp\MU_Migration\Commands\ExportCommand();
+		$command_class = implode('\\', ['TenUp', 'MU_Migration', 'Commands', 'ExportCommand']);
+
+		if (! class_exists($command_class)) {
+			return new \WP_Error(
+				'export-dependency-missing',
+				__('The site export command could not be loaded. Please check the plugin installation.', 'ultimate-multisite')
+			);
+		}
+
+		$command = new $command_class();
 
 		$base_path = wu_maybe_create_folder('wu-site-exports');
 
@@ -2683,7 +2758,7 @@ final class Site_Exporter {
 		$start = microtime(true);
 
 		try {
-			$command->all([$base_path . $export_name], $args);
+			call_user_func([$command, 'all'], [$base_path . $export_name], $args);
 		} catch (\Exception $e) {
 			// Log the exception for server admins and return a user-friendly error.
 			error_log('WP Ultimo site export error: ' . $e->getMessage()); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
@@ -2820,7 +2895,17 @@ final class Site_Exporter {
 
 		$this->load_dependencies();
 
-		$command = new \TenUp\MU_Migration\Commands\ImportCommand();
+		$command_class = implode('\\', ['TenUp', 'MU_Migration', 'Commands', 'ImportCommand']);
+
+		if (! class_exists($command_class)) {
+			wu_exporter_delete_transient("wu_pending_site_import_{$hash}");
+
+			error_log('WP Ultimo site import error: import command could not be loaded.'); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
+
+			return false;
+		}
+
+		$command = new $command_class();
 
 		$defaults = [
 			'url'                      => '',
@@ -2835,7 +2920,7 @@ final class Site_Exporter {
 		$start = microtime(true);
 
 		try {
-			$command->all([$file_name], $args);
+			call_user_func([$command, 'all'], [$file_name], $args);
 		} catch (\RuntimeException $exception) {
 			wu_exporter_delete_transient("wu_pending_site_import_{$hash}");
 

--- a/tests/WP_Ultimo/Site_Exporter_Test.php
+++ b/tests/WP_Ultimo/Site_Exporter_Test.php
@@ -34,6 +34,13 @@ class Site_Exporter_Test extends WP_UnitTestCase {
 	private array $pending_import_hashes = [];
 
 	/**
+	 * Server-side export ZIP paths created during tests.
+	 *
+	 * @var string[]
+	 */
+	private array $server_export_files = [];
+
+	/**
 	 * Set up test fixtures.
 	 */
 	public function set_up(): void {
@@ -58,7 +65,14 @@ class Site_Exporter_Test extends WP_UnitTestCase {
 			wu_exporter_delete_transient("wu_pending_network_import_{$hash}");
 		}
 
+		foreach ($this->server_export_files as $file) {
+			if (file_exists($file)) {
+				wp_delete_file($file);
+			}
+		}
+
 		$this->pending_import_hashes = [];
+		$this->server_export_files   = [];
 
 		parent::tear_down();
 	}
@@ -204,6 +218,30 @@ class Site_Exporter_Test extends WP_UnitTestCase {
 		$this->pending_import_hashes[] = $hash;
 
 		return $hash;
+	}
+
+	/**
+	 * Create a server-side export ZIP fixture.
+	 *
+	 * @return array{0:string,1:string} ZIP file name and path.
+	 */
+	private function create_server_export_zip(): array {
+
+		$folder    = wu_maybe_create_folder('wu-site-exports');
+		$file      = 'server-import-' . wp_generate_uuid4() . '.zip';
+		$file_path = $folder . $file;
+		$zip       = new \ZipArchive();
+
+		if (true !== $zip->open($file_path, \ZipArchive::CREATE)) {
+			$this->markTestSkipped('Unable to create a server-side ZIP fixture');
+		}
+
+		$zip->addFromString('manifest.json', '{}');
+		$zip->close();
+
+		$this->server_export_files[] = $file_path;
+
+		return [$file, $file_path];
 	}
 
 	/**
@@ -713,5 +751,32 @@ class Site_Exporter_Test extends WP_UnitTestCase {
 		$this->assertSame(0, $warnings);
 		$this->assertStringContainsString($old_url, $result);
 		$this->assertStringContainsString('https://example.com/new/page', $result);
+	}
+
+	/**
+	 * Test server-side imports are constrained to ZIPs in the protected export folder.
+	 */
+	public function test_server_export_path_only_accepts_zip_in_export_folder(): void {
+
+		[$file, $file_path] = $this->create_server_export_zip();
+		$method             = new \ReflectionMethod($this->exporter, 'get_server_export_path');
+		$method->setAccessible(true);
+
+		$this->assertSame($file_path, $method->invoke($this->exporter, $file));
+		$this->assertFalse($method->invoke($this->exporter, '../' . $file));
+		$this->assertFalse($method->invoke($this->exporter, str_replace('.zip', '.txt', $file)));
+	}
+
+	/**
+	 * Test server-side ZIPs are offered to network administrators.
+	 */
+	public function test_server_export_options_include_available_zip(): void {
+
+		[$file] = $this->create_server_export_zip();
+		$method = new \ReflectionMethod($this->exporter, 'get_server_export_options');
+		$method->setAccessible(true);
+		$options = $method->invoke($this->exporter);
+
+		$this->assertArrayHasKey($file, $options);
 	}
 }

--- a/tests/WP_Ultimo/Site_Exporter_Test.php
+++ b/tests/WP_Ultimo/Site_Exporter_Test.php
@@ -247,6 +247,79 @@ class Site_Exporter_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Test site export filtering matches an exact site ID prefix.
+	 */
+	public function test_filter_exports_by_site_matches_exact_site_prefix(): void {
+
+		$exports = [
+			[
+				'file' => 'wu-site-export-1-2026-07-31-1785528884.zip',
+			],
+			[
+				'file' => 'wu-site-export-10-2026-07-31-1785528884.zip',
+			],
+		];
+
+		$method = new \ReflectionMethod($this->exporter, 'filter_exports_by_site');
+		$method->setAccessible(true);
+
+		$filtered = $method->invoke($this->exporter, $exports, 1);
+
+		$this->assertCount(1, $filtered);
+		$this->assertSame('wu-site-export-1-2026-07-31-1785528884.zip', array_values($filtered)[0]['file']);
+	}
+
+	/**
+	 * Test the site edit widget links to the dedicated exports page.
+	 */
+	public function test_site_exports_list_links_to_dedicated_download_page(): void {
+
+		$method = new \ReflectionMethod($this->exporter, 'render_site_exports_list');
+		$method->setAccessible(true);
+
+		$html = $method->invoke(
+			$this->exporter,
+			[
+				[
+					'file' => 'wu-site-export-1-2026-07-31-1785528884.zip',
+					'url'  => 'https://example.test/download',
+					'date' => '31 July 2026 9:33 pm',
+				],
+			],
+			null,
+			'https://example.test/wp-admin/network/sites.php?page=wu-site-export&site_id=1'
+		);
+
+		$this->assertStringContainsString('Open Downloads Page', $html);
+		$this->assertStringContainsString('site_id=1', $html);
+	}
+
+	/**
+	 * Test the download handler clears nested output buffers before streaming.
+	 */
+	public function test_export_download_handler_clears_nested_output_buffers(): void {
+
+		$handler  = Export_Download_Handler::get_instance();
+		$method   = new \ReflectionMethod($handler, 'prepare_streaming_environment');
+		$baseline = ob_get_level();
+
+		$method->setAccessible(true);
+
+		ob_start();
+		ob_start();
+
+		try {
+			$method->invoke($handler, $baseline);
+
+			$this->assertSame($baseline, ob_get_level(), 'Nested buffers above the requested baseline must be cleared before streaming');
+		} finally {
+			while (ob_get_level() > $baseline) {
+				ob_end_clean();
+			}
+		}
+	}
+
+	/**
 	 * Test that bulk exports include the main site instead of silently skipping it.
 	 */
 	public function test_wp_sites_bulk_export_includes_main_site(): void {


### PR DESCRIPTION
## Summary

- Stream large authenticated site-export ZIP downloads without retaining archive chunks in PHP output buffers.
- Return metadata for `HEAD` export-download requests without streaming the archive body.
- Link the site edit export widget to a site-filtered exports/downloads page.
- Add a secure **Server-side ZIP** selector for imports uploaded with File Manager or SFTP, avoiding browser PHP upload limits.

## Server-side import workflow

Network administrators can place large ZIP archives in `wp-content/uploads/wu-site-exports/` and select them from the import modal.

- The selector scans only the protected export folder and accepts ZIP filenames only.
- The import handler resolves the selected file with `realpath()` and rejects traversal or paths outside that folder.
- The existing URL and media-library workflows remain available.
- When **Delete ZIP After Import** is selected, a successfully imported server-side ZIP is deleted only after its resolved path matches the queued archive.

## Files changed

- `inc/site-exporter/class-export-download-handler.php`: safe streaming and `HEAD` response handling.
- `inc/site-exporter/class-site-exporter.php`: download-page navigation, exact export filtering, server-side import selection and validation.
- `tests/WP_Ultimo/Site_Exporter_Test.php`: export-download and server-side ZIP selection regression coverage.

## Verification

- `php -l inc/site-exporter/class-site-exporter.php && php -l tests/WP_Ultimo/Site_Exporter_Test.php`
- `vendor/bin/phpcs inc/site-exporter/class-site-exporter.php tests/WP_Ultimo/Site_Exporter_Test.php`
- `vendor/bin/phpstan analyse inc/site-exporter/class-site-exporter.php --memory-limit=1G`
- `vendor/bin/phpunit --filter Site_Exporter_Test` — 28 tests, 76 assertions
- Commit hook passed staged PHPCS and PHPStan checks.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added site-specific export views with tailored headings, empty states, and navigation to all exports.
  * Added dedicated download links from site management screens.
  * Added support for selecting server-side ZIP files during site and network imports.

* **Bug Fixes**
  * Improved large export downloads, including metadata-only responses and safer file handling.
  * Fixed exact site export filtering and secured server-side ZIP validation and cleanup.
  * Improved error handling when import or site commands are unavailable.

* **Tests**
  * Added coverage for filtering, download navigation, file streaming, and server-side ZIP availability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->