### PR TITLE
fix: align SSO test defaults

### DIFF
--- a/tests/WP_Ultimo/SSO/SSO_Coverage_Test.php
+++ b/tests/WP_Ultimo/SSO/SSO_Coverage_Test.php
@@ -33,6 +33,16 @@ class SSO_Coverage_Test extends \WP_UnitTestCase {
 
 		add_filter('wu_sso_enabled', '__return_true');
 
+		/*
+		 * This test class removes temporary redirect-host filters after each test.
+		 * Re-register the production mapping callback because its singleton can
+		 * already exist when a subsequent test starts.
+		 */
+		if (class_exists('\WP_Ultimo\Domain_Mapping')) {
+			$domain_mapping = \WP_Ultimo\Domain_Mapping::get_instance();
+			add_filter('allowed_redirect_hosts', [$domain_mapping, 'allow_network_redirect_hosts'], 20, 2);
+		}
+
 		add_filter(
 			'wu_sso_salt',
 			function () {
@@ -2239,7 +2249,7 @@ class SSO_Coverage_Test extends \WP_UnitTestCase {
 		wp_cache_delete('domain:www.' . $domain_name, 'domain_mappings');
 
 		try {
-			$sso->startup();
+			$sso->init();
 
 			$result = apply_filters('allowed_redirect_hosts', ['mygratis.site'], strtoupper($domain_name));
 

--- a/tests/WP_Ultimo/SSO/SSO_Extended_Test.php
+++ b/tests/WP_Ultimo/SSO/SSO_Extended_Test.php
@@ -1644,6 +1644,8 @@ class SSO_Extended_Test extends \WP_UnitTestCase {
 	 * Test get_setting returns true for enable_sso when set.
 	 */
 	public function test_get_setting_returns_true_for_enable_sso(): void {
+		$previous_enable_sso = wu_get_setting('enable_sso', false);
+
 		wu_save_setting('enable_sso', true);
 
 		try {
@@ -1654,7 +1656,7 @@ class SSO_Extended_Test extends \WP_UnitTestCase {
 			// SSO treats enable_sso via normal option truthiness.
 			$this->assertTrue(wu_string_to_bool($result));
 		} finally {
-			wu_save_setting('enable_sso', false);
+			wu_save_setting('enable_sso', $previous_enable_sso);
 		}
 	}
 

--- a/tests/WP_Ultimo/SSO/SSO_Extended_Test.php
+++ b/tests/WP_Ultimo/SSO/SSO_Extended_Test.php
@@ -1644,12 +1644,18 @@ class SSO_Extended_Test extends \WP_UnitTestCase {
 	 * Test get_setting returns true for enable_sso when set.
 	 */
 	public function test_get_setting_returns_true_for_enable_sso(): void {
-		$sso    = SSO::get_instance();
-		$result = $sso->get_setting('enable_sso', true);
+		wu_save_setting('enable_sso', true);
 
-		// WordPress stores checkbox-like settings as scalars such as '1';
-		// SSO treats enable_sso via normal option truthiness.
-		$this->assertTrue(wu_string_to_bool($result));
+		try {
+			$sso    = SSO::get_instance();
+			$result = $sso->get_setting('enable_sso');
+
+			// WordPress stores checkbox-like settings as scalars such as '1';
+			// SSO treats enable_sso via normal option truthiness.
+			$this->assertTrue(wu_string_to_bool($result));
+		} finally {
+			wu_save_setting('enable_sso', false);
+		}
 	}
 
 	// ------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Align SSO coverage setup with the enabled SSO path and restore the domain-mapping redirect-host callback removed by test cleanup.
- Persist and clean up the enabled SSO setting in the setting test.

## Testing

- Passed: `php -l tests/WP_Ultimo/SSO/SSO_Coverage_Test.php`
- Passed: `php -l tests/WP_Ultimo/SSO/SSO_Extended_Test.php`
- Blocked locally: Composer 2.10.2 could not download three locked packages because GitHub authentication is unavailable and Composer reported no `git` binary for source fallback. Consequently `vendor/bin/phpunit` and `vendor/bin/phpcs` are unavailable; CI must run the focused and full PHP matrix.

Resolves #1747

<!-- aidevops:sig -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved single sign-on test coverage for domain-mapped redirects.
  * Updated setting tests to verify saved SSO configuration values and restore test state afterward.
  * Ensured redirect behavior is tested using the standard SSO initialization flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->