### PR TITLE
fix: isolate settings cache by network

### DIFF
--- a/inc/class-settings.php
+++ b/inc/class-settings.php
@@ -42,6 +42,18 @@ class Settings implements \WP_Ultimo\Interfaces\Singleton {
 	private ?array $settings = null;
 
 	/**
+	 * Network ID associated with the cached settings array.
+	 *
+	 * Long-running requests may switch network context while reusing this
+	 * singleton. Tracking the source network prevents a later save from writing
+	 * another network's cached settings array.
+	 *
+	 * @since 2.15.1
+	 * @var int|null
+	 */
+	private ?int $settings_network_id = null;
+
+	/**
 	 * Holds the sections of the settings page.
 	 *
 	 * @since 2.0.0
@@ -177,9 +189,13 @@ class Settings implements \WP_Ultimo\Interfaces\Singleton {
 	 */
 	public function get_all($check_caps = false) {
 
-		// Get all the settings
-		if (null === $this->settings) {
-			$this->settings = wu_get_option(self::KEY);
+		$current_network_id = get_current_network_id();
+
+		// Reload after a network-context switch instead of reusing another
+		// network's cached full settings array.
+		if (null === $this->settings || $current_network_id !== $this->settings_network_id) {
+			$this->settings            = wu_get_option(self::KEY);
+			$this->settings_network_id = $current_network_id;
 		}
 
 		if (empty($this->settings)) {
@@ -332,7 +348,8 @@ class Settings implements \WP_Ultimo\Interfaces\Singleton {
 
 		$status = wu_save_option(self::KEY, $settings);
 
-		$this->settings = $settings;
+		$this->settings            = $settings;
+		$this->settings_network_id = get_current_network_id();
 
 		return $status;
 	}
@@ -405,7 +422,8 @@ class Settings implements \WP_Ultimo\Interfaces\Singleton {
 
 		wu_save_option(self::KEY, $settings);
 
-		$this->settings = $settings;
+		$this->settings            = $settings;
+		$this->settings_network_id = get_current_network_id();
 
 		do_action('wu_after_save_settings', $settings, $settings_to_save, $saved_settings);
 

--- a/tests/WP_Ultimo/Settings_Test.php
+++ b/tests/WP_Ultimo/Settings_Test.php
@@ -154,6 +154,67 @@ class Settings_Test extends WP_UnitTestCase {
 		$this->assertEquals(['a', 'b', 'c'], $this->settings->get_setting('array_key'));
 	}
 
+	public function test_save_setting_reloads_settings_after_network_context_changes() {
+		global $current_site, $wpdb;
+
+		$source_network_id    = 98765;
+		$target_network_id    = 98766;
+		$original_site        = $current_site;
+		$original_wpdb_siteid = $wpdb->siteid;
+		$settings_property    = new \ReflectionProperty(Settings::class, 'settings');
+		$network_property     = new \ReflectionProperty(Settings::class, 'settings_network_id');
+
+		if (PHP_VERSION_ID < 80100) {
+			$settings_property->setAccessible(true);
+			$network_property->setAccessible(true);
+		}
+
+		update_network_option(
+			$source_network_id,
+			'wp-ultimo_v2_settings',
+			[
+				'network_marker' => 'source',
+				'source_only'    => 'keep',
+			]
+		);
+		update_network_option(
+			$target_network_id,
+			'wp-ultimo_v2_settings',
+			[
+				'network_marker' => 'target',
+				'target_only'    => 'keep',
+			]
+		);
+
+		try {
+			$current_site = (object) ['id' => $source_network_id];
+			$wpdb->siteid = $source_network_id;
+			$settings_property->setValue($this->settings, null);
+			$network_property->setValue($this->settings, null);
+
+			$this->assertSame('source', $this->settings->get_setting('network_marker'));
+
+			$current_site = (object) ['id' => $target_network_id];
+			$wpdb->siteid = $target_network_id;
+
+			$this->assertTrue($this->settings->save_setting('saved_after_switch', true));
+
+			$target_settings = get_network_option($target_network_id, 'wp-ultimo_v2_settings', []);
+
+			$this->assertSame('target', $target_settings['network_marker']);
+			$this->assertSame('keep', $target_settings['target_only']);
+			$this->assertArrayNotHasKey('source_only', $target_settings);
+			$this->assertTrue($target_settings['saved_after_switch']);
+		} finally {
+			$current_site = $original_site;
+			$wpdb->siteid = $original_wpdb_siteid;
+			delete_network_option($source_network_id, 'wp-ultimo_v2_settings');
+			delete_network_option($target_network_id, 'wp-ultimo_v2_settings');
+			$settings_property->setValue($this->settings, null);
+			$network_property->setValue($this->settings, null);
+		}
+	}
+
 	// ------------------------------------------------------------------
 	// get_setting filter
 	// ------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- associate the singleton settings cache with the network that loaded it
- reload settings when WordPress changes network context
- preserve cache ownership after both single-setting and full settings saves
- add a regression test proving a save after a network switch preserves the target network's settings

## Verification

- Settings test suite: 55 tests, 83 assertions passed
- PHP syntax checks passed
- pre-commit PHPCS and PHPStan checks passed
- `git diff --check` passed

<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.291 plugin for [OpenCode](https://opencode.ai) v1.18.25 with gpt-5.6-sol


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed settings cache handling when switching between network contexts.
  * Ensured settings are loaded from and saved to the correct network, preventing values from being carried over incorrectly.

* **Tests**
  * Added coverage for saving settings after a network context change.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->