### PR TITLE
fix(checkout): publish pending sites after commit

### DIFF
--- a/inc/checkout/class-checkout.php
+++ b/inc/checkout/class-checkout.php
@@ -623,6 +623,17 @@ class Checkout {
 		$wpdb->query('START TRANSACTION'); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
 
 		try {
+			/**
+			 * Fires after the checkout database transaction starts.
+			 *
+			 * Site provisioning listeners can use this to defer work that must read
+			 * newly-created checkout records from another database connection.
+			 *
+			 * @since 2.15.2
+			 * @param Checkout $checkout The checkout instance.
+			 */
+			do_action('wu_checkout_transaction_started', $this);
+
 			/*
 			 * Allow developers to intercept an order submission.
 			 */
@@ -658,10 +669,28 @@ class Checkout {
 		if (is_wp_error($this->errors)) {
 			$wpdb->query('ROLLBACK'); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
 
+			/**
+			 * Fires after the checkout database transaction rolls back.
+			 *
+			 * @since 2.15.2
+			 * @param \WP_Error $errors   The checkout errors that caused the rollback.
+			 * @param Checkout  $checkout The checkout instance.
+			 */
+			do_action('wu_checkout_transaction_rolled_back', $this->errors, $this);
+
 			wp_send_json_error($this->errors);
 		}
 
 		$wpdb->query('COMMIT'); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+
+		/**
+		 * Fires after the checkout database transaction commits.
+		 *
+		 * @since 2.15.2
+		 * @param array    $results  Checkout result data.
+		 * @param Checkout $checkout The checkout instance.
+		 */
+		do_action('wu_checkout_transaction_committed', $results, $this);
 
 		// Clean up draft payment if it exists
 		$draft_payment_id = $this->session->get('draft_payment_id');

--- a/inc/checkout/class-checkout.php
+++ b/inc/checkout/class-checkout.php
@@ -676,7 +676,15 @@ class Checkout {
 			 * @param \WP_Error $errors   The checkout errors that caused the rollback.
 			 * @param Checkout  $checkout The checkout instance.
 			 */
-			do_action('wu_checkout_transaction_rolled_back', $this->errors, $this);
+			try {
+				do_action('wu_checkout_transaction_rolled_back', $this->errors, $this);
+			} catch (\Throwable $e) {
+				/*
+				 * The transaction is already rolled back. A lifecycle listener must
+				 * not prevent checkout from returning the original error response.
+				 */
+				wu_maybe_log_error($e);
+			}
 
 			wp_send_json_error($this->errors);
 		}
@@ -690,7 +698,15 @@ class Checkout {
 		 * @param array    $results  Checkout result data.
 		 * @param Checkout $checkout The checkout instance.
 		 */
-		do_action('wu_checkout_transaction_committed', $results, $this);
+		try {
+			do_action('wu_checkout_transaction_committed', $results, $this);
+		} catch (\Throwable $e) {
+			/*
+			 * The order is durable at this point. Log extension failures instead
+			 * of returning an error that could prompt a duplicate payment attempt.
+			 */
+			wu_maybe_log_error($e);
+		}
 
 		// Clean up draft payment if it exists
 		$draft_payment_id = $this->session->get('draft_payment_id');
@@ -1074,11 +1090,12 @@ class Checkout {
 
 				if (wu_get_setting('allow_trial_without_payment_method', false) && $this->customer->get_email_verification() !== 'pending') {
 					/*
-					 * In this particular case, we need to set the status to trialing here as we will not update the membership after and then, publish the site.
+					 * In this particular case, we need to set the status to trialing
+					 * here as we will not update the membership afterward. Saving the
+					 * transition lets Membership_Manager defer site publication until
+					 * the surrounding checkout transaction commits.
 					 */
 					$this->membership->set_status(Membership_Status::TRIALING);
-
-					$this->membership->publish_pending_site_async();
 				}
 
 				$this->membership->save();

--- a/inc/managers/class-membership-manager.php
+++ b/inc/managers/class-membership-manager.php
@@ -102,6 +102,7 @@ class Membership_Manager extends Base_Manager {
 		add_action('wu_checkout_transaction_started', [$this, 'begin_checkout_transaction'], 0, 0);
 		add_action('wu_checkout_transaction_committed', [$this, 'commit_checkout_transaction'], 0, 0);
 		add_action('wu_checkout_transaction_rolled_back', [$this, 'rollback_checkout_transaction'], 0, 0);
+		add_action('wu_membership_post_save', [$this, 'maybe_defer_pending_site_publication'], 20, 2);
 
 		/*
 		 * Deal with delayed/schedule swaps
@@ -467,6 +468,35 @@ class Membership_Manager extends Base_Manager {
 		}
 
 		$membership->publish_pending_site_async();
+	}
+
+	/**
+	 * Queues an eligible pending site when checkout saves without a status change.
+	 *
+	 * Trial retries can save an already-trialing membership, which does not emit a
+	 * status transition. Watching saves only while checkout owns a transaction
+	 * ensures those pending sites are still published after commit without changing
+	 * normal webhook or administrative save behavior.
+	 *
+	 * @since 2.15.2
+	 *
+	 * @param array                        $_data      The saved membership data.
+	 * @param \WP_Ultimo\Models\Membership $membership The saved membership.
+	 * @return void
+	 */
+	public function maybe_defer_pending_site_publication($_data, $membership): void {
+
+		if (
+			! $this->checkout_transaction_in_progress
+			|| ! $this->can_publish_pending_site($membership)
+			|| ! $membership->get_pending_site()
+		) {
+			return;
+		}
+
+		$membership_id = $membership->get_id();
+
+		$this->deferred_pending_site_publications[ $membership_id ] = (int) $membership_id;
 	}
 
 	/**

--- a/inc/managers/class-membership-manager.php
+++ b/inc/managers/class-membership-manager.php
@@ -99,9 +99,9 @@ class Membership_Manager extends Base_Manager {
 
 		add_action('wu_transition_membership_status', [$this, 'handle_pending_site_on_cancellation'], 10, 3);
 
-		add_action('wu_checkout_transaction_started', [$this, 'begin_checkout_transaction'], 10, 0);
-		add_action('wu_checkout_transaction_committed', [$this, 'commit_checkout_transaction'], 10, 0);
-		add_action('wu_checkout_transaction_rolled_back', [$this, 'rollback_checkout_transaction'], 10, 0);
+		add_action('wu_checkout_transaction_started', [$this, 'begin_checkout_transaction'], 0, 0);
+		add_action('wu_checkout_transaction_committed', [$this, 'commit_checkout_transaction'], 0, 0);
+		add_action('wu_checkout_transaction_rolled_back', [$this, 'rollback_checkout_transaction'], 0, 0);
 
 		/*
 		 * Deal with delayed/schedule swaps
@@ -451,15 +451,7 @@ class Membership_Manager extends Base_Manager {
 		 */
 		$membership = wu_get_membership($membership_id);
 
-		/*
-		 * If the customer has not yet verified their email, hold off on
-		 * publishing the pending site. The site will be published later
-		 * when the customer completes email verification (handled in
-		 * Customer_Manager::handle_email_verification()).
-		 */
-		$customer = $membership->get_customer();
-
-		if ($customer && $customer->get_email_verification() === 'pending') {
+		if ( ! $this->can_publish_pending_site($membership)) {
 			return;
 		}
 
@@ -475,6 +467,43 @@ class Membership_Manager extends Base_Manager {
 		}
 
 		$membership->publish_pending_site_async();
+	}
+
+	/**
+	 * Checks whether a membership is still eligible for pending-site publication.
+	 *
+	 * The state is checked from storage immediately before dispatch so gateway or
+	 * add-on changes made later in the same checkout are respected.
+	 *
+	 * @since 2.15.2
+	 *
+	 * @param \WP_Ultimo\Models\Membership|false $membership Membership to check.
+	 * @return bool
+	 */
+	private function can_publish_pending_site($membership): bool {
+
+		if ( ! $membership) {
+			return false;
+		}
+
+		$allowed_statuses = [
+			Membership_Status::ACTIVE,
+			Membership_Status::TRIALING,
+		];
+
+		if ( ! in_array($membership->get_status(), $allowed_statuses, true)) {
+			return false;
+		}
+
+		/*
+		 * If the customer has not yet verified their email, hold off on
+		 * publishing the pending site. The site will be published later
+		 * when the customer completes email verification (handled in
+		 * Customer_Manager::handle_email_verification()).
+		 */
+		$customer = $membership->get_customer();
+
+		return ! $customer || 'pending' !== $customer->get_email_verification();
 	}
 
 	/**
@@ -504,8 +533,18 @@ class Membership_Manager extends Base_Manager {
 		foreach ($membership_ids as $membership_id) {
 			$membership = wu_get_membership($membership_id);
 
-			if ($membership) {
+			if ( ! $this->can_publish_pending_site($membership)) {
+				continue;
+			}
+
+			try {
 				$membership->publish_pending_site_async();
+			} catch (\Throwable $e) {
+				/*
+				 * The checkout transaction is already committed. Log a failed
+				 * dispatch and continue so other memberships and listeners run.
+				 */
+				wu_maybe_log_error($e);
 			}
 		}
 	}

--- a/inc/managers/class-membership-manager.php
+++ b/inc/managers/class-membership-manager.php
@@ -48,6 +48,22 @@ class Membership_Manager extends Base_Manager {
 	protected $model_class = \WP_Ultimo\Models\Membership::class;
 
 	/**
+	 * Whether a checkout database transaction is currently open.
+	 *
+	 * @since 2.15.2
+	 * @var bool
+	 */
+	private $checkout_transaction_in_progress = false;
+
+	/**
+	 * Membership IDs whose pending sites should publish after checkout commits.
+	 *
+	 * @since 2.15.2
+	 * @var int[]
+	 */
+	private $deferred_pending_site_publications = [];
+
+	/**
 	 * Instantiate the necessary hooks.
 	 *
 	 * @since 2.0.0
@@ -82,6 +98,10 @@ class Membership_Manager extends Base_Manager {
 		add_action('wu_transition_membership_status', [$this, 'transition_membership_status'], 10, 3);
 
 		add_action('wu_transition_membership_status', [$this, 'handle_pending_site_on_cancellation'], 10, 3);
+
+		add_action('wu_checkout_transaction_started', [$this, 'begin_checkout_transaction'], 10, 0);
+		add_action('wu_checkout_transaction_committed', [$this, 'commit_checkout_transaction'], 10, 0);
+		add_action('wu_checkout_transaction_rolled_back', [$this, 'rollback_checkout_transaction'], 10, 0);
 
 		/*
 		 * Deal with delayed/schedule swaps
@@ -443,7 +463,63 @@ class Membership_Manager extends Base_Manager {
 			return;
 		}
 
+		/*
+		 * A checkout activates free memberships before its database transaction
+		 * commits. Starting the loopback here lets the second request race the
+		 * commit and fail to load the newly created membership. Publish as soon as
+		 * the checkout signals that its transaction committed instead.
+		 */
+		if ($this->checkout_transaction_in_progress) {
+			$this->deferred_pending_site_publications[ $membership_id ] = (int) $membership_id;
+			return;
+		}
+
 		$membership->publish_pending_site_async();
+	}
+
+	/**
+	 * Marks the beginning of a checkout database transaction.
+	 *
+	 * @since 2.15.2
+	 * @return void
+	 */
+	public function begin_checkout_transaction() {
+
+		$this->checkout_transaction_in_progress   = true;
+		$this->deferred_pending_site_publications = [];
+	}
+
+	/**
+	 * Publishes pending sites after the checkout transaction commits.
+	 *
+	 * @since 2.15.2
+	 * @return void
+	 */
+	public function commit_checkout_transaction() {
+
+		$membership_ids = $this->deferred_pending_site_publications;
+
+		$this->rollback_checkout_transaction();
+
+		foreach ($membership_ids as $membership_id) {
+			$membership = wu_get_membership($membership_id);
+
+			if ($membership) {
+				$membership->publish_pending_site_async();
+			}
+		}
+	}
+
+	/**
+	 * Clears pending-site publications when checkout rolls back.
+	 *
+	 * @since 2.15.2
+	 * @return void
+	 */
+	public function rollback_checkout_transaction() {
+
+		$this->checkout_transaction_in_progress   = false;
+		$this->deferred_pending_site_publications = [];
 	}
 
 	/**

--- a/tests/WP_Ultimo/Managers/Membership_Manager_Test.php
+++ b/tests/WP_Ultimo/Managers/Membership_Manager_Test.php
@@ -996,8 +996,10 @@ class Membership_Manager_Test extends \WP_UnitTestCase {
 		$manager->rollback_checkout_transaction();
 		$manager->commit_checkout_transaction();
 
+		$refreshed = wu_get_membership($membership->get_id());
+
 		$this->assertFalse($published, 'Rolled-back checkout must not publish its pending site.');
-		$this->assertNotFalse($membership->get_pending_site(), 'Rolled-back checkout should leave the pending site untouched.');
+		$this->assertNotFalse($refreshed->get_pending_site(), 'Rolled-back checkout should leave the stored pending site untouched.');
 	}
 
 	/**

--- a/tests/WP_Ultimo/Managers/Membership_Manager_Test.php
+++ b/tests/WP_Ultimo/Managers/Membership_Manager_Test.php
@@ -96,6 +96,9 @@ class Membership_Manager_Test extends \WP_UnitTestCase {
 	 */
 	public function tearDown(): void {
 
+		$this->get_manager_instance()->rollback_checkout_transaction();
+		wu_save_setting('force_publish_sites_sync', false);
+
 		if ($this->customer && ! is_wp_error($this->customer)) {
 			$this->customer->delete();
 		}
@@ -205,6 +208,18 @@ class Membership_Manager_Test extends \WP_UnitTestCase {
 		$this->assertIsInt(
 			has_action('wu_transition_membership_status', [$manager, 'transition_membership_status'])
 		);
+	}
+
+	/**
+	 * Test init registers checkout transaction lifecycle hooks.
+	 */
+	public function test_init_registers_checkout_transaction_hooks(): void {
+
+		$manager = $this->get_manager_instance();
+
+		$this->assertIsInt(has_action('wu_checkout_transaction_started', [$manager, 'begin_checkout_transaction']));
+		$this->assertIsInt(has_action('wu_checkout_transaction_committed', [$manager, 'commit_checkout_transaction']));
+		$this->assertIsInt(has_action('wu_checkout_transaction_rolled_back', [$manager, 'rollback_checkout_transaction']));
 	}
 
 	/**
@@ -850,6 +865,89 @@ class Membership_Manager_Test extends \WP_UnitTestCase {
 
 		// Restore setting.
 		wu_save_setting('force_publish_sites_sync', false);
+	}
+
+	/**
+	 * Publishing waits until checkout commits so the loopback can load the membership.
+	 */
+	public function test_transition_status_defers_publish_until_checkout_commit(): void {
+
+		wu_save_setting('force_publish_sites_sync', true);
+
+		$this->customer->set_email_verification('none');
+		$this->customer->save();
+
+		$membership = $this->create_membership(['status' => Membership_Status::PENDING]);
+
+		$membership->create_pending_site(
+			[
+				'title' => 'Deferred Checkout Site',
+				'path'  => '/deferred-checkout/',
+			]
+		);
+
+		$published = false;
+		add_action(
+			'wu_before_pending_site_published',
+			function () use (&$published) {
+				$published = true;
+			}
+		);
+
+		$manager = $this->get_manager_instance();
+		$manager->begin_checkout_transaction();
+		$manager->transition_membership_status(
+			Membership_Status::PENDING,
+			Membership_Status::ACTIVE,
+			$membership->get_id()
+		);
+
+		$this->assertFalse($published, 'Site publication must not start before the checkout transaction commits.');
+
+		$manager->commit_checkout_transaction();
+
+		$this->assertTrue($published, 'Site publication should start immediately after the checkout transaction commits.');
+	}
+
+	/**
+	 * A rolled-back checkout must discard deferred site publication.
+	 */
+	public function test_checkout_rollback_discards_deferred_site_publish(): void {
+
+		wu_save_setting('force_publish_sites_sync', true);
+
+		$this->customer->set_email_verification('none');
+		$this->customer->save();
+
+		$membership = $this->create_membership(['status' => Membership_Status::PENDING]);
+
+		$membership->create_pending_site(
+			[
+				'title' => 'Rolled Back Checkout Site',
+				'path'  => '/rolled-back-checkout/',
+			]
+		);
+
+		$published = false;
+		add_action(
+			'wu_before_pending_site_published',
+			function () use (&$published) {
+				$published = true;
+			}
+		);
+
+		$manager = $this->get_manager_instance();
+		$manager->begin_checkout_transaction();
+		$manager->transition_membership_status(
+			Membership_Status::PENDING,
+			Membership_Status::ACTIVE,
+			$membership->get_id()
+		);
+		$manager->rollback_checkout_transaction();
+		$manager->commit_checkout_transaction();
+
+		$this->assertFalse($published, 'Rolled-back checkout must not publish its pending site.');
+		$this->assertNotFalse($membership->get_pending_site(), 'Rolled-back checkout should leave the pending site untouched.');
 	}
 
 	// ========================================================================

--- a/tests/WP_Ultimo/Managers/Membership_Manager_Test.php
+++ b/tests/WP_Ultimo/Managers/Membership_Manager_Test.php
@@ -220,6 +220,7 @@ class Membership_Manager_Test extends \WP_UnitTestCase {
 		$this->assertSame(0, has_action('wu_checkout_transaction_started', [$manager, 'begin_checkout_transaction']));
 		$this->assertSame(0, has_action('wu_checkout_transaction_committed', [$manager, 'commit_checkout_transaction']));
 		$this->assertSame(0, has_action('wu_checkout_transaction_rolled_back', [$manager, 'rollback_checkout_transaction']));
+		$this->assertSame(20, has_action('wu_membership_post_save', [$manager, 'maybe_defer_pending_site_publication']));
 	}
 
 	/**
@@ -917,6 +918,44 @@ class Membership_Manager_Test extends \WP_UnitTestCase {
 		$manager->commit_checkout_transaction();
 
 		$this->assertTrue($published, 'Site publication should start immediately after the checkout transaction commits.');
+	}
+
+	/**
+	 * A retry with an already-trialing membership still publishes after commit.
+	 */
+	public function test_trial_retry_without_status_change_defers_publish_until_checkout_commit(): void {
+
+		wu_save_setting('force_publish_sites_sync', true);
+
+		$this->customer->set_email_verification('none');
+		$this->customer->save();
+
+		$membership = $this->create_membership(['status' => Membership_Status::TRIALING]);
+
+		$membership->create_pending_site(
+			[
+				'title' => 'Retried Trial Checkout Site',
+				'path'  => '/retried-trial-checkout/',
+			]
+		);
+
+		$published = false;
+		add_action(
+			'wu_before_pending_site_published',
+			function () use (&$published) {
+				$published = true;
+			}
+		);
+
+		$manager = $this->get_manager_instance();
+		$manager->begin_checkout_transaction();
+
+		$this->assertNotWPError($membership->save());
+		$this->assertFalse($published, 'Retried trial publication must not start before commit.');
+
+		$manager->commit_checkout_transaction();
+
+		$this->assertTrue($published, 'Retried trial publication should start after commit even without a status change.');
 	}
 
 	/**

--- a/tests/WP_Ultimo/Managers/Membership_Manager_Test.php
+++ b/tests/WP_Ultimo/Managers/Membership_Manager_Test.php
@@ -217,9 +217,9 @@ class Membership_Manager_Test extends \WP_UnitTestCase {
 
 		$manager = $this->get_manager_instance();
 
-		$this->assertIsInt(has_action('wu_checkout_transaction_started', [$manager, 'begin_checkout_transaction']));
-		$this->assertIsInt(has_action('wu_checkout_transaction_committed', [$manager, 'commit_checkout_transaction']));
-		$this->assertIsInt(has_action('wu_checkout_transaction_rolled_back', [$manager, 'rollback_checkout_transaction']));
+		$this->assertSame(0, has_action('wu_checkout_transaction_started', [$manager, 'begin_checkout_transaction']));
+		$this->assertSame(0, has_action('wu_checkout_transaction_committed', [$manager, 'commit_checkout_transaction']));
+		$this->assertSame(0, has_action('wu_checkout_transaction_rolled_back', [$manager, 'rollback_checkout_transaction']));
 	}
 
 	/**
@@ -425,6 +425,22 @@ class Membership_Manager_Test extends \WP_UnitTestCase {
 			Membership_Status::PENDING,
 			Membership_Status::TRIALING,
 			$membership->get_id()
+		);
+
+		$this->assertTrue(true);
+	}
+
+	/**
+	 * Test transition handler ignores a missing membership.
+	 */
+	public function test_transition_membership_status_missing_membership_returns_early(): void {
+
+		$manager = $this->get_manager_instance();
+
+		$manager->transition_membership_status(
+			Membership_Status::PENDING,
+			Membership_Status::ACTIVE,
+			999999
 		);
 
 		$this->assertTrue(true);
@@ -803,13 +819,10 @@ class Membership_Manager_Test extends \WP_UnitTestCase {
 			}
 		);
 
-		$manager = $this->get_manager_instance();
+		$membership->set_status(Membership_Status::ACTIVE);
+		$saved = $membership->save();
 
-		$manager->transition_membership_status(
-			Membership_Status::PENDING,
-			Membership_Status::ACTIVE,
-			$membership->get_id()
-		);
+		$this->assertNotWPError($saved);
 
 		$this->assertFalse(
 			$published,
@@ -850,13 +863,10 @@ class Membership_Manager_Test extends \WP_UnitTestCase {
 			}
 		);
 
-		$manager = $this->get_manager_instance();
+		$membership->set_status(Membership_Status::ACTIVE);
+		$saved = $membership->save();
 
-		$manager->transition_membership_status(
-			Membership_Status::PENDING,
-			Membership_Status::ACTIVE,
-			$membership->get_id()
-		);
+		$this->assertNotWPError($saved);
 
 		$this->assertTrue(
 			$published,
@@ -896,11 +906,11 @@ class Membership_Manager_Test extends \WP_UnitTestCase {
 
 		$manager = $this->get_manager_instance();
 		$manager->begin_checkout_transaction();
-		$manager->transition_membership_status(
-			Membership_Status::PENDING,
-			Membership_Status::ACTIVE,
-			$membership->get_id()
-		);
+
+		$membership->set_status(Membership_Status::ACTIVE);
+		$saved = $membership->save();
+
+		$this->assertNotWPError($saved);
 
 		$this->assertFalse($published, 'Site publication must not start before the checkout transaction commits.');
 
@@ -938,16 +948,144 @@ class Membership_Manager_Test extends \WP_UnitTestCase {
 
 		$manager = $this->get_manager_instance();
 		$manager->begin_checkout_transaction();
-		$manager->transition_membership_status(
-			Membership_Status::PENDING,
-			Membership_Status::ACTIVE,
-			$membership->get_id()
-		);
+
+		$membership->set_status(Membership_Status::ACTIVE);
+		$saved = $membership->save();
+
+		$this->assertNotWPError($saved);
+
 		$manager->rollback_checkout_transaction();
 		$manager->commit_checkout_transaction();
 
 		$this->assertFalse($published, 'Rolled-back checkout must not publish its pending site.');
 		$this->assertNotFalse($membership->get_pending_site(), 'Rolled-back checkout should leave the pending site untouched.');
+	}
+
+	/**
+	 * Publication is skipped when an add-on changes the membership before commit.
+	 */
+	public function test_checkout_commit_rechecks_membership_status(): void {
+
+		wu_save_setting('force_publish_sites_sync', true);
+
+		$membership = $this->create_membership(['status' => Membership_Status::PENDING]);
+
+		$membership->create_pending_site(
+			[
+				'title' => 'Status Changed Checkout Site',
+				'path'  => '/status-changed-checkout/',
+			]
+		);
+
+		$published = false;
+		add_action(
+			'wu_before_pending_site_published',
+			function () use (&$published) {
+				$published = true;
+			}
+		);
+
+		$manager = $this->get_manager_instance();
+		$manager->begin_checkout_transaction();
+
+		$membership->set_status(Membership_Status::ACTIVE);
+		$this->assertNotWPError($membership->save());
+
+		$membership->set_status(Membership_Status::ON_HOLD);
+		$this->assertNotWPError($membership->save());
+
+		$manager->commit_checkout_transaction();
+
+		$this->assertFalse($published, 'A membership that is no longer active or trialing must not publish after commit.');
+	}
+
+	/**
+	 * Publication is skipped when email verification becomes pending before commit.
+	 */
+	public function test_checkout_commit_rechecks_email_verification(): void {
+
+		wu_save_setting('force_publish_sites_sync', true);
+
+		$this->customer->set_email_verification('none');
+		$this->customer->save();
+
+		$membership = $this->create_membership(['status' => Membership_Status::PENDING]);
+
+		$membership->create_pending_site(
+			[
+				'title' => 'Verification Changed Checkout Site',
+				'path'  => '/verification-changed-checkout/',
+			]
+		);
+
+		$published = false;
+		add_action(
+			'wu_before_pending_site_published',
+			function () use (&$published) {
+				$published = true;
+			}
+		);
+
+		$manager = $this->get_manager_instance();
+		$manager->begin_checkout_transaction();
+
+		$membership->set_status(Membership_Status::ACTIVE);
+		$this->assertNotWPError($membership->save());
+
+		$this->customer->set_email_verification('pending');
+		$this->assertNotWPError($this->customer->save());
+
+		$manager->commit_checkout_transaction();
+
+		$this->assertFalse($published, 'A membership awaiting email verification must not publish after commit.');
+	}
+
+	/**
+	 * All memberships created by core or add-ons publish once after commit.
+	 */
+	public function test_checkout_commit_publishes_multiple_memberships(): void {
+
+		wu_save_setting('force_publish_sites_sync', true);
+
+		$memberships = [
+			$this->create_membership(['status' => Membership_Status::PENDING]),
+			$this->create_membership(['status' => Membership_Status::PENDING]),
+		];
+
+		foreach ($memberships as $index => $membership) {
+			$membership->create_pending_site(
+				[
+					'title' => 'Deferred Add-on Site ' . $index,
+					'path'  => '/deferred-addon-' . wp_rand() . '/',
+				]
+			);
+		}
+
+		$published_ids = [];
+		add_action(
+			'wu_before_pending_site_published',
+			function ($membership) use (&$published_ids) {
+				$published_ids[] = $membership->get_id();
+			}
+		);
+
+		$manager = $this->get_manager_instance();
+		$manager->begin_checkout_transaction();
+
+		foreach ($memberships as $membership) {
+			$membership->set_status(Membership_Status::ACTIVE);
+			$this->assertNotWPError($membership->save());
+		}
+
+		$this->assertSame([], $published_ids, 'Core and add-on memberships must remain deferred before commit.');
+
+		$manager->commit_checkout_transaction();
+
+		$expected_ids = array_map(fn($membership) => $membership->get_id(), $memberships);
+		sort($expected_ids);
+		sort($published_ids);
+
+		$this->assertSame($expected_ids, $published_ids, 'Every deferred membership should publish exactly once after commit.');
 	}
 
 	// ========================================================================


### PR DESCRIPTION
## Summary

- defer pending-site publication until the checkout database transaction commits
- discard deferred publications when checkout rolls back
- support trial retries, eligibility rechecks, multiple memberships, and add-on lifecycle integration
- isolate post-commit and post-rollback extension failures from the durable checkout response

## Root cause

Free memberships can become active before their checkout transaction commits. The asynchronous site-provisioning loopback then uses a separate database connection and can fail to load the newly created membership. The immediate attempt logs `An unexpected error happened`, while the five-minute watchdog eventually provisions the site.

## Implementation

- `inc/checkout/class-checkout.php`: publish transaction started, committed, and rolled-back lifecycle actions
- `inc/managers/class-membership-manager.php`: queue eligible membership IDs during checkout, including already-trialing retries, then recheck and dispatch after commit
- `tests/WP_Ultimo/Managers/Membership_Manager_Test.php`: cover hook registration, status transitions, trial retries, eligibility changes, multiple memberships, commit dispatch, and rollback discard behavior

## Verification

- `vendor/bin/phpcs inc/checkout/class-checkout.php inc/managers/class-membership-manager.php tests/WP_Ultimo/Managers/Membership_Manager_Test.php`
- `vendor/bin/phpstan analyse inc/checkout/class-checkout.php inc/managers/class-membership-manager.php --no-progress`
- `vendor/bin/phpunit --filter Membership_Manager_Test` — 66 tests, 100 assertions
- `vendor/bin/phpunit --no-coverage --filter Checkout_Test` — 237 tests, 428 assertions, 1 skipped
- browser checkout: membership became active, `pending_site` cleared, and the new site dashboard was immediately accessible without waiting for the watchdog
- memberships log: no new unexpected-error entry after the post-fix checkout

<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.317 plugin for [OpenCode](https://opencode.ai) v1.18.29 with gpt-5.6-sol spent 5h 37m and 1,211,203 tokens on this with the user in an interactive session.