### PR TITLE
fix(setup): prevent duplicate wp-config constants

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -102,6 +102,7 @@
         "wp-ultimo/autoloader-plugin": "dev-main",
         "wordpress/abilities-api": "^0.4.0",
         "wordpress/mcp-adapter": "^0.4.1",
+        "wp-cli/wp-config-transformer": "^1.4.2",
         "rpnzl/arrch": "dev-master#994258bbefb7722243211654c4f78813312cd5ed",
         "amphp/amp": "^2.6.2",
         "amphp/byte-stream": "^1.8.1",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "831d496e4429b3e67e86eabf7b3ddb65",
+    "content-hash": "9d4a3254a00f19cc818095c4e7464fd7",
     "packages": [
         {
             "name": "amphp/amp",
@@ -4366,6 +4366,55 @@
                 "source": "https://github.com/wp-cli/process/tree/v5.9.99"
             },
             "time": "2025-05-06T21:26:50+00:00"
+        },
+        {
+            "name": "wp-cli/wp-config-transformer",
+            "version": "v1.4.6",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/wp-cli/wp-config-transformer.git",
+                "reference": "1ef18784990b85b35202c2d68dbbc4a8fe6615b6"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/wp-cli/wp-config-transformer/zipball/1ef18784990b85b35202c2d68dbbc4a8fe6615b6",
+                "reference": "1ef18784990b85b35202c2d68dbbc4a8fe6615b6",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2.24"
+            },
+            "require-dev": {
+                "wp-cli/wp-cli-tests": "^4.0 || ^5.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "src/WPConfigTransformer.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Frankie Jarrett",
+                    "email": "fjarrett@gmail.com"
+                }
+            ],
+            "description": "Programmatically edit a wp-config.php file.",
+            "homepage": "https://github.com/wp-cli/wp-config-transformer",
+            "support": {
+                "issues": "https://github.com/wp-cli/wp-config-transformer/issues",
+                "source": "https://github.com/wp-cli/wp-config-transformer/tree/v1.4.6"
+            },
+            "time": "2026-04-10T07:32:03+00:00"
         },
         {
             "name": "wp-ultimo/autoloader-plugin",

--- a/inc/helpers/class-wp-config.php
+++ b/inc/helpers/class-wp-config.php
@@ -26,54 +26,319 @@ class WP_Config {
 	 *
 	 * @since 2.0.0
 	 *
-	 * @param string     $constant The name of the constant. e.g. WP_ULTIMO_CONSTANT.
-	 * @param string|int $value The value of that constant.
+	 * @param string          $constant The name of the constant. e.g. WP_ULTIMO_CONSTANT.
+	 * @param string|int|bool $value The value of that constant.
 	 * @return bool|\WP_Error
 	 */
 	public function inject_wp_config_constant($constant, $value) {
 
-		$config_path = $this->get_wp_config_path();
+		return $this->inject_wp_config_constants([$constant => $value]);
+	}
 
-		if ( ! is_writable($config_path)) { // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_is_writable
+	/**
+	 * Inject multiple constants into wp-config.php as one transaction.
+	 *
+	 * Existing definitions are removed before the authoritative definitions are
+	 * added. Transformations happen on a temporary copy so a parser or write
+	 * failure cannot leave a partially updated wp-config.php file behind.
+	 *
+	 * @since 2.15.2
+	 *
+	 * @param array<string, string|int|bool> $constants Constants and their values.
+	 * @return bool|\WP_Error
+	 */
+	public function inject_wp_config_constants($constants) {
 
+		return $this->transform_wp_config_constants($constants, false);
+	}
+
+	/**
+	 * Transform constants on a temporary copy and atomically replace wp-config.php.
+	 *
+	 * @since 2.15.2
+	 *
+	 * @param array<string, string|int|bool|null> $constants Constants and their values.
+	 * @param bool                                $remove_only Whether constants should only be removed.
+	 * @throws \RuntimeException When the temporary transformation cannot be completed.
+	 * @return bool|\WP_Error
+	 */
+	private function transform_wp_config_constants($constants, $remove_only) {
+
+		if ( ! class_exists('WPConfigTransformer')) {
+			return new \WP_Error('missing-wp-config-transformer', __('The wp-config.php transformer is not available.', 'ultimate-multisite'));
+		}
+
+		if (empty($constants)) {
+			return false;
+		}
+
+		foreach (array_keys($constants) as $constant) {
+			if ( ! is_string($constant) || ! preg_match('/^[A-Za-z_][A-Za-z0-9_]*$/', $constant)) {
+				return new \WP_Error('invalid-wp-config-constant', __('An invalid wp-config.php constant name was provided.', 'ultimate-multisite'));
+			}
+		}
+
+		$config_path          = $this->get_wp_config_path();
+		$resolved_config_path = realpath($config_path);
+
+		if (false === $resolved_config_path || ! is_writable($resolved_config_path)) { // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_is_writable
 			// translators: %s is the file name.
 			return new \WP_Error('not-writeable', sprintf(__('The file %s is not writable', 'ultimate-multisite'), $config_path));
 		}
 
-		$config = file($config_path);
+		$original_contents = file_get_contents($resolved_config_path); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
 
-		$line = $this->find_injected_line($config, $constant);
-
-		if (is_bool($value)) {
-			$formatted_value = $value ? 'true' : 'false';
-		} elseif (is_int($value)) {
-			$formatted_value = (string) $value;
-		} else {
-			$formatted_value = "'{$value}'";
+		if (false === $original_contents || '' === trim($original_contents)) {
+			return new \WP_Error('invalid-wp-config', __('The wp-config.php file could not be read or is empty.', 'ultimate-multisite'));
 		}
 
-		$content = str_pad(sprintf("define( '%s', %s );", $constant, $formatted_value), 50) . '// Automatically injected by Ultimate Multisite;';
+		$temporary_path = tempnam(dirname($resolved_config_path), '.wu-wp-config-');
 
-		if (false === $line) {
+		if (false === $temporary_path) {
+			return new \WP_Error('wp-config-temp-file', __('A temporary wp-config.php file could not be created.', 'ultimate-multisite'));
+		}
 
-			// no defined, we just need to inject
-			$hook_line = $this->find_reference_hook_line($config);
+		try {
+			// Direct filesystem access is required to lock and atomically replace this local PHP configuration file.
+			$bytes_written = file_put_contents($temporary_path, $original_contents, LOCK_EX); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents
 
-			if (false === $hook_line) {
-				return new \WP_Error('unknown-wpconfig', __("Ultimate Multisite can't recognize your wp-config.php, please revert it to original state for further process.", 'ultimate-multisite'));
+			if (strlen($original_contents) !== $bytes_written) {
+				throw new \RuntimeException(__('The temporary wp-config.php file could not be written completely.', 'ultimate-multisite'));
 			}
 
-			$config = $this->inject_contents($config, $hook_line + 1, PHP_EOL . $content . PHP_EOL);
+			$file_permissions = fileperms($resolved_config_path);
 
-			return file_put_contents($config_path, implode('', $config), LOCK_EX);
-		} else {
-			[$value, $line] = $line;
-
-			if (true !== $value) {
-				$config[ $line ] = $content . PHP_EOL;
-
-				return file_put_contents($config_path, implode('', $config), LOCK_EX);
+			if (false !== $file_permissions) {
+				chmod($temporary_path, $file_permissions & 0777); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_chmod
 			}
+
+			$normalized_contents = str_replace(["\r\n", "\n\r", "\r"], "\n", $original_contents);
+			$transformer         = new \WPConfigTransformer($temporary_path);
+			$anchor              = $remove_only ? [] : $this->get_transformer_anchor($normalized_contents);
+
+			if (is_wp_error($anchor)) {
+				return $anchor;
+			}
+
+			foreach ($constants as $constant => $value) {
+				$definition_count = $this->count_constant_definitions($original_contents, $constant);
+				$exists           = $transformer->exists('constant', $constant);
+
+				if ($definition_count && ! $exists) {
+					// translators: %s is a PHP constant name.
+					throw new \RuntimeException(sprintf(__('The existing %s definition uses an unsupported format and was not changed.', 'ultimate-multisite'), $constant));
+				}
+
+				if ($exists) {
+					$transformer->remove('constant', $constant);
+				}
+
+				if ( ! $remove_only) {
+					[$transformer_value, $raw] = $this->format_transformer_value($value);
+
+					$transformer->add(
+						'constant',
+						$constant,
+						$transformer_value,
+						[
+							'raw'       => $raw,
+							'anchor'    => $anchor['anchor'],
+							'separator' => "\n",
+							'placement' => $anchor['placement'],
+						]
+					);
+				}
+			}
+
+			$transformed_contents = file_get_contents($temporary_path); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
+
+			if (false === $transformed_contents) {
+				throw new \RuntimeException(__('The transformed wp-config.php file could not be read.', 'ultimate-multisite'));
+			}
+
+			if (str_contains($original_contents, "\r\n")) {
+				$transformed_contents = str_replace("\r\n", "\n", $transformed_contents);
+				$transformed_contents = str_replace("\n", "\r\n", $transformed_contents);
+				$bytes_written        = file_put_contents($temporary_path, $transformed_contents, LOCK_EX); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents
+
+				if (strlen($transformed_contents) !== $bytes_written) {
+					throw new \RuntimeException(__('The temporary wp-config.php file could not be written completely.', 'ultimate-multisite'));
+				}
+			}
+
+			$this->validate_transformed_constants($transformed_contents, array_keys($constants), ! $remove_only);
+
+			if ($original_contents === $transformed_contents) {
+				return false;
+			}
+
+			if (file_get_contents($resolved_config_path) !== $original_contents) { // phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
+				throw new \RuntimeException(__('The wp-config.php file changed while it was being updated. No changes were applied.', 'ultimate-multisite'));
+			}
+
+			// The temporary file is in the same directory, making this an atomic replacement on supported filesystems.
+			if ( ! rename($temporary_path, $resolved_config_path)) { // phpcs:ignore WordPress.WP.AlternativeFunctions.rename_rename
+				throw new \RuntimeException(__('The transformed wp-config.php file could not replace the original file.', 'ultimate-multisite'));
+			}
+
+			if (function_exists('opcache_invalidate')) {
+				opcache_invalidate($resolved_config_path, true);
+			}
+
+			return true;
+		} catch (\Throwable $exception) {
+			return new \WP_Error('wp-config-transform-failed', $exception->getMessage());
+		} finally {
+			if (file_exists($temporary_path)) {
+				wp_delete_file($temporary_path);
+			}
+		}
+	}
+
+	/**
+	 * Format a value for WPConfigTransformer.
+	 *
+	 * @since 2.15.2
+	 *
+	 * @param string|int|bool|null $value Constant value.
+	 * @return array{0: string, 1: bool}
+	 */
+	private function format_transformer_value($value) {
+
+		if (is_bool($value)) {
+			return [$value ? 'true' : 'false', true];
+		}
+
+		if (is_int($value)) {
+			return [(string) $value, true];
+		}
+
+		return [(string) $value, false];
+	}
+
+	/**
+	 * Find a safe placement anchor supported by WPConfigTransformer.
+	 *
+	 * @since 2.15.2
+	 *
+	 * @param string $contents wp-config.php contents.
+	 * @return array{anchor: string, placement: string}|\WP_Error
+	 */
+	private function get_transformer_anchor($contents) {
+
+		$default_anchor = "/* That's all, stop editing!";
+
+		if (str_contains($contents, $default_anchor)) {
+			return [
+				'anchor'    => $default_anchor,
+				'placement' => 'before',
+			];
+		}
+
+		if (preg_match('/^[\t ]*\$table_prefix\s*=.*;[\t ]*$/m', $contents, $matches)) {
+			return [
+				'anchor'    => $matches[0],
+				'placement' => 'after',
+			];
+		}
+
+		if (preg_match('/^[\t ]*(?:require|require_once)\s+ABSPATH\s*\.\s*[\'\"]wp-settings\.php[\'\"]\s*;[\t ]*$/m', $contents, $matches)) {
+			return [
+				'anchor'    => $matches[0],
+				'placement' => 'before',
+			];
+		}
+
+		return new \WP_Error('unknown-wpconfig', __("Ultimate Multisite can't recognize your wp-config.php. No changes were applied.", 'ultimate-multisite'));
+	}
+
+	/**
+	 * Validate PHP syntax and the resulting constant counts.
+	 *
+	 * @since 2.15.2
+	 *
+	 * @param string   $contents wp-config.php contents.
+	 * @param string[] $constants Constant names.
+	 * @param bool     $should_exist Whether each constant should exist once.
+	 * @throws \RuntimeException When the transformed constants fail validation.
+	 * @return void
+	 */
+	private function validate_transformed_constants($contents, $constants, $should_exist) {
+
+		token_get_all($contents, TOKEN_PARSE);
+
+		$expected_count = $should_exist ? 1 : 0;
+
+		foreach ($constants as $constant) {
+			if ($expected_count !== $this->count_constant_definitions($contents, $constant)) {
+				// translators: %s is a PHP constant name.
+				throw new \RuntimeException(sprintf(esc_html__('The transformed wp-config.php file has an unexpected number of %s definitions.', 'ultimate-multisite'), esc_html($constant)));
+			}
+		}
+	}
+
+	/**
+	 * Count define() calls for a constant without executing wp-config.php.
+	 *
+	 * @since 2.15.2
+	 *
+	 * @param string $contents wp-config.php contents.
+	 * @param string $constant Constant name.
+	 * @return int
+	 */
+	private function count_constant_definitions($contents, $constant) {
+
+		$tokens = token_get_all($contents, TOKEN_PARSE);
+		$count  = 0;
+
+		foreach ($tokens as $index => $token) {
+			if ( ! is_array($token) || T_STRING !== $token[0] || 'define' !== strtolower($token[1])) {
+				continue;
+			}
+
+			$opening_parenthesis = $this->next_code_token($tokens, $index + 1);
+
+			if (false === $opening_parenthesis || '(' !== $tokens[ $opening_parenthesis ]) {
+				continue;
+			}
+
+			$name_index = $this->next_code_token($tokens, $opening_parenthesis + 1);
+
+			if (false === $name_index || ! is_array($tokens[ $name_index ]) || T_CONSTANT_ENCAPSED_STRING !== $tokens[ $name_index ][0]) {
+				continue;
+			}
+
+			$name = substr($tokens[ $name_index ][1], 1, -1);
+
+			if ($constant === $name) {
+				++$count;
+			}
+		}
+
+		return $count;
+	}
+
+	/**
+	 * Find the next non-whitespace, non-comment PHP token.
+	 *
+	 * @since 2.15.2
+	 *
+	 * @param array $tokens PHP tokens.
+	 * @param int   $start Starting index.
+	 * @return int|false
+	 */
+	private function next_code_token($tokens, $start) {
+
+		$token_count = count($tokens);
+
+		for ($index = $start; $index < $token_count; ++$index) {
+			$token = $tokens[ $index ];
+
+			if (is_array($token) && in_array($token[0], [T_WHITESPACE, T_COMMENT, T_DOC_COMMENT], true)) {
+				continue;
+			}
+
+			return $index;
 		}
 
 		return false;
@@ -108,10 +373,12 @@ class WP_Config {
 	 */
 	public function get_wp_config_path() {
 
+		$config_path = ABSPATH . 'wp-config.php';
+
 		if (file_exists(ABSPATH . 'wp-config.php')) {
-			return (ABSPATH . 'wp-config.php');
-		} elseif (@file_exists(dirname(ABSPATH) . '/wp-config.php') && ! @file_exists(dirname(ABSPATH) . '/wp-settings.php')) {
-			return (dirname(ABSPATH) . '/wp-config.php');
+			$config_path = ABSPATH . 'wp-config.php';
+		} elseif (file_exists(dirname(ABSPATH) . '/wp-config.php') && ! file_exists(dirname(ABSPATH) . '/wp-settings.php')) {
+			$config_path = dirname(ABSPATH) . '/wp-config.php';
 		} elseif (defined('WP_TESTS_MULTISITE') && constant('WP_TESTS_MULTISITE') === true) {
 			$tests_dir = getenv('WP_TESTS_DIR');
 
@@ -119,10 +386,17 @@ class WP_Config {
 				$tests_dir = rtrim(sys_get_temp_dir(), '/\\') . '/wordpress-tests-lib';
 			}
 
-			return $tests_dir . '/wp-tests-config.php';
+			$config_path = $tests_dir . '/wp-tests-config.php';
 		}
 
-		return ABSPATH . 'wp-config.php';
+		/**
+		 * Filters the wp-config.php path used for configuration updates.
+		 *
+		 * @since 2.15.2
+		 *
+		 * @param string $config_path Absolute path to wp-config.php.
+		 */
+		return (string) apply_filters('wu_wp_config_path', $config_path);
 	}
 
 	/**
@@ -191,34 +465,7 @@ class WP_Config {
 	 */
 	public function revert($constant) {
 
-		$config_path = $this->get_wp_config_path();
-
-		if ( ! is_writable($config_path)) { // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_is_writable
-
-			// translators: %s is the file name.
-			return new \WP_Error('not-writeable', sprintf(__('The file %s is not writable', 'ultimate-multisite'), $config_path));
-		}
-
-		$config = file($config_path);
-
-		$line = $this->find_injected_line($config, $constant);
-
-		if (false === $line) {
-			return;
-		} else {
-			$value = $line[0];
-
-			$line = $line[1];
-
-			if ('true' === $value || '1' === $value) {
-
-				// value is true, we will remove this
-				unset($config[ $line ]);
-
-				// save it
-				return file_put_contents($config_path, implode('', $config), LOCK_EX);
-			}
-		}
+		return $this->transform_wp_config_constants([$constant => null], true);
 	}
 
 	/**

--- a/inc/helpers/class-wp-config.php
+++ b/inc/helpers/class-wp-config.php
@@ -22,548 +22,51 @@ class WP_Config {
 	use \WP_Ultimo\Traits\Singleton;
 
 	/**
-	 * Marker appended to definitions managed by Ultimate Multisite.
-	 *
-	 * @since 2.15.2
-	 * @var string
-	 */
-	private const MANAGED_MARKER = 'Ultimate Multisite managed';
-
-	/**
 	 * Inject the constant into the wp-config.php file.
 	 *
 	 * @since 2.0.0
 	 *
-	 * @param string          $constant The name of the constant. e.g. WP_ULTIMO_CONSTANT.
-	 * @param string|int|bool $value The value of that constant.
+	 * @param string     $constant The name of the constant. e.g. WP_ULTIMO_CONSTANT.
+	 * @param string|int $value The value of that constant.
 	 * @return bool|\WP_Error
 	 */
 	public function inject_wp_config_constant($constant, $value) {
 
-		return $this->inject_wp_config_constants([$constant => $value]);
-	}
-
-	/**
-	 * Inject multiple constants into wp-config.php as one transaction.
-	 *
-	 * Existing definitions are removed before the authoritative definitions are
-	 * added. Transformations happen on a temporary copy so a parser or write
-	 * failure cannot leave a partially updated wp-config.php file behind.
-	 *
-	 * @since 2.15.2
-	 *
-	 * @param array<string, string|int|bool> $constants Constants and their values.
-	 * @return bool|\WP_Error
-	 */
-	public function inject_wp_config_constants($constants) {
-
-		return $this->transform_wp_config_constants($constants, false);
-	}
-
-	/**
-	 * Transform constants on a temporary copy and atomically replace wp-config.php.
-	 *
-	 * @since 2.15.2
-	 *
-	 * @param array<string, string|int|bool|null> $constants Constants and their values.
-	 * @param bool                                $remove_only Whether constants should only be removed.
-	 * @throws \RuntimeException When the temporary transformation cannot be completed.
-	 * @return bool|\WP_Error
-	 */
-	private function transform_wp_config_constants($constants, $remove_only) {
-
-		if ( ! class_exists('WPConfigTransformer')) {
-			return new \WP_Error('missing-wp-config-transformer', __('The wp-config.php transformer is not available.', 'ultimate-multisite'));
-		}
-
-		if (empty($constants)) {
-			return false;
-		}
-
-		foreach (array_keys($constants) as $constant) {
-			if ( ! is_string($constant) || ! preg_match('/^[A-Za-z_][A-Za-z0-9_]*$/', $constant)) {
-				return new \WP_Error('invalid-wp-config-constant', __('An invalid wp-config.php constant name was provided.', 'ultimate-multisite'));
-			}
-		}
-
-		$config_path          = $this->get_wp_config_path();
-		$resolved_config_path = realpath($config_path);
-
-		if (false === $resolved_config_path || ! is_writable($resolved_config_path)) { // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_is_writable
-			// translators: %s is the file name.
-			return new \WP_Error('not-writeable', sprintf(__('The file %s is not writable', 'ultimate-multisite'), $config_path));
-		}
-
-		// Serialize Ultimate Multisite writers with a stable sidecar lock. Lock the
-		// configuration file too, so external writers using flock() cooperate with us.
-		// The final identity and content checks detect completed non-cooperative writes.
-		$lock_path   = rtrim(sys_get_temp_dir(), '/\\') . '/wu-wp-config-' . hash('sha256', $resolved_config_path) . '.lock';
-		$lock_handle = fopen($lock_path, 'c'); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fopen
-
-		if (false === $lock_handle || ! flock($lock_handle, LOCK_EX)) { // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_flock
-			if (is_resource($lock_handle)) {
-				fclose($lock_handle); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fclose
-			}
-
-			return new \WP_Error('wp-config-lock-failed', __('The wp-config.php update lock could not be acquired.', 'ultimate-multisite'));
-		}
-
-		$temporary_path = false;
-		$config_handle  = false;
+		$config_path = $this->get_wp_config_path();
 
 		try {
-			$config_handle = fopen($resolved_config_path, 'r+'); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fopen
+			$wp_config_transformer = new \WPConfigTransformer($config_path);
+			$is_raw_value          = is_bool($value) || is_int($value);
 
-			if (false === $config_handle || ! flock($config_handle, LOCK_EX)) { // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_flock
-				throw new \RuntimeException(__('The wp-config.php file lock could not be acquired.', 'ultimate-multisite'));
+			if (is_bool($value)) {
+				$value = $value ? 'true' : 'false';
 			}
 
-			rewind($config_handle); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_rewind
-			$original_contents = stream_get_contents($config_handle); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_stream_get_contents
-
-			if (false === $original_contents || '' === trim($original_contents)) {
-				throw new \RuntimeException(__('The wp-config.php file could not be read or is empty.', 'ultimate-multisite'));
-			}
-
-			$file_metadata = fstat($config_handle); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fstat
-
-			if (false === $file_metadata) {
-				throw new \RuntimeException(__('The wp-config.php file metadata could not be read.', 'ultimate-multisite'));
-			}
-
-			if ($remove_only) {
-				foreach (array_keys($constants) as $constant) {
-					if (1 !== $this->count_constant_definitions($original_contents, $constant) || ! $this->has_managed_true_definition($original_contents, $constant)) {
-						return false;
-					}
-				}
-			}
-
-			$temporary_path = tempnam(dirname($resolved_config_path), '.wu-wp-config-');
-
-			if (false === $temporary_path) {
-				throw new \RuntimeException(__('A temporary wp-config.php file could not be created.', 'ultimate-multisite'));
-			}
-
-			// Direct filesystem access is required to lock and atomically replace this local PHP configuration file.
-			$bytes_written = file_put_contents($temporary_path, $original_contents, LOCK_EX); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents
-
-			if (strlen($original_contents) !== $bytes_written) {
-				throw new \RuntimeException(__('The temporary wp-config.php file could not be written completely.', 'ultimate-multisite'));
-			}
-
-			$this->preserve_file_metadata($temporary_path, $file_metadata);
-
-			$normalized_contents = str_replace(["\r\n", "\n\r", "\r"], "\n", $original_contents);
-			$transformer         = new \WPConfigTransformer($temporary_path);
-			$anchor              = $remove_only ? [] : $this->get_transformer_anchor($normalized_contents);
-
-			if (is_wp_error($anchor)) {
-				return $anchor;
-			}
-
-			foreach ($constants as $constant => $value) {
-				$definition_count = $this->count_constant_definitions($original_contents, $constant);
-				$exists           = $transformer->exists('constant', $constant);
-
-				if ($definition_count && ! $exists) {
-					// translators: %s is a PHP constant name.
-					throw new \RuntimeException(sprintf(__('The existing %s definition uses an unsupported format and was not changed.', 'ultimate-multisite'), $constant));
-				}
-
-				if ($exists) {
-					$transformer->remove('constant', $constant);
-				}
-
-				if ( ! $remove_only) {
-					[$transformer_value, $raw] = $this->format_transformer_value($value);
-
-					$transformer->add(
-						'constant',
-						$constant,
-						$transformer_value,
-						[
-							'raw'       => $raw,
-							'anchor'    => $anchor['anchor'],
-							'separator' => "\n",
-							'placement' => $anchor['placement'],
-						]
-					);
-				}
-			}
-
-			$transformed_contents = file_get_contents($temporary_path); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
-
-			if (false === $transformed_contents) {
-				throw new \RuntimeException(__('The transformed wp-config.php file could not be read.', 'ultimate-multisite'));
-			}
-
-			if ( ! $remove_only) {
-				foreach (array_keys($constants) as $constant) {
-					$transformed_contents = $this->mark_managed_definition($transformed_contents, $constant);
-				}
-			}
-
-			if (str_contains($original_contents, "\r\n")) {
-				$transformed_contents = str_replace("\r\n", "\n", $transformed_contents);
-				$transformed_contents = str_replace("\n", "\r\n", $transformed_contents);
-			}
-
-			$bytes_written = file_put_contents($temporary_path, $transformed_contents, LOCK_EX); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents
-
-			if (strlen($transformed_contents) !== $bytes_written) {
-				throw new \RuntimeException(__('The temporary wp-config.php file could not be written completely.', 'ultimate-multisite'));
-			}
-
-			$this->validate_transformed_constants($transformed_contents, array_keys($constants), ! $remove_only);
-
-			if ($original_contents === $transformed_contents) {
-				return false;
-			}
-
-			clearstatcache(true, $resolved_config_path);
-			$current_metadata = stat($resolved_config_path); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_stat
-
-			if (
-				false === $current_metadata
-				|| $file_metadata['dev'] !== $current_metadata['dev']
-				|| $file_metadata['ino'] !== $current_metadata['ino']
-				|| file_get_contents($resolved_config_path) !== $original_contents // phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
-			) {
-				throw new \RuntimeException(__('The wp-config.php file changed while it was being updated. No changes were applied.', 'ultimate-multisite'));
-			}
-
-			// The temporary file is in the same directory, making this an atomic replacement on supported filesystems.
-			if ( ! rename($temporary_path, $resolved_config_path)) { // phpcs:ignore WordPress.WP.AlternativeFunctions.rename_rename
-				throw new \RuntimeException(__('The transformed wp-config.php file could not replace the original file.', 'ultimate-multisite'));
-			}
-
-			if (function_exists('opcache_invalidate')) {
-				opcache_invalidate($resolved_config_path, true);
-			}
-
-			return true;
-		} catch (\Throwable $exception) {
-			return new \WP_Error('wp-config-transform-failed', $exception->getMessage());
-		} finally {
-			if (is_string($temporary_path) && file_exists($temporary_path)) {
-				wp_delete_file($temporary_path);
-			}
-
-			if (is_resource($config_handle)) {
-				flock($config_handle, LOCK_UN); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_flock
-				fclose($config_handle); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fclose
-			}
-
-			flock($lock_handle, LOCK_UN); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_flock
-			fclose($lock_handle); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fclose
+			return $wp_config_transformer->update(
+				'constant',
+				$constant,
+				(string) $value,
+				['raw' => $is_raw_value]
+			);
+		} catch (\Exception $exception) {
+			return new \WP_Error('wp-config-update-failed', $exception->getMessage());
 		}
 	}
 
 	/**
-	 * Preserve ownership, group, and mode on an atomic replacement file.
-	 *
-	 * @since 2.15.2
-	 *
-	 * @param string $path Temporary replacement path.
-	 * @param array  $metadata Original file metadata from stat().
-	 * @throws \RuntimeException When metadata cannot be preserved.
-	 * @return void
-	 */
-	private function preserve_file_metadata($path, $metadata) {
-
-		$mode = $metadata['mode'] & 07777;
-
-		$current_owner = fileowner($path); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fileowner
-
-		if (false !== $current_owner && (int) $metadata['uid'] !== $current_owner && ! chown($path, (int) $metadata['uid'])) { // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_chown
-			throw new \RuntimeException(esc_html__('The wp-config.php file owner could not be preserved.', 'ultimate-multisite'));
-		}
-
-		$current_group = filegroup($path); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_filegroup
-
-		if (false !== $current_group && (int) $metadata['gid'] !== $current_group && ! chgrp($path, (int) $metadata['gid'])) { // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_chgrp
-			throw new \RuntimeException(esc_html__('The wp-config.php file group could not be preserved.', 'ultimate-multisite'));
-		}
-
-		// Ownership changes can clear setuid/setgid bits, so restore the mode last.
-		if ( ! chmod($path, $mode)) { // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_chmod
-			throw new \RuntimeException(esc_html__('The wp-config.php file permissions could not be preserved.', 'ultimate-multisite'));
-		}
-	}
-
-	/**
-	 * Format a value for WPConfigTransformer.
-	 *
-	 * @since 2.15.2
-	 *
-	 * @param string|int|bool|null $value Constant value.
-	 * @return array{0: string, 1: bool}
-	 */
-	private function format_transformer_value($value) {
-
-		if (is_bool($value)) {
-			return [$value ? 'true' : 'false', true];
-		}
-
-		if (is_int($value)) {
-			return [(string) $value, true];
-		}
-
-		return [(string) $value, false];
-	}
-
-	/**
-	 * Mark the normalized definition created by WPConfigTransformer.
-	 *
-	 * @since 2.15.2
-	 *
-	 * @param string $contents wp-config.php contents.
-	 * @param string $constant Constant name.
-	 * @throws \RuntimeException When the generated definition cannot be marked.
-	 * @return string
-	 */
-	private function mark_managed_definition($contents, $constant) {
-
-		$pattern = '/^([\t ]*define\(\s*([\'\"])' . preg_quote($constant, '/') . '\2\s*,[^\r\n]*\);)[\t ]*$/m';
-		$result  = preg_replace($pattern, '$1 // ' . self::MANAGED_MARKER, $contents, 1, $replacement_count);
-
-		if ( ! is_string($result) || 1 !== $replacement_count) {
-			// translators: %s is a PHP constant name.
-			throw new \RuntimeException(sprintf(esc_html__('The generated %s definition could not be marked as managed.', 'ultimate-multisite'), esc_html($constant)));
-		}
-
-		return $result;
-	}
-
-	/**
-	 * Check whether a true definition has the Ultimate Multisite marker.
-	 *
-	 * @since 2.15.2
-	 *
-	 * @param string $contents wp-config.php contents.
-	 * @param string $constant Constant name.
-	 * @return bool
-	 */
-	private function has_managed_true_definition($contents, $constant) {
-
-		$pattern = '/^[\t ]*define\(\s*([\'\"])' . preg_quote($constant, '/') . '\1\s*,\s*(?:true|1)\s*\);[\t ]*\/\/[\t ]*' . preg_quote(self::MANAGED_MARKER, '/') . '[\t ]*\r?$/mi';
-
-		return 1 === preg_match($pattern, $contents);
-	}
-
-	/**
-	 * Find a safe placement anchor supported by WPConfigTransformer.
-	 *
-	 * @since 2.15.2
-	 *
-	 * @param string $contents wp-config.php contents.
-	 * @return array{anchor: string, placement: string}|\WP_Error
-	 */
-	private function get_transformer_anchor($contents) {
-
-		$default_anchor   = "/* That's all, stop editing!";
-		$default_patterns = $this->get_default_reference_patterns();
-		$patterns         = apply_filters('wu_wp_config_reference_hook_line_patterns', $default_patterns);
-
-		// A customized pattern list is authoritative, matching the legacy API.
-		if ($patterns !== $default_patterns) {
-			$custom_anchor = $this->find_pattern_anchor($contents, $patterns);
-
-			if ($custom_anchor) {
-				return $custom_anchor;
-			}
-		}
-
-		if (str_contains($contents, $default_anchor)) {
-			return [
-				'anchor'    => $default_anchor,
-				'placement' => 'before',
-			];
-		}
-
-		if (preg_match('/^[\t ]*\$table_prefix\s*=.*;[\t ]*$/m', $contents, $matches)) {
-			return [
-				'anchor'    => $matches[0],
-				'placement' => 'after',
-			];
-		}
-
-		if (preg_match('/^[\t ]*(?:require|require_once)\s+ABSPATH\s*\.\s*[\'\"]wp-settings\.php[\'\"]\s*;[\t ]*$/m', $contents, $matches)) {
-			return [
-				'anchor'    => $matches[0],
-				'placement' => 'before',
-			];
-		}
-
-		$pattern_anchor = $this->find_pattern_anchor($contents, $patterns);
-
-		if ($pattern_anchor) {
-			return $pattern_anchor;
-		}
-
-		return new \WP_Error('unknown-wpconfig', __("Ultimate Multisite can't recognize your wp-config.php. No changes were applied.", 'ultimate-multisite'));
-	}
-
-	/**
-	 * Get the default patterns used to locate a wp-config.php injection point.
-	 *
-	 * @since 2.15.2
-	 *
-	 * @return array<string, int>
-	 */
-	private function get_default_reference_patterns() {
-
-		global $wpdb;
-
-		return [
-			'/^\$table_prefix\s*=\s*[\'|\"]' . $wpdb->prefix . '[\'|\"]/' => 0,
-			'/^( ){0,}\$table_prefix\s*=.*[\'|\"]' . $wpdb->prefix . '[\'|\"]/' => 0,
-			'/(\/\* That\'s all, stop editing! Happy publishing\. \*\/)/' => -2,
-			'/<\?php/' => 0,
-		];
-	}
-
-	/**
-	 * Find an anchor from an ordered list of legacy reference patterns.
-	 *
-	 * @since 2.15.2
-	 *
-	 * @param string $contents wp-config.php contents.
-	 * @param array  $patterns Regular expressions keyed to line offsets.
-	 * @return array{anchor: string, placement: string}|null
-	 */
-	private function find_pattern_anchor($contents, $patterns) {
-
-		$config_lines = preg_split('/\n/', $contents);
-
-		if ( ! is_array($config_lines) || ! is_array($patterns)) {
-			return null;
-		}
-
-		foreach ($patterns as $pattern => $lines_to_add) {
-			foreach ($config_lines as $line) {
-				if (preg_match($pattern, (string) $line)) {
-					return [
-						'anchor'    => $line,
-						'placement' => $lines_to_add < 0 ? 'before' : 'after',
-					];
-				}
-			}
-		}
-
-		return null;
-	}
-
-	/**
-	 * Validate PHP syntax and the resulting constant counts.
-	 *
-	 * @since 2.15.2
-	 *
-	 * @param string   $contents wp-config.php contents.
-	 * @param string[] $constants Constant names.
-	 * @param bool     $should_exist Whether each constant should exist once.
-	 * @throws \RuntimeException When the transformed constants fail validation.
-	 * @return void
-	 */
-	private function validate_transformed_constants($contents, $constants, $should_exist) {
-
-		token_get_all($contents, TOKEN_PARSE);
-
-		$expected_count = $should_exist ? 1 : 0;
-
-		foreach ($constants as $constant) {
-			if ($expected_count !== $this->count_constant_definitions($contents, $constant)) {
-				// translators: %s is a PHP constant name.
-				throw new \RuntimeException(sprintf(esc_html__('The transformed wp-config.php file has an unexpected number of %s definitions.', 'ultimate-multisite'), esc_html($constant)));
-			}
-		}
-	}
-
-	/**
-	 * Count define() calls for a constant without executing wp-config.php.
-	 *
-	 * @since 2.15.2
-	 *
-	 * @param string $contents wp-config.php contents.
-	 * @param string $constant Constant name.
-	 * @return int
-	 */
-	private function count_constant_definitions($contents, $constant) {
-
-		$tokens = token_get_all($contents, TOKEN_PARSE);
-		$count  = 0;
-
-		foreach ($tokens as $index => $token) {
-			if ( ! is_array($token) || T_STRING !== $token[0] || 'define' !== strtolower($token[1])) {
-				continue;
-			}
-
-			$opening_parenthesis = $this->next_code_token($tokens, $index + 1);
-
-			if (false === $opening_parenthesis || '(' !== $tokens[ $opening_parenthesis ]) {
-				continue;
-			}
-
-			$name_index = $this->next_code_token($tokens, $opening_parenthesis + 1);
-
-			if (false === $name_index || ! is_array($tokens[ $name_index ]) || T_CONSTANT_ENCAPSED_STRING !== $tokens[ $name_index ][0]) {
-				continue;
-			}
-
-			$name = substr($tokens[ $name_index ][1], 1, -1);
-
-			if ($constant === $name) {
-				++$count;
-			}
-		}
-
-		return $count;
-	}
-
-	/**
-	 * Find the next non-whitespace, non-comment PHP token.
-	 *
-	 * @since 2.15.2
-	 *
-	 * @param array $tokens PHP tokens.
-	 * @param int   $start Starting index.
-	 * @return int|false
-	 */
-	private function next_code_token($tokens, $start) {
-
-		$token_count = count($tokens);
-
-		for ($index = $start; $index < $token_count; ++$index) {
-			$token = $tokens[ $index ];
-
-			if (is_array($token) && in_array($token[0], [T_WHITESPACE, T_COMMENT, T_DOC_COMMENT], true)) {
-				continue;
-			}
-
-			return $index;
-		}
-
-		return false;
-	}
-
-	/**
-	 * Actually inserts the new lines into the array of wp-config.php lines.
+	 * Legacy compatibility method that no longer modifies config contents.
 	 *
 	 * @since 2.0.0
+	 * @deprecated 2.15.2 No replacement.
 	 *
 	 * @param array  $content_array Array containing the original lines of the file being edited.
 	 * @param int    $line Line number to inject the new content at.
 	 * @param string $value Value to add to that specific line.
-	 * @return array New array containing the lines of the modified file.
+	 * @return array The original content array.
 	 */
-	public function inject_contents($content_array, $line, $value) {
+	public function inject_contents($content_array, $line, $value) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed -- Parameters retained for backwards compatibility.
 
-		if ( ! is_array($value)) {
-			$value = [$value];
-		}
-
-		array_splice($content_array, $line, 0, $value);
+		_doing_it_wrong(__METHOD__, esc_html__('This method is deprecated and no longer performs any operation.', 'ultimate-multisite'), '2.15.2');
 
 		return $content_array;
 	}
@@ -576,12 +79,10 @@ class WP_Config {
 	 */
 	public function get_wp_config_path() {
 
-		$config_path = ABSPATH . 'wp-config.php';
-
 		if (file_exists(ABSPATH . 'wp-config.php')) {
-			$config_path = ABSPATH . 'wp-config.php';
-		} elseif (file_exists(dirname(ABSPATH) . '/wp-config.php') && ! file_exists(dirname(ABSPATH) . '/wp-settings.php')) {
-			$config_path = dirname(ABSPATH) . '/wp-config.php';
+			return (ABSPATH . 'wp-config.php');
+		} elseif (@file_exists(dirname(ABSPATH) . '/wp-config.php') && ! @file_exists(dirname(ABSPATH) . '/wp-settings.php')) { // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged -- Parent directory access may be restricted.
+			return (dirname(ABSPATH) . '/wp-config.php');
 		} elseif (defined('WP_TESTS_MULTISITE') && constant('WP_TESTS_MULTISITE') === true) {
 			$tests_dir = getenv('WP_TESTS_DIR');
 
@@ -589,66 +90,26 @@ class WP_Config {
 				$tests_dir = rtrim(sys_get_temp_dir(), '/\\') . '/wordpress-tests-lib';
 			}
 
-			$config_path = $tests_dir . '/wp-tests-config.php';
+			return $tests_dir . '/wp-tests-config.php';
 		}
 
-		/**
-		 * Filters the wp-config.php path used for configuration updates.
-		 *
-		 * @since 2.15.2
-		 *
-		 * @param string $config_path Absolute path to wp-config.php.
-		 */
-		return (string) apply_filters('wu_wp_config_path', $config_path);
+		return ABSPATH . 'wp-config.php';
 	}
 
 	/**
-	 * Find reference line for injection.
-	 *
-	 * We need a hook point we can use as reference to inject our constants.
-	 * For now, we are using the line defining the $table_prefix.
-	 * e.g. $table_prefix = 'wp_';
-	 * We retrieve that line via RegEx.
+	 * Legacy compatibility method that no longer searches config contents.
 	 *
 	 * @since 2.0.0
+	 * @deprecated 2.15.2 No replacement.
 	 *
 	 * @param array $config Array containing the lines of the config file, for searching.
-	 * @return false|int Line number.
+	 * @return false
 	 */
-	public function find_reference_hook_line($config) {
+	public function find_reference_hook_line($config) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.Found -- Parameter retained for backwards compatibility.
 
-		/**
-		 * We check for three patterns when trying to figure our
-		 * where we can inject our constants:
-		 *
-		 * 1. We search for the $table_prefix variable definition;
-		 * 2. We search for more complex $table_prefix definitions - the ones that
-		 *    use env variables, for example;
-		 * 3. If that's not available, we look for the 'Happy Publishing' comment;
-		 * 4. If that's also not available, we look for the beginning of the file.
-		 *
-		 * The key represents the pattern and the value the number of lines to add.
-		 * A negative number of lines can be passed to write before the found line,
-		 * instead of writing after it.
-		 */
-		$patterns = apply_filters(
-			'wu_wp_config_reference_hook_line_patterns',
-			$this->get_default_reference_patterns()
-		);
+		_doing_it_wrong(__METHOD__, esc_html__('This method is deprecated and no longer performs any operation.', 'ultimate-multisite'), '2.15.2');
 
-		$line = 1;
-
-		foreach ($patterns as $pattern => $lines_to_add) {
-			foreach ($config as $k => $line) {
-				if (preg_match($pattern, (string) $line)) {
-					$line = $k + $lines_to_add;
-
-					break 2;
-				}
-			}
-		}
-
-		return $line;
+		return false;
 	}
 
 	/**
@@ -661,48 +122,30 @@ class WP_Config {
 	 */
 	public function revert($constant) {
 
-		$config = file($this->get_wp_config_path());
-
-		if (false === $config) {
-			return new \WP_Error('invalid-wp-config', __('The wp-config.php file could not be read.', 'ultimate-multisite'));
-		}
-
-		$contents = implode('', $config);
+		$config_path = $this->get_wp_config_path();
 
 		try {
-			$definition_count = $this->count_constant_definitions($contents, $constant);
-		} catch (\Throwable $exception) {
-			return new \WP_Error('wp-config-transform-failed', $exception->getMessage());
-		}
+			$wp_config_transformer = new \WPConfigTransformer($config_path);
 
-		if (
-			1 !== $definition_count
-			|| ! $this->has_managed_true_definition($contents, $constant)
-		) {
-			return false;
+			return $wp_config_transformer->remove('constant', $constant);
+		} catch (\Exception $exception) {
+			return new \WP_Error('wp-config-update-failed', $exception->getMessage());
 		}
-
-		return $this->transform_wp_config_constants([$constant => null], true);
 	}
 
 	/**
-	 * Checks for the injected line inside of the wp-config.php file.
+	 * Legacy compatibility method that no longer searches config contents.
 	 *
 	 * @since 2.0.0
+	 * @deprecated 2.15.2 No replacement.
 	 *
 	 * @param array  $config Array containing the lines of the config file, for searching.
 	 * @param string $constant The constant name.
-	 * @return mixed[]|bool
+	 * @return false
 	 */
-	public function find_injected_line($config, $constant) {
+	public function find_injected_line($config, $constant) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed -- Parameters retained for backwards compatibility.
 
-		$pattern = "/^define\(\s*['\"]" . preg_quote($constant, '/') . "['\"],(.*)\)/";
-
-		foreach ($config as $k => $line) {
-			if (preg_match($pattern, (string) $line, $matches)) {
-				return [trim($matches[1]), $k];
-			}
-		}
+		_doing_it_wrong(__METHOD__, esc_html__('This method is deprecated and no longer performs any operation.', 'ultimate-multisite'), '2.15.2');
 
 		return false;
 	}

--- a/inc/helpers/class-wp-config.php
+++ b/inc/helpers/class-wp-config.php
@@ -22,6 +22,14 @@ class WP_Config {
 	use \WP_Ultimo\Traits\Singleton;
 
 	/**
+	 * Marker appended to definitions managed by Ultimate Multisite.
+	 *
+	 * @since 2.15.2
+	 * @var string
+	 */
+	private const MANAGED_MARKER = 'Ultimate Multisite managed';
+
+	/**
 	 * Inject the constant into the wp-config.php file.
 	 *
 	 * @since 2.0.0
@@ -86,6 +94,8 @@ class WP_Config {
 			return new \WP_Error('not-writeable', sprintf(__('The file %s is not writable', 'ultimate-multisite'), $config_path));
 		}
 
+		// Serialize Ultimate Multisite writers. The content comparison below also detects
+		// external changes made before the final atomic replacement.
 		$lock_path   = rtrim(sys_get_temp_dir(), '/\\') . '/wu-wp-config-' . hash('sha256', $resolved_config_path) . '.lock';
 		$lock_handle = fopen($lock_path, 'c'); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fopen
 
@@ -171,14 +181,21 @@ class WP_Config {
 				throw new \RuntimeException(__('The transformed wp-config.php file could not be read.', 'ultimate-multisite'));
 			}
 
+			if ( ! $remove_only) {
+				foreach (array_keys($constants) as $constant) {
+					$transformed_contents = $this->mark_managed_definition($transformed_contents, $constant);
+				}
+			}
+
 			if (str_contains($original_contents, "\r\n")) {
 				$transformed_contents = str_replace("\r\n", "\n", $transformed_contents);
 				$transformed_contents = str_replace("\n", "\r\n", $transformed_contents);
-				$bytes_written        = file_put_contents($temporary_path, $transformed_contents, LOCK_EX); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents
+			}
 
-				if (strlen($transformed_contents) !== $bytes_written) {
-					throw new \RuntimeException(__('The temporary wp-config.php file could not be written completely.', 'ultimate-multisite'));
-				}
+			$bytes_written = file_put_contents($temporary_path, $transformed_contents, LOCK_EX); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents
+
+			if (strlen($transformed_contents) !== $bytes_written) {
+				throw new \RuntimeException(__('The temporary wp-config.php file could not be written completely.', 'ultimate-multisite'));
 			}
 
 			$this->validate_transformed_constants($transformed_contents, array_keys($constants), ! $remove_only);
@@ -227,10 +244,6 @@ class WP_Config {
 
 		$mode = $metadata['mode'] & 07777;
 
-		if ( ! chmod($path, $mode)) { // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_chmod
-			throw new \RuntimeException(esc_html__('The wp-config.php file permissions could not be preserved.', 'ultimate-multisite'));
-		}
-
 		$current_owner = fileowner($path); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fileowner
 
 		if (false !== $current_owner && (int) $metadata['uid'] !== $current_owner && ! chown($path, (int) $metadata['uid'])) { // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_chown
@@ -241,6 +254,11 @@ class WP_Config {
 
 		if (false !== $current_group && (int) $metadata['gid'] !== $current_group && ! chgrp($path, (int) $metadata['gid'])) { // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_chgrp
 			throw new \RuntimeException(esc_html__('The wp-config.php file group could not be preserved.', 'ultimate-multisite'));
+		}
+
+		// Ownership changes can clear setuid/setgid bits, so restore the mode last.
+		if ( ! chmod($path, $mode)) { // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_chmod
+			throw new \RuntimeException(esc_html__('The wp-config.php file permissions could not be preserved.', 'ultimate-multisite'));
 		}
 	}
 
@@ -266,6 +284,29 @@ class WP_Config {
 	}
 
 	/**
+	 * Mark the normalized definition created by WPConfigTransformer.
+	 *
+	 * @since 2.15.2
+	 *
+	 * @param string $contents wp-config.php contents.
+	 * @param string $constant Constant name.
+	 * @throws \RuntimeException When the generated definition cannot be marked.
+	 * @return string
+	 */
+	private function mark_managed_definition($contents, $constant) {
+
+		$pattern = '/^([\t ]*define\(\s*([\'\"])' . preg_quote($constant, '/') . '\2\s*,[^\r\n]*\);)[\t ]*$/m';
+		$result  = preg_replace($pattern, '$1 // ' . self::MANAGED_MARKER, $contents, 1, $replacement_count);
+
+		if ( ! is_string($result) || 1 !== $replacement_count) {
+			// translators: %s is a PHP constant name.
+			throw new \RuntimeException(sprintf(esc_html__('The generated %s definition could not be marked as managed.', 'ultimate-multisite'), esc_html($constant)));
+		}
+
+		return $result;
+	}
+
+	/**
 	 * Find a safe placement anchor supported by WPConfigTransformer.
 	 *
 	 * @since 2.15.2
@@ -275,7 +316,25 @@ class WP_Config {
 	 */
 	private function get_transformer_anchor($contents) {
 
-		$default_anchor = "/* That's all, stop editing!";
+		global $wpdb;
+
+		$default_anchor   = "/* That's all, stop editing!";
+		$default_patterns = [
+			'/^\$table_prefix\s*=\s*[\'|\"]' . $wpdb->prefix . '[\'|\"]/' => 0,
+			'/^( ){0,}\$table_prefix\s*=.*[\'|\"]' . $wpdb->prefix . '[\'|\"]/' => 0,
+			'/(\/\* That\'s all, stop editing! Happy publishing\. \*\/)/' => -2,
+			'/<\?php/' => 0,
+		];
+		$patterns         = apply_filters('wu_wp_config_reference_hook_line_patterns', $default_patterns);
+
+		// A customized pattern list is authoritative, matching the legacy API.
+		if ($patterns !== $default_patterns) {
+			$custom_anchor = $this->find_pattern_anchor($contents, $patterns);
+
+			if ($custom_anchor) {
+				return $custom_anchor;
+			}
+		}
 
 		if (str_contains($contents, $default_anchor)) {
 			return [
@@ -298,34 +357,44 @@ class WP_Config {
 			];
 		}
 
+		$pattern_anchor = $this->find_pattern_anchor($contents, $patterns);
+
+		if ($pattern_anchor) {
+			return $pattern_anchor;
+		}
+
+		return new \WP_Error('unknown-wpconfig', __("Ultimate Multisite can't recognize your wp-config.php. No changes were applied.", 'ultimate-multisite'));
+	}
+
+	/**
+	 * Find an anchor from an ordered list of legacy reference patterns.
+	 *
+	 * @since 2.15.2
+	 *
+	 * @param string $contents wp-config.php contents.
+	 * @param array  $patterns Regular expressions keyed to line offsets.
+	 * @return array{anchor: string, placement: string}|null
+	 */
+	private function find_pattern_anchor($contents, $patterns) {
+
 		$config_lines = preg_split('/\n/', $contents);
 
-		if (is_array($config_lines)) {
-			global $wpdb;
+		if ( ! is_array($config_lines) || ! is_array($patterns)) {
+			return null;
+		}
 
-			$patterns = apply_filters(
-				'wu_wp_config_reference_hook_line_patterns',
-				[
-					'/^\$table_prefix\s*=\s*[\'|\"]' . $wpdb->prefix . '[\'|\"]/' => 0,
-					'/^( ){0,}\$table_prefix\s*=.*[\'|\"]' . $wpdb->prefix . '[\'|\"]/' => 0,
-					'/(\/\* That\'s all, stop editing! Happy publishing\. \*\/)/' => -2,
-					'/<\?php/' => 0,
-				]
-			);
-
-			foreach ($patterns as $pattern => $lines_to_add) {
-				foreach ($config_lines as $line) {
-					if (preg_match($pattern, (string) $line)) {
-						return [
-							'anchor'    => $line,
-							'placement' => $lines_to_add < 0 ? 'before' : 'after',
-						];
-					}
+		foreach ($patterns as $pattern => $lines_to_add) {
+			foreach ($config_lines as $line) {
+				if (preg_match($pattern, (string) $line)) {
+					return [
+						'anchor'    => $line,
+						'placement' => $lines_to_add < 0 ? 'before' : 'after',
+					];
 				}
 			}
 		}
 
-		return new \WP_Error('unknown-wpconfig', __("Ultimate Multisite can't recognize your wp-config.php. No changes were applied.", 'ultimate-multisite'));
+		return null;
 	}
 
 	/**
@@ -548,8 +617,13 @@ class WP_Config {
 		}
 
 		$injected_line = $this->find_injected_line($config, $constant);
+		$contents      = implode('', $config);
 
-		if (false === $injected_line || ! in_array(rtrim($injected_line[0], ';'), ['true', '1'], true)) {
+		if (
+			1 !== $this->count_constant_definitions($contents, $constant)
+			|| false === $injected_line
+			|| ! in_array(rtrim($injected_line[0], ';'), ['true', '1'], true)
+		) {
 			return false;
 		}
 

--- a/inc/helpers/class-wp-config.php
+++ b/inc/helpers/class-wp-config.php
@@ -94,8 +94,9 @@ class WP_Config {
 			return new \WP_Error('not-writeable', sprintf(__('The file %s is not writable', 'ultimate-multisite'), $config_path));
 		}
 
-		// Serialize Ultimate Multisite writers. The content comparison below also detects
-		// external changes made before the final atomic replacement.
+		// Serialize Ultimate Multisite writers with a stable sidecar lock. Lock the
+		// configuration file too, so external writers using flock() cooperate with us.
+		// The final identity and content checks detect completed non-cooperative writes.
 		$lock_path   = rtrim(sys_get_temp_dir(), '/\\') . '/wu-wp-config-' . hash('sha256', $resolved_config_path) . '.lock';
 		$lock_handle = fopen($lock_path, 'c'); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fopen
 
@@ -108,18 +109,34 @@ class WP_Config {
 		}
 
 		$temporary_path = false;
+		$config_handle  = false;
 
 		try {
-			$original_contents = file_get_contents($resolved_config_path); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
+			$config_handle = fopen($resolved_config_path, 'r+'); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fopen
+
+			if (false === $config_handle || ! flock($config_handle, LOCK_EX)) { // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_flock
+				throw new \RuntimeException(__('The wp-config.php file lock could not be acquired.', 'ultimate-multisite'));
+			}
+
+			rewind($config_handle); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_rewind
+			$original_contents = stream_get_contents($config_handle); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_stream_get_contents
 
 			if (false === $original_contents || '' === trim($original_contents)) {
 				throw new \RuntimeException(__('The wp-config.php file could not be read or is empty.', 'ultimate-multisite'));
 			}
 
-			$file_metadata = stat($resolved_config_path); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_stat
+			$file_metadata = fstat($config_handle); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fstat
 
 			if (false === $file_metadata) {
 				throw new \RuntimeException(__('The wp-config.php file metadata could not be read.', 'ultimate-multisite'));
+			}
+
+			if ($remove_only) {
+				foreach (array_keys($constants) as $constant) {
+					if (1 !== $this->count_constant_definitions($original_contents, $constant) || ! $this->has_managed_true_definition($original_contents, $constant)) {
+						return false;
+					}
+				}
 			}
 
 			$temporary_path = tempnam(dirname($resolved_config_path), '.wu-wp-config-');
@@ -204,7 +221,15 @@ class WP_Config {
 				return false;
 			}
 
-			if (file_get_contents($resolved_config_path) !== $original_contents) { // phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
+			clearstatcache(true, $resolved_config_path);
+			$current_metadata = stat($resolved_config_path); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_stat
+
+			if (
+				false === $current_metadata
+				|| $file_metadata['dev'] !== $current_metadata['dev']
+				|| $file_metadata['ino'] !== $current_metadata['ino']
+				|| file_get_contents($resolved_config_path) !== $original_contents // phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
+			) {
 				throw new \RuntimeException(__('The wp-config.php file changed while it was being updated. No changes were applied.', 'ultimate-multisite'));
 			}
 
@@ -223,6 +248,11 @@ class WP_Config {
 		} finally {
 			if (is_string($temporary_path) && file_exists($temporary_path)) {
 				wp_delete_file($temporary_path);
+			}
+
+			if (is_resource($config_handle)) {
+				flock($config_handle, LOCK_UN); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_flock
+				fclose($config_handle); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fclose
 			}
 
 			flock($lock_handle, LOCK_UN); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_flock
@@ -304,6 +334,22 @@ class WP_Config {
 		}
 
 		return $result;
+	}
+
+	/**
+	 * Check whether a true definition has the Ultimate Multisite marker.
+	 *
+	 * @since 2.15.2
+	 *
+	 * @param string $contents wp-config.php contents.
+	 * @param string $constant Constant name.
+	 * @return bool
+	 */
+	private function has_managed_true_definition($contents, $constant) {
+
+		$pattern = '/^[\t ]*define\(\s*([\'\"])' . preg_quote($constant, '/') . '\1\s*,\s*(?:true|1)\s*\);[\t ]*\/\/[\t ]*' . preg_quote(self::MANAGED_MARKER, '/') . '[\t ]*\r?$/mi';
+
+		return 1 === preg_match($pattern, $contents);
 	}
 
 	/**
@@ -616,13 +662,11 @@ class WP_Config {
 			return new \WP_Error('invalid-wp-config', __('The wp-config.php file could not be read.', 'ultimate-multisite'));
 		}
 
-		$injected_line = $this->find_injected_line($config, $constant);
-		$contents      = implode('', $config);
+		$contents = implode('', $config);
 
 		if (
 			1 !== $this->count_constant_definitions($contents, $constant)
-			|| false === $injected_line
-			|| ! in_array(rtrim($injected_line[0], ';'), ['true', '1'], true)
+			|| ! $this->has_managed_true_definition($contents, $constant)
 		) {
 			return false;
 		}
@@ -641,7 +685,7 @@ class WP_Config {
 	 */
 	public function find_injected_line($config, $constant) {
 
-		$pattern = "/^define\(\s*['|\"]" . $constant . "['|\"],(.*)\)/";
+		$pattern = "/^define\(\s*['\"]" . preg_quote($constant, '/') . "['\"],(.*)\)/";
 
 		foreach ($config as $k => $line) {
 			if (preg_match($pattern, (string) $line, $matches)) {

--- a/inc/helpers/class-wp-config.php
+++ b/inc/helpers/class-wp-config.php
@@ -362,15 +362,8 @@ class WP_Config {
 	 */
 	private function get_transformer_anchor($contents) {
 
-		global $wpdb;
-
 		$default_anchor   = "/* That's all, stop editing!";
-		$default_patterns = [
-			'/^\$table_prefix\s*=\s*[\'|\"]' . $wpdb->prefix . '[\'|\"]/' => 0,
-			'/^( ){0,}\$table_prefix\s*=.*[\'|\"]' . $wpdb->prefix . '[\'|\"]/' => 0,
-			'/(\/\* That\'s all, stop editing! Happy publishing\. \*\/)/' => -2,
-			'/<\?php/' => 0,
-		];
+		$default_patterns = $this->get_default_reference_patterns();
 		$patterns         = apply_filters('wu_wp_config_reference_hook_line_patterns', $default_patterns);
 
 		// A customized pattern list is authoritative, matching the legacy API.
@@ -410,6 +403,25 @@ class WP_Config {
 		}
 
 		return new \WP_Error('unknown-wpconfig', __("Ultimate Multisite can't recognize your wp-config.php. No changes were applied.", 'ultimate-multisite'));
+	}
+
+	/**
+	 * Get the default patterns used to locate a wp-config.php injection point.
+	 *
+	 * @since 2.15.2
+	 *
+	 * @return array<string, int>
+	 */
+	private function get_default_reference_patterns() {
+
+		global $wpdb;
+
+		return [
+			'/^\$table_prefix\s*=\s*[\'|\"]' . $wpdb->prefix . '[\'|\"]/' => 0,
+			'/^( ){0,}\$table_prefix\s*=.*[\'|\"]' . $wpdb->prefix . '[\'|\"]/' => 0,
+			'/(\/\* That\'s all, stop editing! Happy publishing\. \*\/)/' => -2,
+			'/<\?php/' => 0,
+		];
 	}
 
 	/**
@@ -605,8 +617,6 @@ class WP_Config {
 	 */
 	public function find_reference_hook_line($config) {
 
-		global $wpdb;
-
 		/**
 		 * We check for three patterns when trying to figure our
 		 * where we can inject our constants:
@@ -623,12 +633,7 @@ class WP_Config {
 		 */
 		$patterns = apply_filters(
 			'wu_wp_config_reference_hook_line_patterns',
-			[
-				'/^\$table_prefix\s*=\s*[\'|\"]' . $wpdb->prefix . '[\'|\"]/' => 0,
-				'/^( ){0,}\$table_prefix\s*=.*[\'|\"]' . $wpdb->prefix . '[\'|\"]/' => 0,
-				'/(\/\* That\'s all, stop editing! Happy publishing\. \*\/)/' => -2,
-				'/<\?php/' => 0,
-			]
+			$this->get_default_reference_patterns()
 		);
 
 		$line = 1;

--- a/inc/helpers/class-wp-config.php
+++ b/inc/helpers/class-wp-config.php
@@ -664,8 +664,14 @@ class WP_Config {
 
 		$contents = implode('', $config);
 
+		try {
+			$definition_count = $this->count_constant_definitions($contents, $constant);
+		} catch (\Throwable $exception) {
+			return new \WP_Error('wp-config-transform-failed', $exception->getMessage());
+		}
+
 		if (
-			1 !== $this->count_constant_definitions($contents, $constant)
+			1 !== $definition_count
 			|| ! $this->has_managed_true_definition($contents, $constant)
 		) {
 			return false;

--- a/inc/helpers/class-wp-config.php
+++ b/inc/helpers/class-wp-config.php
@@ -86,19 +86,38 @@ class WP_Config {
 			return new \WP_Error('not-writeable', sprintf(__('The file %s is not writable', 'ultimate-multisite'), $config_path));
 		}
 
-		$original_contents = file_get_contents($resolved_config_path); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
+		$lock_path   = rtrim(sys_get_temp_dir(), '/\\') . '/wu-wp-config-' . hash('sha256', $resolved_config_path) . '.lock';
+		$lock_handle = fopen($lock_path, 'c'); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fopen
 
-		if (false === $original_contents || '' === trim($original_contents)) {
-			return new \WP_Error('invalid-wp-config', __('The wp-config.php file could not be read or is empty.', 'ultimate-multisite'));
+		if (false === $lock_handle || ! flock($lock_handle, LOCK_EX)) { // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_flock
+			if (is_resource($lock_handle)) {
+				fclose($lock_handle); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fclose
+			}
+
+			return new \WP_Error('wp-config-lock-failed', __('The wp-config.php update lock could not be acquired.', 'ultimate-multisite'));
 		}
 
-		$temporary_path = tempnam(dirname($resolved_config_path), '.wu-wp-config-');
-
-		if (false === $temporary_path) {
-			return new \WP_Error('wp-config-temp-file', __('A temporary wp-config.php file could not be created.', 'ultimate-multisite'));
-		}
+		$temporary_path = false;
 
 		try {
+			$original_contents = file_get_contents($resolved_config_path); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
+
+			if (false === $original_contents || '' === trim($original_contents)) {
+				throw new \RuntimeException(__('The wp-config.php file could not be read or is empty.', 'ultimate-multisite'));
+			}
+
+			$file_metadata = stat($resolved_config_path); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_stat
+
+			if (false === $file_metadata) {
+				throw new \RuntimeException(__('The wp-config.php file metadata could not be read.', 'ultimate-multisite'));
+			}
+
+			$temporary_path = tempnam(dirname($resolved_config_path), '.wu-wp-config-');
+
+			if (false === $temporary_path) {
+				throw new \RuntimeException(__('A temporary wp-config.php file could not be created.', 'ultimate-multisite'));
+			}
+
 			// Direct filesystem access is required to lock and atomically replace this local PHP configuration file.
 			$bytes_written = file_put_contents($temporary_path, $original_contents, LOCK_EX); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents
 
@@ -106,11 +125,7 @@ class WP_Config {
 				throw new \RuntimeException(__('The temporary wp-config.php file could not be written completely.', 'ultimate-multisite'));
 			}
 
-			$file_permissions = fileperms($resolved_config_path);
-
-			if (false !== $file_permissions) {
-				chmod($temporary_path, $file_permissions & 0777); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_chmod
-			}
+			$this->preserve_file_metadata($temporary_path, $file_metadata);
 
 			$normalized_contents = str_replace(["\r\n", "\n\r", "\r"], "\n", $original_contents);
 			$transformer         = new \WPConfigTransformer($temporary_path);
@@ -189,9 +204,43 @@ class WP_Config {
 		} catch (\Throwable $exception) {
 			return new \WP_Error('wp-config-transform-failed', $exception->getMessage());
 		} finally {
-			if (file_exists($temporary_path)) {
+			if (is_string($temporary_path) && file_exists($temporary_path)) {
 				wp_delete_file($temporary_path);
 			}
+
+			flock($lock_handle, LOCK_UN); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_flock
+			fclose($lock_handle); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fclose
+		}
+	}
+
+	/**
+	 * Preserve ownership, group, and mode on an atomic replacement file.
+	 *
+	 * @since 2.15.2
+	 *
+	 * @param string $path Temporary replacement path.
+	 * @param array  $metadata Original file metadata from stat().
+	 * @throws \RuntimeException When metadata cannot be preserved.
+	 * @return void
+	 */
+	private function preserve_file_metadata($path, $metadata) {
+
+		$mode = $metadata['mode'] & 07777;
+
+		if ( ! chmod($path, $mode)) { // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_chmod
+			throw new \RuntimeException(esc_html__('The wp-config.php file permissions could not be preserved.', 'ultimate-multisite'));
+		}
+
+		$current_owner = fileowner($path); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fileowner
+
+		if (false !== $current_owner && (int) $metadata['uid'] !== $current_owner && ! chown($path, (int) $metadata['uid'])) { // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_chown
+			throw new \RuntimeException(esc_html__('The wp-config.php file owner could not be preserved.', 'ultimate-multisite'));
+		}
+
+		$current_group = filegroup($path); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_filegroup
+
+		if (false !== $current_group && (int) $metadata['gid'] !== $current_group && ! chgrp($path, (int) $metadata['gid'])) { // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_chgrp
+			throw new \RuntimeException(esc_html__('The wp-config.php file group could not be preserved.', 'ultimate-multisite'));
 		}
 	}
 
@@ -247,6 +296,33 @@ class WP_Config {
 				'anchor'    => $matches[0],
 				'placement' => 'before',
 			];
+		}
+
+		$config_lines = preg_split('/\n/', $contents);
+
+		if (is_array($config_lines)) {
+			global $wpdb;
+
+			$patterns = apply_filters(
+				'wu_wp_config_reference_hook_line_patterns',
+				[
+					'/^\$table_prefix\s*=\s*[\'|\"]' . $wpdb->prefix . '[\'|\"]/' => 0,
+					'/^( ){0,}\$table_prefix\s*=.*[\'|\"]' . $wpdb->prefix . '[\'|\"]/' => 0,
+					'/(\/\* That\'s all, stop editing! Happy publishing\. \*\/)/' => -2,
+					'/<\?php/' => 0,
+				]
+			);
+
+			foreach ($patterns as $pattern => $lines_to_add) {
+				foreach ($config_lines as $line) {
+					if (preg_match($pattern, (string) $line)) {
+						return [
+							'anchor'    => $line,
+							'placement' => $lines_to_add < 0 ? 'before' : 'after',
+						];
+					}
+				}
+			}
 		}
 
 		return new \WP_Error('unknown-wpconfig', __("Ultimate Multisite can't recognize your wp-config.php. No changes were applied.", 'ultimate-multisite'));
@@ -464,6 +540,18 @@ class WP_Config {
 	 * @return mixed
 	 */
 	public function revert($constant) {
+
+		$config = file($this->get_wp_config_path());
+
+		if (false === $config) {
+			return new \WP_Error('invalid-wp-config', __('The wp-config.php file could not be read.', 'ultimate-multisite'));
+		}
+
+		$injected_line = $this->find_injected_line($config, $constant);
+
+		if (false === $injected_line || ! in_array(rtrim($injected_line[0], ';'), ['true', '1'], true)) {
+			return false;
+		}
 
 		return $this->transform_wp_config_constants([$constant => null], true);
 	}

--- a/inc/installers/class-multisite-network-installer.php
+++ b/inc/installers/class-multisite-network-installer.php
@@ -245,13 +245,12 @@ class Multisite_Network_Installer extends Base_Installer {
 			'BLOG_ID_CURRENT_SITE' => 1,
 		];
 
-		foreach ($constants as $constant => $value) {
-			$result = $wp_config->inject_wp_config_constant($constant, $value);
+		$result = $wp_config->inject_wp_config_constants($constants);
 
-			if (is_wp_error($result)) {
-				throw new \Exception(esc_html($result->get_error_message()));
-			}
+		if (is_wp_error($result)) {
+			throw new \Exception(esc_html($result->get_error_message()));
 		}
+
 		wp_cache_flush();
 	}
 
@@ -284,7 +283,7 @@ class Multisite_Network_Installer extends Base_Installer {
 		$sitemeta_table = $wpdb->base_prefix . 'sitemeta';
 		$network_id     = get_current_network_id();
 
-		// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+		// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 		$existing = $wpdb->get_row(
 			$wpdb->prepare(
 				"SELECT meta_id, meta_value FROM {$sitemeta_table} WHERE meta_key = %s AND site_id = %d",
@@ -311,7 +310,7 @@ class Multisite_Network_Installer extends Base_Installer {
 
 		$active_plugins[ WP_ULTIMO_PLUGIN_BASENAME ] = time();
 
-		$serialized = serialize($active_plugins);
+		$serialized = serialize($active_plugins); // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.serialize_serialize -- This is WordPress's required active_sitewide_plugins format.
 
 		if ($existing) {
 			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery

--- a/inc/installers/class-multisite-network-installer.php
+++ b/inc/installers/class-multisite-network-installer.php
@@ -245,12 +245,13 @@ class Multisite_Network_Installer extends Base_Installer {
 			'BLOG_ID_CURRENT_SITE' => 1,
 		];
 
-		$result = $wp_config->inject_wp_config_constants($constants);
+		foreach ($constants as $constant => $value) {
+			$result = $wp_config->inject_wp_config_constant($constant, $value);
 
-		if (is_wp_error($result)) {
-			throw new \Exception(esc_html($result->get_error_message()));
+			if (is_wp_error($result)) {
+				throw new \Exception(esc_html($result->get_error_message()));
+			}
 		}
-
 		wp_cache_flush();
 	}
 

--- a/inc/integrations/host-providers/class-base-host-provider.php
+++ b/inc/integrations/host-providers/class-base-host-provider.php
@@ -509,9 +509,7 @@ abstract class Base_Host_Provider implements DNS_Provider_Interface {
 		 */
 		$values = shortcode_atts(array_flip($this->get_all_constants()), $constant_values);
 
-		foreach ($values as $constant => $value) {
-			WP_Config::get_instance()->inject_wp_config_constant($constant, $value);
-		}
+		WP_Config::get_instance()->inject_wp_config_constants($values);
 	}
 
 	/**

--- a/inc/integrations/host-providers/class-base-host-provider.php
+++ b/inc/integrations/host-providers/class-base-host-provider.php
@@ -497,7 +497,7 @@ abstract class Base_Host_Provider implements DNS_Provider_Interface {
 	 * @since 2.0.0
 	 *
 	 * @param array $constant_values Key => Value of the necessary constants.
-	 * @return void
+	 * @return bool|\WP_Error
 	 */
 	public function setup_constants($constant_values) {
 		/*
@@ -509,7 +509,7 @@ abstract class Base_Host_Provider implements DNS_Provider_Interface {
 		 */
 		$values = shortcode_atts(array_flip($this->get_all_constants()), $constant_values);
 
-		WP_Config::get_instance()->inject_wp_config_constants($values);
+		return WP_Config::get_instance()->inject_wp_config_constants($values);
 	}
 
 	/**

--- a/inc/integrations/host-providers/class-base-host-provider.php
+++ b/inc/integrations/host-providers/class-base-host-provider.php
@@ -497,7 +497,7 @@ abstract class Base_Host_Provider implements DNS_Provider_Interface {
 	 * @since 2.0.0
 	 *
 	 * @param array $constant_values Key => Value of the necessary constants.
-	 * @return bool|\WP_Error
+	 * @return void
 	 */
 	public function setup_constants($constant_values) {
 		/*
@@ -509,7 +509,9 @@ abstract class Base_Host_Provider implements DNS_Provider_Interface {
 		 */
 		$values = shortcode_atts(array_flip($this->get_all_constants()), $constant_values);
 
-		return WP_Config::get_instance()->inject_wp_config_constants($values);
+		foreach ($values as $constant => $value) {
+			WP_Config::get_instance()->inject_wp_config_constant($constant, $value);
+		}
 	}
 
 	/**

--- a/tests/WP_Ultimo/Helpers/WP_Config_Test.php
+++ b/tests/WP_Ultimo/Helpers/WP_Config_Test.php
@@ -12,6 +12,16 @@ class WP_Config_Test extends WP_UnitTestCase {
 	protected $wp_config;
 
 	/**
+	 * @var string
+	 */
+	protected $config_path;
+
+	/**
+	 * @var callable
+	 */
+	protected $config_path_filter;
+
+	/**
 	 * Set up test fixtures.
 	 */
 	public function setUp(): void {
@@ -19,6 +29,22 @@ class WP_Config_Test extends WP_UnitTestCase {
 		parent::setUp();
 
 		$this->wp_config = WP_Config::get_instance();
+	}
+
+	/**
+	 * Remove temporary configuration files.
+	 */
+	public function tearDown(): void {
+
+		if ($this->config_path_filter) {
+			remove_filter('wu_wp_config_path', $this->config_path_filter);
+		}
+
+		if ($this->config_path && file_exists($this->config_path)) {
+			wp_delete_file($this->config_path);
+		}
+
+		parent::tearDown();
 	}
 
 	/**
@@ -41,6 +67,88 @@ class WP_Config_Test extends WP_UnitTestCase {
 
 		$this->assertIsString($path);
 		$this->assertStringContainsString('.php', $path);
+	}
+
+	/**
+	 * Test duplicate constants are replaced by one authoritative definition.
+	 */
+	public function test_inject_wp_config_constants_removes_duplicates(): void {
+
+		$this->use_config_contents(
+			"<?php\n" .
+			"define( 'MULTISITE', false );\n" .
+			"  define(\n\t'MULTISITE',\n\ttrue\n);\n" .
+			"\$table_prefix = 'wp_';\n" .
+			"/* That's all, stop editing! Happy publishing. */\n" .
+			"require_once ABSPATH . 'wp-settings.php';\n"
+		);
+
+		$result = $this->wp_config->inject_wp_config_constants(
+			[
+				'MULTISITE'           => true,
+				'DOMAIN_CURRENT_SITE' => "www.roberto's.example",
+			]
+		);
+
+		$this->assertTrue($result);
+
+		$contents = file_get_contents($this->config_path); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
+
+		$this->assertSame(1, preg_match_all('/\bdefine\s*\(\s*[\'\"]MULTISITE[\'\"]/', $contents));
+		$this->assertStringContainsString("define( 'MULTISITE', true );", $contents);
+		$this->assertStringContainsString("define( 'DOMAIN_CURRENT_SITE', 'www.roberto\\'s.example' );", $contents);
+	}
+
+	/**
+	 * Test table prefix is used when the standard WordPress comment is absent.
+	 */
+	public function test_inject_wp_config_constant_uses_table_prefix_fallback(): void {
+
+		$this->use_config_contents(
+			"<?php\r\n" .
+			"\$table_prefix = 'wp_';\r\n" .
+			"require_once ABSPATH . 'wp-settings.php';\r\n"
+		);
+
+		$result   = $this->wp_config->inject_wp_config_constant('SUNRISE', true);
+		$contents = file_get_contents($this->config_path); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
+
+		$this->assertTrue($result);
+		$this->assertStringContainsString("\$table_prefix = 'wp_';\r\ndefine( 'SUNRISE', true );", $contents);
+	}
+
+	/**
+	 * Test failed syntax validation leaves the original file untouched.
+	 */
+	public function test_inject_wp_config_constant_preserves_original_on_invalid_php(): void {
+
+		$original = "<?php\ndefine( 'BROKEN', true;\n/* That's all, stop editing! Happy publishing. */\n";
+
+		$this->use_config_contents($original);
+
+		$result = $this->wp_config->inject_wp_config_constant('SUNRISE', true);
+
+		$this->assertWPError($result);
+		$this->assertSame($original, file_get_contents($this->config_path)); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
+	}
+
+	/**
+	 * Test revert removes every ordinary definition of a constant.
+	 */
+	public function test_revert_removes_duplicate_definitions(): void {
+
+		$this->use_config_contents(
+			"<?php\n" .
+			"define( 'SUNRISE', true );\n" .
+			"defined( 'SUNRISE' ) || define( 'SUNRISE', false );\n" .
+			"/* That's all, stop editing! Happy publishing. */\n"
+		);
+
+		$result   = $this->wp_config->revert('SUNRISE');
+		$contents = file_get_contents($this->config_path); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
+
+		$this->assertTrue($result);
+		$this->assertStringNotContainsString("'SUNRISE'", $contents);
 	}
 
 	/**
@@ -184,5 +292,20 @@ class WP_Config_Test extends WP_UnitTestCase {
 		$result = $this->wp_config->find_reference_hook_line($config);
 
 		$this->assertIsInt($result);
+	}
+
+	/**
+	 * Point WP_Config at a temporary fixture.
+	 *
+	 * @param string $contents Fixture contents.
+	 */
+	protected function use_config_contents($contents): void {
+
+		$this->config_path = wp_tempnam('wp-config.php');
+		file_put_contents($this->config_path, $contents); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents
+
+		$this->config_path_filter = fn() => $this->config_path;
+
+		add_filter('wu_wp_config_path', $this->config_path_filter);
 	}
 }

--- a/tests/WP_Ultimo/Helpers/WP_Config_Test.php
+++ b/tests/WP_Ultimo/Helpers/WP_Config_Test.php
@@ -152,6 +152,62 @@ class WP_Config_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Test revert preserves a user-owned false definition.
+	 */
+	public function test_revert_preserves_false_definition(): void {
+
+		$original = "<?php\ndefine( 'SUNRISE', false );\n/* That's all, stop editing! Happy publishing. */\n";
+
+		$this->use_config_contents($original);
+
+		$result = $this->wp_config->revert('SUNRISE');
+
+		$this->assertFalse($result);
+		$this->assertSame($original, file_get_contents($this->config_path)); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
+	}
+
+	/**
+	 * Test custom reference patterns remain valid transformer anchors.
+	 */
+	public function test_inject_wp_config_constant_uses_custom_reference_pattern(): void {
+
+		$this->use_config_contents("<?php\n// CUSTOM CONFIG ANCHOR\n");
+
+		$filter = static fn() => ['/^\/\/ CUSTOM CONFIG ANCHOR$/' => 0];
+		add_filter('wu_wp_config_reference_hook_line_patterns', $filter);
+
+		$result = $this->wp_config->inject_wp_config_constant('SUNRISE', true);
+
+		remove_filter('wu_wp_config_reference_hook_line_patterns', $filter);
+
+		$contents = file_get_contents($this->config_path); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
+
+		$this->assertTrue($result);
+		$this->assertStringContainsString("// CUSTOM CONFIG ANCHOR\ndefine( 'SUNRISE', true );", $contents);
+	}
+
+	/**
+	 * Test atomic replacement preserves filesystem metadata.
+	 */
+	public function test_inject_wp_config_constant_preserves_file_metadata(): void {
+
+		$this->use_config_contents("<?php\n\$table_prefix = 'wp_';\n");
+		chmod($this->config_path, 0640); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_chmod
+
+		$owner = fileowner($this->config_path); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fileowner
+		$group = filegroup($this->config_path); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_filegroup
+
+		$result = $this->wp_config->inject_wp_config_constant('SUNRISE', true);
+
+		clearstatcache(true, $this->config_path);
+
+		$this->assertTrue($result);
+		$this->assertSame(0640, fileperms($this->config_path) & 0777);
+		$this->assertSame($owner, fileowner($this->config_path)); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fileowner
+		$this->assertSame($group, filegroup($this->config_path)); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_filegroup
+	}
+
+	/**
 	 * Test inject_contents inserts at correct position.
 	 */
 	public function test_inject_contents_inserts_at_position(): void {

--- a/tests/WP_Ultimo/Helpers/WP_Config_Test.php
+++ b/tests/WP_Ultimo/Helpers/WP_Config_Test.php
@@ -12,14 +12,9 @@ class WP_Config_Test extends WP_UnitTestCase {
 	protected $wp_config;
 
 	/**
-	 * @var string
+	 * @var string[]
 	 */
-	protected $config_path;
-
-	/**
-	 * @var callable
-	 */
-	protected $config_path_filter;
+	protected $temporary_files = [];
 
 	/**
 	 * Set up test fixtures.
@@ -32,19 +27,49 @@ class WP_Config_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Remove temporary configuration files.
+	 * Clean up test fixtures.
 	 */
 	public function tearDown(): void {
 
-		if ($this->config_path_filter) {
-			remove_filter('wu_wp_config_path', $this->config_path_filter);
-		}
-
-		if ($this->config_path && file_exists($this->config_path)) {
-			wp_delete_file($this->config_path);
+		foreach ($this->temporary_files as $temporary_file) {
+			unlink($temporary_file);
 		}
 
 		parent::tearDown();
+	}
+
+	/**
+	 * Test injecting a constant does not create another definition.
+	 */
+	public function test_inject_wp_config_constant_does_not_create_duplicate(): void {
+
+		$wp_config = $this->create_testable_wp_config(
+			"<?php\n\n/* That's all, stop editing! Happy publishing. */\n"
+		);
+
+		$this->assertTrue($wp_config->inject_wp_config_constant('WU_TEST_CONSTANT', true));
+		$this->assertTrue($wp_config->inject_wp_config_constant('WU_TEST_CONSTANT', false));
+
+		$contents = file_get_contents($wp_config->get_wp_config_path());
+
+		$this->assertSame(1, substr_count($contents, 'WU_TEST_CONSTANT'));
+		$this->assertStringContainsString("define( 'WU_TEST_CONSTANT', false );", $contents);
+	}
+
+	/**
+	 * Test updating a constant does not remove existing definitions.
+	 */
+	public function test_inject_wp_config_constant_does_not_remove_existing_definitions(): void {
+
+		$wp_config = $this->create_testable_wp_config(
+			"<?php\n\ndefine( 'WU_TEST_CONSTANT', false );\ndefine( 'WU_TEST_CONSTANT', true );\n\n/* That's all, stop editing! Happy publishing. */\n"
+		);
+
+		$this->assertTrue($wp_config->inject_wp_config_constant('WU_TEST_CONSTANT', false));
+
+		$contents = file_get_contents($wp_config->get_wp_config_path());
+
+		$this->assertSame(2, substr_count($contents, 'WU_TEST_CONSTANT'));
 	}
 
 	/**
@@ -70,342 +95,74 @@ class WP_Config_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Test duplicate constants are replaced by one authoritative definition.
+	 * Test reverting a constant delegates to WPConfigTransformer.
 	 */
-	public function test_inject_wp_config_constants_removes_duplicates(): void {
+	public function test_revert_removes_constant(): void {
 
-		$this->use_config_contents(
-			"<?php\n" .
-			"define( 'MULTISITE', false );\n" .
-			"  define(\n\t'MULTISITE',\n\ttrue\n);\n" .
-			"\$table_prefix = 'wp_';\n" .
-			"/* That's all, stop editing! Happy publishing. */\n" .
-			"require_once ABSPATH . 'wp-settings.php';\n"
+		$wp_config = $this->create_testable_wp_config(
+			"<?php\n\ndefine( 'WU_TEST_CONSTANT', true );\n\n/* That's all, stop editing! Happy publishing. */\n"
 		);
 
-		$result = $this->wp_config->inject_wp_config_constants(
-			[
-				'MULTISITE'           => true,
-				'DOMAIN_CURRENT_SITE' => "www.roberto's.example",
-			]
-		);
+		$this->assertTrue($wp_config->revert('WU_TEST_CONSTANT'));
 
-		$this->assertTrue($result);
+		$contents = file_get_contents($wp_config->get_wp_config_path());
 
-		$contents = file_get_contents($this->config_path); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
-
-		$this->assertSame(1, preg_match_all('/\bdefine\s*\(\s*[\'\"]MULTISITE[\'\"]/', $contents));
-		$this->assertStringContainsString("define( 'MULTISITE', true );", $contents);
-		$this->assertStringContainsString("define( 'DOMAIN_CURRENT_SITE', 'www.roberto\\'s.example' );", $contents);
+		$this->assertStringNotContainsString('WU_TEST_CONSTANT', $contents);
 	}
 
 	/**
-	 * Test table prefix is used when the standard WordPress comment is absent.
+	 * Test inject_contents remains as a deprecated no-op.
 	 */
-	public function test_inject_wp_config_constant_uses_table_prefix_fallback(): void {
-
-		$this->use_config_contents(
-			"<?php\r\n" .
-			"\$table_prefix = 'wp_';\r\n" .
-			"require_once ABSPATH . 'wp-settings.php';\r\n"
-		);
-
-		$result   = $this->wp_config->inject_wp_config_constant('SUNRISE', true);
-		$contents = file_get_contents($this->config_path); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
-
-		$this->assertTrue($result);
-		$this->assertStringContainsString("\$table_prefix = 'wp_';\r\ndefine( 'SUNRISE', true );", $contents);
-	}
-
-	/**
-	 * Test failed syntax validation leaves the original file untouched.
-	 */
-	public function test_inject_wp_config_constant_preserves_original_on_invalid_php(): void {
-
-		$original = "<?php\ndefine( 'BROKEN', true;\n/* That's all, stop editing! Happy publishing. */\n";
-
-		$this->use_config_contents($original);
-
-		$result = $this->wp_config->inject_wp_config_constant('SUNRISE', true);
-
-		$this->assertWPError($result);
-		$this->assertSame($original, file_get_contents($this->config_path)); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
-	}
-
-	/**
-	 * Test revert reports invalid PHP without changing the original file.
-	 */
-	public function test_revert_preserves_original_on_invalid_php(): void {
-
-		$original = "<?php\ndefine( 'SUNRISE', true ); // Ultimate Multisite managed\nif (\n";
-
-		$this->use_config_contents($original);
-
-		$result = $this->wp_config->revert('SUNRISE');
-
-		$this->assertWPError($result);
-		$this->assertSame('wp-config-transform-failed', $result->get_error_code());
-		$this->assertSame($original, file_get_contents($this->config_path)); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
-	}
-
-	/**
-	 * Test revert refuses to remove ambiguous mixed definitions.
-	 */
-	public function test_revert_preserves_mixed_duplicate_definitions(): void {
-
-		$original =
-			"<?php\n" .
-			"define( 'SUNRISE', true );\n" .
-			"defined( 'SUNRISE' ) || define( 'SUNRISE', false );\n" .
-			"/* That's all, stop editing! Happy publishing. */\n";
-
-		$this->use_config_contents($original);
-
-		$result = $this->wp_config->revert('SUNRISE');
-
-		$this->assertFalse($result);
-		$this->assertSame($original, file_get_contents($this->config_path)); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
-	}
-
-	/**
-	 * Test revert preserves a user-owned false definition.
-	 */
-	public function test_revert_preserves_false_definition(): void {
-
-		$original = "<?php\ndefine( 'SUNRISE', false );\n/* That's all, stop editing! Happy publishing. */\n";
-
-		$this->use_config_contents($original);
-
-		$result = $this->wp_config->revert('SUNRISE');
-
-		$this->assertFalse($result);
-		$this->assertSame($original, file_get_contents($this->config_path)); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
-	}
-
-	/**
-	 * Test revert preserves a user-owned true definition without the managed marker.
-	 */
-	public function test_revert_preserves_user_owned_true_definition(): void {
-
-		$original = "<?php\ndefine( 'SUNRISE', true );\n/* That's all, stop editing! Happy publishing. */\n";
-
-		$this->use_config_contents($original);
-
-		$result = $this->wp_config->revert('SUNRISE');
-
-		$this->assertFalse($result);
-		$this->assertSame($original, file_get_contents($this->config_path)); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
-	}
-
-	/**
-	 * Test revert removes a single managed true definition.
-	 */
-	public function test_revert_removes_managed_definition(): void {
-
-		$this->use_config_contents("<?php\n\$table_prefix = 'wp_';\n");
-
-		$this->assertTrue($this->wp_config->inject_wp_config_constant('SUNRISE', true));
-		$this->assertTrue($this->wp_config->revert('SUNRISE'));
-		$this->assertStringNotContainsString("'SUNRISE'", file_get_contents($this->config_path)); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
-	}
-
-	/**
-	 * Test custom reference patterns remain valid transformer anchors.
-	 */
-	public function test_inject_wp_config_constant_uses_custom_reference_pattern(): void {
-
-		$this->use_config_contents("<?php\n// CUSTOM CONFIG ANCHOR\n\$table_prefix = 'wp_';\n/* That's all, stop editing! Happy publishing. */\n");
-
-		$filter = static fn() => ['/^\/\/ CUSTOM CONFIG ANCHOR$/' => 0];
-		add_filter('wu_wp_config_reference_hook_line_patterns', $filter);
-
-		$result = $this->wp_config->inject_wp_config_constant('SUNRISE', true);
-
-		remove_filter('wu_wp_config_reference_hook_line_patterns', $filter);
-
-		$contents = file_get_contents($this->config_path); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
-
-		$this->assertTrue($result);
-		$this->assertStringContainsString("// CUSTOM CONFIG ANCHOR\ndefine( 'SUNRISE', true ); // Ultimate Multisite managed", $contents);
-		$this->assertStringNotContainsString("\$table_prefix = 'wp_';\ndefine( 'SUNRISE', true );", $contents);
-	}
-
-	/**
-	 * Test atomic replacement preserves owner, group, and mode metadata.
-	 */
-	public function test_inject_wp_config_constant_preserves_file_metadata(): void {
-
-		$this->use_config_contents("<?php\n\$table_prefix = 'wp_';\n");
-		chmod($this->config_path, 0640); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_chmod
-
-		$owner = fileowner($this->config_path); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fileowner
-		$group = filegroup($this->config_path); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_filegroup
-
-		$result = $this->wp_config->inject_wp_config_constant('SUNRISE', true);
-
-		clearstatcache(true, $this->config_path);
-
-		$this->assertTrue($result);
-		$this->assertSame(0640, fileperms($this->config_path) & 0777);
-		$this->assertSame($owner, fileowner($this->config_path)); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fileowner
-		$this->assertSame($group, filegroup($this->config_path)); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_filegroup
-	}
-
-	/**
-	 * Test inject_contents inserts at correct position.
-	 */
-	public function test_inject_contents_inserts_at_position(): void {
+	public function test_inject_contents_is_deprecated_noop(): void {
 
 		$content = ['line1', 'line2', 'line3'];
 
-		$result = $this->wp_config->inject_contents($content, 1, 'inserted');
+		$this->setExpectedIncorrectUsage(WP_Config::class . '::inject_contents');
 
-		$this->assertCount(4, $result);
-		$this->assertEquals('line1', $result[0]);
-		$this->assertEquals('inserted', $result[1]);
-		$this->assertEquals('line2', $result[2]);
-		$this->assertEquals('line3', $result[3]);
+		$this->assertSame($content, $this->wp_config->inject_contents($content, 1, 'inserted'));
 	}
 
 	/**
-	 * Test inject_contents at beginning.
+	 * Test find_injected_line remains as a deprecated no-op.
 	 */
-	public function test_inject_contents_at_beginning(): void {
+	public function test_find_injected_line_is_deprecated_noop(): void {
 
-		$content = ['line1', 'line2'];
+		$this->setExpectedIncorrectUsage(WP_Config::class . '::find_injected_line');
 
-		$result = $this->wp_config->inject_contents($content, 0, 'first');
-
-		$this->assertCount(3, $result);
-		$this->assertEquals('first', $result[0]);
-		$this->assertEquals('line1', $result[1]);
+		$this->assertFalse($this->wp_config->find_injected_line([], 'WU_TEST_CONSTANT'));
 	}
 
 	/**
-	 * Test inject_contents at end.
+	 * Test find_reference_hook_line remains as a deprecated no-op.
 	 */
-	public function test_inject_contents_at_end(): void {
+	public function test_find_reference_hook_line_is_deprecated_noop(): void {
 
-		$content = ['line1', 'line2'];
+		$this->setExpectedIncorrectUsage(WP_Config::class . '::find_reference_hook_line');
 
-		$result = $this->wp_config->inject_contents($content, 2, 'last');
-
-		$this->assertCount(3, $result);
-		$this->assertEquals('last', $result[2]);
+		$this->assertFalse($this->wp_config->find_reference_hook_line([]));
 	}
 
 	/**
-	 * Test inject_contents with array value.
-	 */
-	public function test_inject_contents_with_array_value(): void {
-
-		$content = ['line1', 'line3'];
-
-		$result = $this->wp_config->inject_contents($content, 1, ['line2a', 'line2b']);
-
-		$this->assertCount(4, $result);
-		$this->assertEquals('line2a', $result[1]);
-		$this->assertEquals('line2b', $result[2]);
-	}
-
-	/**
-	 * Test find_injected_line finds existing constant.
-	 */
-	public function test_find_injected_line_finds_constant(): void {
-
-		$config = [
-			"<?php\n",
-			"define( 'WP_DEBUG', false );\n",
-			"define( 'WU_TEST_CONSTANT', 'test_value' ); // Automatically injected\n",
-			"\$table_prefix = 'wp_';\n",
-		];
-
-		$result = $this->wp_config->find_injected_line($config, 'WU_TEST_CONSTANT');
-
-		$this->assertIsArray($result);
-		$this->assertEquals(2, $result[1]);
-	}
-
-	/**
-	 * Test find_injected_line returns false for missing constant.
-	 */
-	public function test_find_injected_line_returns_false_for_missing(): void {
-
-		$config = [
-			"<?php\n",
-			"define( 'WP_DEBUG', false );\n",
-		];
-
-		$result = $this->wp_config->find_injected_line($config, 'NONEXISTENT_CONSTANT');
-
-		$this->assertFalse($result);
-	}
-
-	/**
-	 * Test find_reference_hook_line finds table_prefix line.
-	 */
-	public function test_find_reference_hook_line_finds_table_prefix(): void {
-
-		global $wpdb;
-
-		$config = [
-			"<?php\n",
-			"define( 'DB_NAME', 'wordpress' );\n",
-			"\$table_prefix = '{$wpdb->prefix}';\n",
-			"require_once ABSPATH . 'wp-settings.php';\n",
-		];
-
-		$result = $this->wp_config->find_reference_hook_line($config);
-
-		$this->assertIsInt($result);
-		$this->assertEquals(2, $result);
-	}
-
-	/**
-	 * Test find_reference_hook_line finds Happy Publishing comment.
-	 */
-	public function test_find_reference_hook_line_finds_happy_publishing(): void {
-
-		$config = [
-			"<?php\n",
-			"define( 'DB_NAME', 'wordpress' );\n",
-			"/* That's all, stop editing! Happy publishing. */\n",
-			"require_once ABSPATH . 'wp-settings.php';\n",
-		];
-
-		$result = $this->wp_config->find_reference_hook_line($config);
-
-		// The Happy Publishing pattern uses -2 offset
-		$this->assertIsInt($result);
-	}
-
-	/**
-	 * Test find_reference_hook_line finds php opening tag as fallback.
-	 */
-	public function test_find_reference_hook_line_finds_php_tag_fallback(): void {
-
-		$config = [
-			"<?php\n",
-			"// Some custom config\n",
-		];
-
-		$result = $this->wp_config->find_reference_hook_line($config);
-
-		$this->assertIsInt($result);
-	}
-
-	/**
-	 * Point WP_Config at a temporary fixture.
+	 * Create a WP_Config mock backed by a temporary wp-config.php file.
 	 *
-	 * @param string $contents Fixture contents.
+	 * @param string $contents Config file contents.
+	 * @return WP_Config
 	 */
-	protected function use_config_contents($contents): void {
+	protected function create_testable_wp_config($contents) {
 
-		$this->config_path = wp_tempnam('wp-config.php');
-		file_put_contents($this->config_path, $contents); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents
+		$config_path = tempnam(sys_get_temp_dir(), 'wu-wp-config-');
 
-		$this->config_path_filter = fn() => $this->config_path;
+		file_put_contents($config_path, $contents);
 
-		add_filter('wu_wp_config_path', $this->config_path_filter);
+		$this->temporary_files[] = $config_path;
+
+		$wp_config = $this->getMockBuilder(WP_Config::class)
+			->disableOriginalConstructor()
+			->onlyMethods(['get_wp_config_path'])
+			->getMock();
+
+		$wp_config->method('get_wp_config_path')->willReturn($config_path);
+
+		return $wp_config;
 	}
 }

--- a/tests/WP_Ultimo/Helpers/WP_Config_Test.php
+++ b/tests/WP_Ultimo/Helpers/WP_Config_Test.php
@@ -167,6 +167,18 @@ class WP_Config_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Test revert removes a single managed true definition.
+	 */
+	public function test_revert_removes_managed_definition(): void {
+
+		$this->use_config_contents("<?php\n\$table_prefix = 'wp_';\n");
+
+		$this->assertTrue($this->wp_config->inject_wp_config_constant('SUNRISE', true));
+		$this->assertTrue($this->wp_config->revert('SUNRISE'));
+		$this->assertStringNotContainsString("'SUNRISE'", file_get_contents($this->config_path)); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
+	}
+
+	/**
 	 * Test custom reference patterns remain valid transformer anchors.
 	 */
 	public function test_inject_wp_config_constant_uses_custom_reference_pattern(): void {

--- a/tests/WP_Ultimo/Helpers/WP_Config_Test.php
+++ b/tests/WP_Ultimo/Helpers/WP_Config_Test.php
@@ -133,22 +133,22 @@ class WP_Config_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Test revert removes every ordinary definition of a constant.
+	 * Test revert refuses to remove ambiguous mixed definitions.
 	 */
-	public function test_revert_removes_duplicate_definitions(): void {
+	public function test_revert_preserves_mixed_duplicate_definitions(): void {
 
-		$this->use_config_contents(
+		$original =
 			"<?php\n" .
 			"define( 'SUNRISE', true );\n" .
 			"defined( 'SUNRISE' ) || define( 'SUNRISE', false );\n" .
-			"/* That's all, stop editing! Happy publishing. */\n"
-		);
+			"/* That's all, stop editing! Happy publishing. */\n";
 
-		$result   = $this->wp_config->revert('SUNRISE');
-		$contents = file_get_contents($this->config_path); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
+		$this->use_config_contents($original);
 
-		$this->assertTrue($result);
-		$this->assertStringNotContainsString("'SUNRISE'", $contents);
+		$result = $this->wp_config->revert('SUNRISE');
+
+		$this->assertFalse($result);
+		$this->assertSame($original, file_get_contents($this->config_path)); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
 	}
 
 	/**
@@ -171,7 +171,7 @@ class WP_Config_Test extends WP_UnitTestCase {
 	 */
 	public function test_inject_wp_config_constant_uses_custom_reference_pattern(): void {
 
-		$this->use_config_contents("<?php\n// CUSTOM CONFIG ANCHOR\n");
+		$this->use_config_contents("<?php\n// CUSTOM CONFIG ANCHOR\n\$table_prefix = 'wp_';\n/* That's all, stop editing! Happy publishing. */\n");
 
 		$filter = static fn() => ['/^\/\/ CUSTOM CONFIG ANCHOR$/' => 0];
 		add_filter('wu_wp_config_reference_hook_line_patterns', $filter);
@@ -183,7 +183,8 @@ class WP_Config_Test extends WP_UnitTestCase {
 		$contents = file_get_contents($this->config_path); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
 
 		$this->assertTrue($result);
-		$this->assertStringContainsString("// CUSTOM CONFIG ANCHOR\ndefine( 'SUNRISE', true );", $contents);
+		$this->assertStringContainsString("// CUSTOM CONFIG ANCHOR\ndefine( 'SUNRISE', true ); // Ultimate Multisite managed", $contents);
+		$this->assertStringNotContainsString("\$table_prefix = 'wp_';\ndefine( 'SUNRISE', true );", $contents);
 	}
 
 	/**

--- a/tests/WP_Ultimo/Helpers/WP_Config_Test.php
+++ b/tests/WP_Ultimo/Helpers/WP_Config_Test.php
@@ -133,6 +133,22 @@ class WP_Config_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Test revert reports invalid PHP without changing the original file.
+	 */
+	public function test_revert_preserves_original_on_invalid_php(): void {
+
+		$original = "<?php\ndefine( 'SUNRISE', true ); // Ultimate Multisite managed\nif (\n";
+
+		$this->use_config_contents($original);
+
+		$result = $this->wp_config->revert('SUNRISE');
+
+		$this->assertWPError($result);
+		$this->assertSame('wp-config-transform-failed', $result->get_error_code());
+		$this->assertSame($original, file_get_contents($this->config_path)); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
+	}
+
+	/**
 	 * Test revert refuses to remove ambiguous mixed definitions.
 	 */
 	public function test_revert_preserves_mixed_duplicate_definitions(): void {

--- a/tests/WP_Ultimo/Helpers/WP_Config_Test.php
+++ b/tests/WP_Ultimo/Helpers/WP_Config_Test.php
@@ -167,6 +167,21 @@ class WP_Config_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Test revert preserves a user-owned true definition without the managed marker.
+	 */
+	public function test_revert_preserves_user_owned_true_definition(): void {
+
+		$original = "<?php\ndefine( 'SUNRISE', true );\n/* That's all, stop editing! Happy publishing. */\n";
+
+		$this->use_config_contents($original);
+
+		$result = $this->wp_config->revert('SUNRISE');
+
+		$this->assertFalse($result);
+		$this->assertSame($original, file_get_contents($this->config_path)); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
+	}
+
+	/**
 	 * Test revert removes a single managed true definition.
 	 */
 	public function test_revert_removes_managed_definition(): void {
@@ -200,7 +215,7 @@ class WP_Config_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Test atomic replacement preserves filesystem metadata.
+	 * Test atomic replacement preserves owner, group, and mode metadata.
 	 */
 	public function test_inject_wp_config_constant_preserves_file_metadata(): void {
 


### PR DESCRIPTION
## Summary

- add `wp-cli/wp-config-transformer` as a runtime dependency
- delegate constant writes directly to `WPConfigTransformer::update()` so missing constants are added and existing constants are updated without creating another definition
- delegate `revert()` to `WPConfigTransformer::remove()`
- keep legacy public parsing helpers as deprecated compatibility no-ops with `_doing_it_wrong()` notices

## Implementation

- `inc/helpers/class-wp-config.php`: retains the public write, revert, and path methods; removes custom parsing and mutation behavior
- multisite and host-provider setup continue calling `inject_wp_config_constant()` once per constant
- `tests/WP_Ultimo/Helpers/WP_Config_Test.php`: covers add/update behavior, preservation of existing duplicate definitions, transformer-backed removal, and deprecated no-op compatibility methods
- searched 29 available addon repositories plus the CAPTCHA checkout and addon template; none call `WP_Config`

## Verification

- `vendor/bin/phpunit --filter WP_Config_Test`: 8 tests, 17 assertions
- scoped PHPCS passed for the helper and callers
- scoped PHPStan passed
- `composer validate --strict --no-check-publish` passed with existing project metadata warnings
- pre-commit PHPCS and PHPStan hooks passed

<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.306 plugin for [OpenCode](https://opencode.ai) v1.18.29 with gpt-5.6-sol spent 2h 5m and 459,679 tokens on this with the user in an interactive session.
