### PR TITLE
fix(site-exporter): enqueue Import Site uploader

### DIFF
--- a/inc/site-exporter/class-site-exporter.php
+++ b/inc/site-exporter/class-site-exporter.php
@@ -1420,10 +1420,14 @@ final class Site_Exporter {
 		 * registered on the parent page using event delegation so it is present
 		 * before the modal opens.
 		 *
-		 * Hook: "wp-ultimo_page_wp-ultimo-sites" (network admin submenu under
-		 * parent slug "wp-ultimo", menu slug "wp-ultimo-sites").
+		 * The `wp-ultimo` parent is an admin-bar menu rather than a registered
+		 * WordPress admin-menu parent. WordPress therefore emits
+		 * `admin_page_wp-ultimo-sites` for the network Sites page. Keep the
+		 * legacy submenu hook too for installations that register that parent.
 		 */
-		if ('wp-ultimo_page_wp-ultimo-sites' === $hook) {
+		$wp_sites_hooks = ['admin_page_wp-ultimo-sites', 'wp-ultimo_page_wp-ultimo-sites'];
+
+		if (in_array($hook, $wp_sites_hooks, true)) {
 			wp_enqueue_media();
 
 			wp_add_inline_script(

--- a/tests/WP_Ultimo/Site_Exporter_Test.php
+++ b/tests/WP_Ultimo/Site_Exporter_Test.php
@@ -247,6 +247,24 @@ class Site_Exporter_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Test the Ultimate Multisite Sites page receives the delegated ZIP-upload handler.
+	 */
+	public function test_wp_sites_scripts_enqueue_zip_upload_handler_for_actual_admin_hook(): void {
+
+		$this->exporter->enqueue_wp_sites_scripts('admin_page_wp-ultimo-sites');
+
+		$this->assertTrue(
+			wp_script_is('media-editor', 'registered'),
+			'The media editor script must be available on the Ultimate Multisite Sites page'
+		);
+
+		$inline_scripts = wp_scripts()->get_data('media-editor', 'after');
+
+		$this->assertIsArray($inline_scripts);
+		$this->assertStringContainsString('#wu-upload-zip-btn', implode("\n", $inline_scripts));
+	}
+
+	/**
 	 * Test that bulk exports include the main site instead of silently skipping it.
 	 */
 	public function test_wp_sites_bulk_export_includes_main_site(): void {


### PR DESCRIPTION
## Summary

- enqueue the Import Site media-library handler for the actual Network Admin page hook, `admin_page_wp-ultimo-sites`
- retain support for the legacy submenu hook used where `wp-ultimo` is registered as an admin-menu parent
- add a regression test that verifies the real page hook attaches the delegated `#wu-upload-zip-btn` handler

## Cause

`wp-ultimo` is an admin-bar parent rather than a registered WordPress admin-menu parent on the affected Network Admin page. WordPress therefore generates `admin_page_wp-ultimo-sites`, while the importer previously accepted only `wp-ultimo_page_wp-ultimo-sites`; the media library and delegated click handler were never loaded.

## Verification

- `php -l inc/site-exporter/class-site-exporter.php`
- `php -l tests/WP_Ultimo/Site_Exporter_Test.php`
- `vendor/bin/phpcs --standard=.phpcs.xml.dist inc/site-exporter/class-site-exporter.php tests/WP_Ultimo/Site_Exporter_Test.php`
- `vendor/bin/phpstan analyse --configuration=phpstan.neon.dist --no-progress inc/site-exporter/class-site-exporter.php tests/WP_Ultimo/Site_Exporter_Test.php`
- isolated PHP harness: confirmed the actual page hook enqueues the media library and registers the ZIP-upload handler

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.209 plugin for [OpenCode](https://opencode.ai) v1.18.9 with gpt-5.6-terra


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Restored media-upload functionality on the WordPress Sites admin page.
  * ZIP uploads now work correctly when accessing the page through the current admin hook.

* **Tests**
  * Added regression coverage to verify that the media editor and ZIP-upload handler load as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->