### PR TITLE
fix(auth): avoid repeated passwordless table checks

### DIFF
--- a/inc/auth/class-passwordless-auth-manager.php
+++ b/inc/auth/class-passwordless-auth-manager.php
@@ -53,7 +53,6 @@ class Passwordless_Auth_Manager {
 		}
 
 		add_action('init', [$this, 'register_assets']);
-		add_action('init', [$this, 'maybe_install_tables'], 5);
 
 		add_action('login_enqueue_scripts', [$this, 'enqueue_login_assets']);
 		add_action('login_form', [$this, 'render_wp_login_form']);
@@ -124,53 +123,6 @@ class Passwordless_Auth_Manager {
 			add_action('wp_ajax_' . $action, [$this, $method]);
 			add_action('wu_ajax_' . $action, [$this, $method]);
 		}
-	}
-
-	/**
-	 * Installs auth tables when an upgraded site first needs them.
-	 *
-	 * @since 2.13.2
-	 * @return void
-	 */
-	public function maybe_install_tables() {
-
-		$table_names = [
-			'passkey_credential_table',
-			'webauthn_challenge_table',
-			'email_otp_attempt_table',
-		];
-
-		foreach ($table_names as $table_name) {
-			$table = WP_Ultimo()->tables->{$table_name} ?? null;
-
-			if ($table && method_exists($table, 'install') && ! $this->table_exists($table->table_name)) {
-				$table->install();
-			}
-		}
-	}
-
-	/**
-	 * Checks if a database table already exists.
-	 *
-	 * BerlinDB caches table existence early in the request, so upgraded/test
-	 * environments need a direct SHOW TABLES check before calling install().
-	 *
-	 * @since 2.13.2
-	 * @param string $table_name Fully qualified table name.
-	 * @return bool
-	 */
-	protected function table_exists($table_name) {
-
-		global $wpdb;
-
-		$table_name = sanitize_key($table_name);
-
-		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
-		$found = $wpdb->get_var(
-			$wpdb->prepare('SHOW TABLES LIKE %s', $table_name)
-		);
-
-		return $found === $table_name;
 	}
 
 	/**

--- a/tests/WP_Ultimo/Auth/Passwordless_Auth_Test.php
+++ b/tests/WP_Ultimo/Auth/Passwordless_Auth_Test.php
@@ -184,6 +184,26 @@ class Passwordless_Auth_Test extends \WP_UnitTestCase {
 	}
 
 	/**
+	 * Tests auth tables use the standard versioned table upgrade lifecycle.
+	 */
+	public function test_auth_tables_use_standard_upgrade_hooks() {
+
+		$manager = Passwordless_Auth_Manager::get_instance();
+
+		$this->assertFalse(method_exists($manager, 'maybe_install_tables'));
+
+		$tables = [
+			WP_Ultimo()->tables->passkey_credential_table,
+			WP_Ultimo()->tables->webauthn_challenge_table,
+			WP_Ultimo()->tables->email_otp_attempt_table,
+		];
+
+		foreach ($tables as $table) {
+			$this->assertSame(10, has_action('admin_init', [$table, 'maybe_upgrade']));
+		}
+	}
+
+	/**
 	 * Tests passkey authentication fails closed when usage cannot be persisted.
 	 */
 	public function test_passkey_authentication_fails_when_usage_update_fails() {


### PR DESCRIPTION
## Summary

- remove the passwordless manager's request-time custom table existence loop
- rely on the versioned BerlinDB `admin_init` upgrade hooks already registered through `Table_Loader`
- add regression coverage confirming all three passwordless tables use the standard lifecycle

## Verification

- `vendor/bin/phpunit --filter Passwordless_Auth_Test` (8 tests, 44 assertions)
- `vendor/bin/phpcs inc/auth/class-passwordless-auth-manager.php tests/WP_Ultimo/Auth/Passwordless_Auth_Test.php`
- `vendor/bin/phpstan analyse inc/auth/class-passwordless-auth-manager.php tests/WP_Ultimo/Auth/Passwordless_Auth_Test.php --no-progress`
- `.githooks/pre-commit`

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.247 plugin for [OpenCode](https://opencode.ai) v1.18.9 with gpt-5.6-sol spent 8m and 165,549 tokens on this with the user in an interactive session.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Authentication tables now use the standard upgrade lifecycle, improving consistency and reliability during updates.
  * Removed the legacy on-demand table installation behavior.

* **Tests**
  * Added coverage confirming authentication tables register their standard upgrade callbacks correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->