### PR TITLE
fix: extend screenshot request timeout

### DIFF
--- a/inc/helpers/class-screenshot.php
+++ b/inc/helpers/class-screenshot.php
@@ -196,13 +196,13 @@ class Screenshot {
 		$response = wp_remote_get(
 			$url,
 			[
-				'timeout'    => 50,
+				'timeout'    => 120,
 				'user-agent' => 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36',
 			]
 		);
 
 		if (is_wp_error($response)) {
-			wu_log_add('screenshot-generator', $log_prefix . $response->get_error_message(), LogLevel::ERROR);
+			wu_log_add('screenshot-generator', $log_prefix . $response->get_error_message(), LogLevel::WARNING);
 
 			return false;
 		}

--- a/tests/WP_Ultimo/Helpers/Screenshot_Test.php
+++ b/tests/WP_Ultimo/Helpers/Screenshot_Test.php
@@ -7,6 +7,7 @@
 
 namespace WP_Ultimo\Helpers;
 
+use Psr\Log\LogLevel;
 use WP_UnitTestCase;
 
 require_once __DIR__ . '/screenshot-test-imagecreatefromstring.php';
@@ -302,16 +303,37 @@ class Screenshot_Test extends WP_UnitTestCase {
 		$this->assertFalse($result);
 	}
 
-	public function test_save_image_returns_false_on_wp_error() {
+	public function test_save_image_uses_extended_timeout_and_warns_on_request_failure() {
+		$original_logging_level = wu_get_setting('error_logging_level', 'default');
+		$request_args           = null;
+		$logged_level           = null;
+		$log_listener           = function ($handle, $message, $level) use (&$logged_level) {
+			if ('screenshot-generator' === $handle) {
+				$logged_level = $level;
+			}
+		};
+
+		wu_save_setting('error_logging_level', 'all');
+		add_action('wu_log_add', $log_listener, 10, 3);
 		add_filter(
 			'pre_http_request',
-			function () {
+			function ($preempt, $args) use (&$request_args) {
+				$request_args = $args;
+
 				return new \WP_Error('http_request_failed', 'Connection timed out.');
-			}
+			},
+			10,
+			2
 		);
 
 		$result = Screenshot::save_image_from_url('https://example.com/test');
+
+		remove_action('wu_log_add', $log_listener, 10);
+		wu_save_setting('error_logging_level', $original_logging_level);
+
 		$this->assertFalse($result);
+		$this->assertSame(120, $request_args['timeout']);
+		$this->assertSame(LogLevel::WARNING, $logged_level);
 	}
 
 	public function test_save_image_accepts_png_body() {

--- a/tests/WP_Ultimo/Helpers/Screenshot_Test.php
+++ b/tests/WP_Ultimo/Helpers/Screenshot_Test.php
@@ -312,24 +312,23 @@ class Screenshot_Test extends WP_UnitTestCase {
 				$logged_level = $level;
 			}
 		};
+		$http_filter            = function ($preempt, $args) use (&$request_args) {
+			$request_args = $args;
 
-		wu_save_setting('error_logging_level', 'all');
-		add_action('wu_log_add', $log_listener, 10, 3);
-		add_filter(
-			'pre_http_request',
-			function ($preempt, $args) use (&$request_args) {
-				$request_args = $args;
+			return new \WP_Error('http_request_failed', 'Connection timed out.');
+		};
 
-				return new \WP_Error('http_request_failed', 'Connection timed out.');
-			},
-			10,
-			2
-		);
+		try {
+			wu_save_setting('error_logging_level', 'all');
+			add_action('wu_log_add', $log_listener, 10, 3);
+			add_filter('pre_http_request', $http_filter, 10, 2);
 
-		$result = Screenshot::save_image_from_url('https://example.com/test');
-
-		remove_action('wu_log_add', $log_listener, 10);
-		wu_save_setting('error_logging_level', $original_logging_level);
+			$result = Screenshot::save_image_from_url('https://example.com/test');
+		} finally {
+			remove_action('wu_log_add', $log_listener, 10);
+			remove_filter('pre_http_request', $http_filter, 10);
+			wu_save_setting('error_logging_level', $original_logging_level);
+		}
 
 		$this->assertFalse($result);
 		$this->assertSame(120, $request_args['timeout']);


### PR DESCRIPTION
## Summary

- increase screenshot-provider HTTP timeout from 50 to 120 seconds for slower Microlink renders
- log transport failures as warnings so transient thumbnail timeouts do not trigger recent-error notices
- preserve fallback behavior and cover the timeout and log severity with a regression test

## Verification

- vendor/bin/phpunit --filter Screenshot_Test — 32 tests, 42 assertions
- vendor/bin/phpcs inc/helpers/class-screenshot.php tests/WP_Ultimo/Helpers/Screenshot_Test.php
- vendor/bin/phpstan analyse inc/helpers/class-screenshot.php --no-progress

<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.265 plugin for [OpenCode](https://opencode.ai) v1.18.18 with gpt-5.6-sol spent 6m and 139,437 tokens on this with the user in an interactive session.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Extended image download requests to allow up to 120 seconds.
  * HTTP request failures are now recorded as warnings instead of errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->