### PR TITLE
test: cover unset multiple-account query context

### DIFF
--- a/tests/WP_Ultimo/Multiple_Accounts_Compat_Test.php
+++ b/tests/WP_Ultimo/Multiple_Accounts_Compat_Test.php
@@ -38,6 +38,26 @@ class Multiple_Accounts_Compat_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Test user query filter tolerates an unset wpdb function call context.
+	 */
+	public function test_fix_user_query_tolerates_unset_func_call(): void {
+
+		global $wpdb;
+
+		$func_call = $wpdb->func_call ?? null;
+
+		unset($wpdb->func_call);
+
+		$query = 'SELECT * FROM wp_users';
+
+		try {
+			$this->assertSame($query, \WP_Ultimo\Compat\Multiple_Accounts_Compat::get_instance()->fix_user_query($query));
+		} finally {
+			$wpdb->func_call = $func_call;
+		}
+	}
+
+	/**
 	 * Test unrelated user columns tolerate null output from earlier filters.
 	 */
 	public function test_add_column_content_returns_empty_string_for_null_unrelated_column(): void {


### PR DESCRIPTION
## Summary

- Add regression coverage for an unset `$wpdb->func_call` context.

## Testing

- `php -l tests/WP_Ultimo/Multiple_Accounts_Compat_Test.php`

## Runtime Testing

- Self-assessed: test-only change; no local WordPress runtime is available.

Resolves #1722

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.252 plugin for [OpenCode](https://opencode.ai) v1.18.9 with gpt-5.6-terra spent 2m and 61,594 tokens on this as a headless worker. Overall, 32m since this issue was created.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage to verify user queries remain intact when database call metadata is unavailable.
  * Confirmed database state is restored after compatibility checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->