### PR TITLE
fix(sso): preserve spaces in authentication cookies

### DIFF
--- a/inc/sso/auth-functions.php
+++ b/inc/sso/auth-functions.php
@@ -16,8 +16,6 @@
  * @subpackage SSO
  */
 
-use Delight\Cookie\Cookie;
-
 defined('ABSPATH') || exit;
 
 
@@ -151,11 +149,37 @@ if ( ! function_exists('wp_set_auth_cookie') ) :
 			return;
 		}
 
-		Cookie::setcookie($auth_cookie_name, $auth_cookie, $expire, PLUGINS_COOKIE_PATH, COOKIE_DOMAIN, $secure, true, $secure ? 'None' : 'Lax');
-		Cookie::setcookie($auth_cookie_name, $auth_cookie, $expire, ADMIN_COOKIE_PATH, COOKIE_DOMAIN, $secure, true, $secure ? 'None' : 'Lax');
-		Cookie::setcookie(LOGGED_IN_COOKIE, $logged_in_cookie, $expire, COOKIEPATH, COOKIE_DOMAIN, $secure_logged_in_cookie, true, $secure_logged_in_cookie ? 'None' : 'Lax');
+		/*
+		 * Use PHP's native cookie encoding, as WordPress does. Delight encodes
+		 * spaces as '+', but PHP decodes incoming cookies with rawurldecode(),
+		 * leaving a literal '+' in space-containing usernames and breaking auth.
+		 */
+		$auth_cookie_options = [
+			'expires'  => $expire,
+			'path'     => PLUGINS_COOKIE_PATH,
+			'domain'   => (string) COOKIE_DOMAIN,
+			'secure'   => (bool) $secure,
+			'httponly' => true,
+			'samesite' => $secure ? 'None' : 'Lax',
+		];
+
+		setcookie($auth_cookie_name, $auth_cookie, $auth_cookie_options);
+		$auth_cookie_options['path'] = ADMIN_COOKIE_PATH;
+		setcookie($auth_cookie_name, $auth_cookie, $auth_cookie_options);
+
+		$logged_in_cookie_options = [
+			'expires'  => $expire,
+			'path'     => COOKIEPATH,
+			'domain'   => (string) COOKIE_DOMAIN,
+			'secure'   => (bool) $secure_logged_in_cookie,
+			'httponly' => true,
+			'samesite' => $secure_logged_in_cookie ? 'None' : 'Lax',
+		];
+
+		setcookie(LOGGED_IN_COOKIE, $logged_in_cookie, $logged_in_cookie_options);
 		if ( COOKIEPATH !== SITECOOKIEPATH ) {
-			Cookie::setcookie(LOGGED_IN_COOKIE, $logged_in_cookie, $expire, SITECOOKIEPATH, COOKIE_DOMAIN, $secure_logged_in_cookie, true, $secure_logged_in_cookie ? 'None' : 'Lax');
+			$logged_in_cookie_options['path'] = SITECOOKIEPATH;
+			setcookie(LOGGED_IN_COOKIE, $logged_in_cookie, $logged_in_cookie_options);
 		}
 	}
 


### PR DESCRIPTION
## Summary

- Fix SSO login failures for existing WordPress usernames containing spaces in `inc/sso/auth-functions.php`.
- Replace Delight Cookie calls with native PHP `setcookie()` options, matching WordPress core's cookie-value encoding.
- Preserve authentication and logged-in cookie paths, domain, expiry, Secure, HttpOnly, and SameSite behavior, including the alternate site cookie path.

## Root cause

Delight Cookie uses `urlencode()`, which writes spaces as `+`. PHP's incoming cookie decoding preserves that plus sign, so WordPress looks up a different username and raises `auth_cookie_bad_username`. The subsequent `confirm_admin_email` request sees a logged-out user and redirects back to login.

Native `setcookie()` writes spaces as `%20`, which round-trips correctly. This fixes the writer rather than weakening authentication validation or broadening cookie paths.

## Reproduction and verification

Using a synthetic space-containing username (`ssorepro space`) on a local subdomain Multisite, with an expired administration-email confirmation interval:

| Configuration | Encoded username | Confirmation result |
| --- | --- | --- |
| Original SSO enabled | `ssorepro+space` | HTTP 302 back to login |
| SSO disabled | `ssorepro%20space` | HTTP 200, confirmation form |
| Patched SSO enabled | `ssorepro%20space` | HTTP 200, confirmation form |

The patched writer was loaded before WordPress's pluggable functions through an isolated local PHP HTTP router. These are manual HTTP regression checks, not a newly added automated browser test. The reproduction used HTTP on WordPress 7.1; production HTTPS was not modified or used for authenticated testing.

Checks passed:

- `php -l inc/sso/auth-functions.php`
- `vendor/bin/phpcs inc/sso/auth-functions.php`
- `vendor/bin/phpstan analyse inc/sso/auth-functions.php --no-progress`
- Existing PHPUnit `SSO_Extended_Test` (exit 0)
- `git diff --check`
- Pre-commit PHPCS and PHPStan hooks

To repeat the regression, create a user through `wp_insert_user()` with a space in `user_login`, add that user as a subsite administrator, expire the subsite's `admin_email_lifespan`, and log in directly on the subsite. Verify that SSO startup actually loads the overridden `wp_set_auth_cookie()` function; enabling the setting alone is insufficient if plugin setup is unfinished. Inspect only cookie metadata and synthetic username encoding, never real session-token values.

<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.317 plugin for [OpenCode](https://opencode.ai) v1.18.30 with gpt-6-astra spent 22h 9m and 250,359 tokens on this with the user in an interactive session.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed authentication for usernames containing spaces.
  - Improved login reliability by ensuring authentication cookies are encoded and stored correctly.
  - Updated authentication cookie handling to support secure and logged-in sessions consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->