### PR TITLE
GH#1787: split PHPUnit CI execution

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -109,7 +109,20 @@ jobs:
 
       - name: Run PHPUnit Tests
         if: matrix.php-version != '8.3'
-        run: vendor/bin/phpunit
+        run: |
+          for test_path in tests/WP_Ultimo/*; do
+            if [ -d "$test_path" ] || [ "${test_path%_Test.php}" != "$test_path" ]; then
+              vendor/bin/phpunit "$test_path"
+            fi
+          done
+          vendor/bin/phpunit tests/Admin_Pages
+          vendor/bin/phpunit tests/Builders
+          vendor/bin/phpunit tests/functional
+          vendor/bin/phpunit tests/unit
+          for test_path in tests/*_Test.php; do
+            [ -e "$test_path" ] || continue
+            vendor/bin/phpunit "$test_path"
+          done
 
       - name: Run PHPUnit Tests with Coverage
         if: matrix.php-version == '8.3'


### PR DESCRIPTION
## Summary

- Split non-coverage PHPUnit execution into first-level test groups so each process releases memory before the next group.
- Preserve the full test set, immediate failure propagation, and the existing PHP 8.3 coverage command.

## Verification

- git diff --check
- Python YAML parse of .github/workflows/tests.yml
- Existing pre-commit hook checks
- Independent closeout review of path coverage and sh -e failure propagation

## Runtime Testing

High-risk CI resource-management change. Local vendor dependencies are unavailable, so required runtime verification is the pull-request PHP 8.2, 8.3, and 8.4 matrix. The required non-coverage jobs must complete without exit code 137.

Resolves #1787


<!-- aidevops:origin:worker -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.297 plugin for [OpenCode](https://opencode.ai) v1.18.27 with gpt-5.6-terra spent 10m and 354,535 tokens on this as a headless worker.
