### PR TITLE
GH#1697: fix: render password fallback on custom login pages

### DIFF
--- a/inc/auth/class-passwordless-auth-manager.php
+++ b/inc/auth/class-passwordless-auth-manager.php
@@ -728,7 +728,7 @@ class Passwordless_Auth_Manager {
 	 * @since 2.13.2
 	 * @return bool
 	 */
-	protected function is_password_fallback() {
+	public function is_password_fallback() {
 
 		return isset($_GET['wu_password_fallback']); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 	}

--- a/inc/ui/class-login-form-element.php
+++ b/inc/ui/class-login-form-element.php
@@ -808,7 +808,7 @@ class Login_Form_Element extends Base_Element {
 
 			$passwordless_auth = \WP_Ultimo\Auth\Passwordless_Auth_Manager::get_instance();
 
-			if ($passwordless_auth->is_enabled()) {
+			if ($passwordless_auth->is_enabled() && ! $passwordless_auth->is_password_fallback()) {
 				$fields = [
 					'passwordless_login' => [
 						'type'            => 'html',

--- a/tests/WP_Ultimo/UI/Login_Form_Element_Test.php
+++ b/tests/WP_Ultimo/UI/Login_Form_Element_Test.php
@@ -34,4 +34,36 @@ class Login_Form_Element_Test extends WP_UnitTestCase {
 		$this->assertSame('1', $query['wu_password_fallback']);
 		$this->assertSame($redirect_to, $query['redirect_to']);
 	}
+
+	/**
+	 * Test passwordless fallback renders the regular login form.
+	 */
+	public function test_passwordless_fallback_renders_regular_login_form(): void {
+
+		$element         = Login_Form_Element::get_instance();
+		$setting         = wu_get_setting('use_passwordless_login', 0);
+		$current_user_id = get_current_user_id();
+
+		try {
+			wp_set_current_user(0);
+			wu_save_setting('use_passwordless_login', 1);
+			unset($_GET['wu_password_fallback'], $_REQUEST['wu_password_fallback']);
+
+			$element->setup();
+
+			$this->assertStringContainsString('wu-passwordless-auth', $element->get_content([]));
+
+			$_GET['wu_password_fallback']     = '1';
+			$_REQUEST['wu_password_fallback'] = '1';
+
+			$markup = $element->get_content([]);
+
+			$this->assertStringContainsString('name="pwd"', $markup);
+			$this->assertStringNotContainsString('wu-passwordless-auth', $markup);
+		} finally {
+			wu_save_setting('use_passwordless_login', $setting);
+			wp_set_current_user($current_user_id);
+			unset($_GET['wu_password_fallback'], $_REQUEST['wu_password_fallback']);
+		}
+	}
 }


### PR DESCRIPTION
## Summary

- Expose the existing password-fallback request predicate to custom login rendering.
- Render standard username/password controls when wu_password_fallback=1 is requested.
- Cover passwordless and fallback custom-login form states.

## Testing

- PHPCS: passwordless auth manager, login form element, and login form element test
- PHPUnit: Login_Form_Element_Test
- PHPUnit: Passwordless_Auth_Test

Resolves #1697

<!-- aidevops:sig -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Passwordless login now correctly falls back to the standard username and password form when a fallback request is detected.
  * Passwordless login remains available for eligible requests without the fallback flag.

* **Tests**
  * Added coverage to verify both passwordless and fallback login flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->