### PR TITLE
GH#1819: display lifetime membership expiration

### DIFF
--- a/inc/list-tables/class-customers-membership-list-table.php
+++ b/inc/list-tables/class-customers-membership-list-table.php
@@ -46,7 +46,16 @@ class Customers_Membership_List_Table extends Membership_List_Table {
 
 		$p = $item->get_plan();
 
-		$expired = strtotime((string) $item->get_date_expiration()) <= time();
+		$date_expiration = $item->get_date_expiration();
+
+		if (empty($date_expiration) || '0000-00-00 00:00:00' === $date_expiration) {
+			// translators: %1$s: lifetime membership label, %2$s: lifetime expiration description.
+			$expiration_label = sprintf('%1$s / %2$s', __('Lifetime', 'ultimate-multisite'), __('It never expires', 'ultimate-multisite'));
+		} else {
+			$expired = time() >= strtotime($date_expiration);
+			// translators: %s is a placeholder for the human-readable time difference, e.g., "2 hours ago".
+			$expiration_label = sprintf($expired ? __('Expired %s', 'ultimate-multisite') : __('Expiring %s', 'ultimate-multisite'), wu_human_time_diff(strtotime($date_expiration)));
+		}
 
 		$product_count = 1 + count($item->get_addon_ids());
 
@@ -54,7 +63,7 @@ class Customers_Membership_List_Table extends Membership_List_Table {
 
 		if ( ! $p) {
 			$products_list = '';
-		} elseif ($addon_count === 0) {
+		} elseif (0 === $addon_count) {
 			// translators: %s: the product name.
 			$products_list = sprintf(__('Contains %s', 'ultimate-multisite'), $p->get_name());
 		} else {
@@ -95,8 +104,7 @@ class Customers_Membership_List_Table extends Membership_List_Table {
 				'date_expiration' => [
 					'icon'  => 'dashicons-wu-calendar1 wu-align-middle wu-mr-1',
 					'label' => __('Expires', 'ultimate-multisite'),
-					// translators: %s is a placeholder for the human-readable time difference, e.g., "2 hours ago"
-					'value' => sprintf($expired ? __('Expired %s', 'ultimate-multisite') : __('Expiring %s', 'ultimate-multisite'), wu_human_time_diff(strtotime((string) $item->get_date_expiration()))),
+					'value' => $expiration_label,
 				],
 				'date_created'    => [
 					'icon'  => 'dashicons-wu-calendar1 wu-align-middle wu-mr-1',

--- a/inc/list-tables/class-customers-membership-list-table.php
+++ b/inc/list-tables/class-customers-membership-list-table.php
@@ -50,7 +50,7 @@ class Customers_Membership_List_Table extends Membership_List_Table {
 
 		if (empty($date_expiration) || '0000-00-00 00:00:00' === $date_expiration) {
 			// translators: %1$s: lifetime membership label, %2$s: lifetime expiration description.
-			$expiration_label = sprintf('%1$s / %2$s', __('Lifetime', 'ultimate-multisite'), __('It never expires', 'ultimate-multisite'));
+			$expiration_label = sprintf(__('%1$s / %2$s', 'ultimate-multisite'), __('Lifetime', 'ultimate-multisite'), __('It never expires', 'ultimate-multisite'));
 		} else {
 			$expired = time() >= strtotime($date_expiration);
 			// translators: %s is a placeholder for the human-readable time difference, e.g., "2 hours ago".

--- a/tests/WP_Ultimo/List_Tables/Customers_Membership_List_Table_Test.php
+++ b/tests/WP_Ultimo/List_Tables/Customers_Membership_List_Table_Test.php
@@ -117,15 +117,29 @@ class Customers_Membership_List_Table_Test extends WP_UnitTestCase {
 	// =========================================================================
 
 	/**
-	 * Test column_responsive outputs HTML without throwing.
-	 *
-	 * Note: wu_responsive_table_row() is a template helper not available in unit
-	 * test environment. We verify the method is callable and the item getters are
-	 * invoked correctly by checking the method exists and the column is defined.
+	 * Test column_responsive renders lifetime expiration labels.
 	 */
-	public function test_column_responsive_method_exists(): void {
+	public function test_column_responsive_renders_lifetime_expiration_labels(): void {
 
-		$this->assertTrue( method_exists( $this->table, 'column_responsive' ) );
+		foreach ( ['', null, '0000-00-00 00:00:00'] as $date_expiration ) {
+			$output = $this->get_column_responsive_output( $date_expiration );
+
+			$this->assertStringContainsString( 'Lifetime / It never expires', $output );
+			$this->assertStringNotContainsString( 'Expired', $output );
+			$this->assertStringNotContainsString( 'Expiring', $output );
+		}
+	}
+
+	/**
+	 * Test column_responsive renders future and past expiration labels.
+	 */
+	public function test_column_responsive_renders_timed_expiration_labels(): void {
+
+		$future_output = $this->get_column_responsive_output( gmdate( 'Y-m-d H:i:s', time() + DAY_IN_SECONDS ) );
+		$past_output   = $this->get_column_responsive_output( gmdate( 'Y-m-d H:i:s', time() - DAY_IN_SECONDS ) );
+
+		$this->assertStringContainsString( 'Expiring', $future_output );
+		$this->assertStringContainsString( 'Expired', $past_output );
 	}
 
 	/**
@@ -136,5 +150,48 @@ class Customers_Membership_List_Table_Test extends WP_UnitTestCase {
 		$columns = $this->table->get_columns();
 
 		$this->assertArrayHasKey( 'responsive', $columns );
+	}
+
+	/**
+	 * Returns the responsive membership card output for an expiration date.
+	 *
+	 * @param string|null $date_expiration Membership expiration date.
+	 * @return string
+	 */
+	private function get_column_responsive_output($date_expiration): string {
+
+		$item = $this->getMockBuilder( \stdClass::class )
+			->addMethods(
+				[
+					'get_plan',
+					'get_addon_ids',
+					'get_id',
+					'get_hash',
+					'get_status_label',
+					'get_status_class',
+					'get_price_description',
+					'get_gateway',
+					'get_date_expiration',
+					'get_date_created',
+				]
+			)
+			->getMock();
+
+		$item->method( 'get_plan' )->willReturn( false );
+		$item->method( 'get_addon_ids' )->willReturn( [] );
+		$item->method( 'get_id' )->willReturn( 1 );
+		$item->method( 'get_hash' )->willReturn( 'membership-hash' );
+		$item->method( 'get_status_label' )->willReturn( 'Pending' );
+		$item->method( 'get_status_class' )->willReturn( 'wu-bg-yellow-200' );
+		$item->method( 'get_price_description' )->willReturn( 'Free' );
+		$item->method( 'get_gateway' )->willReturn( 'manual' );
+		$item->method( 'get_date_expiration' )->willReturn( $date_expiration );
+		$item->method( 'get_date_created' )->willReturn( '2025-01-01 00:00:00' );
+
+		ob_start();
+
+		$this->table->column_responsive( $item );
+
+		return (string) ob_get_clean();
 	}
 }


### PR DESCRIPTION
## Summary

- Display the **Lifetime / It never expires** label on customer membership cards when expiration is empty, null, or zero.
- Preserve existing Expiring and Expired labels for future and past dates.
- Add output assertions for lifetime and timed expiration states.

## Testing

- `vendor/bin/phpunit --filter Customers_Membership_List_Table_Test`
- `vendor/bin/phpcs inc/list-tables/class-customers-membership-list-table.php tests/WP_Ultimo/List_Tables/Customers_Membership_List_Table_Test.php`
- `vendor/bin/phpstan analyse inc/list-tables/class-customers-membership-list-table.php`

Resolves #1819

<!-- aidevops:origin:worker -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.317 plugin for [OpenCode](https://opencode.ai) v1.18.30 with gpt-5.6-terra spent 10m and 106,922 tokens on this as a headless worker.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved membership expiration labels in responsive customer views.
  - Lifetime memberships now display “Lifetime / It never expires.”
  - Memberships are clearly labeled as “Expiring” or “Expired” based on their expiration date, including memberships expiring at the current time.
- **Tests**
  - Added coverage for lifetime, expiring, and expired membership display states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->