### PR TITLE
fix(setup): show footer credit options after toggle

### DIFF
--- a/inc/admin-pages/class-setup-wizard-admin-page.php
+++ b/inc/admin-pages/class-setup-wizard-admin-page.php
@@ -976,13 +976,14 @@ class Setup_Wizard_Admin_Page extends Wizard_Admin_Page {
 
 			wp_add_inline_script('wu-setup-wizard-extra', 'document.addEventListener("DOMContentLoaded", () => wu_initialize_imagepicker());', 'after');
 
-			// All these just so the toggle of footer credits shows the other options.
 			wp_register_script('wu-vue', wu_get_asset('lib/vue.js', 'js'), [], wu_get_version(), true);
 			wp_register_script('wu-money-mask', wu_get_asset('lib/v-money.js', 'js'), ['wu-vue'], wu_get_version(), true);
 			wp_register_script('wu-input-mask', wu_get_asset('lib/vue-the-mask.js', 'js'), ['wu-vue'], wu_get_version(), true);
 			wp_register_script('wu-vue-apps', wu_get_asset('vue-apps.js', 'js'), ['wu-functions', 'wu-vue', 'wu-money-mask', 'wu-input-mask', 'wp-hooks'], wu_get_version(), true);
-			wp_enqueue_script('wu-vue-apps');
 		}
+
+		// Required for conditional settings fields, including the footer credit options.
+		wp_enqueue_script('wu-vue-apps');
 
 		wp_enqueue_script('wu-setup-wizard-extra', wu_get_asset('setup-wizard-extra.js', 'js'), ['jquery', 'wu-fields', 'wu-functions', 'wubox'], wu_get_version(), true);
 

--- a/tests/WP_Ultimo/Admin_Pages/Setup_Wizard_Admin_Page_Test.php
+++ b/tests/WP_Ultimo/Admin_Pages/Setup_Wizard_Admin_Page_Test.php
@@ -434,6 +434,24 @@ class Setup_Wizard_Admin_Page_Test extends WP_UnitTestCase {
 		$this->assertTrue(true);
 	}
 
+	public function test_register_scripts_enqueues_vue_apps_when_plugin_is_loaded(): void {
+		$plugin     = WP_Ultimo();
+		$reflection = new \ReflectionClass($plugin);
+		$property   = $reflection->getProperty('loaded');
+		$was_loaded = $property->getValue($plugin);
+
+		$property->setValue($plugin, true);
+		wp_dequeue_script('wu-vue-apps');
+
+		try {
+			$this->page->register_scripts();
+			$this->assertTrue(wp_script_is('wu-vue-apps', 'enqueued'));
+		} finally {
+			$property->setValue($plugin, $was_loaded);
+			wp_dequeue_script('wu-vue-apps');
+		}
+	}
+
 	/**
 	 * Test that Vue script is registered with minified version when SCRIPT_DEBUG is off.
 	 */


### PR DESCRIPTION
## Summary

- enqueue the Vue settings app on the setup wizard even after Ultimate Multisite has fully loaded
- restore reactive visibility for the Footer Credit Type and Custom Footer HTML fields
- add regression coverage for the loaded-plugin setup-wizard path

## Verification

- `vendor/bin/phpcs inc/admin-pages/class-setup-wizard-admin-page.php tests/WP_Ultimo/Admin_Pages/Setup_Wizard_Admin_Page_Test.php`
- `vendor/bin/phpstan analyse inc/admin-pages/class-setup-wizard-admin-page.php tests/WP_Ultimo/Admin_Pages/Setup_Wizard_Admin_Page_Test.php --no-progress`
- `vendor/bin/phpunit --filter Setup_Wizard_Admin_Page_Test` (93 tests, 148 assertions)

<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.317 plugin for [OpenCode](https://opencode.ai) v1.18.29 with gpt-5.6-sol


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Ensured setup wizard interface elements load correctly regardless of the plugin’s initialization state.
  * Conditional settings fields, including footer credit options, now display as expected.

* **Tests**
  * Added coverage confirming the required interface assets load when the plugin is already initialized.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->