### PR TITLE
fix(checkout): clarify manual pending confirmation

### DIFF
--- a/inc/ui/class-thank-you-element.php
+++ b/inc/ui/class-thank-you-element.php
@@ -310,6 +310,30 @@ class Thank_You_Element extends Base_Element {
 	}
 
 	/**
+	 * Gets the pending payment message for the current gateway.
+	 *
+	 * The generic pending message remains available for asynchronous payment
+	 * gateways and customer overrides. Manual payments use their own default
+	 * because an administrator, rather than a payment processor, confirms them.
+	 *
+	 * @since 2.15.3
+	 *
+	 * @param \WP_Ultimo\Models\Payment $payment The payment being displayed.
+	 * @param string                    $message The configured pending payment message.
+	 * @return string
+	 */
+	public function get_pending_thank_you_message($payment, $message) {
+
+		$default_message = __('Thank you for your order! We are waiting on the payment processor to confirm your payment, which can take up to 5 minutes. We will notify you via email when your site is ready.', 'ultimate-multisite');
+
+		if ('manual' === $payment->get_gateway() && 'pending' === $payment->get_status() && $default_message === $message) {
+			return __('Thank you for your order! Please follow the payment instructions below. An administrator will confirm your payment and notify you by email when your site is ready.', 'ultimate-multisite');
+		}
+
+		return $message;
+	}
+
+	/**
 	 * Runs early on the request lifecycle as soon as we detect the shortcode is present.
 	 *
 	 * @since 2.0.0
@@ -377,6 +401,8 @@ class Thank_You_Element extends Base_Element {
 		$atts['customer'] = $this->customer;
 
 		$atts = wp_parse_args($atts, $this->defaults());
+
+		$atts['thank_you_message_pending'] = $this->get_pending_thank_you_message($this->payment, $atts['thank_you_message_pending']);
 
 		/*
 		 * Deal with conversion tracking

--- a/tests/WP_Ultimo/UI/Thank_You_Element_Test.php
+++ b/tests/WP_Ultimo/UI/Thank_You_Element_Test.php
@@ -1,0 +1,114 @@
+<?php
+/**
+ * Tests for the thank-you element's gateway-aware pending messages.
+ *
+ * @package WP_Ultimo\Tests
+ */
+
+namespace WP_Ultimo\UI;
+
+use WP_UnitTestCase;
+
+/**
+ * Test class for thank-you pending payment messages.
+ */
+class Thank_You_Element_Test extends WP_UnitTestCase {
+
+	/**
+	 * Provides pending payment message scenarios.
+	 *
+	 * @return array
+	 */
+	public function pending_message_provider(): array {
+
+		$default_message = 'Thank you for your order! We are waiting on the payment processor to confirm your payment, which can take up to 5 minutes. We will notify you via email when your site is ready.';
+
+		return [
+			'pending manual payment'     => [
+				'manual',
+				'pending',
+				$default_message,
+				'Thank you for your order! Please follow the payment instructions below. An administrator will confirm your payment and notify you by email when your site is ready.',
+			],
+			'pending electronic payment' => [
+				'stripe',
+				'pending',
+				$default_message,
+				$default_message,
+			],
+			'completed manual payment'   => [
+				'manual',
+				'completed',
+				$default_message,
+				$default_message,
+			],
+			'custom pending message'     => [
+				'manual',
+				'pending',
+				'Your custom payment confirmation message.',
+				'Your custom payment confirmation message.',
+			],
+		];
+	}
+
+	/**
+	 * Renders the appropriate pending message for each gateway and payment status.
+	 *
+	 * @dataProvider pending_message_provider
+	 */
+	public function test_get_pending_thank_you_message(string $gateway, string $status, string $message, string $expected): void {
+
+		$payment = new class($gateway, $status) {
+
+			/**
+			 * The gateway identifier.
+			 *
+			 * @var string
+			 */
+			private $gateway;
+
+			/**
+			 * The payment status.
+			 *
+			 * @var string
+			 */
+			private $status;
+
+			/**
+			 * Creates the payment double.
+			 *
+			 * @param string $gateway The gateway identifier.
+			 * @param string $status The payment status.
+			 */
+			public function __construct(string $gateway, string $status) {
+
+				$this->gateway = $gateway;
+				$this->status  = $status;
+			}
+
+			/**
+			 * Gets the gateway identifier.
+			 *
+			 * @return string
+			 */
+			public function get_gateway(): string {
+
+				return $this->gateway;
+			}
+
+			/**
+			 * Gets the payment status.
+			 *
+			 * @return string
+			 */
+			public function get_status(): string {
+
+				return $this->status;
+			}
+		};
+
+		$message = Thank_You_Element::get_instance()->get_pending_thank_you_message($payment, $message);
+
+		$this->assertSame($expected, $message);
+	}
+}


### PR DESCRIPTION
## Summary

- Use manual-payment confirmation copy only for the default pending message.
- Preserve customized messages and electronic gateway pending copy.
- Add gateway/status coverage for pending thank-you message selection.

## Testing

- `vendor/bin/phpcs inc/ui/class-thank-you-element.php tests/WP_Ultimo/UI/Thank_You_Element_Test.php`
- `vendor/bin/phpunit --filter Thank_You_Element_Test`

Resolves #1821

<!-- aidevops:sig -->
