### PR TITLE
GH#1759: fix(deps): update qs lockfile resolution

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3119,8 +3119,8 @@ packages:
     resolution: {integrity: sha512-kXuQdQTB6oN3KhI6V4acnBSZx8D2I4xzZvn9+wFLLFCoBNQY/sFnCW6c43OL7pOQ2HvGV4lnWIXNmgfp7cTWhQ==}
     engines: {node: '>=20'}
 
-  qs@6.14.0:
-    resolution: {integrity: sha512-YWWTjgABSKcvs/nWBi9PycY/JiPJqOD4JA6o9Sej2AtvSGarXxKC3OQSk4pAarbdQlKAh5D4FCQkJNkW+GAn3w==}
+  qs@6.15.3:
+    resolution: {integrity: sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==}
     engines: {node: '>=0.6'}
 
   queue-microtask@1.2.3:
@@ -4632,7 +4632,7 @@ snapshots:
       json-stringify-safe: 5.0.1
       mime-types: 2.1.35
       performance-now: 2.1.0
-      qs: 6.14.0
+      qs: 6.15.3
       safe-buffer: 5.2.1
       tough-cookie: 5.1.2
       tunnel-agent: 0.6.0
@@ -7262,7 +7262,7 @@ snapshots:
     dependencies:
       hookified: 1.14.0
 
-  qs@6.14.0:
+  qs@6.15.3:
     dependencies:
       side-channel: 1.1.1
 


### PR DESCRIPTION
## Summary

- Resolve qs 6.15.3 for the Cypress request dependency in pnpm-lock.yaml.

## Testing

- `pnpm install --frozen-lockfile --ignore-scripts`
- `pnpm list qs --depth Infinity`
- `pnpm run lint:css`

Resolves #1759

<!-- aidevops:origin:worker -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.297 plugin for [OpenCode](https://opencode.ai) v1.18.26 with gpt-5.6-terra
