### PR TITLE
fix: send locale with newsletter opt-ins

### DIFF
--- a/inc/class-newsletter.php
+++ b/inc/class-newsletter.php
@@ -80,6 +80,7 @@ class Newsletter {
 							'status'     => 'confirmed',
 							'first_name' => $settings['company_name'],
 							'country'    => $settings['company_country'],
+							'language'   => determine_locale(),
 						]
 					),
 					'headers' => [

--- a/tests/WP_Ultimo/Newsletter_Test.php
+++ b/tests/WP_Ultimo/Newsletter_Test.php
@@ -71,4 +71,57 @@ class Newsletter_Test extends WP_UnitTestCase {
 
 		$this->assertSame($settings, $result);
 	}
+
+	/**
+	 * Test confirmed newsletter subscriptions include the resolved locale.
+	 */
+	public function test_confirmed_subscription_includes_resolved_locale(): void {
+
+		$newsletter       = \WP_Ultimo\Newsletter::get_instance();
+		$captured_payload = [];
+		$settings         = [
+			'company_email'   => 'test@example.com',
+			'company_name'    => 'Test Company',
+			'company_country' => 'US',
+		];
+
+		$locale_filter = static function () {
+			return 'fr_FR';
+		};
+
+		$http_request_filter = static function ($preempt, $args) use (&$captured_payload) {
+			$captured_payload = json_decode($args['body'], true);
+
+			return [
+				'body'     => '',
+				'headers'  => [],
+				'response' => [
+					'code'    => 200,
+					'message' => 'OK',
+				],
+			];
+		};
+
+		add_filter('determine_locale', $locale_filter);
+		add_filter('pre_http_request', $http_request_filter, 10, 2);
+
+		try {
+			$result = $newsletter->maybe_update_newsletter_subscription($settings, ['newsletter_optin' => '1'], []);
+		} finally {
+			remove_filter('pre_http_request', $http_request_filter, 10);
+			remove_filter('determine_locale', $locale_filter);
+		}
+
+		$this->assertSame($settings, $result);
+		$this->assertSame(
+			[
+				'email'      => 'test@example.com',
+				'status'     => 'confirmed',
+				'first_name' => 'Test Company',
+				'country'    => 'US',
+				'language'   => 'fr_FR',
+			],
+			$captured_payload
+		);
+	}
 }


### PR DESCRIPTION
## Summary

- Sends the request-resolved locale with confirmed newsletter subscriptions.
- Captures the outbound JSON in a regression test without network access.

## Testing

- vendor/bin/phpunit --filter Newsletter_Test
- vendor/bin/phpcs inc/class-newsletter.php tests/WP_Ultimo/Newsletter_Test.php

Resolves #1703

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.231 plugin for [OpenCode](https://opencode.ai) v1.18.9 with gpt-5.6-terra


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Newsletter subscription requests now include the site’s language setting.

* **Bug Fixes**
  * Improved locale handling for confirmed newsletter subscriptions.

* **Tests**
  * Added coverage to verify that the correct language is included without altering existing settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->