### PR TITLE
Fix undefined $parent warning in order bump template

### DIFF
--- a/views/checkout/templates/order-bump/simple.php
+++ b/views/checkout/templates/order-bump/simple.php
@@ -40,15 +40,12 @@ if (false !== $product_variation) {
 			</div>
 		</div>
 	</div>
-	<?php if (! $parent || ! method_exists($parent, 'has_product')) : ?>
-		<div v-if="!($parent.has_product('<?php echo esc_js($product->get_id()); ?>') || $parent.has_product('<?php echo esc_js($product->get_slug()); ?>'))" class="wu-ml-2">
-			<a href="#" @click.prevent="$parent.add_product('<?php echo esc_js($product->get_id()); ?>')" class="button btn"><?php esc_html_e('Add to Cart', 'ultimate-multisite'); ?></a>
-		</div>
-	<?php else : ?>
-		<div v-else class="wu-ml-2">
-			<a href="#" @click.prevent="$parent.remove_product('<?php echo esc_js($product->get_id()); ?>', '<?php echo esc_js($product->get_slug()); ?>')" class="button btn"><?php esc_html_e('Remove', 'ultimate-multisite'); ?></a>
-			<input type="hidden" name="products[]" value="<?php echo esc_attr($product->get_id()); ?>">
-		</div>
-	<?php endif; ?>
+	<div v-if="!($parent.has_product('<?php echo esc_js($product->get_id()); ?>') || $parent.has_product('<?php echo esc_js($product->get_slug()); ?>'))" class="wu-ml-2">
+		<a href="#" @click.prevent="$parent.add_product('<?php echo esc_js($product->get_id()); ?>')" class="button btn"><?php esc_html_e('Add to Cart', 'ultimate-multisite'); ?></a>
+	</div>
+	<div v-else class="wu-ml-2">
+		<a href="#" @click.prevent="$parent.remove_product('<?php echo esc_js($product->get_id()); ?>', '<?php echo esc_js($product->get_slug()); ?>')" class="button btn"><?php esc_html_e('Remove', 'ultimate-multisite'); ?></a>
+		<input type="hidden" name="products[]" value="<?php echo esc_attr($product->get_id()); ?>">
+	</div>
 	<div class="wu-absolute wu--inset-px wu-rounded-lg wu-border-solid wu-pointer-events-none wu-top-0 wu-bottom-0 wu-right-0 wu-left-0" :class="($parent.has_product('<?php echo esc_js($product->get_id()); ?>') || $parent.has_product('<?php echo esc_js($product->get_slug()); ?>')) ? 'wu-border-blue-500' : 'wu-border-transparent'" aria-hidden="true"></div>
 </div>


### PR DESCRIPTION
## Summary

- remove the accidental PHP check for Vue's `$parent` component reference
- restore adjacent `v-if` and `v-else` order-bump controls
- prevent an undefined-variable warning when rendering the checkout template

## Testing

- `php -l views/checkout/templates/order-bump/simple.php`
- `vendor/bin/phpcs views/checkout/templates/order-bump/simple.php`
- `WP_TESTS_DIR=/tmp/wordpress-tests-lib vendor/bin/phpunit tests/WP_Ultimo/Checkout/Signup_Fields/Signup_Field_Order_Bump_Test.php`
- direct template render with PHP warnings converted to exceptions; confirmed both Vue branches are present


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved order-bump controls during checkout by ensuring add/remove options and product details display correctly based on the current selection.
  * Preserved dynamic visibility of controls for a more consistent checkout experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->