### PR TITLE
fix: align Composer release metadata

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "ultimate-multisite/ultimate-multisite",
     "homepage": "https://UltimateMultisite.com",
     "description": "The Multisite Website as a Service (WaaS) plugin.",
-    "version": "2.5.0",
+    "version": "2.15.1",
     "authors": [
         {
             "name": "Arindo Duque",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "a7c66a4c175ca451efc114556a00cf44",
+    "content-hash": "831d496e4429b3e67e86eabf7b3ddb65",
     "packages": [
         {
             "name": "amphp/amp",


### PR DESCRIPTION
## Summary

- align the root Composer package version with the `2.15.1` plugin release
- refresh the committed lockfile content hash without changing dependencies

## Context

Follow-up to #1732. The expanded release audit found that `composer.json` still reported `2.5.0` after the `2.15.1` release preparation merged.

Files changed:

- `composer.json`
- `composer.lock`

## Verification

- `composer validate --no-check-publish --no-interaction`
- `git diff --check origin/main..HEAD`
- expanded release audit: 59/59 plugin runtime versions aligned and zero Composer version advisories

<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.278 plugin for [OpenCode](https://opencode.ai) v1.18.18 with gpt-5.6-sol spent 1d 13h and 3,045,628 tokens on this with the user in an interactive session.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Composer package to version 2.15.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->