### PR TITLE
fix(i18n): normalize translator comments

### DIFF
--- a/inc/integrations/host-providers/class-base-host-provider.php
+++ b/inc/integrations/host-providers/class-base-host-provider.php
@@ -288,7 +288,7 @@ abstract class Base_Host_Provider implements DNS_Provider_Interface {
 
 		$actions = [
 			'activate' => [
-				// translators: %s is the integration name
+				// translators: %s is the integration name.
 				'title' => sprintf(__('Setup %s', 'ultimate-multisite'), $this->get_title()),
 				'url'   => wu_network_admin_url(
 					'wp-ultimo-hosting-integration-wizard',
@@ -565,7 +565,7 @@ abstract class Base_Host_Provider implements DNS_Provider_Interface {
 
 		$explainer_lines = [
 			'will'     => [
-				// translators: %s is the name of the integration e.g. RunCloud
+				// translators: %s: hosting provider name.
 				'send_domains' => sprintf(__('Send API calls to %s servers with domain names added to this network', 'ultimate-multisite'), $this->get_title()),
 			],
 			'will_not' => [],
@@ -573,11 +573,11 @@ abstract class Base_Host_Provider implements DNS_Provider_Interface {
 
 		if ($this->supports('autossl')) {
 
-			// translators: %s is the name of the integration e.g. RunCloud
+			// translators: %s: hosting provider name.
 			$explainer_lines['will'][] = sprintf(__('Fetch and install a SSL certificate on %s platform after the domain is added.', 'ultimate-multisite'), $this->get_title());
 		} else {
 
-			// translators: %s is the name of the integration e.g. RunCloud
+			// translators: %s: hosting provider name.
 			$explainer_lines['will_not'][] = sprintf(__('Fetch and install a SSL certificate on %s platform after the domain is added. This needs to be done manually.', 'ultimate-multisite'), $this->get_title());
 		}
 

--- a/views/base/addons/details.php
+++ b/views/base/addons/details.php
@@ -75,7 +75,7 @@ style="background-image:url(<?php echo esc_url($addon->images[0]['thumbnail']); 
 
 						<li>
 							<strong><?php esc_html_e('Requires Ultimate Multisite Version:', 'ultimate-multisite'); ?></strong>
-							<?php // translators: %s minimun required version number. ?>
+							<?php // translators: %s minimum required version number. ?>
 							<?php printf(esc_html__('%s or higher', 'ultimate-multisite'), esc_html($addon->requires_version)); ?>
 						</li>
 

--- a/views/checkout/paypal/confirm.php
+++ b/views/checkout/paypal/confirm.php
@@ -36,7 +36,7 @@ if ($membership->is_recurring() && $should_auto_renew) {
 		if ($original_cart->get_cart_type() === 'downgrade') {
 			$subtotal = wu_format_currency($payment->get_subtotal(), $payment->get_currency());
 			if ($is_trial_setup) {
-				// translators: %1$s is the start date, %2$s is the subtotal amount, and %3$s is the description of how often.
+				// translators: %1$s the date membership will start, %2$s amount to be billed, %3$s the description of how often.
 				$notes[] = sprintf(__('Your updated membership will start on %1$s, from that date you will be billed %2$s %3$s.', 'ultimate-multisite'), $date, $subtotal, $desc);
 			} else {
 				$date_renew = wp_date(get_option('date_format'), strtotime($membership->get_date_expiration(), wu_get_current_time('timestamp', true)));

--- a/views/checkout/templates/pricing-table/legacy.php
+++ b/views/checkout/templates/pricing-table/legacy.php
@@ -308,7 +308,7 @@ if (null !== $first_recurring_product) {
 				$prices_total = [
 					3  => __('every 3 months', 'ultimate-multisite'),
 					6  => sprintf(
-						// translators: %1$s: the duration number, %2$s: the duration unit.
+						// translators: %1$s: the duration number, %2$s: the duration unit (days, weeks, months, etc).
 						__('every %1$s %2$s', 'ultimate-multisite'),
 						6,
 						wu_get_translatable_string('months')

--- a/views/wizards/paypal-setup/instructions.php
+++ b/views/wizards/paypal-setup/instructions.php
@@ -18,8 +18,8 @@ $mode_label = $sandbox_mode
 
 <p class="wu-text-lg wu-text-gray-600 wu-my-4 wu-mb-6">
 	<?php
-	/* translators: %s: "Sandbox" or "Live" */
 	printf(
+		/* translators: %s: "Sandbox" or "Live" */
 		esc_html__('Follow these four steps to copy a Client ID and Secret out of the PayPal Developer Dashboard. You are setting up the %s environment.', 'ultimate-multisite'),
 		'<strong>' . esc_html($mode_label) . '</strong>'
 	);


### PR DESCRIPTION
## Summary

- normalize translator comments shared by repeated source strings
- move the PayPal setup placeholder comment next to its translation call
- eliminate duplicate-comment and missing-comment warnings from POT generation

## Verification

- `npm run makepot` — completed without warnings
- `vendor/bin/phpcs inc/integrations/host-providers/class-base-host-provider.php views/base/addons/details.php views/checkout/paypal/confirm.php views/checkout/templates/pricing-table/legacy.php views/wizards/paypal-setup/instructions.php`
- `vendor/bin/phpstan analyse inc/integrations/host-providers/class-base-host-provider.php views/base/addons/details.php views/checkout/paypal/confirm.php views/checkout/templates/pricing-table/legacy.php views/wizards/paypal-setup/instructions.php --no-progress`
- pre-commit PHPCS and PHPStan hooks

## Notes

The generated POT file is omitted because `npm run makepot` currently produces substantial unrelated template drift.

<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.317 plugin for [OpenCode](https://opencode.ai) v1.18.29 with gpt-5.6-sol spent 10m and 98,350 tokens on this with the user in an interactive session.