### PR TITLE
test: isolate SSO default setting fallback

### DIFF
--- a/tests/unit/SSO_Test.php
+++ b/tests/unit/SSO_Test.php
@@ -42,10 +42,29 @@ class SSO_Test extends \WP_UnitTestCase {
 	}
 
 	public function test_with_sso_returns_same_url_when_default_setting_is_disabled(): void {
-		$url      = 'https://example.com/path?foo=bar';
-		$with_sso = SSO::with_sso($url);
+		$settings          = \WP_Ultimo\Settings::get_instance();
+		$original_settings = $settings->get_all();
+		$all_settings      = $original_settings;
 
-		$this->assertSame($url, $with_sso, 'URL should be unchanged when the default SSO setting is disabled');
+		unset($all_settings['enable_sso']);
+		wu_save_option(\WP_Ultimo\Settings::KEY, $all_settings);
+
+		$settings_property = new \ReflectionProperty(\WP_Ultimo\Settings::class, 'settings');
+		if (PHP_VERSION_ID < 80100) {
+			$settings_property->setAccessible(true);
+		}
+		$settings_property->setValue($settings, null);
+
+		$url      = 'https://example.com/path?foo=bar';
+
+		try {
+			$with_sso = SSO::with_sso($url);
+
+			$this->assertSame($url, $with_sso, 'URL should be unchanged when the default SSO setting is disabled');
+		} finally {
+			wu_save_option(\WP_Ultimo\Settings::KEY, $original_settings);
+			$settings_property->setValue($settings, null);
+		}
 	}
 
 	public function test_encode_decode_roundtrip_uses_hashids(): void {

--- a/tests/unit/SSO_Test.php
+++ b/tests/unit/SSO_Test.php
@@ -55,7 +55,7 @@ class SSO_Test extends \WP_UnitTestCase {
 		}
 		$settings_property->setValue($settings, null);
 
-		$url      = 'https://example.com/path?foo=bar';
+		$url = 'https://example.com/path?foo=bar';
 
 		try {
 			$with_sso = SSO::with_sso($url);


### PR DESCRIPTION
## Summary

- Isolate the unset `enable_sso` default-path test from persisted settings.
- Reset the Settings cache before exercising the fallback and restore the original settings afterward.

## Testing

- `php -l tests/unit/SSO_Test.php`
- `git diff --check`
- Not run: PHPUnit and PHPCS require unavailable Composer dependencies.

Resolves #1742

<!-- aidevops:origin:worker -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.291 plugin for [OpenCode](https://opencode.ai) v1.18.25 with gpt-5.6-terra


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved SSO test coverage for scenarios where the default SSO setting is disabled.
  * Verified that SSO-related URL handling remains unchanged when settings are customized.
  * Tests now safely preserve and restore application settings, preventing configuration changes from affecting other test cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->