### PR TITLE
GH#1788: remove PHP 8.5 reflection deprecations

### DIFF
--- a/tests/WP_Ultimo/Installers/Default_Content_Installer_Test.php
+++ b/tests/WP_Ultimo/Installers/Default_Content_Installer_Test.php
@@ -212,7 +212,6 @@ class Default_Content_Installer_Test extends \WP_UnitTestCase {
 
 		$ref    = new \ReflectionClass( $this->installer );
 		$method = $ref->getMethod( 'done_creating_products' );
-		$method->setAccessible( true );
 
 		$result = $method->invoke( $this->installer );
 		$this->assertFalse( $result );
@@ -239,7 +238,6 @@ class Default_Content_Installer_Test extends \WP_UnitTestCase {
 
 		$ref    = new \ReflectionClass( $this->installer );
 		$method = $ref->getMethod( 'done_creating_products' );
-		$method->setAccessible( true );
 
 		$result = $method->invoke( $this->installer );
 		$this->assertTrue( $result );
@@ -261,7 +259,6 @@ class Default_Content_Installer_Test extends \WP_UnitTestCase {
 	public function test_done_creating_checkout_forms_returns_bool(): void {
 		$ref    = new \ReflectionClass( $this->installer );
 		$method = $ref->getMethod( 'done_creating_checkout_forms' );
-		$method->setAccessible( true );
 
 		$result = $method->invoke( $this->installer );
 		$this->assertIsBool( $result );
@@ -282,7 +279,6 @@ class Default_Content_Installer_Test extends \WP_UnitTestCase {
 
 		$ref    = new \ReflectionClass( $this->installer );
 		$method = $ref->getMethod( 'done_creating_checkout_forms' );
-		$method->setAccessible( true );
 
 		$result = $method->invoke( $this->installer );
 		$this->assertTrue( $result );
@@ -301,7 +297,6 @@ class Default_Content_Installer_Test extends \WP_UnitTestCase {
 	public function test_done_creating_emails_returns_bool(): void {
 		$ref    = new \ReflectionClass( $this->installer );
 		$method = $ref->getMethod( 'done_creating_emails' );
-		$method->setAccessible( true );
 
 		$result = $method->invoke( $this->installer );
 		$this->assertIsBool( $result );
@@ -319,7 +314,6 @@ class Default_Content_Installer_Test extends \WP_UnitTestCase {
 
 		$ref    = new \ReflectionClass( $this->installer );
 		$method = $ref->getMethod( 'done_creating_login_page' );
-		$method->setAccessible( true );
 
 		$result = $method->invoke( $this->installer );
 		$this->assertFalse( $result );
@@ -333,7 +327,6 @@ class Default_Content_Installer_Test extends \WP_UnitTestCase {
 
 		$ref    = new \ReflectionClass( $this->installer );
 		$method = $ref->getMethod( 'done_creating_login_page' );
-		$method->setAccessible( true );
 
 		$result = $method->invoke( $this->installer );
 		$this->assertFalse( $result );
@@ -355,7 +348,6 @@ class Default_Content_Installer_Test extends \WP_UnitTestCase {
 
 		$ref    = new \ReflectionClass( $this->installer );
 		$method = $ref->getMethod( 'done_creating_login_page' );
-		$method->setAccessible( true );
 
 		$result = $method->invoke( $this->installer );
 		$this->assertTrue( $result );
@@ -382,7 +374,6 @@ class Default_Content_Installer_Test extends \WP_UnitTestCase {
 
 		$ref    = new \ReflectionClass( $this->installer );
 		$method = $ref->getMethod( 'ensure_currency_defaults' );
-		$method->setAccessible( true );
 		$method->invoke( $this->installer );
 
 		$this->assertSame( 'USD', wu_get_setting( 'currency_symbol' ) );
@@ -401,7 +392,6 @@ class Default_Content_Installer_Test extends \WP_UnitTestCase {
 
 		$ref    = new \ReflectionClass( $this->installer );
 		$method = $ref->getMethod( 'ensure_currency_defaults' );
-		$method->setAccessible( true );
 		$method->invoke( $this->installer );
 
 		$this->assertSame( 'EUR', wu_get_setting( 'currency_symbol' ) );
@@ -416,7 +406,6 @@ class Default_Content_Installer_Test extends \WP_UnitTestCase {
 
 		$ref    = new \ReflectionClass( $this->installer );
 		$method = $ref->getMethod( 'ensure_currency_defaults' );
-		$method->setAccessible( true );
 		$method->invoke( $this->installer );
 
 		// 0 is a valid stored value and must NOT be overwritten with 2.
@@ -431,7 +420,6 @@ class Default_Content_Installer_Test extends \WP_UnitTestCase {
 
 		$ref    = new \ReflectionClass( $this->installer );
 		$method = $ref->getMethod( 'ensure_currency_defaults' );
-		$method->setAccessible( true );
 		$method->invoke( $this->installer );
 
 		$this->assertSame( 2, wu_get_setting( 'precision' ) );
@@ -736,7 +724,6 @@ class Default_Content_Installer_Test extends \WP_UnitTestCase {
 
 		$ref    = new \ReflectionClass( $this->installer );
 		$method = $ref->getMethod( 'done_creating_login_page' );
-		$method->setAccessible( true );
 
 		$result = $method->invoke( $this->installer );
 		$this->assertTrue( $result );
@@ -782,7 +769,6 @@ class Default_Content_Installer_Test extends \WP_UnitTestCase {
 		// Check if template site already exists and skip if so.
 		$ref    = new \ReflectionClass( $this->installer );
 		$method = $ref->getMethod( 'done_creating_template_site' );
-		$method->setAccessible( true );
 
 		if ( $method->invoke( $this->installer ) ) {
 			$this->markTestSkipped( 'Template site already exists.' );
@@ -806,7 +792,6 @@ class Default_Content_Installer_Test extends \WP_UnitTestCase {
 
 		$ref    = new \ReflectionClass( $this->installer );
 		$method = $ref->getMethod( 'done_creating_template_site' );
-		$method->setAccessible( true );
 
 		$result = $method->invoke( $this->installer );
 		$this->assertFalse( $result );
@@ -827,7 +812,6 @@ class Default_Content_Installer_Test extends \WP_UnitTestCase {
 
 		$ref    = new \ReflectionClass( $this->installer );
 		$method = $ref->getMethod( 'done_creating_template_site' );
-		$method->setAccessible( true );
 
 		// Should not throw — just verify it completes.
 		$result = $method->invoke( $this->installer );

--- a/tests/WP_Ultimo/Integrations/Host_Providers/CPanel_Host_Provider_Test.php
+++ b/tests/WP_Ultimo/Integrations/Host_Providers/CPanel_Host_Provider_Test.php
@@ -85,7 +85,6 @@ class CPanel_Host_Provider_Test extends WP_UnitTestCase {
 	private function inject_api($api): void {
 
 		$ref = new \ReflectionProperty(CPanel_Host_Provider::class, 'api');
-		$ref->setAccessible(true);
 		$ref->setValue($this->provider, $api);
 	}
 
@@ -1414,7 +1413,6 @@ class CPanel_Host_Provider_Test extends WP_UnitTestCase {
 	public function test_format_record_name_at_returns_zone_with_dot(): void {
 
 		$method = new \ReflectionMethod($this->provider, 'format_record_name');
-		$method->setAccessible(true);
 
 		$this->assertSame('example.com.', $method->invoke($this->provider, '@', 'example.com'));
 	}
@@ -1425,7 +1423,6 @@ class CPanel_Host_Provider_Test extends WP_UnitTestCase {
 	public function test_format_record_name_empty_returns_zone_with_dot(): void {
 
 		$method = new \ReflectionMethod($this->provider, 'format_record_name');
-		$method->setAccessible(true);
 
 		$this->assertSame('example.com.', $method->invoke($this->provider, '', 'example.com'));
 	}
@@ -1436,7 +1433,6 @@ class CPanel_Host_Provider_Test extends WP_UnitTestCase {
 	public function test_format_record_name_subdomain_appends_zone(): void {
 
 		$method = new \ReflectionMethod($this->provider, 'format_record_name');
-		$method->setAccessible(true);
 
 		$this->assertSame('www.example.com.', $method->invoke($this->provider, 'www', 'example.com'));
 	}
@@ -1447,7 +1443,6 @@ class CPanel_Host_Provider_Test extends WP_UnitTestCase {
 	public function test_format_record_name_already_ends_with_zone(): void {
 
 		$method = new \ReflectionMethod($this->provider, 'format_record_name');
-		$method->setAccessible(true);
 
 		$this->assertSame('test.example.com.', $method->invoke($this->provider, 'test.example.com', 'example.com'));
 	}
@@ -1458,7 +1453,6 @@ class CPanel_Host_Provider_Test extends WP_UnitTestCase {
 	public function test_format_record_name_fqdn_returns_as_is(): void {
 
 		$method = new \ReflectionMethod($this->provider, 'format_record_name');
-		$method->setAccessible(true);
 
 		$this->assertSame('already.fqdn.', $method->invoke($this->provider, 'already.fqdn.', 'example.com'));
 	}
@@ -1473,7 +1467,6 @@ class CPanel_Host_Provider_Test extends WP_UnitTestCase {
 	public function test_ensure_trailing_dot_adds_dot(): void {
 
 		$method = new \ReflectionMethod($this->provider, 'ensure_trailing_dot');
-		$method->setAccessible(true);
 
 		$this->assertSame('example.com.', $method->invoke($this->provider, 'example.com'));
 	}
@@ -1484,7 +1477,6 @@ class CPanel_Host_Provider_Test extends WP_UnitTestCase {
 	public function test_ensure_trailing_dot_does_not_double_add(): void {
 
 		$method = new \ReflectionMethod($this->provider, 'ensure_trailing_dot');
-		$method->setAccessible(true);
 
 		$this->assertSame('example.com.', $method->invoke($this->provider, 'example.com.'));
 	}
@@ -1495,7 +1487,6 @@ class CPanel_Host_Provider_Test extends WP_UnitTestCase {
 	public function test_ensure_trailing_dot_with_subdomain(): void {
 
 		$method = new \ReflectionMethod($this->provider, 'ensure_trailing_dot');
-		$method->setAccessible(true);
 
 		$this->assertSame('mail.example.com.', $method->invoke($this->provider, 'mail.example.com'));
 	}


### PR DESCRIPTION
## Summary

- Remove redundant reflection accessibility calls from the two tests identified in the PHP 8.5 failure logs.
- Preserve the existing reflection-based assertions and test behaviour on PHP 8.2+.

## Testing

- `php -l tests/WP_Ultimo/Integrations/Host_Providers/CPanel_Host_Provider_Test.php`
- `php -l tests/WP_Ultimo/Installers/Default_Content_Installer_Test.php`
- Focused PHPUnit tests were not run: `composer install --no-interaction --prefer-dist` could not authenticate to download `wp-coding-standards/wpcs`, and its source fallback reported `git` unavailable.

## Runtime Testing

Self-assessed: this is a medium-risk CI/test-compatibility change. The exact-head GitHub Actions matrix is required for runtime validation because local Composer dependencies could not be installed.

Resolves #1788

<!-- aidevops:origin:worker -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.297 plugin for [OpenCode](https://opencode.ai) v1.18.27 with gpt-5.6-terra spent 4m and 142,857 tokens on this as a headless worker.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated reflection-based tests to align with current PHP behavior.
  * Test coverage and assertions remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->