### PR TITLE
fix(sso): detect direct custom domains for magic links

### DIFF
--- a/inc/sso/class-magic-link.php
+++ b/inc/sso/class-magic-link.php
@@ -402,21 +402,27 @@ class Magic_Link {
 			return false;
 		}
 
-		// Check if site has a primary mapped domain.
+		// Prefer the primary mapped domain, but fall back to the site's active URL.
+		// Some multisite configurations store custom domains directly in wp_blogs.
 		$primary_domain = $site->get_primary_mapped_domain();
-
-		if ( ! $primary_domain ) {
-			return false;
-		}
 
 		// Get the main site domain.
 		$main_site_domain = wp_parse_url(get_site_url(wu_get_main_site_id()), PHP_URL_HOST);
 
-		// Get the custom domain.
-		$custom_domain = $primary_domain->get_domain();
+		// Get the target domain.
+		$site_domain = $primary_domain
+			? $primary_domain->get_domain()
+			: wp_parse_url($site->get_active_site_url(), PHP_URL_HOST);
 
-		// If not a subdomain we need a magic link
-		return ! str_ends_with($custom_domain, $main_site_domain);
+		if ( ! $main_site_domain || ! $site_domain ) {
+			return false;
+		}
+
+		$main_site_domain = strtolower(rtrim($main_site_domain, '.'));
+		$site_domain      = strtolower(rtrim($site_domain, '.'));
+
+		// Sites on the main domain or one of its subdomains share authentication cookies.
+		return $site_domain !== $main_site_domain && ! str_ends_with($site_domain, '.' . $main_site_domain);
 	}
 
 	/**

--- a/tests/WP_Ultimo/SSO/Magic_Link_Test.php
+++ b/tests/WP_Ultimo/SSO/Magic_Link_Test.php
@@ -491,6 +491,37 @@ class Magic_Link_Test extends \WP_UnitTestCase {
 	}
 
 	/**
+	 * Test site_needs_magic_link detects a custom domain stored directly on the site.
+	 */
+	public function test_site_needs_magic_link_direct_custom_domain() {
+
+		$site_id = self::factory()->blog->create(
+			[
+				'domain' => 'direct-domain.example.test',
+				'path'   => '/',
+			]
+		);
+
+		$this->assertTrue($this->get_instance()->site_needs_magic_link($site_id));
+	}
+
+	/**
+	 * Test site_needs_magic_link excludes subdomains of the main site.
+	 */
+	public function test_site_needs_magic_link_main_site_subdomain() {
+
+		$main_site_domain = wp_parse_url(get_site_url(wu_get_main_site_id()), PHP_URL_HOST);
+		$site_id          = self::factory()->blog->create(
+			[
+				'domain' => 'customer.' . $main_site_domain,
+				'path'   => '/',
+			]
+		);
+
+		$this->assertFalse($this->get_instance()->site_needs_magic_link($site_id));
+	}
+
+	/**
 	 * Test maybe_convert_to_magic_link returns original URL when disabled.
 	 */
 	public function test_maybe_convert_to_magic_link_disabled() {

--- a/tests/WP_Ultimo/SSO/Magic_Link_Test.php
+++ b/tests/WP_Ultimo/SSO/Magic_Link_Test.php
@@ -495,14 +495,15 @@ class Magic_Link_Test extends \WP_UnitTestCase {
 	 */
 	public function test_site_needs_magic_link_direct_custom_domain() {
 
-		$site_id = self::factory()->blog->create(
+		$site = wu_create_site(
 			[
 				'domain' => 'direct-domain.example.test',
 				'path'   => '/',
 			]
 		);
 
-		$this->assertTrue($this->get_instance()->site_needs_magic_link($site_id));
+		$this->assertNotWPError($site);
+		$this->assertTrue($this->get_instance()->site_needs_magic_link($site->get_id()));
 	}
 
 	/**
@@ -511,14 +512,15 @@ class Magic_Link_Test extends \WP_UnitTestCase {
 	public function test_site_needs_magic_link_main_site_subdomain() {
 
 		$main_site_domain = wp_parse_url(get_site_url(wu_get_main_site_id()), PHP_URL_HOST);
-		$site_id          = self::factory()->blog->create(
+		$site             = wu_create_site(
 			[
 				'domain' => 'customer.' . $main_site_domain,
 				'path'   => '/',
 			]
 		);
 
-		$this->assertFalse($this->get_instance()->site_needs_magic_link($site_id));
+		$this->assertNotWPError($site);
+		$this->assertFalse($this->get_instance()->site_needs_magic_link($site->get_id()));
 	}
 
 	/**


### PR DESCRIPTION
## Summary

- detect custom domains stored directly in `wp_blogs` when no primary domain-mapping record exists
- normalize hostnames and distinguish the main domain and its real subdomains from unrelated suffix matches
- add regression coverage for direct custom domains and main-domain subdomains

## Verification

- `vendor/bin/phpunit --filter Magic_Link_Test` — 33 tests, 42 assertions
- `vendor/bin/phpcs inc/sso/class-magic-link.php tests/WP_Ultimo/SSO/Magic_Link_Test.php`
- `vendor/bin/phpstan analyse inc/sso/class-magic-link.php --no-progress`
- `git diff --check`

---
<!-- aidevops:sig -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved magic-link domain detection when a site lacks a primary mapped domain by using its active URL.
  - Standardized domain comparisons by handling capitalization and trailing dots consistently.
  - Prevented magic links from being incorrectly required for subdomains of the main site.
  - Added safeguards for missing domain information and domains that only partially match the main domain.

- **Tests**
  - Added coverage for direct custom domains and main-site subdomains.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->