### PR TITLE
fix: guard multiple accounts query context

### DIFF
--- a/inc/compat/class-multiple-accounts-compat.php
+++ b/inc/compat/class-multiple-accounts-compat.php
@@ -122,7 +122,9 @@ class Multiple_Accounts_Compat {
 
 		$search = "\$db->get_row(\"SELECT * FROM $wpdb->users WHERE user_email";
 
-		if ( str_starts_with($wpdb->func_call, $search)) {
+		$func_call = $wpdb->func_call ?? '';
+
+		if ( str_starts_with($func_call, $search)) {
 			$prefix = "SELECT * FROM $wpdb->users WHERE user_email";
 
 			$last = substr($query, strlen($prefix));

--- a/tests/WP_Ultimo/Multiple_Accounts_Compat_Test.php
+++ b/tests/WP_Ultimo/Multiple_Accounts_Compat_Test.php
@@ -18,6 +18,26 @@ use WP_UnitTestCase;
 class Multiple_Accounts_Compat_Test extends WP_UnitTestCase {
 
 	/**
+	 * Test user query filter tolerates missing wpdb function call context.
+	 */
+	public function test_fix_user_query_tolerates_null_func_call(): void {
+
+		global $wpdb;
+
+		$func_call = $wpdb->func_call ?? null;
+
+		$wpdb->func_call = null;
+
+		$query = 'SELECT * FROM wp_users';
+
+		try {
+			$this->assertSame($query, \WP_Ultimo\Compat\Multiple_Accounts_Compat::get_instance()->fix_user_query($query));
+		} finally {
+			$wpdb->func_call = $func_call;
+		}
+	}
+
+	/**
 	 * Test unrelated user columns tolerate null output from earlier filters.
 	 */
 	public function test_add_column_content_returns_empty_string_for_null_unrelated_column(): void {


### PR DESCRIPTION
## Summary

- Guard the Multiple Accounts compatibility query filter when wpdb func_call is unset or null.
- Add regression coverage for fix_user_query() receiving a null function-call context.

## Verification

- php -l inc/compat/class-multiple-accounts-compat.php
- php -l tests/WP_Ultimo/Multiple_Accounts_Compat_Test.php
- vendor/bin/phpcs inc/compat/class-multiple-accounts-compat.php tests/WP_Ultimo/Multiple_Accounts_Compat_Test.php
- vendor/bin/phpunit --filter Multiple_Accounts_Compat_Test
- Pre-commit hook: PHPCS + PHPStan on staged PHP files

---
<!-- aidevops:sig -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved compatibility when processing queries if the database function-call value is unavailable or null.
  - Queries are now preserved correctly in this scenario.

- **Tests**
  - Added coverage to verify safe handling of missing database function-call values and restoration of the original state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->