### PR TITLE
fix: guard unavailable current network

### DIFF
--- a/inc/class-settings.php
+++ b/inc/class-settings.php
@@ -94,7 +94,7 @@ class Settings implements \WP_Ultimo\Interfaces\Singleton {
 
 		global $current_site;
 
-		if ($current_site->id !== $network_id) {
+		if ( ! $current_site || $current_site->id !== $network_id) {
 			return $status;
 		}
 
@@ -139,7 +139,7 @@ class Settings implements \WP_Ultimo\Interfaces\Singleton {
 
 		global $current_site;
 
-		if ($current_site->id !== $network_id) {
+		if ( ! $current_site || $current_site->id !== $network_id) {
 			return $status;
 		}
 
@@ -160,7 +160,7 @@ class Settings implements \WP_Ultimo\Interfaces\Singleton {
 
 		global $current_site;
 
-		if ($current_site->id !== $network_id || is_bool($status)) {
+		if ( ! $current_site || $current_site->id !== $network_id || is_bool($status)) {
 			return $status;
 		}
 

--- a/tests/WP_Ultimo/Settings_Test.php
+++ b/tests/WP_Ultimo/Settings_Test.php
@@ -360,6 +360,22 @@ class Settings_Test extends WP_UnitTestCase {
 		$this->assertEquals($status, $result);
 	}
 
+	public function test_network_option_filters_return_original_values_without_current_site() {
+		global $current_site;
+
+		$original_current_site = $current_site;
+		$current_site          = null;
+		$plugins_status        = ['plugins' => false];
+
+		try {
+			$this->assertSame('none', $this->settings->force_registration_status('none', 'registration', 1));
+			$this->assertSame('original', $this->settings->force_add_new_users('original', 'add_new_users', 1));
+			$this->assertSame($plugins_status, $this->settings->force_plugins_menu($plugins_status, 'menu_items', 1));
+		} finally {
+			$current_site = $original_current_site;
+		}
+	}
+
 	// ------------------------------------------------------------------
 	// init
 	// ------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- preserve WordPress network-option values when the current network global is unavailable
- guard the registration, new-user, and plugins-menu filters against a null `$current_site`
- add regression coverage for all three filter callbacks

## Verification

- `vendor/bin/phpcs inc/class-settings.php tests/WP_Ultimo/Settings_Test.php`
- `vendor/bin/phpstan analyse inc/class-settings.php --no-progress`
- `vendor/bin/phpunit --filter Settings_Test` — 54 tests, 77 assertions

<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.275 plugin for [OpenCode](https://opencode.ai) v1.18.18 with gpt-5.6-sol spent 4m and 152,687 tokens on this with the user in an interactive session.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved settings handling when the current site is unavailable.
  * Preserved existing values in network settings filters under these conditions.
  * Continued to correctly bypass plugin-menu processing for boolean statuses.

* **Tests**
  * Added regression coverage for settings behavior without an available current site.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->