### PR TITLE
GH#1694: use product fixture helper

### DIFF
--- a/tests/WP_Ultimo/Models/Membership_Test.php
+++ b/tests/WP_Ultimo/Models/Membership_Test.php
@@ -1091,23 +1091,23 @@ class Membership_Test extends \WP_UnitTestCase {
 
 		add_filter('wu_plan_product_types', $register_network_type);
 
-		$network_product = new Product(
+		$network_product = wu_create_product(
 			[
-				'name'          => 'Network Plan',
-				'slug'          => 'network-plan-' . wp_generate_password(6, false),
-				'description'   => 'A custom plan type registered by an addon',
-				'pricing_type'  => 'paid',
-				'amount'        => 49.00,
-				'currency'      => 'USD',
-				'duration'      => 1,
-				'duration_unit' => 'month',
-				'type'          => 'network',
-				'recurring'     => true,
-				'active'        => true,
+				'name'            => 'Network Plan',
+				'slug'            => 'network-plan-' . wp_generate_password(6, false),
+				'description'     => 'A custom plan type registered by an addon',
+				'pricing_type'    => 'paid',
+				'amount'          => 49.00,
+				'currency'        => 'USD',
+				'duration'        => 1,
+				'duration_unit'   => 'month',
+				'type'            => 'network',
+				'recurring'       => true,
+				'active'          => true,
+				'skip_validation' => true,
 			]
 		);
-		$network_product->set_skip_validation(true);
-		$network_product->save();
+		$this->assertNotWPError($network_product);
 
 		$cart = new \WP_Ultimo\Checkout\Cart(
 			[

--- a/tests/WP_Ultimo/Models/Membership_Test.php
+++ b/tests/WP_Ultimo/Models/Membership_Test.php
@@ -1451,7 +1451,7 @@ class Membership_Test extends \WP_UnitTestCase {
 	/**
 	 * Test renew() DOES clear date_cancellation when reactivating a cancelled membership.
 	 *
-	 * renew() is called by reactivate(), and also directly by gateways via IPN/webhook.
+	 * Renew() is called by reactivate(), and also directly by gateways via IPN/webhook.
 	 * It must clear the cancellation timestamp when the previous status was CANCELLED
 	 * so that cancelled membership records are cleaned up in a single save.
 	 */


### PR DESCRIPTION
Resolves #1694
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.227 plugin for [OpenCode](https://opencode.ai) v1.18.9 with gpt-5.6-terra


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved coverage for custom plan swaps by validating network product creation and explicitly checking for errors.
  * Updated related test documentation for consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->