### PR TITLE
GH#1715: isolate admin bar test filter

### DIFF
--- a/tests/WP_Ultimo/SSO/Admin_Bar_Magic_Links_Test.php
+++ b/tests/WP_Ultimo/SSO/Admin_Bar_Magic_Links_Test.php
@@ -104,8 +104,12 @@ class Admin_Bar_Magic_Links_Test extends WP_UnitTestCase {
 		};
 
 		add_filter('wu_magic_link_url', $magic_link_filter);
-		$this->magic_links->modify_my_sites_menu($admin_bar);
-		remove_filter('wu_magic_link_url', $magic_link_filter);
+
+		try {
+			$this->magic_links->modify_my_sites_menu($admin_bar);
+		} finally {
+			remove_filter('wu_magic_link_url', $magic_link_filter);
+		}
 
 		$dashboard_node = $admin_bar->get_node('blog-' . $site_id . '-d');
 		$site_node      = $admin_bar->get_node('blog-' . $site_id . '-c');


### PR DESCRIPTION
## Summary

- Ensure the magic-link test removes its temporary filter even when menu modification throws.

## Testing

- `vendor/bin/phpcs tests/WP_Ultimo/SSO/Admin_Bar_Magic_Links_Test.php`
- `vendor/bin/phpunit --filter Admin_Bar_Magic_Links_Test` (9 tests, 29 assertions)

## Runtime Testing

- Self-assessed: low-risk test-only cleanup. The focused WordPress PHPUnit suite exercised the affected test class.

Resolves #1715


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.250 plugin for [OpenCode](https://opencode.ai) v1.18.9 with gpt-5.6-terra spent 2m and 112,344 tokens on this as a headless worker.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved test cleanup to ensure temporary settings are always removed, even when an operation encounters an error.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->