### PR TITLE
fix: update Rocket authentication request

### DIFF
--- a/inc/integrations/providers/rocket/class-rocket-integration.php
+++ b/inc/integrations/providers/rocket/class-rocket-integration.php
@@ -155,7 +155,7 @@ class Rocket_Integration extends Integration {
 
 		if (! $token) {
 			$response = wp_remote_post(
-				'https://api.rocket.net/v1/auth/login',
+				'https://api.rocket.net/v1/login',
 				[
 					'blocking' => true,
 					'method'   => 'POST',
@@ -166,7 +166,7 @@ class Rocket_Integration extends Integration {
 					],
 					'body'     => wp_json_encode(
 						[
-							'email'    => $this->get_credential('WU_ROCKET_EMAIL'),
+							'username' => $this->get_credential('WU_ROCKET_EMAIL'),
 							'password' => $this->get_credential('WU_ROCKET_PASSWORD'),
 						]
 					),
@@ -174,11 +174,11 @@ class Rocket_Integration extends Integration {
 			);
 
 			if (! is_wp_error($response)) {
-				$body = json_decode(wp_remote_retrieve_body($response), true);
+				$body   = json_decode(wp_remote_retrieve_body($response), true);
+				$result = isset($body['result']) && is_array($body['result']) ? $body['result'] : [];
+				$token  = $body['token'] ?? $body['access_token'] ?? $result['token'] ?? $result['access_token'] ?? false;
 
-				if (isset($body['token']) || isset($body['access_token'])) {
-					$token = $body['token'] ?? $body['access_token'];
-
+				if ($token) {
 					set_site_transient('wu_rocket_token', $token, 50 * MINUTE_IN_SECONDS);
 				} else {
 					wu_log_add('integration-rocket', '[Auth] Failed to retrieve token: ' . wp_remote_retrieve_body($response), \Psr\Log\LogLevel::ERROR);

--- a/tests/WP_Ultimo/Integrations/Providers/Rocket_Domain_Mapping_Test.php
+++ b/tests/WP_Ultimo/Integrations/Providers/Rocket_Domain_Mapping_Test.php
@@ -152,4 +152,85 @@ class Rocket_Domain_Mapping_Test extends WP_UnitTestCase {
 
 		$this->assertNotNull($result);
 	}
+
+	/**
+	 * @dataProvider rocket_access_token_response_provider
+	 */
+	public function test_get_rocket_access_token_uses_login_endpoint_and_supported_token_response(array $response_body, string $expected_token): void {
+
+		delete_site_transient('wu_rocket_token');
+
+		$integration = $this->getMockBuilder(Rocket_Integration::class)
+			->onlyMethods(['get_credential'])
+			->getMock();
+
+		$integration->method('get_credential')
+			->willReturnMap(
+				[
+					['WU_ROCKET_EMAIL', 'rocket-user@example.com'],
+					['WU_ROCKET_PASSWORD', 'rocket-password'],
+				]
+			);
+
+		$request_seen = false;
+		$http_filter  = function ($preempt, array $args, string $url) use (&$request_seen, $response_body) {
+			$request_seen = true;
+
+			$this->assertSame('https://api.rocket.net/v1/login', $url);
+			$this->assertSame('POST', $args['method']);
+			$this->assertSame('application/json', $args['headers']['Content-Type']);
+			$this->assertSame('application/json', $args['headers']['Accept']);
+			$this->assertSame(
+				[
+					'username' => 'rocket-user@example.com',
+					'password' => 'rocket-password',
+				],
+				json_decode($args['body'], true)
+			);
+
+			return [
+				'headers'  => [],
+				'body'     => wp_json_encode($response_body),
+				'response' => [
+					'code'    => 200,
+					'message' => 'OK',
+				],
+				'cookies'  => [],
+			];
+		};
+
+		add_filter('pre_http_request', $http_filter, 10, 3);
+
+		try {
+			$token = $integration->get_rocket_access_token();
+		} finally {
+			remove_filter('pre_http_request', $http_filter, 10);
+			delete_site_transient('wu_rocket_token');
+		}
+
+		$this->assertTrue($request_seen);
+		$this->assertSame($expected_token, $token);
+	}
+
+	public function rocket_access_token_response_provider(): array {
+
+		return [
+			'direct token'          => [
+				['token' => 'direct-token'],
+				'direct-token',
+			],
+			'direct access token'   => [
+				['access_token' => 'direct-access-token'],
+				'direct-access-token',
+			],
+			'nested token'          => [
+				['result' => ['token' => 'nested-token']],
+				'nested-token',
+			],
+			'nested access token'   => [
+				['result' => ['access_token' => 'nested-access-token']],
+				'nested-access-token',
+			],
+		];
+	}
 }


### PR DESCRIPTION
## Summary

- update Rocket.net authentication to call the v1 login endpoint with `username` credentials
- support direct and nested token fields from Rocket login responses
- add focused Rocket integration coverage for request URL/body and accepted token response locations

## Verification

- `vendor/bin/phpcs inc/integrations/providers/rocket/class-rocket-integration.php`
- `vendor/bin/phpunit --filter Rocket`

---
<!-- aidevops:sig -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Rocket.net authentication by using the correct login endpoint and credential format.
  - Added support for token responses in multiple supported formats.
  - Improved token caching and cleanup during authentication.

- **Tests**
  - Added coverage for login requests, response handling, token extraction, and transient cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->