### PR TITLE
fix(duplication): preserve empty table schemas

### DIFF
--- a/inc/compat/class-general-compat.php
+++ b/inc/compat/class-general-compat.php
@@ -119,7 +119,6 @@ class General_Compat {
 		 * @see https://fluentcrm.com/
 		 */
 		add_action('wp_insert_site', [$this, 'fix_fluent_pro_site_duplication']);
-		add_filter('wu_mucd_should_copy_table', [$this, 'force_copy_fluentcrm_tables'], 10, 3);
 
 		/**
 		 * WordPress Core - HTTPS scheme fix for subdomain installs.
@@ -752,30 +751,6 @@ class General_Compat {
 			// Here we use this function due FluentCrm($class_name) returns an instance not working with remove_action
 			$this->hard_remove_action('set_user_role', [$class_name, 'maybeAutoAlterTags'], 11);
 		}
-	}
-
-	/**
-	 * Ensure FluentCRM's per-site table schemas are copied during duplication.
-	 *
-	 * FluentCRM relationship tables can be empty on a template site while still
-	 * being required by queries on the cloned site. The duplication optimizer
-	 * normally skips empty custom tables, so force all FluentCRM tables through
-	 * the normal schema-and-data copy path.
-	 *
-	 * @since 2.5.1
-	 *
-	 * @param bool   $copy            Whether the table should be copied.
-	 * @param string $table           Full source table name.
-	 * @param string $table_base_name Source table name without blog prefix.
-	 * @return bool
-	 */
-	public function force_copy_fluentcrm_tables($copy, $table, $table_base_name) {
-
-		if (str_starts_with((string) $table_base_name, 'fc_')) {
-			return true;
-		}
-
-		return $copy;
 	}
 
 	/**

--- a/inc/compat/class-general-compat.php
+++ b/inc/compat/class-general-compat.php
@@ -119,6 +119,7 @@ class General_Compat {
 		 * @see https://fluentcrm.com/
 		 */
 		add_action('wp_insert_site', [$this, 'fix_fluent_pro_site_duplication']);
+		add_filter('wu_mucd_should_copy_table', [$this, 'force_copy_fluentcrm_tables'], 10, 3);
 
 		/**
 		 * WordPress Core - HTTPS scheme fix for subdomain installs.
@@ -751,6 +752,30 @@ class General_Compat {
 			// Here we use this function due FluentCrm($class_name) returns an instance not working with remove_action
 			$this->hard_remove_action('set_user_role', [$class_name, 'maybeAutoAlterTags'], 11);
 		}
+	}
+
+	/**
+	 * Ensure FluentCRM's per-site table schemas are copied during duplication.
+	 *
+	 * FluentCRM relationship tables can be empty on a template site while still
+	 * being required by queries on the cloned site. The duplication optimizer
+	 * normally skips empty custom tables, so force all FluentCRM tables through
+	 * the normal schema-and-data copy path.
+	 *
+	 * @since 2.5.1
+	 *
+	 * @param bool   $copy            Whether the table should be copied.
+	 * @param string $table           Full source table name.
+	 * @param string $table_base_name Source table name without blog prefix.
+	 * @return bool
+	 */
+	public function force_copy_fluentcrm_tables($copy, $table, $table_base_name) {
+
+		if (str_starts_with((string) $table_base_name, 'fc_')) {
+			return true;
+		}
+
+		return $copy;
 	}
 
 	/**

--- a/inc/duplication/data.php
+++ b/inc/duplication/data.php
@@ -154,10 +154,9 @@ if ( ! class_exists('MUCD_Data') ) {
 		 *
 		 * Runtime-only tables are skipped by default because queues, logs, caches,
 		 * analytics, and sessions are regenerated on the destination site. Empty
-		 * optional/custom tables are also skipped to avoid spending most of the
-		 * duplication time cloning schemas with no template data. WordPress core
-		 * content/config tables are always copied because wpmu_create_blog() creates
-		 * destination defaults that must be replaced with template values.
+		 * per-site tables are copied by default so plugins retain the complete schema
+		 * they expect on the destination. Installations can opt into skipping empty
+		 * optional tables through the dedicated filter.
 		 *
 		 * @since 2.5.1
 		 *
@@ -182,7 +181,7 @@ if ( ! class_exists('MUCD_Data') ) {
 			 *
 			 * Returning true forces a table to be copied; returning false skips it.
 			 * This preserves extension control over custom table duplication while
-			 * keeping the default path optimized for empty/runtime template tables.
+			 * keeping runtime table exclusions centralized.
 			 *
 			 * @since 2.5.1
 			 *
@@ -297,7 +296,7 @@ if ( ! class_exists('MUCD_Data') ) {
 			 * @param int  $from_site_id      Source site ID.
 			 * @param int  $to_site_id        Target site ID.
 			 */
-			return (bool) apply_filters('wu_mucd_skip_empty_tables', true, $from_site_id, $to_site_id);
+			return (bool) apply_filters('wu_mucd_skip_empty_tables', false, $from_site_id, $to_site_id);
 		}
 
 		/**

--- a/tests/WP_Ultimo/Duplication/MUCD_Data_Test.php
+++ b/tests/WP_Ultimo/Duplication/MUCD_Data_Test.php
@@ -647,13 +647,14 @@ class MUCD_Data_Test extends WP_UnitTestCase {
 	public function test_should_copy_table_keeps_empty_optional_tables_by_default() {
 		global $wpdb;
 
-		$table = $wpdb->get_blog_prefix() . 'fc_subscriber_pivot';
+		$table_base_name = 'fc_wp_ultimo_test_subscriber_pivot';
+		$table           = $wpdb->get_blog_prefix() . $table_base_name;
 
 		$this->create_table_selection_fixture($table);
 
 		try {
 			$this->assertTrue(
-				\MUCD_Data::should_copy_table($table, 'fc_subscriber_pivot', get_current_blog_id(), 123)
+				\MUCD_Data::should_copy_table($table, $table_base_name, get_current_blog_id(), 123)
 			);
 		} finally {
 			$this->drop_table_selection_fixture($table);

--- a/tests/WP_Ultimo/Duplication/MUCD_Data_Test.php
+++ b/tests/WP_Ultimo/Duplication/MUCD_Data_Test.php
@@ -642,18 +642,18 @@ class MUCD_Data_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Test empty optional template tables are skipped by default.
+	 * Test empty optional template tables are copied by default.
 	 */
-	public function test_should_copy_table_skips_empty_optional_tables() {
+	public function test_should_copy_table_keeps_empty_optional_tables_by_default() {
 		global $wpdb;
 
-		$table = $wpdb->get_blog_prefix() . 'wu_empty_runtime_fixture';
+		$table = $wpdb->get_blog_prefix() . 'fc_subscriber_pivot';
 
 		$this->create_table_selection_fixture($table);
 
 		try {
-			$this->assertFalse(
-				\MUCD_Data::should_copy_table($table, 'wu_empty_runtime_fixture', get_current_blog_id(), 123)
+			$this->assertTrue(
+				\MUCD_Data::should_copy_table($table, 'fc_subscriber_pivot', get_current_blog_id(), 123)
 			);
 		} finally {
 			$this->drop_table_selection_fixture($table);
@@ -696,21 +696,25 @@ class MUCD_Data_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Test empty FluentCRM tables are copied so their schemas exist on clones.
+	 * Test installations can opt into skipping empty optional tables.
 	 */
-	public function test_should_copy_table_keeps_empty_fluentcrm_tables() {
+	public function test_should_copy_table_can_skip_empty_optional_tables_when_enabled() {
 		global $wpdb;
 
-		$table = $wpdb->get_blog_prefix() . 'fc_subscriber_pivot';
+		$table  = $wpdb->get_blog_prefix() . 'wu_empty_runtime_fixture';
+		$filter = static function () {
+			return true;
+		};
 
 		$this->create_table_selection_fixture($table);
-		\WP_Ultimo\Compat\General_Compat::get_instance();
+		add_filter('wu_mucd_skip_empty_tables', $filter, 10, 3);
 
 		try {
-			$this->assertTrue(
-				\MUCD_Data::should_copy_table($table, 'fc_subscriber_pivot', get_current_blog_id(), 123)
+			$this->assertFalse(
+				\MUCD_Data::should_copy_table($table, 'wu_empty_runtime_fixture', get_current_blog_id(), 123)
 			);
 		} finally {
+			remove_filter('wu_mucd_skip_empty_tables', $filter, 10);
 			$this->drop_table_selection_fixture($table);
 		}
 	}

--- a/tests/WP_Ultimo/Duplication/MUCD_Data_Test.php
+++ b/tests/WP_Ultimo/Duplication/MUCD_Data_Test.php
@@ -696,6 +696,26 @@ class MUCD_Data_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Test empty FluentCRM tables are copied so their schemas exist on clones.
+	 */
+	public function test_should_copy_table_keeps_empty_fluentcrm_tables() {
+		global $wpdb;
+
+		$table = $wpdb->get_blog_prefix() . 'fc_subscriber_pivot';
+
+		$this->create_table_selection_fixture($table);
+		\WP_Ultimo\Compat\General_Compat::get_instance();
+
+		try {
+			$this->assertTrue(
+				\MUCD_Data::should_copy_table($table, 'fc_subscriber_pivot', get_current_blog_id(), 123)
+			);
+		} finally {
+			$this->drop_table_selection_fixture($table);
+		}
+	}
+
+	/**
 	 * Test filters can force-copy a table skipped by default.
 	 */
 	public function test_should_copy_table_filter_can_force_copy() {
@@ -752,7 +772,8 @@ class MUCD_Data_Test extends WP_UnitTestCase {
 
 		$this->drop_table_selection_fixture($table);
 
-		$wpdb->query( // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Test fixture table name cannot be bound.
+		$wpdb->query( // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Test fixture table name cannot be bound.
+			// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Test fixture table name cannot be bound.
 			"CREATE TABLE `{$table}` (id bigint(20) unsigned NOT NULL AUTO_INCREMENT, value varchar(20) NOT NULL DEFAULT '', PRIMARY KEY  (id))"
 		);
 	}


### PR DESCRIPTION
## Summary

- copy empty per-site table schemas during site duplication by default
- retain explicit exclusions for runtime tables such as queues, logs, caches, and sessions
- preserve the existing filter so installations can deliberately opt into skipping empty optional tables
- cover the reported empty FluentCRM `fc_subscriber_pivot` table and the opt-in behavior

## Root cause

The clone optimizer treated an empty custom table as unnecessary and omitted its schema. Plugins can require those schemas immediately after provisioning even when the source table has no rows, as FluentCRM does with `fc_subscriber_pivot`.

## Verification

- `vendor/bin/phpunit --filter MUCD_Data_Test --no-coverage` — 32 tests, 105 assertions
- `vendor/bin/phpstan analyse inc/duplication/data.php inc/compat/class-general-compat.php --no-progress`
- `vendor/bin/phpcs inc/duplication/data.php inc/compat/class-general-compat.php tests/WP_Ultimo/Duplication/MUCD_Data_Test.php` — 0 errors
- pre-commit PHPCS and PHPStan checks passed

<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.266 plugin for [OpenCode](https://opencode.ai) v1.18.18 with gpt-5.6-sol spent 34m and 408,931 tokens on this with the user in an interactive session.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Empty per-site tables are now copied by default during site duplication, preserving their structure and expected data layout.
  * Optional empty tables can still be skipped when the corresponding setting is enabled.

* **Documentation**
  * Updated table-copying guidance to clarify default behavior and available filtering options.
  * Clarified which runtime tables are excluded from copying.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->