### PR TITLE
GH#1756: fix: remediate js-yaml dependency alert

### DIFF
--- a/package.json
+++ b/package.json
@@ -109,7 +109,7 @@
   "overrides": {
     "@babel/core": "7.29.6",
     "glob": "^10.5.0",
-    "js-yaml": "4.3.0",
+    "js-yaml": "4.3.1",
     "minimatch@^3": "3.1.4",
     "minimatch@^9": "9.0.9",
     "picomatch": "4.0.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,6 +6,7 @@ settings:
 
 overrides:
   '@babel/core': 7.29.6
+  js-yaml: 4.3.1
   postcss: 8.5.23
   uuid: 11.1.1
 
@@ -2628,8 +2629,8 @@ packages:
     resolution: {integrity: sha512-S99WuO3HlhO3XN41EtYUNl9zzXjoJx7QvmipxsJVxtCBT0YHEFy+iOJhjSvrmV12nYhWpZaM8lPHkJm0yUMbag==}
     hasBin: true
 
-  js-yaml@4.3.0:
-    resolution: {integrity: sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==}
+  js-yaml@4.3.1:
+    resolution: {integrity: sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==}
     hasBin: true
 
   jsbn@0.1.1:
@@ -4680,7 +4681,7 @@ snapshots:
       globals: 13.24.0
       ignore: 5.3.2
       import-fresh: 3.3.1
-      js-yaml: 4.3.0
+      js-yaml: 4.3.1
       minimatch: 3.1.4
       strip-json-comments: 3.1.1
     transitivePeerDependencies:
@@ -5726,7 +5727,7 @@ snapshots:
     dependencies:
       env-paths: 2.2.1
       import-fresh: 3.3.1
-      js-yaml: 4.3.0
+      js-yaml: 4.3.1
       parse-json: 5.2.0
     optionalDependencies:
       typescript: 5.9.3
@@ -6234,7 +6235,7 @@ snapshots:
       imurmurhash: 0.1.4
       is-glob: 4.0.3
       is-path-inside: 3.0.3
-      js-yaml: 4.3.0
+      js-yaml: 4.3.1
       json-stable-stringify-without-jsonify: 1.0.1
       levn: 0.4.1
       lodash.merge: 4.6.2
@@ -6812,7 +6813,7 @@ snapshots:
       argparse: 1.0.10
       esprima: 4.0.1
 
-  js-yaml@4.3.0:
+  js-yaml@4.3.1:
     dependencies:
       argparse: 2.0.1
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -6,5 +6,6 @@ allowBuilds:
 
 overrides:
   '@babel/core': 7.29.6
+  js-yaml: 4.3.1
   postcss: 8.5.23
   uuid: 11.1.1


### PR DESCRIPTION
## Summary

Updated the npm and pnpm js-yaml overrides and refreshed the pnpm lock resolution to 4.3.1.

## Files Changed

package.json, pnpm-lock.yaml, pnpm-workspace.yaml

## Runtime Testing

- **Risk level:** Medium
- **Verification:** self-assessed — pnpm install --lockfile-only --frozen-lockfile --ignore-scripts; pnpm audit --json (no js-yaml advisory); pnpm run quality

Resolves #1756


<!-- aidevops:origin:worker -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.317 plugin for [OpenCode](https://opencode.ai) v1.18.29 with gpt-5.6-terra spent 3d 23h and 12,134,574 tokens on this as a headless worker.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the bundled `js-yaml` version to 4.3.1 for improved dependency maintenance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->