### PR TITLE
fix: avoid caching transient database misses

### DIFF
--- a/inc/functions/sunrise.php
+++ b/inc/functions/sunrise.php
@@ -27,7 +27,7 @@ function wu_should_load_sunrise() {
  *
  * @since 2.15.2
  *
- * @return array|false Stored settings, or false when unavailable.
+ * @return array|\WP_Error Stored settings, or a database error when unavailable.
  */
 function wu_get_settings_early() {
 	global $wpdb;
@@ -66,7 +66,7 @@ function wu_get_settings_early() {
 		return $settings;
 	}
 
-	return empty($query_error) ? [] : false;
+	return empty($query_error) ? [] : new \WP_Error('wu_early_settings_query_failed', $query_error);
 }
 
 /**
@@ -88,6 +88,10 @@ function wu_get_setting_early($setting, $default_value = false) {
 
 	$settings = wu_get_settings_early();
 
+	if (is_wp_error($settings)) {
+		return $default_value;
+	}
+
 	return wu_get_isset($settings, $setting, $default_value);
 }
 
@@ -108,6 +112,10 @@ function wu_save_setting_early($key, $value) {
 	}
 
 	$settings = wu_get_settings_early();
+
+	if (is_wp_error($settings)) {
+		return $settings;
+	}
 
 	if ( ! is_array($settings)) {
 		return false;

--- a/inc/functions/sunrise.php
+++ b/inc/functions/sunrise.php
@@ -23,6 +23,53 @@ function wu_should_load_sunrise() {
 }
 
 /**
+ * Get all settings before the regular settings API is available.
+ *
+ * @since 2.15.2
+ *
+ * @return array|false Stored settings, or false when unavailable.
+ */
+function wu_get_settings_early() {
+	global $wpdb;
+
+	$settings_key = 'wp-ultimo_' . \WP_Ultimo\Settings::KEY;
+	$settings     = get_network_option(null, $settings_key);
+
+	if (is_array($settings)) {
+		return $settings;
+	}
+
+	$network_id     = get_current_network_id();
+	$notoptions_key = "{$network_id}:notoptions";
+	$suppress       = $wpdb->suppress_errors();
+	$row            = $wpdb->get_row( // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+		$wpdb->prepare("SELECT meta_value FROM {$wpdb->sitemeta} WHERE meta_key = %s AND site_id = %d", $settings_key, $network_id)
+	);
+	$query_error    = $wpdb->last_error;
+	$wpdb->suppress_errors($suppress);
+
+	if (is_object($row)) {
+		$settings = maybe_unserialize($row->meta_value);
+		wp_cache_set("{$network_id}:{$settings_key}", $settings, 'site-options');
+	}
+
+	if (is_object($row) || ! empty($query_error)) {
+		$notoptions = wp_cache_get($notoptions_key, 'site-options');
+
+		if (is_array($notoptions) && isset($notoptions[ $settings_key ])) {
+			unset($notoptions[ $settings_key ]);
+			wp_cache_set($notoptions_key, $notoptions, 'site-options');
+		}
+	}
+
+	if (is_array($settings)) {
+		return $settings;
+	}
+
+	return empty($query_error) ? [] : false;
+}
+
+/**
  * Get a setting value, when te normal APIs are not available.
  *
  * Should only be used if we're running in sunrise.
@@ -39,9 +86,7 @@ function wu_get_setting_early($setting, $default_value = false) {
 		_doing_it_wrong('wu_get_setting_early', esc_html__('Regular setting APIs are already available. You should use wu_get_setting() instead.', 'ultimate-multisite'), '2.0.0');
 	}
 
-	$settings_key = \WP_Ultimo\Settings::KEY;
-
-	$settings = get_network_option(null, 'wp-ultimo_' . $settings_key);
+	$settings = wu_get_settings_early();
 
 	return wu_get_isset($settings, $setting, $default_value);
 }
@@ -62,13 +107,15 @@ function wu_save_setting_early($key, $value) {
 		_doing_it_wrong('wu_save_setting_early', esc_html__('Regular setting APIs are already available. You should use wu_save_setting() instead.', 'ultimate-multisite'), '2.0.20');
 	}
 
-	$settings_key = \WP_Ultimo\Settings::KEY;
+	$settings = wu_get_settings_early();
 
-	$settings = get_network_option(null, 'wp-ultimo_' . $settings_key);
+	if ( ! is_array($settings)) {
+		return false;
+	}
 
 	$settings[ $key ] = $value;
 
-	return update_network_option(null, 'wp-ultimo_' . $settings_key, $settings);
+	return update_network_option(null, 'wp-ultimo_' . \WP_Ultimo\Settings::KEY, $settings);
 }
 
 /**

--- a/inc/models/class-domain.php
+++ b/inc/models/class-domain.php
@@ -641,11 +641,14 @@ class Domain extends Base_Model {
 		$domain_table = "{$wpdb->base_prefix}wu_domain_mappings";
 
 		$mappings = $wpdb->get_results($wpdb->prepare('SELECT * FROM ' . $domain_table . ' WHERE blog_id = %d ORDER BY primary_domain DESC, active DESC, secure DESC', $site)); //phpcs:ignore
+		$query_error = $wpdb->last_error;
 
 		$wpdb->suppress_errors($suppress);
 
 		if ( ! $mappings) {
-			wp_cache_set('id:' . $site, 'none', 'domain_mapping');
+			if (empty($query_error)) {
+				wp_cache_set('id:' . $site, 'none', 'domain_mapping');
+			}
 
 			return false;
 		}
@@ -714,14 +717,16 @@ class Domain extends Base_Model {
 		$suppress = $wpdb->suppress_errors();
 
 		$mapping = $wpdb->get_row($query); // phpcs:ignore
+		$query_error = $wpdb->last_error;
 
 		$wpdb->suppress_errors($suppress);
 
 		if (empty($mapping)) {
-
-			// Cache that it doesn't exist
-			foreach ($domains as $domain) {
-				wp_cache_set('domain:' . $domain, 'notexists', 'domain_mappings');
+			if (empty($query_error)) {
+				// Cache that it doesn't exist
+				foreach ($domains as $domain) {
+					wp_cache_set('domain:' . $domain, 'notexists', 'domain_mappings');
+				}
 			}
 
 			return null;

--- a/tests/WP_Ultimo/Functions/Sunrise_Functions_Test.php
+++ b/tests/WP_Ultimo/Functions/Sunrise_Functions_Test.php
@@ -110,6 +110,7 @@ class Sunrise_Functions_Test extends WP_UnitTestCase {
 		global $wpdb;
 
 		$this->setExpectedIncorrectUsage('wu_get_setting_early');
+		$this->setExpectedIncorrectUsage('wu_save_setting_early');
 
 		$network_id     = get_current_network_id();
 		$option_name    = 'wp-ultimo_' . \WP_Ultimo\Settings::KEY;
@@ -124,7 +125,9 @@ class Sunrise_Functions_Test extends WP_UnitTestCase {
 		add_filter('query', $filter);
 
 		try {
-			$result = wu_get_setting_early('enable_domain_mapping', 'query_failed');
+			$settings = wu_get_settings_early();
+			$result   = wu_get_setting_early('enable_domain_mapping', 'query_failed');
+			$saved    = wu_save_setting_early('enable_domain_mapping', true);
 		} finally {
 			remove_filter('query', $filter);
 			$wpdb->suppress_errors($suppress);
@@ -132,7 +135,10 @@ class Sunrise_Functions_Test extends WP_UnitTestCase {
 
 		$notoptions = wp_cache_get($notoptions_key, 'site-options');
 
+		$this->assertWPError($settings);
+		$this->assertSame('wu_early_settings_query_failed', $settings->get_error_code());
 		$this->assertSame('query_failed', $result);
+		$this->assertWPError($saved);
 		$this->assertFalse(is_array($notoptions) && isset($notoptions[ $option_name ]));
 	}
 

--- a/tests/WP_Ultimo/Functions/Sunrise_Functions_Test.php
+++ b/tests/WP_Ultimo/Functions/Sunrise_Functions_Test.php
@@ -76,6 +76,67 @@ class Sunrise_Functions_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Test wu_get_setting_early recovers from a stale notoptions marker.
+	 */
+	public function test_get_setting_early_recovers_from_stale_notoptions_marker(): void {
+
+		$this->setExpectedIncorrectUsage('wu_get_setting_early');
+
+		$network_id     = get_current_network_id();
+		$option_name    = 'wp-ultimo_' . \WP_Ultimo\Settings::KEY;
+		$cache_key      = "{$network_id}:{$option_name}";
+		$notoptions_key = "{$network_id}:notoptions";
+		$settings       = get_network_option($network_id, $option_name, []);
+
+		$settings['stale_cache_recovery'] = 'recovered';
+		update_network_option($network_id, $option_name, $settings);
+		wp_cache_delete($cache_key, 'site-options');
+		wp_cache_set($notoptions_key, [$option_name => true], 'site-options');
+
+		$result     = wu_get_setting_early('stale_cache_recovery', false);
+		$notoptions = wp_cache_get($notoptions_key, 'site-options');
+
+		$this->assertSame('recovered', $result);
+		$this->assertArrayNotHasKey($option_name, $notoptions);
+
+		unset($settings['stale_cache_recovery']);
+		update_network_option($network_id, $option_name, $settings);
+	}
+
+	/**
+	 * Test a failed settings query does not leave a persistent negative marker.
+	 */
+	public function test_get_setting_early_does_not_cache_database_errors_as_missing(): void {
+		global $wpdb;
+
+		$this->setExpectedIncorrectUsage('wu_get_setting_early');
+
+		$network_id     = get_current_network_id();
+		$option_name    = 'wp-ultimo_' . \WP_Ultimo\Settings::KEY;
+		$notoptions_key = "{$network_id}:notoptions";
+		$filter         = static function ($query) use ($option_name) {
+			return str_contains($query, 'SELECT meta_value') && str_contains($query, $option_name) ? 'SELECT broken syntax' : $query;
+		};
+
+		wp_cache_delete("{$network_id}:{$option_name}", 'site-options');
+		wp_cache_delete($notoptions_key, 'site-options');
+		$suppress = $wpdb->suppress_errors();
+		add_filter('query', $filter);
+
+		try {
+			$result = wu_get_setting_early('enable_domain_mapping', 'query_failed');
+		} finally {
+			remove_filter('query', $filter);
+			$wpdb->suppress_errors($suppress);
+		}
+
+		$notoptions = wp_cache_get($notoptions_key, 'site-options');
+
+		$this->assertSame('query_failed', $result);
+		$this->assertFalse(is_array($notoptions) && isset($notoptions[ $option_name ]));
+	}
+
+	/**
 	 * Test wu_save_setting_early stores a value retrievable by wu_get_setting_early.
 	 */
 	public function test_save_setting_early_stores_value(): void {

--- a/tests/WP_Ultimo/Managers/Domain_Manager_Test.php
+++ b/tests/WP_Ultimo/Managers/Domain_Manager_Test.php
@@ -875,6 +875,32 @@ class Domain_Manager_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Test Domain::get_by_site does not cache database errors as an empty result.
+	 */
+	public function test_get_by_site_does_not_cache_database_errors(): void {
+		global $wpdb;
+
+		$blog_id = $this->create_test_blog();
+		$filter  = static function ($query) use ($wpdb, $blog_id) {
+			return str_contains($query, $wpdb->base_prefix . 'wu_domain_mappings') && str_contains($query, 'blog_id = ' . $blog_id) ? 'SELECT broken syntax' : $query;
+		};
+
+		wp_cache_delete('id:' . $blog_id, 'domain_mapping');
+		$suppress = $wpdb->suppress_errors();
+		add_filter('query', $filter);
+
+		try {
+			$mappings = Domain::get_by_site($blog_id);
+		} finally {
+			remove_filter('query', $filter);
+			$wpdb->suppress_errors($suppress);
+		}
+
+		$this->assertFalse($mappings);
+		$this->assertFalse(wp_cache_get('id:' . $blog_id, 'domain_mapping'));
+	}
+
+	/**
 	 * Test Domain::get_by_site returns WP_Error for invalid site ID.
 	 */
 	public function test_get_by_site_invalid_id(): void {
@@ -925,6 +951,32 @@ class Domain_Manager_Test extends WP_UnitTestCase {
 		$fetched = Domain::get_by_domain('nonexistent-domain-xyz.example.com');
 
 		$this->assertNull($fetched);
+	}
+
+	/**
+	 * Test Domain::get_by_domain does not cache database errors as missing domains.
+	 */
+	public function test_get_by_domain_does_not_cache_database_errors(): void {
+		global $wpdb;
+
+		$domain = 'query-error-domain.example.com';
+		$filter = static function ($query) use ($wpdb, $domain) {
+			return str_contains($query, $wpdb->base_prefix . 'wu_domain_mappings') && str_contains($query, $domain) ? 'SELECT broken syntax' : $query;
+		};
+
+		wp_cache_delete('domain:' . $domain, 'domain_mappings');
+		$suppress = $wpdb->suppress_errors();
+		add_filter('query', $filter);
+
+		try {
+			$fetched = Domain::get_by_domain($domain);
+		} finally {
+			remove_filter('query', $filter);
+			$wpdb->suppress_errors($suppress);
+		}
+
+		$this->assertNull($fetched);
+		$this->assertFalse(wp_cache_get('domain:' . $domain, 'domain_mappings'));
 	}
 
 	/**


### PR DESCRIPTION
## Summary

- recover early Ultimate Multisite settings directly from `sitemeta` when a cached network-option miss hides an existing row
- remove stale `notoptions` entries and avoid rewriting the complete settings array after a database error
- avoid caching domain lookup misses when the underlying query failed
- add regressions for stale settings markers and failed settings/domain queries

## Why

WordPress network-option reads can cache a missing-option marker when a database query returns an error. With persistent object caching, that false negative can outlive the transient error and disable settings-dependent mapped-domain bootstrap. Domain lookups had the same risk because query errors were cached as valid misses.

## Verification

- `vendor/bin/phpcs inc/functions/sunrise.php`
- `vendor/bin/phpcs inc/models/class-domain.php`
- `vendor/bin/phpstan analyse inc/functions/sunrise.php inc/models/class-domain.php --no-progress`
- `vendor/bin/phpunit --no-coverage --filter Sunrise_Functions_Test`
- `vendor/bin/phpunit --no-coverage --filter '/test_get_by_(site|domain)/'`
- pre-commit quality hook: PHPCS and PHPStan passed

<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.291 plugin for [OpenCode](https://opencode.ai) v1.18.25 with gpt-5.6-sol


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved early settings retrieval when cached settings markers are stale or database access temporarily fails.
  * Prevented failed settings lookups from being incorrectly cached as missing.
  * Domain lookups can now retry after database errors instead of retaining an incorrect “not found” result.

* **Tests**
  * Added coverage for stale cache markers and database-error recovery scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->