### PR TITLE
fix(ci): batch PHPUnit test runs

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -109,7 +109,11 @@ jobs:
 
       - name: Run PHPUnit Tests
         if: matrix.php-version != '8.3'
-        run: vendor/bin/phpunit
+        run: |
+          # The full suite exceeds the container memory limit when run in one PHP process.
+          # Restart PHPUnit between small batches so every test file still runs.
+          find tests -name '*_Test.php' -type f -print0 \
+            | xargs -0 -r -n 50 vendor/bin/phpunit
 
       - name: Run PHPUnit Tests with Coverage
         if: matrix.php-version == '8.3'


### PR DESCRIPTION
Summary: batches non-coverage PHPUnit runs by 50 test files to release accumulated process memory while retaining full test coverage. Testing: git diff --check; pre-commit hook passed. Resolves #1786.
<!-- aidevops:origin:worker -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.297 plugin for [OpenCode](https://opencode.ai) v1.18.27 with gpt-5.6-terra
