### PR TITLE
fix: recognize external cron schedulers

### DIFF
--- a/inc/class-requirements.php
+++ b/inc/class-requirements.php
@@ -178,6 +178,21 @@ class Requirements {
 	 */
 	public static function check_wp_cron(): bool {
 
+		/**
+		 * Filters the detected WP-Cron status.
+		 *
+		 * Return a boolean to bypass the native checks, or null to run them.
+		 *
+		 * @since 2.5.1
+		 *
+		 * @param bool|null $status_override Cron status override. Default null.
+		 */
+		$status_override = apply_filters('wu_wp_cron_status_override', null);
+
+		if (is_bool($status_override)) {
+			return $status_override;
+		}
+
 		global $wp_version;
 
 		if (defined('DISABLE_WP_CRON') && DISABLE_WP_CRON) {

--- a/tests/WP_Ultimo/Requirements_Test.php
+++ b/tests/WP_Ultimo/Requirements_Test.php
@@ -24,6 +24,7 @@ class Requirements_Test extends \WP_UnitTestCase {
 		Requirements::$met = null;
 		remove_all_filters('wu_wp_cron_status_override');
 		delete_site_transient('wp-ultimo-cron-test-ok');
+		delete_transient('wp-ultimo-cron-test-ok');
 	}
 
 	/**
@@ -32,6 +33,7 @@ class Requirements_Test extends \WP_UnitTestCase {
 	public function tear_down(): void {
 		remove_all_filters('wu_wp_cron_status_override');
 		delete_site_transient('wp-ultimo-cron-test-ok');
+		delete_transient('wp-ultimo-cron-test-ok');
 
 		parent::tear_down();
 	}
@@ -119,10 +121,29 @@ class Requirements_Test extends \WP_UnitTestCase {
 	 */
 	public function test_check_wp_cron_null_override(): void {
 
-		set_site_transient('wp-ultimo-cron-test-ok', 1, HOUR_IN_SECONDS);
+		$native_check_called = false;
+		$http_filter         = static function () use (&$native_check_called) {
+			$native_check_called = true;
+
+			return [
+				'response' => [
+					'code'    => 500,
+					'message' => 'Cron unavailable',
+				],
+			];
+		};
+
+		add_filter('pre_http_request', $http_filter);
 		add_filter('wu_wp_cron_status_override', '__return_null');
 
-		$this->assertTrue(Requirements::check_wp_cron());
+		try {
+			$result = Requirements::check_wp_cron();
+		} finally {
+			remove_filter('pre_http_request', $http_filter);
+		}
+
+		$this->assertTrue($native_check_called);
+		$this->assertFalse($result);
 	}
 
 	/**

--- a/tests/WP_Ultimo/Requirements_Test.php
+++ b/tests/WP_Ultimo/Requirements_Test.php
@@ -121,29 +121,31 @@ class Requirements_Test extends \WP_UnitTestCase {
 	 */
 	public function test_check_wp_cron_null_override(): void {
 
-		$native_check_called = false;
-		$http_filter         = static function () use (&$native_check_called) {
-			$native_check_called = true;
+		$native_result = Requirements::check_wp_cron();
 
-			return [
-				'response' => [
-					'code'    => 500,
-					'message' => 'Cron unavailable',
-				],
-			];
+		delete_site_transient('wp-ultimo-cron-test-ok');
+		delete_transient('wp-ultimo-cron-test-ok');
+
+		$override_called = false;
+		$override_input  = false;
+		$override_filter = static function ($status) use (&$override_called, &$override_input) {
+			$override_called = true;
+			$override_input  = $status;
+
+			return null;
 		};
 
-		add_filter('pre_http_request', $http_filter);
-		add_filter('wu_wp_cron_status_override', '__return_null');
+		add_filter('wu_wp_cron_status_override', $override_filter);
 
 		try {
-			$result = Requirements::check_wp_cron();
+			$override_result = Requirements::check_wp_cron();
 		} finally {
-			remove_filter('pre_http_request', $http_filter);
+			remove_filter('wu_wp_cron_status_override', $override_filter);
 		}
 
-		$this->assertTrue($native_check_called);
-		$this->assertFalse($result);
+		$this->assertTrue($override_called);
+		$this->assertNull($override_input);
+		$this->assertSame($native_result, $override_result);
 	}
 
 	/**

--- a/tests/WP_Ultimo/Requirements_Test.php
+++ b/tests/WP_Ultimo/Requirements_Test.php
@@ -22,6 +22,18 @@ class Requirements_Test extends \WP_UnitTestCase {
 		parent::set_up();
 
 		Requirements::$met = null;
+		remove_all_filters('wu_wp_cron_status_override');
+		delete_site_transient('wp-ultimo-cron-test-ok');
+	}
+
+	/**
+	 * Remove cron status test state after each test.
+	 */
+	public function tear_down(): void {
+		remove_all_filters('wu_wp_cron_status_override');
+		delete_site_transient('wp-ultimo-cron-test-ok');
+
+		parent::tear_down();
 	}
 
 	/**
@@ -61,6 +73,56 @@ class Requirements_Test extends \WP_UnitTestCase {
 	public function test_check_wp_version_passes(): void {
 
 		$this->assertTrue(Requirements::check_wp_version());
+	}
+
+	/**
+	 * Test a true cron status override bypasses native checks.
+	 */
+	public function test_check_wp_cron_true_override(): void {
+
+		$native_check_called = false;
+		$http_filter         = static function () use (&$native_check_called) {
+			$native_check_called = true;
+
+			return [
+				'response' => [
+					'code'    => 500,
+					'message' => 'Cron unavailable',
+				],
+			];
+		};
+
+		add_filter('pre_http_request', $http_filter);
+		add_filter('wu_wp_cron_status_override', '__return_true');
+
+		$result = Requirements::check_wp_cron();
+
+		remove_filter('pre_http_request', $http_filter);
+
+		$this->assertFalse($native_check_called);
+		$this->assertTrue($result);
+	}
+
+	/**
+	 * Test a false cron status override bypasses native checks.
+	 */
+	public function test_check_wp_cron_false_override(): void {
+
+		set_site_transient('wp-ultimo-cron-test-ok', 1, HOUR_IN_SECONDS);
+		add_filter('wu_wp_cron_status_override', '__return_false');
+
+		$this->assertFalse(Requirements::check_wp_cron());
+	}
+
+	/**
+	 * Test a null cron status override preserves native checks.
+	 */
+	public function test_check_wp_cron_null_override(): void {
+
+		set_site_transient('wp-ultimo-cron-test-ok', 1, HOUR_IN_SECONDS);
+		add_filter('wu_wp_cron_status_override', '__return_null');
+
+		$this->assertTrue(Requirements::check_wp_cron());
 	}
 
 	/**


### PR DESCRIPTION
## Summary
- add a nullable `wu_wp_cron_status_override` requirement filter
- allow an external scheduler integration to report WP-Cron as healthy when `DISABLE_WP_CRON` is enabled
- preserve existing native checks when no integration provides an override

## Problem
Ultimate Multisite currently fails its WP-Cron requirement immediately when `DISABLE_WP_CRON` is true, even when a healthy external scheduler is actively processing cron.

## Verification
- `php -l inc/class-requirements.php`
- `php -l tests/WP_Ultimo/Requirements_Test.php`
- `git diff --check`

Regression tests cover true, false, and null override behavior. Focused PHPUnit could not run locally because the worktree does not contain Composer development dependencies.

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.230 plugin for [OpenCode](https://opencode.ai) v1.18.9 with gpt-5.6-sol spent 2d 2h and 10,425,136 tokens on this with the user in an interactive session.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for overriding the reported WP-Cron status through a configurable filter.
  * Boolean overrides immediately report WP-Cron as enabled or disabled; leaving the override unset preserves existing checks.

* **Tests**
  * Added coverage for enabled, disabled, and unset WP-Cron overrides.
  * Improved cleanup for cron-related settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->