### PR TITLE
GH#1822: warn before paid checkout without a gateway

### DIFF
--- a/inc/checkout/class-checkout.php
+++ b/inc/checkout/class-checkout.php
@@ -905,7 +905,7 @@ class Checkout {
 			*/
 		if ($cart->should_collect_payment() === false) {
 			$gateway = wu_get_gateway('free');
-		} elseif ( ! $gateway || $gateway->get_id() === 'free') {
+		} elseif ( ! $gateway || $gateway->get_id() === 'free' || ! array_key_exists($gateway_id, wu_get_active_gateway_as_options())) {
 			return new \WP_Error('no-gateway', __('Payment gateway not registered.', 'ultimate-multisite'));
 		}
 
@@ -3198,8 +3198,8 @@ class Checkout {
 				$gateway = wu_get_gateway($payment->get_gateway());
 			} elseif ($this->order->should_collect_payment() === false) {
 				$gateway = wu_get_gateway('free');
-			} elseif ($gateway && $gateway->get_id() === 'free') {
-					$this->errors = new \WP_Error('no-gateway', __('Payment gateway not registered.', 'ultimate-multisite'));
+			} elseif ( ! $gateway || $gateway->get_id() === 'free' || ! array_key_exists($gateway->get_id(), wu_get_active_gateway_as_options())) {
+				$this->errors = new \WP_Error('no-gateway', __('Payment gateway not registered.', 'ultimate-multisite'));
 
 					return false;
 			}

--- a/inc/class-dashboard-widgets.php
+++ b/inc/class-dashboard-widgets.php
@@ -237,7 +237,7 @@ class Dashboard_Widgets implements \WP_Ultimo\Interfaces\Singleton {
 						'tab' => 'payment-gateways',
 					]
 				),
-				'done'              => ! empty(wu_get_active_gateways()),
+				'done'              => ! empty(wu_get_active_gateway_as_options()),
 			],
 			'your-first-customer' => [
 				'done'              => ! empty(wu_get_customers()),

--- a/tests/WP_Ultimo/Checkout/Checkout_Test.php
+++ b/tests/WP_Ultimo/Checkout/Checkout_Test.php
@@ -3254,6 +3254,58 @@ class Checkout_Test extends WP_UnitTestCase {
 		unset($_REQUEST['gateway']);
 	}
 
+	/**
+	 * Test process_order rejects a paid cart when no public gateway is active.
+	 */
+	public function test_process_order_returns_error_when_no_active_gateway_for_paid_cart(): void {
+
+		$paid_plan = wu_create_product([
+			'name'          => 'No Gateway Test Plan',
+			'slug'          => 'no-gateway-test-plan-' . wp_rand(1000, 9999),
+			'amount'        => 29.99,
+			'recurring'     => true,
+			'duration'      => 1,
+			'duration_unit' => 'month',
+			'type'          => 'plan',
+			'pricing_type'  => 'paid',
+			'active'        => true,
+		]);
+
+		if (is_wp_error($paid_plan)) {
+			$this->markTestSkipped('Product creation failed: ' . $paid_plan->get_error_message());
+		}
+
+		$active_gateways = wu_get_setting('active_gateways', []);
+		$checkout        = Checkout::get_instance();
+		$reflection      = new \ReflectionClass($checkout);
+		$setup_prop      = $reflection->getProperty('already_setup');
+
+		if (PHP_VERSION_ID < 80100) {
+			$setup_prop->setAccessible(true);
+		}
+
+		try {
+			$setup_prop->setValue($checkout, true);
+			wu_save_setting('active_gateways', []);
+			$this->ensure_session($checkout);
+
+			$this->assertNotFalse(wu_get_gateway('manual'));
+
+			$_REQUEST['products'] = [$paid_plan->get_id()];
+			$_REQUEST['gateway']  = 'manual';
+
+			$result = $checkout->process_order();
+
+			$this->assertWPError($result);
+			$this->assertSame('no-gateway', $result->get_error_code());
+		} finally {
+			$setup_prop->setValue($checkout, false);
+			wu_save_setting('active_gateways', $active_gateways);
+			$paid_plan->delete();
+			unset($_REQUEST['products'], $_REQUEST['gateway']);
+		}
+	}
+
 	// -------------------------------------------------------------------------
 	// process_checkout — error paths
 	// -------------------------------------------------------------------------

--- a/views/checkout/fields/field-payment-methods.php
+++ b/views/checkout/fields/field-payment-methods.php
@@ -27,6 +27,14 @@ $active_gateways = wu_get_active_gateway_as_options();
 
 	?>
 
+	<?php if (empty($active_gateways)) : ?>
+
+		<div class="wu-p-3 wu-bg-yellow-50 wu-border wu-border-solid wu-border-yellow-200 wu-rounded-sm wu-text-yellow-800" role="alert">
+			<?php esc_html_e('No payment methods are currently available. Please contact the site administrator.', 'ultimate-multisite'); ?>
+		</div>
+
+	<?php endif; ?>
+
 	<?php foreach ($active_gateways as $option_value => $option_name) : ?>
 
 		<?php if (count($active_gateways) === 1) : ?>

--- a/views/wizards/setup/ready.php
+++ b/views/wizards/setup/ready.php
@@ -36,6 +36,24 @@ defined('ABSPATH') || exit;
 		<?php esc_html_e('You now have everything you need in place to start building your Website as a Service business!', 'ultimate-multisite'); ?>
 	</p>
 
+	<?php if (empty(wu_get_active_gateway_as_options())) : ?>
+
+		<p class="wu-text-sm wu-text-yellow-800 wu-my-4">
+			<?php
+			printf(
+				/* translators: %s is a link to the payment gateway settings page */
+				esc_html__('Before accepting paid signups, configure a payment method under %s. Free signups do not require a payment method.', 'ultimate-multisite'),
+				sprintf(
+					'<a href="%s" class="wu-text-blue-600 hover:wu-underline">%s</a>',
+					esc_url(wu_network_admin_url('wp-ultimo-settings', ['tab' => 'payment-gateways'])),
+					esc_html__('Settings → Payment Gateways', 'ultimate-multisite')
+				)
+			);
+			?>
+		</p>
+
+	<?php endif; ?>
+
 	<p class="wu-text-sm wu-text-gray-500 wu-my-4">
 		<?php
 		printf(


### PR DESCRIPTION
## Summary

- Adds a setup-wizard handoff and checkout notice when no public gateway is available.
- Rejects paid checkout submissions that select no active public gateway.
- Covers the zero-active-gateway paid-cart path.

## Testing

- `vendor/bin/phpcs inc/checkout/class-checkout.php inc/class-dashboard-widgets.php views/checkout/fields/field-payment-methods.php views/wizards/setup/ready.php tests/WP_Ultimo/Checkout/Checkout_Test.php`
- `vendor/bin/phpunit --filter test_process_order_returns_error_when_no_active_gateway_for_paid_cart`
- Pre-commit PHPStan

## Runtime Testing

runtime-verified: The scoped PHPUnit test ran against the WordPress Multisite test environment.

Resolves #1822

<!-- aidevops:origin:worker -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.317 plugin for [OpenCode](https://opencode.ai) v1.18.30 with gpt-5.6-terra spent 12m and 154,643 tokens on this as a headless worker.
