### PR TITLE
fix: prevent setup wizard ready content overflow

### DIFF
--- a/views/wizards/setup/ready.php
+++ b/views/wizards/setup/ready.php
@@ -6,7 +6,7 @@
  */
 defined('ABSPATH') || exit;
 ?>
-<div class="wu-bg-white wu-p-4 wu--mx-6 wu-flex wu-content-center" style="height: 400px;">
+<div class="wu-bg-white wu-p-4 wu--mx-6 wu-flex wu-content-center" style="min-height: 400px;">
 
 	<div class="wu-self-center wu-text-center wu-w-full">
 
@@ -67,4 +67,3 @@ defined('ABSPATH') || exit;
 
 </div>
 <!-- End Submit Box -->
-


### PR DESCRIPTION
## Summary

- Allow the setup wizard ready panel to grow beyond its desktop minimum height.
- Keep the confirmation action below all mobile content instead of overlaying it.

## Verification

- php -l views/wizards/setup/ready.php
- vendor/bin/phpcs views/wizards/setup/ready.php
- Pre-commit hook (PHPCS and PHPStan)

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.250 plugin for [OpenCode](https://opencode.ai) v1.18.9 with gpt-5.6-terra


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the setup completion screen layout to use a minimum height, improving flexibility across different screen sizes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->