### PR TITLE
GH#1815: fix(setup): propagate wp-config update errors

### DIFF
--- a/inc/integrations/host-providers/class-base-host-provider.php
+++ b/inc/integrations/host-providers/class-base-host-provider.php
@@ -497,7 +497,7 @@ abstract class Base_Host_Provider implements DNS_Provider_Interface {
 	 * @since 2.0.0
 	 *
 	 * @param array $constant_values Key => Value of the necessary constants.
-	 * @return void
+	 * @return bool|\WP_Error Whether a constant was updated, or an update error.
 	 */
 	public function setup_constants($constant_values) {
 		/*
@@ -507,11 +507,20 @@ abstract class Base_Host_Provider implements DNS_Provider_Interface {
 		 *
 		 * Note that this is also performed on the get_constants_string.
 		 */
-		$values = shortcode_atts(array_flip($this->get_all_constants()), $constant_values);
+		$values  = shortcode_atts(array_flip($this->get_all_constants()), $constant_values);
+		$updated = false;
 
 		foreach ($values as $constant => $value) {
-			WP_Config::get_instance()->inject_wp_config_constant($constant, $value);
+			$result = WP_Config::get_instance()->inject_wp_config_constant($constant, $value);
+
+			if (is_wp_error($result)) {
+				return $result;
+			}
+
+			$updated = $updated || $result;
 		}
+
+		return $updated;
 	}
 
 	/**


### PR DESCRIPTION
## Summary

- Propagate the first wp-config write error from host-provider setup.
- Return whether any allowed constant was updated.

## Testing

- `vendor/bin/phpcs inc/integrations/host-providers/class-base-host-provider.php`
- `vendor/bin/phpstan analyse inc/integrations/host-providers/class-base-host-provider.php`
- `vendor/bin/phpunit --filter Base_Host_Provider_Test`

Resolves #1815

<!-- aidevops:origin:worker -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.317 plugin for [OpenCode](https://opencode.ai) v1.18.30 with gpt-5.6-terra spent 8m and 127,923 tokens on this as a headless worker.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Configuration setup now reports whether updates were applied successfully.
  - Setup errors are surfaced immediately, improving reliability and visibility when configuration changes cannot be completed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->