### PR TITLE
fix(sso): lazily generate admin-bar magic links

### DIFF
--- a/inc/sso/class-admin-bar-magic-links.php
+++ b/inc/sso/class-admin-bar-magic-links.php
@@ -104,11 +104,11 @@ class Admin_Bar_Magic_Links {
 		$site_id = absint($site_id);
 
 		return add_query_arg(
-			array(
+			[
 				'action'                => self::ADMIN_POST_ACTION,
 				self::SITE_ID_QUERY_ARG => $site_id,
 				'_wpnonce'              => wp_create_nonce($this->get_admin_bar_nonce_action($site_id)),
-			),
+			],
 			admin_url('admin-post.php')
 		);
 	}
@@ -145,7 +145,7 @@ class Admin_Bar_Magic_Links {
 		}
 
 		$allow_destination_host = static function ($allowed_hosts, $host) use ($destination_host) {
-			if (strtolower($destination_host) === strtolower($host)) {
+			if (0 === strcasecmp($destination_host, $host)) {
 				$allowed_hosts[] = $destination_host;
 			}
 

--- a/inc/sso/class-admin-bar-magic-links.php
+++ b/inc/sso/class-admin-bar-magic-links.php
@@ -23,6 +23,22 @@ class Admin_Bar_Magic_Links {
 	use \WP_Ultimo\Traits\Singleton;
 
 	/**
+	 * Admin-post action used to lazily resolve a dashboard link.
+	 *
+	 * @since 2.0.0
+	 * @var string
+	 */
+	const ADMIN_POST_ACTION = 'wu_admin_bar_magic_link';
+
+	/**
+	 * Query argument containing the requested site ID.
+	 *
+	 * @since 2.0.0
+	 * @var string
+	 */
+	const SITE_ID_QUERY_ARG = 'wu_site_id';
+
+	/**
 	 * Initialize hooks.
 	 *
 	 * @since 2.0.0
@@ -33,6 +49,9 @@ class Admin_Bar_Magic_Links {
 		// Hook late to modify the URLs after WordPress core adds them.
 		add_action('admin_bar_menu', array($this, 'modify_my_sites_menu'), 999);
 
+		// Resolve dashboard URLs only after the user selects a site.
+		add_action('admin_post_' . self::ADMIN_POST_ACTION, array($this, 'handle_admin_bar_magic_link'));
+
 		// Hook early into admin_page_access_denied to show magic links.
 		add_action('admin_page_access_denied', array($this, 'show_access_denied_with_magic_links'), 5);
 	}
@@ -42,7 +61,8 @@ class Admin_Bar_Magic_Links {
 	 *
 	 * This function hooks into the admin bar after WordPress core has
 	 * added all the My Sites menu items, and replaces dashboard URLs
-	 * with magic links for sites that have custom domains.
+	 * with same-origin lazy redirect URLs. Magic links are generated only
+	 * after the user selects a dashboard link.
 	 *
 	 * @since 2.0.0
 	 *
@@ -56,27 +76,160 @@ class Admin_Bar_Magic_Links {
 			return;
 		}
 
-		// Process each node.
+		// Process each dashboard node without resolving its destination.
 		foreach ($wp_admin_bar->get_nodes() as $node) {
-			$parts = explode('-', $node->id);
-			if (count($parts) >= 3 && 'blog' === $parts[0] && is_numeric($parts[1]) && 'd' === $parts[2]) {
-				$site_id = (int) $parts[1];
-			} else {
+			if ( ! preg_match('/^blog-(\d+)-d$/', $node->id, $matches)) {
 				continue;
 			}
 
-			// Generate magic link.
-			$magic_link = wu_get_admin_url($site_id);
+			$site_id = (int) $matches[1];
 
-			if ( ! $magic_link ) {
-				continue;
-			}
-
-			// Update the node with the magic link.
-			$node->href = $magic_link;
+			// Keep the click on this authenticated origin until it is validated.
+			$node->href = $this->get_admin_bar_action_url($site_id);
 
 			$wp_admin_bar->add_node($node);
 		}
+	}
+
+	/**
+	 * Build the same-origin action URL for a site's dashboard link.
+	 *
+	 * @since 2.0.0
+	 *
+	 * @param int $site_id Site ID.
+	 * @return string
+	 */
+	public function get_admin_bar_action_url($site_id) {
+
+		$site_id = absint($site_id);
+
+		return add_query_arg(
+			array(
+				'action'                => self::ADMIN_POST_ACTION,
+				self::SITE_ID_QUERY_ARG => $site_id,
+				'_wpnonce'              => wp_create_nonce($this->get_admin_bar_nonce_action($site_id)),
+			),
+			admin_url('admin-post.php')
+		);
+	}
+
+	/**
+	 * Resolve a selected dashboard link and redirect to its validated destination.
+	 *
+	 * @since 2.0.0
+	 * @return void
+	 */
+	public function handle_admin_bar_magic_link(): void {
+
+		if ( ! is_user_logged_in() ) {
+			wp_die(esc_html__('You do not have permission to access this site.', 'ultimate-multisite'), 403);
+		}
+
+		$site_id = $this->get_requested_site_id();
+		$nonce   = $this->get_requested_nonce();
+
+		if ( ! $site_id || ! $nonce || ! wp_verify_nonce($nonce, $this->get_admin_bar_nonce_action($site_id)) ) {
+			wp_die(esc_html__('The requested site link is invalid.', 'ultimate-multisite'), 403);
+		}
+
+		$destination = $this->get_site_dashboard_url($site_id);
+
+		if ( ! $destination ) {
+			wp_die(esc_html__('You do not have permission to access this site.', 'ultimate-multisite'), 403);
+		}
+
+		$destination_host = wp_parse_url($destination, PHP_URL_HOST);
+
+		if ( ! is_string($destination_host) || '' === $destination_host ) {
+			wp_die(esc_html__('The requested site link is invalid.', 'ultimate-multisite'), 403);
+		}
+
+		$allow_destination_host = static function ($allowed_hosts, $host) use ($destination_host) {
+			if (strtolower($destination_host) === strtolower($host)) {
+				$allowed_hosts[] = $destination_host;
+			}
+
+			return $allowed_hosts;
+		};
+
+		add_filter('allowed_redirect_hosts', $allow_destination_host, 100, 2);
+		$redirected = wp_safe_redirect($destination, 302, 'Ultimate-Multisite');
+		remove_filter('allowed_redirect_hosts', $allow_destination_host, 100);
+
+		if ( ! $redirected ) {
+			wp_die(esc_html__('The requested site link is invalid.', 'ultimate-multisite'), 403);
+		}
+
+		exit;
+	}
+
+	/**
+	 * Return the verified dashboard destination for a site.
+	 *
+	 * @since 2.0.0
+	 *
+	 * @param int $site_id Site ID.
+	 * @return false|string
+	 */
+	public function get_site_dashboard_url($site_id) {
+
+		$site_id = absint($site_id);
+		$site    = get_site($site_id);
+
+		if (
+			! $site instanceof \WP_Site
+			|| $site->deleted
+			|| $site->spam
+			|| $site->archived
+			|| (! is_super_admin() && ! is_user_member_of_blog(get_current_user_id(), $site_id))
+		) {
+			return false;
+		}
+
+		return wu_get_admin_url($site_id);
+	}
+
+	/**
+	 * Get the nonce action for a site's dashboard link.
+	 *
+	 * @since 2.0.0
+	 *
+	 * @param int $site_id Site ID.
+	 * @return string
+	 */
+	protected function get_admin_bar_nonce_action($site_id) {
+
+		return self::ADMIN_POST_ACTION . '_' . absint($site_id);
+	}
+
+	/**
+	 * Get a validated site ID from the request.
+	 *
+	 * @since 2.0.0
+	 * @return false|int
+	 */
+	protected function get_requested_site_id() {
+
+		$site_id = wu_request(self::SITE_ID_QUERY_ARG);
+
+		if ( ! is_string($site_id) || ! ctype_digit($site_id) || ! absint($site_id) ) {
+			return false;
+		}
+
+		return absint($site_id);
+	}
+
+	/**
+	 * Get a nonce string from the request.
+	 *
+	 * @since 2.0.0
+	 * @return false|string
+	 */
+	protected function get_requested_nonce() {
+
+		$nonce = wu_request('_wpnonce');
+
+		return is_string($nonce) ? $nonce : false;
 	}
 
 	/**

--- a/inc/sso/class-magic-link.php
+++ b/inc/sso/class-magic-link.php
@@ -236,7 +236,7 @@ class Magic_Link {
 			return false;
 		}
 
-		if (is_user_member_of_blog($user_id, $site_id)) {
+		if (is_super_admin($user_id) || is_user_member_of_blog($user_id, $site_id)) {
 			return true;
 		}
 		// Check if the site is the dashboard site in WP Frontend Admin which the user would not be a member of.

--- a/tests/WP_Ultimo/SSO/Admin_Bar_Magic_Links_Test.php
+++ b/tests/WP_Ultimo/SSO/Admin_Bar_Magic_Links_Test.php
@@ -78,22 +78,22 @@ class Admin_Bar_Magic_Links_Test extends WP_UnitTestCase {
 		$admin_bar = new \WP_Admin_Bar();
 		$admin_bar->initialize();
 		$admin_bar->add_node(
-			array(
+			[
 				'id'   => 'blog-' . $site_id . '-d',
 				'href' => 'https://example.test/original-dashboard',
-			)
+			]
 		);
 		$admin_bar->add_node(
-			array(
+			[
 				'id'   => 'blog-' . $site_id . '-c',
 				'href' => 'https://example.test/original-site',
-			)
+			]
 		);
 		$admin_bar->add_node(
-			array(
+			[
 				'id'   => 'blog-' . $site_id . '-d-extra',
 				'href' => 'https://example.test/malformed-dashboard',
-			)
+			]
 		);
 
 		$generated_magic_links = 0;
@@ -110,13 +110,17 @@ class Admin_Bar_Magic_Links_Test extends WP_UnitTestCase {
 		$dashboard_node = $admin_bar->get_node('blog-' . $site_id . '-d');
 		$site_node      = $admin_bar->get_node('blog-' . $site_id . '-c');
 		$malformed_node = $admin_bar->get_node('blog-' . $site_id . '-d-extra');
-		$action_args    = array();
+		$action_args    = [];
+		$action_url     = admin_url('admin-post.php');
 
 		wp_parse_str(wp_parse_url($dashboard_node->href, PHP_URL_QUERY), $action_args);
 
 		$this->assertSame(Admin_Bar_Magic_Links::ADMIN_POST_ACTION, $action_args['action']);
 		$this->assertSame((string) $site_id, $action_args[ Admin_Bar_Magic_Links::SITE_ID_QUERY_ARG ]);
 		$this->assertNotFalse(wp_verify_nonce($action_args['_wpnonce'], Admin_Bar_Magic_Links::ADMIN_POST_ACTION . '_' . $site_id));
+		$this->assertSame(wp_parse_url($action_url, PHP_URL_SCHEME), wp_parse_url($dashboard_node->href, PHP_URL_SCHEME));
+		$this->assertSame(wp_parse_url($action_url, PHP_URL_HOST), wp_parse_url($dashboard_node->href, PHP_URL_HOST));
+		$this->assertSame(wp_parse_url($action_url, PHP_URL_PATH), wp_parse_url($dashboard_node->href, PHP_URL_PATH));
 		$this->assertSame(0, $generated_magic_links);
 		$this->assertSame('https://example.test/original-site', $site_node->href);
 		$this->assertSame('https://example.test/malformed-dashboard', $malformed_node->href);
@@ -132,12 +136,18 @@ class Admin_Bar_Magic_Links_Test extends WP_UnitTestCase {
 		add_user_to_blog($site_id, $user_id, 'administrator');
 		wp_set_current_user($user_id);
 
-		$this->assertSame(wu_get_admin_url($site_id), $this->magic_links->get_site_dashboard_url($site_id));
-		$this->assertFalse($this->magic_links->get_site_dashboard_url(999999));
+		add_filter('wu_magic_links_enabled', '__return_false');
 
-		$inaccessible_site_id = self::factory()->blog->create();
+		try {
+			$this->assertSame(get_admin_url($site_id), $this->magic_links->get_site_dashboard_url($site_id));
+			$this->assertFalse($this->magic_links->get_site_dashboard_url(999999));
 
-		$this->assertFalse($this->magic_links->get_site_dashboard_url($inaccessible_site_id));
+			$inaccessible_site_id = self::factory()->blog->create();
+
+			$this->assertFalse($this->magic_links->get_site_dashboard_url($inaccessible_site_id));
+		} finally {
+			remove_filter('wu_magic_links_enabled', '__return_false');
+		}
 	}
 
 	/**
@@ -153,8 +163,8 @@ class Admin_Bar_Magic_Links_Test extends WP_UnitTestCase {
 			$nonce_method->setAccessible(true);
 		}
 
-		$_REQUEST[ Admin_Bar_Magic_Links::SITE_ID_QUERY_ARG ] = array('invalid'); // phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Tests malformed request input.
-		$_REQUEST['_wpnonce']                                 = array('invalid'); // phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Tests malformed request input.
+		$_REQUEST[ Admin_Bar_Magic_Links::SITE_ID_QUERY_ARG ] = ['invalid']; // phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Tests malformed request input.
+		$_REQUEST['_wpnonce']                                 = ['invalid']; // phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Tests malformed request input.
 
 		try {
 			$this->assertFalse($site_id_method->invoke($this->magic_links));
@@ -175,22 +185,23 @@ class Admin_Bar_Magic_Links_Test extends WP_UnitTestCase {
 		add_user_to_blog($site_id, $user_id, 'administrator');
 		wp_set_current_user($user_id);
 
-		$_REQUEST = array( // phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Sets the handler request fixture.
+		$_REQUEST = [ // phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Sets the handler request fixture.
 			Admin_Bar_Magic_Links::SITE_ID_QUERY_ARG => (string) $site_id,
 			'_wpnonce'                               => wp_create_nonce(Admin_Bar_Magic_Links::ADMIN_POST_ACTION . '_' . $site_id),
 			'redirect_to'                            => 'https://attacker.example.test/',
-		);
+		];
 
-		$redirect        = array();
+		$redirect        = [];
 		$redirect_filter = static function ($location, $status) use (&$redirect) {
-			$redirect = array(
+			$redirect = [
 				'location' => $location,
 				'status'   => $status,
-			);
+			];
 
 			throw new \RuntimeException('redirect_intercepted');
 		};
 
+		add_filter('wu_magic_links_enabled', '__return_false');
 		add_filter('wp_redirect', $redirect_filter, 10, 2);
 
 		try {
@@ -198,6 +209,7 @@ class Admin_Bar_Magic_Links_Test extends WP_UnitTestCase {
 		} catch (\RuntimeException $e) {
 			$this->assertSame('redirect_intercepted', $e->getMessage());
 		} finally {
+			remove_filter('wu_magic_links_enabled', '__return_false');
 			remove_filter('wp_redirect', $redirect_filter, 10);
 			$_REQUEST = $request; // phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Restores the request fixture.
 		}
@@ -218,26 +230,26 @@ class Admin_Bar_Magic_Links_Test extends WP_UnitTestCase {
 		wp_set_current_user($user_id);
 
 		$mapping = wu_create_domain(
-			array(
+			[
 				'blog_id'        => $site_id,
 				'domain'         => 'admin-bar-magic-links.example.test',
 				'active'         => true,
 				'primary_domain' => true,
 				'secure'         => false,
 				'stage'          => \WP_Ultimo\Database\Domains\Domain_Stage::DONE,
-			)
+			]
 		);
 
 		$this->assertNotWPError($mapping);
 
-		$_REQUEST = array( // phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Sets the handler request fixture.
+		$_REQUEST = [ // phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Sets the handler request fixture.
 			Admin_Bar_Magic_Links::SITE_ID_QUERY_ARG => (string) $site_id,
 			'_wpnonce'                               => wp_create_nonce(Admin_Bar_Magic_Links::ADMIN_POST_ACTION . '_' . $site_id),
 			'redirect_to'                            => 'https://attacker.example.test/',
-		);
+		];
 
 		$magic_link        = 'https://admin-bar-magic-links.example.test/wp-admin/?wu_magic_token=test-token';
-		$redirect          = array();
+		$redirect          = [];
 		$redirect_to       = '';
 		$filter_user_id    = 0;
 		$filter_site_id    = 0;
@@ -249,10 +261,10 @@ class Admin_Bar_Magic_Links_Test extends WP_UnitTestCase {
 			return $magic_link;
 		};
 		$redirect_filter   = static function ($location, $status) use (&$redirect) {
-			$redirect = array(
+			$redirect = [
 				'location' => $location,
 				'status'   => $status,
-			);
+			];
 
 			throw new \RuntimeException('redirect_intercepted');
 		};
@@ -299,10 +311,10 @@ class Admin_Bar_Magic_Links_Test extends WP_UnitTestCase {
 		add_filter('wp_die_handler', $die_handler, 1);
 
 		try {
-			$_REQUEST = array( // phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Sets the handler request fixture.
+			$_REQUEST = [ // phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Sets the handler request fixture.
 				Admin_Bar_Magic_Links::SITE_ID_QUERY_ARG => (string) $site_id,
 				'_wpnonce'                               => 'invalid-nonce',
-			);
+			];
 
 			try {
 				$this->magic_links->handle_admin_bar_magic_link();
@@ -312,10 +324,10 @@ class Admin_Bar_Magic_Links_Test extends WP_UnitTestCase {
 			}
 
 			$inaccessible_site_id = self::factory()->blog->create();
-			$_REQUEST             = array( // phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Sets the handler request fixture.
+			$_REQUEST             = [ // phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Sets the handler request fixture.
 				Admin_Bar_Magic_Links::SITE_ID_QUERY_ARG => (string) $inaccessible_site_id,
 				'_wpnonce'                               => wp_create_nonce(Admin_Bar_Magic_Links::ADMIN_POST_ACTION . '_' . $inaccessible_site_id),
-			);
+			];
 
 			try {
 				$this->magic_links->handle_admin_bar_magic_link();

--- a/tests/WP_Ultimo/SSO/Admin_Bar_Magic_Links_Test.php
+++ b/tests/WP_Ultimo/SSO/Admin_Bar_Magic_Links_Test.php
@@ -163,4 +163,161 @@ class Admin_Bar_Magic_Links_Test extends WP_UnitTestCase {
 			$_REQUEST = $request; // phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Restores malformed request input fixture.
 		}
 	}
+
+	/**
+	 * Test the handler redirects to the resolved same-domain dashboard URL.
+	 */
+	public function test_handle_admin_bar_magic_link_redirects_to_resolved_same_domain_url(): void {
+		$user_id = self::factory()->user->create();
+		$site_id = get_current_blog_id();
+		$request = $_REQUEST; // phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Restores the request fixture.
+
+		add_user_to_blog($site_id, $user_id, 'administrator');
+		wp_set_current_user($user_id);
+
+		$_REQUEST = array( // phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Sets the handler request fixture.
+			Admin_Bar_Magic_Links::SITE_ID_QUERY_ARG => (string) $site_id,
+			'_wpnonce'                               => wp_create_nonce(Admin_Bar_Magic_Links::ADMIN_POST_ACTION . '_' . $site_id),
+			'redirect_to'                            => 'https://attacker.example.test/',
+		);
+
+		$redirect        = array();
+		$redirect_filter = static function ($location, $status) use (&$redirect) {
+			$redirect = array(
+				'location' => $location,
+				'status'   => $status,
+			);
+
+			throw new \RuntimeException('redirect_intercepted');
+		};
+
+		add_filter('wp_redirect', $redirect_filter, 10, 2);
+
+		try {
+			$this->magic_links->handle_admin_bar_magic_link();
+		} catch (\RuntimeException $e) {
+			$this->assertSame('redirect_intercepted', $e->getMessage());
+		} finally {
+			remove_filter('wp_redirect', $redirect_filter, 10);
+			$_REQUEST = $request; // phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Restores the request fixture.
+		}
+
+		$this->assertSame(get_admin_url($site_id), $redirect['location']);
+		$this->assertSame(302, $redirect['status']);
+	}
+
+	/**
+	 * Test the handler permits the resolved mapped-domain magic link only.
+	 */
+	public function test_handle_admin_bar_magic_link_redirects_to_resolved_mapped_domain_url(): void {
+		$user_id = self::factory()->user->create();
+		$site_id = self::factory()->blog->create();
+		$request = $_REQUEST; // phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Restores the request fixture.
+
+		add_user_to_blog($site_id, $user_id, 'administrator');
+		wp_set_current_user($user_id);
+
+		$mapping = wu_create_domain(
+			array(
+				'blog_id'        => $site_id,
+				'domain'         => 'admin-bar-magic-links.example.test',
+				'active'         => true,
+				'primary_domain' => true,
+				'secure'         => false,
+				'stage'          => \WP_Ultimo\Database\Domains\Domain_Stage::DONE,
+			)
+		);
+
+		$this->assertNotWPError($mapping);
+
+		$_REQUEST = array( // phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Sets the handler request fixture.
+			Admin_Bar_Magic_Links::SITE_ID_QUERY_ARG => (string) $site_id,
+			'_wpnonce'                               => wp_create_nonce(Admin_Bar_Magic_Links::ADMIN_POST_ACTION . '_' . $site_id),
+			'redirect_to'                            => 'https://attacker.example.test/',
+		);
+
+		$magic_link        = 'https://admin-bar-magic-links.example.test/wp-admin/?wu_magic_token=test-token';
+		$redirect          = array();
+		$redirect_to       = '';
+		$magic_link_filter = static function ($url, $filter_user_id, $filter_site_id, $filter_redirect_to) use (&$redirect_to, $magic_link) {
+			$redirect_to = $filter_redirect_to;
+
+			return $magic_link;
+		};
+		$redirect_filter   = static function ($location, $status) use (&$redirect) {
+			$redirect = array(
+				'location' => $location,
+				'status'   => $status,
+			);
+
+			throw new \RuntimeException('redirect_intercepted');
+		};
+
+		add_filter('wu_magic_links_enabled', '__return_true');
+		add_filter('wu_magic_link_url', $magic_link_filter, 10, 4);
+		add_filter('wp_redirect', $redirect_filter, 10, 2);
+
+		try {
+			$this->magic_links->handle_admin_bar_magic_link();
+		} catch (\RuntimeException $e) {
+			$this->assertSame('redirect_intercepted', $e->getMessage());
+		} finally {
+			remove_filter('wu_magic_links_enabled', '__return_true');
+			remove_filter('wu_magic_link_url', $magic_link_filter, 10);
+			remove_filter('wp_redirect', $redirect_filter, 10);
+			$_REQUEST = $request; // phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Restores the request fixture.
+		}
+
+		$this->assertSame($magic_link, $redirect['location']);
+		$this->assertSame(302, $redirect['status']);
+		$this->assertSame(get_admin_url($site_id), $redirect_to);
+	}
+
+	/**
+	 * Test invalid nonces and inaccessible sites are rejected by the handler.
+	 */
+	public function test_handle_admin_bar_magic_link_rejects_invalid_nonce_and_inaccessible_site(): void {
+		$user_id = self::factory()->user->create();
+		$site_id = get_current_blog_id();
+		$request = $_REQUEST; // phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Restores the request fixture.
+
+		add_user_to_blog($site_id, $user_id, 'administrator');
+		wp_set_current_user($user_id);
+
+		$die_handler = static function () {
+			return static function ($message) {
+				throw new \WPDieException(esc_html((string) $message));
+			};
+		};
+
+		add_filter('wp_die_handler', $die_handler, 1);
+
+		try {
+			$_REQUEST = array( // phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Sets the handler request fixture.
+				Admin_Bar_Magic_Links::SITE_ID_QUERY_ARG => (string) $site_id,
+				'_wpnonce'                               => 'invalid-nonce',
+			);
+
+			try {
+				$this->magic_links->handle_admin_bar_magic_link();
+			} catch (\WPDieException $e) {
+				$this->assertSame('The requested site link is invalid.', $e->getMessage());
+			}
+
+			$inaccessible_site_id = self::factory()->blog->create();
+			$_REQUEST             = array( // phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Sets the handler request fixture.
+				Admin_Bar_Magic_Links::SITE_ID_QUERY_ARG => (string) $inaccessible_site_id,
+				'_wpnonce'                               => wp_create_nonce(Admin_Bar_Magic_Links::ADMIN_POST_ACTION . '_' . $inaccessible_site_id),
+			);
+
+			try {
+				$this->magic_links->handle_admin_bar_magic_link();
+			} catch (\WPDieException $e) {
+				$this->assertSame('You do not have permission to access this site.', $e->getMessage());
+			}
+		} finally {
+			remove_filter('wp_die_handler', $die_handler, 1);
+			$_REQUEST = $request; // phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Restores the request fixture.
+		}
+	}
 }

--- a/tests/WP_Ultimo/SSO/Admin_Bar_Magic_Links_Test.php
+++ b/tests/WP_Ultimo/SSO/Admin_Bar_Magic_Links_Test.php
@@ -60,4 +60,107 @@ class Admin_Bar_Magic_Links_Test extends WP_UnitTestCase {
 
 		$this->assertTrue(true); // No exception thrown.
 	}
+
+	/**
+	 * Test dashboard nodes are changed to lazy same-origin action URLs.
+	 */
+	public function test_modify_my_sites_menu_uses_lazy_action_urls(): void {
+		$user_id = self::factory()->user->create();
+		$site_id = get_current_blog_id();
+
+		add_user_to_blog($site_id, $user_id, 'administrator');
+		wp_set_current_user($user_id);
+
+		if ( ! class_exists('\WP_Admin_Bar') ) {
+			require_once ABSPATH . WPINC . '/class-wp-admin-bar.php';
+		}
+
+		$admin_bar = new \WP_Admin_Bar();
+		$admin_bar->initialize();
+		$admin_bar->add_node(
+			array(
+				'id'   => 'blog-' . $site_id . '-d',
+				'href' => 'https://example.test/original-dashboard',
+			)
+		);
+		$admin_bar->add_node(
+			array(
+				'id'   => 'blog-' . $site_id . '-c',
+				'href' => 'https://example.test/original-site',
+			)
+		);
+		$admin_bar->add_node(
+			array(
+				'id'   => 'blog-' . $site_id . '-d-extra',
+				'href' => 'https://example.test/malformed-dashboard',
+			)
+		);
+
+		$generated_magic_links = 0;
+		$magic_link_filter     = static function ($url) use (&$generated_magic_links) {
+			++$generated_magic_links;
+
+			return $url;
+		};
+
+		add_filter('wu_magic_link_url', $magic_link_filter);
+		$this->magic_links->modify_my_sites_menu($admin_bar);
+		remove_filter('wu_magic_link_url', $magic_link_filter);
+
+		$dashboard_node = $admin_bar->get_node('blog-' . $site_id . '-d');
+		$site_node      = $admin_bar->get_node('blog-' . $site_id . '-c');
+		$malformed_node = $admin_bar->get_node('blog-' . $site_id . '-d-extra');
+		$action_args    = array();
+
+		wp_parse_str(wp_parse_url($dashboard_node->href, PHP_URL_QUERY), $action_args);
+
+		$this->assertSame(Admin_Bar_Magic_Links::ADMIN_POST_ACTION, $action_args['action']);
+		$this->assertSame((string) $site_id, $action_args[ Admin_Bar_Magic_Links::SITE_ID_QUERY_ARG ]);
+		$this->assertNotFalse(wp_verify_nonce($action_args['_wpnonce'], Admin_Bar_Magic_Links::ADMIN_POST_ACTION . '_' . $site_id));
+		$this->assertSame(0, $generated_magic_links);
+		$this->assertSame('https://example.test/original-site', $site_node->href);
+		$this->assertSame('https://example.test/malformed-dashboard', $malformed_node->href);
+	}
+
+	/**
+	 * Test only accessible, existing sites can resolve dashboard URLs.
+	 */
+	public function test_get_site_dashboard_url_rejects_inaccessible_and_missing_sites(): void {
+		$user_id = self::factory()->user->create();
+		$site_id = get_current_blog_id();
+
+		add_user_to_blog($site_id, $user_id, 'administrator');
+		wp_set_current_user($user_id);
+
+		$this->assertSame(wu_get_admin_url($site_id), $this->magic_links->get_site_dashboard_url($site_id));
+		$this->assertFalse($this->magic_links->get_site_dashboard_url(999999));
+
+		$inaccessible_site_id = self::factory()->blog->create();
+
+		$this->assertFalse($this->magic_links->get_site_dashboard_url($inaccessible_site_id));
+	}
+
+	/**
+	 * Test malformed request values cannot reach nonce or site validation.
+	 */
+	public function test_request_values_reject_arrays(): void {
+		$site_id_method = new \ReflectionMethod($this->magic_links, 'get_requested_site_id');
+		$nonce_method   = new \ReflectionMethod($this->magic_links, 'get_requested_nonce');
+		$request        = $_REQUEST; // phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Tests malformed request input.
+
+		if (PHP_VERSION_ID < 80100) {
+			$site_id_method->setAccessible(true);
+			$nonce_method->setAccessible(true);
+		}
+
+		$_REQUEST[ Admin_Bar_Magic_Links::SITE_ID_QUERY_ARG ] = array('invalid'); // phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Tests malformed request input.
+		$_REQUEST['_wpnonce']                                 = array('invalid'); // phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Tests malformed request input.
+
+		try {
+			$this->assertFalse($site_id_method->invoke($this->magic_links));
+			$this->assertFalse($nonce_method->invoke($this->magic_links));
+		} finally {
+			$_REQUEST = $request; // phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Restores malformed request input fixture.
+		}
+	}
 }

--- a/tests/WP_Ultimo/SSO/Admin_Bar_Magic_Links_Test.php
+++ b/tests/WP_Ultimo/SSO/Admin_Bar_Magic_Links_Test.php
@@ -239,8 +239,12 @@ class Admin_Bar_Magic_Links_Test extends WP_UnitTestCase {
 		$magic_link        = 'https://admin-bar-magic-links.example.test/wp-admin/?wu_magic_token=test-token';
 		$redirect          = array();
 		$redirect_to       = '';
-		$magic_link_filter = static function ($url, $filter_user_id, $filter_site_id, $filter_redirect_to) use (&$redirect_to, $magic_link) {
-			$redirect_to = $filter_redirect_to;
+		$filter_user_id    = 0;
+		$filter_site_id    = 0;
+		$magic_link_filter = static function ($url, $magic_link_user_id, $magic_link_site_id, $filter_redirect_to) use (&$filter_user_id, &$filter_site_id, &$redirect_to, $magic_link) {
+			$filter_user_id = $magic_link_user_id;
+			$filter_site_id = $magic_link_site_id;
+			$redirect_to    = $filter_redirect_to;
 
 			return $magic_link;
 		};
@@ -270,6 +274,8 @@ class Admin_Bar_Magic_Links_Test extends WP_UnitTestCase {
 
 		$this->assertSame($magic_link, $redirect['location']);
 		$this->assertSame(302, $redirect['status']);
+		$this->assertSame($user_id, $filter_user_id);
+		$this->assertSame($site_id, $filter_site_id);
 		$this->assertSame(get_admin_url($site_id), $redirect_to);
 	}
 
@@ -300,6 +306,7 @@ class Admin_Bar_Magic_Links_Test extends WP_UnitTestCase {
 
 			try {
 				$this->magic_links->handle_admin_bar_magic_link();
+				$this->fail('Expected the invalid nonce request to terminate via wp_die().');
 			} catch (\WPDieException $e) {
 				$this->assertSame('The requested site link is invalid.', $e->getMessage());
 			}
@@ -312,6 +319,7 @@ class Admin_Bar_Magic_Links_Test extends WP_UnitTestCase {
 
 			try {
 				$this->magic_links->handle_admin_bar_magic_link();
+				$this->fail('Expected the inaccessible site request to terminate via wp_die().');
 			} catch (\WPDieException $e) {
 				$this->assertSame('You do not have permission to access this site.', $e->getMessage());
 			}

--- a/tests/WP_Ultimo/SSO/Magic_Link_Test.php
+++ b/tests/WP_Ultimo/SSO/Magic_Link_Test.php
@@ -153,6 +153,29 @@ class Magic_Link_Test extends \WP_UnitTestCase {
 	}
 
 	/**
+	 * Test verify_user_site_access allows super administrators on every site.
+	 */
+	public function test_verify_user_site_access_super_admin() {
+
+		$instance = $this->get_instance();
+		$user_id  = self::factory()->user->create();
+		$site_id  = self::factory()->blog->create();
+		$ref      = new \ReflectionMethod($instance, 'verify_user_site_access');
+
+		if (PHP_VERSION_ID < 80100) {
+			$ref->setAccessible(true);
+		}
+
+		grant_super_admin($user_id);
+
+		try {
+			$this->assertTrue($ref->invoke($instance, $user_id, $site_id));
+		} finally {
+			revoke_super_admin($user_id);
+		}
+	}
+
+	/**
 	 * Test verify_user_site_access with invalid user.
 	 */
 	public function test_verify_user_site_access_invalid_user() {


### PR DESCRIPTION
## Summary

- Replace eager My Sites dashboard magic links with same-origin, nonce-protected admin-post redirects.
- Resolve the selected site only after validating the user, site ID, and site-specific nonce.
- Preserve mapped-domain magic links and super-administrator access.

## Testing

- `vendor/bin/phpunit --filter Admin_Bar_Magic_Links_Test`
- `vendor/bin/phpunit --filter Magic_Link_Test`
- `vendor/bin/phpcs inc/sso/class-admin-bar-magic-links.php inc/sso/class-magic-link.php tests/WP_Ultimo/SSO/Admin_Bar_Magic_Links_Test.php tests/WP_Ultimo/SSO/Magic_Link_Test.php`
- `vendor/bin/phpstan analyse inc/sso/class-admin-bar-magic-links.php inc/sso/class-magic-link.php`

Resolves #1711

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.247 plugin for [OpenCode](https://opencode.ai) v1.18.9 with gpt-5.6-terra


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved admin-bar dashboard links with secure, same-origin redirects.
  * Prevented access to missing or unauthorized sites.
  * Allowed super administrators to access any site dashboard.
  * Rejected invalid request parameters and unsafe redirect destinations.
  * Preserved safe redirects for mapped domains and validated destinations.

* **Tests**
  * Added coverage for secure dashboard links, access restrictions, invalid parameters, mapped-domain redirects, and super-administrator access.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->