### PR TITLE
fix: provision Action Scheduler tables per site

### DIFF
--- a/inc/class-cron.php
+++ b/inc/class-cron.php
@@ -30,6 +30,8 @@ class Cron implements \WP_Ultimo\Interfaces\Singleton {
 
 	use \WP_Ultimo\Traits\Singleton;
 
+	private const ACTION_SCHEDULER_SCHEMA_CHECK_TRANSIENT = 'wu_action_scheduler_schema_checked';
+
 	/**
 	 * Instantiate the necessary hooks.
 	 *
@@ -83,7 +85,17 @@ class Cron implements \WP_Ultimo\Interfaces\Singleton {
 	 */
 	public function maybe_ensure_action_scheduler_tables(): void {
 
-		$this->ensure_action_scheduler_tables();
+		if (false !== get_transient(self::ACTION_SCHEDULER_SCHEMA_CHECK_TRANSIENT)) {
+			return;
+		}
+
+		if ($this->ensure_action_scheduler_tables()) {
+			set_transient(
+				self::ACTION_SCHEDULER_SCHEMA_CHECK_TRANSIENT,
+				1,
+				5 * MINUTE_IN_SECONDS
+			);
+		}
 	}
 
 	/**

--- a/inc/class-cron.php
+++ b/inc/class-cron.php
@@ -38,6 +38,13 @@ class Cron implements \WP_Ultimo\Interfaces\Singleton {
 	 */
 	public function init(): void {
 		/*
+		 * Action Scheduler does not create per-site tables when WordPress merely
+		 * switches blogs. Repair skipped template-clone schemas before scheduling.
+		 */
+		add_action('init', [$this, 'maybe_ensure_action_scheduler_tables'], 2);
+		add_action('wp_initialize_site', [$this, 'initialize_site_action_scheduler_tables'], 200);
+
+		/*
 		 * Creates general schedules for general uses.
 		 */
 		add_action('init', [$this, 'create_schedules']);
@@ -66,6 +73,95 @@ class Cron implements \WP_Ultimo\Interfaces\Singleton {
 		add_action('wu_membership_check', [$this, 'membership_expired_check'], 20);
 
 		add_action('wu_async_mark_membership_as_expired', [$this, 'async_mark_membership_as_expired'], 10);
+	}
+
+	/**
+	 * Repair the current site's Action Scheduler tables when needed.
+	 *
+	 * @since 2.15.1
+	 * @return void
+	 */
+	public function maybe_ensure_action_scheduler_tables(): void {
+
+		$this->ensure_action_scheduler_tables();
+	}
+
+	/**
+	 * Ensure the current site's Action Scheduler tables exist.
+	 *
+	 * Action Scheduler normally gates dbDelta() behind schema-version options.
+	 * Site duplication intentionally excludes queue tables, so a destination can
+	 * retain a current schema option while the corresponding tables are absent.
+	 * Force an idempotent schema pass only when one of the required tables is
+	 * missing.
+	 *
+	 * @since 2.15.1
+	 * @return bool Whether all Action Scheduler tables exist after the repair.
+	 */
+	public function ensure_action_scheduler_tables(): bool {
+
+		$schema_classes = [
+			'ActionScheduler_StoreSchema',
+			'ActionScheduler_LoggerSchema',
+		];
+
+		foreach ($schema_classes as $schema_class) {
+			if ( ! class_exists($schema_class) || ! method_exists($schema_class, 'tables_exist')) {
+				return false;
+			}
+
+			$schema = new $schema_class();
+			if ($schema->tables_exist()) {
+				continue;
+			}
+
+			if (method_exists($schema, 'init')) {
+				$schema->init();
+			}
+
+			if ( ! method_exists($schema, 'register_tables')) {
+				return false;
+			}
+
+			$schema->register_tables(true);
+			if ( ! $schema->tables_exist()) {
+				return false;
+			}
+		}
+
+		return true;
+	}
+
+	/**
+	 * Create empty Action Scheduler tables while WordPress initializes a site.
+	 *
+	 * The tables are created before Ultimate Multisite copies a template. Queue
+	 * tables remain excluded from the copy, while the new site's empty schemas
+	 * and schema-version options survive the duplication process.
+	 *
+	 * @since 2.15.1
+	 * @param \WP_Site $site Newly initialized site.
+	 * @return void
+	 */
+	public function initialize_site_action_scheduler_tables(\WP_Site $site): void {
+
+		$site_id = (int) $site->blog_id;
+		if ($site_id < 1) {
+			return;
+		}
+
+		$switched = get_current_blog_id() !== $site_id;
+		if ($switched) {
+			switch_to_blog($site_id);
+		}
+
+		try {
+			$this->ensure_action_scheduler_tables();
+		} finally {
+			if ($switched) {
+				restore_current_blog();
+			}
+		}
 	}
 
 	/**

--- a/tests/WP_Ultimo/Cron_Test.php
+++ b/tests/WP_Ultimo/Cron_Test.php
@@ -64,10 +64,86 @@ class Cron_Test extends WP_UnitTestCase {
 		$this->cron->init();
 
 		$this->assertGreaterThan(0, has_action('init', [$this->cron, 'create_schedules']));
+		$this->assertSame(2, has_action('init', [$this->cron, 'maybe_ensure_action_scheduler_tables']));
+		$this->assertSame(200, has_action('wp_initialize_site', [$this->cron, 'initialize_site_action_scheduler_tables']));
 		$this->assertGreaterThan(0, has_action('init', [$this->cron, 'schedule_membership_check']));
 		$this->assertGreaterThan(0, has_action('wu_membership_check', [$this->cron, 'membership_renewal_check']));
 		$this->assertGreaterThan(0, has_action('wu_membership_check', [$this->cron, 'membership_trial_check']));
 		$this->assertGreaterThan(0, has_action('wu_membership_check', [$this->cron, 'membership_expired_check']));
+	}
+
+	/**
+	 * Test missing Action Scheduler tables are recreated for a site.
+	 */
+	public function test_initialize_site_action_scheduler_tables_repairs_missing_tables(): void {
+
+		global $wpdb;
+
+		$original_site_id = get_current_blog_id();
+		$site_id          = self::factory()->blog->create();
+		$site             = get_site($site_id);
+		$this->assertInstanceOf(\WP_Site::class, $site);
+
+		switch_to_blog($site_id);
+		$table_names = [
+			$wpdb->prefix . 'actionscheduler_actions',
+			$wpdb->prefix . 'actionscheduler_claims',
+			$wpdb->prefix . 'actionscheduler_groups',
+			$wpdb->prefix . 'actionscheduler_logs',
+		];
+		foreach ($table_names as $table_name) {
+			$wpdb->query("DROP TABLE IF EXISTS `{$table_name}`"); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+		}
+
+		// The WordPress test suite rewrites CREATE/DROP TABLE to temporary tables.
+		// Action Scheduler checks table existence with SHOW TABLES, which cannot
+		// see temporary tables, so exercise the repair with normal tables first.
+		remove_filter('query', [$this, '_create_temporary_tables']);
+		remove_filter('query', [$this, '_drop_temporary_tables']);
+
+		try {
+			$this->assertTrue($this->cron->ensure_action_scheduler_tables());
+
+			foreach ($table_names as $table_name) {
+				$this->assertSame(
+					$table_name,
+					$wpdb->get_var($wpdb->prepare('SHOW TABLES LIKE %s', $wpdb->esc_like($table_name))),
+					"Action Scheduler table was not recreated: {$table_name}"
+				);
+			}
+
+			foreach ($table_names as $table_name) {
+				$wpdb->query("DROP TABLE IF EXISTS `{$table_name}`"); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+			}
+
+			restore_current_blog();
+			$this->cron->initialize_site_action_scheduler_tables($site);
+			$this->assertSame($original_site_id, get_current_blog_id());
+
+			switch_to_blog($site_id);
+			foreach ($table_names as $table_name) {
+				$this->assertSame(
+					$table_name,
+					$wpdb->get_var($wpdb->prepare('SHOW TABLES LIKE %s', $wpdb->esc_like($table_name))),
+					"Action Scheduler table was not recreated by the site initialization hook: {$table_name}"
+				);
+			}
+		} finally {
+			if (get_current_blog_id() !== $site_id) {
+				switch_to_blog($site_id);
+			}
+
+			foreach ($table_names as $table_name) {
+				$wpdb->query("DROP TABLE IF EXISTS `{$table_name}`"); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+			}
+
+			while (ms_is_switched()) {
+				restore_current_blog();
+			}
+
+			add_filter('query', [$this, '_create_temporary_tables']);
+			add_filter('query', [$this, '_drop_temporary_tables']);
+		}
 	}
 
 	/**

--- a/tests/WP_Ultimo/Cron_Test.php
+++ b/tests/WP_Ultimo/Cron_Test.php
@@ -84,24 +84,33 @@ class Cron_Test extends WP_UnitTestCase {
 		$site             = get_site($site_id);
 		$this->assertInstanceOf(\WP_Site::class, $site);
 
-		switch_to_blog($site_id);
-		$table_names = [
-			$wpdb->prefix . 'actionscheduler_actions',
-			$wpdb->prefix . 'actionscheduler_claims',
-			$wpdb->prefix . 'actionscheduler_groups',
-			$wpdb->prefix . 'actionscheduler_logs',
-		];
-		foreach ($table_names as $table_name) {
-			$wpdb->query("DROP TABLE IF EXISTS `{$table_name}`"); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.InterpolatedNotPrepared
-		}
-
-		// The WordPress test suite rewrites CREATE/DROP TABLE to temporary tables.
-		// Action Scheduler checks table existence with SHOW TABLES, which cannot
-		// see temporary tables, so exercise the repair with normal tables first.
-		remove_filter('query', [$this, '_create_temporary_tables']);
-		remove_filter('query', [$this, '_drop_temporary_tables']);
-
+		$table_names     = [];
+		$filters_removed = false;
 		try {
+			switch_to_blog($site_id);
+			$table_names = [
+				$wpdb->prefix . 'actionscheduler_actions',
+				$wpdb->prefix . 'actionscheduler_claims',
+				$wpdb->prefix . 'actionscheduler_groups',
+				$wpdb->prefix . 'actionscheduler_logs',
+			];
+
+			// Remove the temporary schemas created by wp_initialize_site().
+			foreach ($table_names as $table_name) {
+				$wpdb->query("DROP TABLE IF EXISTS `{$table_name}`"); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+			}
+
+			// Exercise dbDelta() with normal tables because SHOW TABLES cannot see
+			// the temporary tables created by the WordPress PHPUnit filters.
+			remove_filter('query', [$this, '_create_temporary_tables']);
+			remove_filter('query', [$this, '_drop_temporary_tables']);
+			$filters_removed = true;
+
+			// Remove any leaked regular schemas so this always exercises repair.
+			foreach ($table_names as $table_name) {
+				$wpdb->query("DROP TABLE IF EXISTS `{$table_name}`"); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+			}
+
 			$this->assertTrue($this->cron->ensure_action_scheduler_tables());
 
 			foreach ($table_names as $table_name) {
@@ -129,6 +138,11 @@ class Cron_Test extends WP_UnitTestCase {
 				);
 			}
 		} finally {
+			if ( ! $filters_removed) {
+				remove_filter('query', [$this, '_create_temporary_tables']);
+				remove_filter('query', [$this, '_drop_temporary_tables']);
+			}
+
 			if (get_current_blog_id() !== $site_id) {
 				switch_to_blog($site_id);
 			}


### PR DESCRIPTION
## Summary

- self-heal missing Action Scheduler tables for the current multisite blog before scheduling starts
- provision empty Action Scheduler tables during `wp_initialize_site`, without copying queue data from templates
- preserve the caller's blog context and cover direct repair, lifecycle-hook repair, and hook registration

## Verification

- `vendor/bin/phpunit --filter Cron_Test` (11 tests, 28 assertions)
- `vendor/bin/phpcs inc/class-cron.php tests/WP_Ultimo/Cron_Test.php`
- `vendor/bin/phpstan analyse inc/class-cron.php --no-progress`
- `php -l inc/class-cron.php`
- `php -l tests/WP_Ultimo/Cron_Test.php`
- `composer validate --strict` (valid with existing package warnings)

The full repository quality command remains blocked by existing lint violations in unrelated files. A broad PHPUnit run exceeded five minutes after more than 5,600 tests; the focused Cron suite passes.

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.245 plugin for [OpenCode](https://opencode.ai) v1.18.9 with gpt-5.5 spent 3h 34m and 1,540,429 tokens on this with the user in an interactive session.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Automatically repairs missing Action Scheduler tables during scheduled-task initialization.
  * Ensures newly created sites have the required scheduling tables.
  * Improves reliability in multisite environments by safely restoring the active site after repairs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->