### PR TITLE
fix(sso): disable SSO by default

### DIFF
--- a/inc/class-settings.php
+++ b/inc/class-settings.php
@@ -2202,7 +2202,7 @@ class Settings implements \WP_Ultimo\Interfaces\Singleton {
 			'domain_mapping_instructions'        => '',
 
 			// SSO (registered via hooks)
-			'enable_sso'                         => 1,
+			'enable_sso'                         => 0,
 
 			// Other
 			'hide_tours'                         => 0,

--- a/inc/managers/class-domain-manager.php
+++ b/inc/managers/class-domain-manager.php
@@ -866,7 +866,7 @@ class Domain_Manager extends Base_Manager {
 				'title'   => __('Enable Single Sign-On', 'ultimate-multisite'),
 				'desc'    => __('Enables the Single Sign-on functionality.', 'ultimate-multisite'),
 				'type'    => 'toggle',
-				'default' => 1,
+				'default' => 0,
 			]
 		);
 

--- a/inc/sso/class-sso.php
+++ b/inc/sso/class-sso.php
@@ -81,7 +81,7 @@ class SSO {
 	 */
 	public function is_enabled() {
 
-		$enabled = $this->get_setting('enable_sso', true);
+		$enabled = $this->get_setting('enable_sso');
 
 		if (has_filter('mercator.sso.enabled')) {
 			$enabled = apply_filters_deprecated('mercator.sso.enabled', $enabled, '2.0.0', 'wu_sso_enabled');

--- a/inc/sso/class-sso.php
+++ b/inc/sso/class-sso.php
@@ -97,7 +97,7 @@ class SSO {
 		 * @param bool $enabled Should SSO be enabled? True for on, false-ish for off.
 		 * @return bool If SSO is enabled or not.
 		 */
-		return apply_filters('wu_sso_enabled', $enabled);
+		return (bool) apply_filters('wu_sso_enabled', $enabled);
 	}
 
 	/**

--- a/tests/unit/SSO_Test.php
+++ b/tests/unit/SSO_Test.php
@@ -26,19 +26,26 @@ class SSO_Test extends \WP_UnitTestCase {
 
 	public function test_with_sso_appends_query_param_when_enabled(): void {
 		add_filter('wu_sso_enabled', '__return_true');
-		$url     = 'https://example.com/path?foo=bar';
-		$withSso = SSO::with_sso($url);
+		$url      = 'https://example.com/path?foo=bar';
+		$with_sso = SSO::with_sso($url);
 
-		$this->assertStringContainsString('sso=login', $withSso, 'SSO query arg should be added');
-		$this->assertStringContainsString('foo=bar', $withSso, 'Original query args should be preserved');
+		$this->assertStringContainsString('sso=login', $with_sso, 'SSO query arg should be added');
+		$this->assertStringContainsString('foo=bar', $with_sso, 'Original query args should be preserved');
 	}
 
 	public function test_with_sso_returns_same_url_when_disabled(): void {
 		add_filter('wu_sso_enabled', '__return_false');
-		$url     = 'https://example.com/path?foo=bar';
-		$withSso = SSO::with_sso($url);
+		$url      = 'https://example.com/path?foo=bar';
+		$with_sso = SSO::with_sso($url);
 
-		$this->assertSame($url, $withSso, 'URL should be unchanged when SSO disabled');
+		$this->assertSame($url, $with_sso, 'URL should be unchanged when SSO disabled');
+	}
+
+	public function test_with_sso_returns_same_url_when_default_setting_is_disabled(): void {
+		$url      = 'https://example.com/path?foo=bar';
+		$with_sso = SSO::with_sso($url);
+
+		$this->assertSame($url, $with_sso, 'URL should be unchanged when the default SSO setting is disabled');
 	}
 
 	public function test_encode_decode_roundtrip_uses_hashids(): void {


### PR DESCRIPTION
## Summary

- default Single Sign-On to off for fresh Ultimate Multisite installations
- align the settings map, settings UI field, and runtime fallback
- preserve existing installations' explicitly saved SSO setting

## Verification

- `vendor/bin/phpcs inc/class-settings.php inc/managers/class-domain-manager.php inc/sso/class-sso.php`
- `vendor/bin/phpstan analyse inc/class-settings.php inc/managers/class-domain-manager.php inc/sso/class-sso.php --no-progress`
- `vendor/bin/phpunit tests/WP_Ultimo/Settings_Test.php`
- `vendor/bin/phpunit tests/WP_Ultimo/SSO/SSO_Test.php`
- `vendor/bin/phpunit tests/WP_Ultimo/SSO/SSO_Extended_Test.php`

<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.291 plugin for [OpenCode](https://opencode.ai) v1.18.25 with gpt-5.6-sol spent 3h 9m and 585,982 tokens on this with the user in an interactive session.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Behavior Changes**
  * Single Sign-On is now disabled by default for new installations.
  * Existing configurations without an explicit SSO setting will no longer automatically enable SSO.
  * Administrators can enable SSO manually when needed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->