### PR TITLE
fix(checkout): restore keyboard plan selection

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -1,0 +1,9 @@
+# Ultimate Multisite design notes
+
+## Checkout plan selection
+
+The default checkout pricing-table list presents each selectable plan with a
+visible native radio control. The focused control keeps the existing card focus
+ring, while the selected control retains the blue card border. Contact-us cards
+use a non-submitting button so they remain keyboard operable without becoming a
+checkout selection.

--- a/views/checkout/templates/pricing-table/list.php
+++ b/views/checkout/templates/pricing-table/list.php
@@ -34,11 +34,25 @@ foreach ($products as $index => &$_product) {
 		id="wu-product-<?php echo esc_attr($product->get_id()); ?>"
 		class="wu-relative wu-block wu-rounded-lg wu-border wu-border-gray-300 wu-bg-white wu-border-solid wu-shadow-sm wu-px-6 wu-py-4 wu-cursor-pointer hover:wu-border-gray-400 sm:wu-flex sm:wu-justify-between focus-within:wu-ring-1 focus-within:wu-ring-offset-2 focus-within:wu-ring-indigo-500">
 
-		<input v-if="<?php echo wp_json_encode($product->get_pricing_type() !== 'contact_us'); ?>" v-on:click="$parent.add_plan(<?php echo esc_attr($product->get_id()); ?>)" type="checkbox" name="products[]" value="<?php echo esc_attr($product->get_id()); ?>" class="screen-reader-text wu-hidden">
-
-		<input v-else v-on:click="$parent.open_url('<?php echo esc_url($product->get_contact_us_link()); ?>', '_blank');" type="checkbox" name="products[]" value="<?php echo esc_attr($product->get_id()); ?>" class="screen-reader-text wu-hidden">
-
 		<div class="wu-flex wu-items-center">
+			<input
+				v-if="<?php echo wp_json_encode($product->get_pricing_type() !== 'contact_us'); ?>"
+				v-on:change="$parent.add_plan(<?php echo esc_attr($product->get_id()); ?>)"
+				v-bind:checked="$parent.plan === <?php echo esc_attr($product->get_id()); ?>"
+				type="radio"
+				name="products[]"
+				value="<?php echo esc_attr($product->get_id()); ?>"
+				class="wu-mr-3 wu-h-4 wu-w-4 wu-flex-shrink-0"
+			>
+
+			<input
+				v-else
+				v-on:click="$parent.open_url('<?php echo esc_url($product->get_contact_us_link()); ?>', '_blank');"
+				type="button"
+				value="<?php esc_attr_e('Contact us', 'ultimate-multisite'); ?>"
+				class="button button-secondary wu-mr-3 wu-flex-shrink-0"
+			>
+
 			<div class="wu-text-sm">
 			<span id="server-size-0-label" class="wu-font-semibold wu-block wu-text-gray-900">
 				<?php echo esc_html($product->get_name()); ?>

--- a/views/checkout/templates/pricing-table/list.php
+++ b/views/checkout/templates/pricing-table/list.php
@@ -47,7 +47,7 @@ foreach ($products as $index => &$_product) {
 
 			<input
 				v-else
-				v-on:click="$parent.open_url('<?php echo esc_url($product->get_contact_us_link()); ?>', '_blank');"
+				v-on:click="$parent.open_url(<?php echo esc_attr(wp_json_encode(esc_url_raw($product->get_contact_us_link()))); ?>, '_blank');"
 				type="button"
 				value="<?php esc_attr_e('Contact us', 'ultimate-multisite'); ?>"
 				class="button button-secondary wu-mr-3 wu-flex-shrink-0"


### PR DESCRIPTION
## Summary

- Restore keyboard selection for default checkout plan cards with visible native radio controls.
- Preserve the selected-card indicator, visible card focus, and non-submitting contact-us action.
- Document the checkout selection interaction.

## Testing

- `vendor/bin/phpcs views/checkout/templates/pricing-table/list.php`
- `php -l views/checkout/templates/pricing-table/list.php`
- `vendor/bin/phpunit --filter Signup_Field_Pricing_Table_Test`

Resolves #1817

<!-- aidevops:origin:worker -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.317 plugin for [OpenCode](https://opencode.ai) v1.18.30 with gpt-5.6-terra


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Plan selection in the pricing table now uses visible radio buttons.
  - Selected plans retain the blue card border, while focused controls preserve the existing focus ring.
  - Contact-us options provide a keyboard-accessible button that opens the contact link in a new tab without selecting a checkout plan.

- **Documentation**
  - Added design notes documenting pricing-table selection and accessibility behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->