### PR TITLE
fix(i18n): correct source translation warnings

### DIFF
--- a/inc/class-scripts.php
+++ b/inc/class-scripts.php
@@ -343,8 +343,8 @@ class Scripts {
 	 */
 	public function localize_moment() {
 
-		$time_format = get_option('time_format', __('g:i a')); // phpcs:ignore WordPress.WP.I18n.MissingArgDomain
-		$date_format = get_option('date_format', __('F j, Y')); // phpcs:ignore WordPress.WP.I18n.MissingArgDomain
+		$time_format = get_option('time_format', 'g:i a');
+		$date_format = get_option('date_format', 'F j, Y');
 
 		$long_date_formats = array_map(
 			'wu_convert_php_date_format_to_moment_js_format',

--- a/inc/gateways/class-paypal-gateway.php
+++ b/inc/gateways/class-paypal-gateway.php
@@ -531,25 +531,25 @@ class PayPal_Gateway extends Base_PayPal_Gateway {
 			if ($recurring_total !== $cart_total) {
 				if ('downgrade' === $type) {
 					if ($is_trial_setup) {
-						// translators: $1$s the date membership will start, $2$s amount to be billed.
-						$notes[] = sprintf(__('Your updated membership will start on $1$s, from that date you will be billed %2$s every month.', 'ultimate-multisite'), $date, $recurring_total_format);
+						// translators: %1$s the date membership will start, %2$s amount to be billed.
+						$notes[] = sprintf(__('Your updated membership will start on %1$s, from that date you will be billed %2$s every month.', 'ultimate-multisite'), $date, $recurring_total_format);
 					} else {
 						$date_renew = wp_date(get_option('date_format'), strtotime($membership->get_date_expiration(), wu_get_current_time('timestamp', true)));
-						// translators: $1$s the date membership will start, $2$s amount to be billed, %3$s the description of how often.
+						// translators: %1$s the date membership will start, %2$s amount to be billed, %3$s the description of how often.
 						$notes[] = sprintf(__('Your updated membership will start on %1$s, from that date you will be billed %2$s %3$s.', 'ultimate-multisite'), $date_renew, $recurring_total_format, $desc);
 					}
 				} elseif ($is_trial_setup) {
-					// translators: $1$s amount to be billed, $2$s how often
+					// translators: %1$s amount to be billed, %2$s how often
 					$notes[] = sprintf(__('After the first payment you will be billed %1$s %2$s.', 'ultimate-multisite'), $recurring_total_format, $desc);
 				} else {
-					// translators: $1$s amount to be billed, $2$s how often
+					// translators: %1$s amount to be billed, %2$s how often
 					$notes[] = sprintf(__('After this payment you will be billed %1$s %2$s.', 'ultimate-multisite'), $recurring_total_format, $desc);
 				}
 			} elseif ($is_trial_setup) {
-					// translators: $1$s amount to be billed, $2$s how often
+					// translators: %1$s amount to be billed, %2$s how often
 					$notes[] = sprintf(__('From that date, you will be billed %1$s %2$s.', 'ultimate-multisite'), $recurring_total_format, $desc);
 			} else {
-				// translators: $1$s how often
+				// translators: %1$s how often
 				$notes[] = sprintf(__('After this payment you will be billed %1$s.', 'ultimate-multisite'), $desc);
 			}
 		}

--- a/lang/ultimate-multisite.pot
+++ b/lang/ultimate-multisite.pot
@@ -16835,40 +16835,42 @@ msgstr ""
 msgid "Your trial period will end on %1$s."
 msgstr ""
 
-#. translators: $1$s the date membership will start, $2$s amount to be billed.
+#. translators: %1$s the date membership will start, %2$s amount to be billed.
 #: inc/gateways/class-paypal-gateway.php:535
 #, php-format
-msgid "Your updated membership will start on $1$s, from that date you will be billed %2$s every month."
+msgid "Your updated membership will start on %1$s, from that date you will be billed %2$s every month."
 msgstr ""
 
-#. translators: $1$s the date membership will start, $2$s amount to be billed, %3$s the description of how often.
+#. translators: %1$s the date membership will start, %2$s amount to be billed, %3$s the description of how often.
+#. translators: %1$s is the start date, %2$s is the subtotal amount, and %3$s is the description of how often.
 #: inc/gateways/class-paypal-gateway.php:539
+#: views/checkout/paypal/confirm.php:40
 #: views/checkout/paypal/confirm.php:44
 #, php-format
 msgid "Your updated membership will start on %1$s, from that date you will be billed %2$s %3$s."
 msgstr ""
 
-#. translators: $1$s amount to be billed, $2$s how often
+#. translators: %1$s amount to be billed, %2$s how often
 #: inc/gateways/class-paypal-gateway.php:543
 #, php-format
 msgid "After the first payment you will be billed %1$s %2$s."
 msgstr ""
 
-#. translators: $1$s amount to be billed, $2$s how often
+#. translators: %1$s amount to be billed, %2$s how often
 #: inc/gateways/class-paypal-gateway.php:546
 #: views/checkout/paypal/confirm.php:52
 #, php-format
 msgid "After this payment you will be billed %1$s %2$s."
 msgstr ""
 
-#. translators: $1$s amount to be billed, $2$s how often
+#. translators: %1$s amount to be billed, %2$s how often
 #: inc/gateways/class-paypal-gateway.php:550
 #: views/checkout/paypal/confirm.php:59
 #, php-format
 msgid "From that date, you will be billed %1$s %2$s."
 msgstr ""
 
-#. translators: $1$s how often
+#. translators: %1$s how often
 #: inc/gateways/class-paypal-gateway.php:553
 #: views/checkout/paypal/confirm.php:62
 #, php-format
@@ -24644,12 +24646,6 @@ msgstr ""
 msgid "No Products Found."
 msgstr ""
 
-#. translators: %1$s is the start date, %2$s is the subtotal amount, and %3$s is the description of how often.
-#: views/checkout/paypal/confirm.php:40
-#, php-format
-msgid "Your updated membership will start on $1$s, from that date you will be billed %2$s %3$s."
-msgstr ""
-
 #. translators: %1$s is the membership level, %2$s is the initial amount, and %3$s is the currency description
 #: views/checkout/paypal/confirm.php:49
 #, php-format
@@ -26260,7 +26256,7 @@ msgstr ""
 #. translators: %s hash of membership.
 #: views/ui/toolbox.php:66
 #, php-format
-msgid "Membership <Strong>%s</strong>"
+msgid "Membership <strong>%s</strong>"
 msgstr ""
 
 #. translators: %s is the integration name

--- a/views/checkout/paypal/confirm.php
+++ b/views/checkout/paypal/confirm.php
@@ -37,10 +37,10 @@ if ($membership->is_recurring() && $should_auto_renew) {
 			$subtotal = wu_format_currency($payment->get_subtotal(), $payment->get_currency());
 			if ($is_trial_setup) {
 				// translators: %1$s is the start date, %2$s is the subtotal amount, and %3$s is the description of how often.
-				$notes[] = sprintf(__('Your updated membership will start on $1$s, from that date you will be billed %2$s %3$s.', 'ultimate-multisite'), $date, $subtotal, $desc);
+				$notes[] = sprintf(__('Your updated membership will start on %1$s, from that date you will be billed %2$s %3$s.', 'ultimate-multisite'), $date, $subtotal, $desc);
 			} else {
 				$date_renew = wp_date(get_option('date_format'), strtotime($membership->get_date_expiration(), wu_get_current_time('timestamp', true)));
-				// translators: $1$s the date membership will start, $2$s amount to be billed, %3$s the description of how often.
+				// translators: %1$s the date membership will start, %2$s amount to be billed, %3$s the description of how often.
 				$notes[] = sprintf(__('Your updated membership will start on %1$s, from that date you will be billed %2$s %3$s.', 'ultimate-multisite'), $date_renew, $subtotal, $desc);
 			}
 		} elseif ($is_trial_setup) {
@@ -48,17 +48,17 @@ if ($membership->is_recurring() && $should_auto_renew) {
 			// translators: %1$s is the membership level, %2$s is the initial amount, and %3$s is the currency description
 			$notes[] = sprintf(__('After the first payment of %1$s you will be billed %2$s %3$s.', 'ultimate-multisite'), $initial_amount_format, $recurring_total_format, $desc);
 		} else {
-			// translators: $1$s amount to be billed, $2$s how often
+			// translators: %1$s amount to be billed, %2$s how often
 			$notes[] = sprintf(__('After this payment you will be billed %1$s %2$s.', 'ultimate-multisite'), $recurring_total_format, $desc);
 		}
 	} else {
 		$recurring_total_format = wu_format_currency($recurring_total, $payment->get_currency());
 
 		if ($is_trial_setup) {
-			// translators: $1$s amount to be billed, $2$s how often
+			// translators: %1$s amount to be billed, %2$s how often
 			$notes[] = sprintf(__('From that date, you will be billed %1$s %2$s.', 'ultimate-multisite'), $recurring_total_format, $desc);
 		} else {
-			// translators: $1$s how often
+			// translators: %1$s how often
 			$notes[] = sprintf(__('After this payment you will be billed %1$s.', 'ultimate-multisite'), $desc);
 		}
 	}

--- a/views/ui/toolbox.php
+++ b/views/ui/toolbox.php
@@ -63,7 +63,7 @@ defined('ABSPATH') || exit;
 				class="dashicons-wu-circular-graph wu-text-sm wu-w-auto wu-h-auto wu-align-text-bottom wu-relative"></span>
 			<span class="">
 				<?php // translators: %s hash of membership. ?>
-				<?php printf(wp_kses_post(__('Membership <Strong>%s</strong>', 'ultimate-multisite')), esc_html($membership->get_hash())); ?>
+				<?php printf(wp_kses_post(__('Membership <strong>%s</strong>', 'ultimate-multisite')), esc_html($membership->get_hash())); ?>
 			</span>
 			<span id="wu-toolbox-membership-status" class="wu-inline-block wu-w-3 wu-h-3 wu-rounded-full wu-align-text-top <?php echo esc_attr($membership->get_status_class()); ?>" <?php wu_tooltip_text($membership->get_status_label()); ?>>
 				&nbsp;


### PR DESCRIPTION
## Summary

- fix malformed positional placeholders in PayPal membership notices
- correct translator comments and synchronize the affected POT entries
- stop translating PHP date-format defaults and normalize toolbox HTML markup

## Why

These English source defects generated repeated validation warnings in the Ukrainian WordPress.org translation project. Correcting the source strings prevents translators from having to work around invalid placeholders, unnecessary date-format translation, and inconsistent markup.

## Verification

- `vendor/bin/phpcs inc/class-scripts.php inc/gateways/class-paypal-gateway.php views/checkout/paypal/confirm.php views/ui/toolbox.php`
- `vendor/bin/phpstan analyse inc/class-scripts.php inc/gateways/class-paypal-gateway.php views/checkout/paypal/confirm.php views/ui/toolbox.php --no-progress`
- `vendor/bin/phpunit --filter Scripts_Test` — 19 tests, 61 assertions
- `vendor/bin/phpunit --filter PayPal_Gateway_Test` — 106 tests, 189 assertions, 1 skipped
- `msgfmt --check --check-format lang/ultimate-multisite.pot`
- pre-commit PHPCS and PHPStan hooks

## Notes

`npm run makepot` currently produces substantial unrelated POT drift, so the checked-in template was updated only for the source strings changed here.

<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.297 plugin for [OpenCode](https://opencode.ai) v1.18.26 with gpt-5.6-sol spent 12h 37m and 597,080 tokens on this with the user in an interactive session.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected PayPal checkout notes so membership start dates appear properly for applicable recurring-payment changes.
  * Fixed formatting placeholders in PayPal checkout messages, improving translated and displayed text.
  * Corrected membership label markup for consistent display and translation handling.

* **Localization**
  * Standardized date and time format defaults and corrected related translation entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->