### PR TITLE
test: verify persisted membership expiration

### DIFF
--- a/tests/WP_Ultimo/Checkout/Checkout_Test.php
+++ b/tests/WP_Ultimo/Checkout/Checkout_Test.php
@@ -4134,17 +4134,20 @@ class Checkout_Test extends WP_UnitTestCase {
 		}
 
 		$this->assertInstanceOf(\WP_Ultimo\Models\Membership::class, $result);
-		$this->assertSame($expected_expiration, $result->get_date_expiration());
-		$this->assertStringStartsNotWith('1970-', $result->get_date_expiration());
 
-		$event_payload = wu_generate_event_payload('membership', $result);
+		$persisted_membership = wu_get_membership($result->get_id());
+		$this->assertInstanceOf(\WP_Ultimo\Models\Membership::class, $persisted_membership);
+		$this->assertSame($expected_expiration, $persisted_membership->get_date_expiration());
+		$this->assertStringStartsNotWith('1970-', $persisted_membership->get_date_expiration());
+
+		$event_payload = wu_generate_event_payload('membership', $persisted_membership);
 		$this->assertSame($expected_expiration, $event_payload['membership_date_expiration']);
 		$this->assertSame(
 			date_i18n(get_option('date_format'), wu_date($expected_expiration)->format('U')),
-			$result->get_formatted_date('date_expiration')
+			$persisted_membership->get_formatted_date('date_expiration')
 		);
 
-		$result->delete();
+		$persisted_membership->delete();
 		$recurring_plan->delete();
 		$order_prop->setValue($checkout, null);
 	}


### PR DESCRIPTION
Resolves #1737\n\n<!-- aidevops:sig -->
<!-- aidevops:origin:worker -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.286 plugin for [OpenCode](https://opencode.ai) v1.18.18 with gpt-5.6-terra spent 3m and 84,229 tokens on this as a headless worker.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved coverage for recurring membership expiration by verifying persisted membership data, expiration formatting, and event payload values.
  * Enhanced test cleanup to remove reloaded membership records.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->