### PR TITLE
fix: normalize spaces in generated usernames

### DIFF
--- a/inc/functions/customer.php
+++ b/inc/functions/customer.php
@@ -321,7 +321,7 @@ function wu_get_all_customer_meta($customer_id, $include_unset = true) {
  * @param bool   $single       To return single values or not.
  * @return mixed
  */
-function wu_get_customer_meta($customer_id, $meta_key, $default = false, $single = true) {
+function wu_get_customer_meta($customer_id, $meta_key, $default = false, $single = true) { // phpcs:ignore Universal.NamingConventions.NoReservedKeywordParameterNames.defaultFound -- Preserve the public parameter name for named-argument compatibility.
 
 	$customer = wu_get_customer($customer_id);
 
@@ -524,6 +524,12 @@ function wu_username_from_email($email, $new_user_args = [], $suffix = '') {
 	if ($suffix) {
 		$username .= $suffix;
 	}
+
+	/*
+	 * sanitize_user() preserves spaces in compound names. Match our WooCommerce
+	 * username convention, before checking blocked names and existing users.
+	 */
+	$username = preg_replace('/\s+/', '.', $username);
 
 	$illegal_logins = (array) apply_filters('illegal_user_logins', []); // phpcs:ignore
 

--- a/tests/WP_Ultimo/Functions/Customer_Functions_Test.php
+++ b/tests/WP_Ultimo/Functions/Customer_Functions_Test.php
@@ -180,6 +180,81 @@ class Customer_Functions_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * @dataProvider generated_username_names
+	 */
+	public function test_username_from_email_normalizes_name_spaces($first_name, $last_name, $expected): void {
+
+		$username = wu_username_from_email('username-probe@example.com', [
+			'first_name' => $first_name,
+			'last_name'  => $last_name,
+		]);
+
+		$this->assertSame($expected, $username);
+	}
+
+	public static function generated_username_names(): array {
+
+		return [
+			'compound first name' => ['Alice Beth', 'Example', 'alice.beth.example'],
+			'compound last name'  => ['Alice', 'Van Example', 'alice.van.example'],
+			'repeated spaces'     => ['  Alice   Beth  ', '  Van   Example  ', 'alice.beth.van.example'],
+			'already normalized'  => ['Alice.Beth', 'Example-Smith', 'alice.beth.example-smith'],
+		];
+	}
+
+	public function test_username_from_email_checks_normalized_name_for_collisions(): void {
+
+		$user_id  = self::factory()->user->create(['user_login' => 'alice.beth.example']);
+		$username = wu_username_from_email('username-probe@example.com', [
+			'first_name' => 'Alice Beth',
+			'last_name'  => 'Example',
+		]);
+
+		$this->assertMatchesRegularExpression('/^alice\.beth\.example-\d{4}$/', $username);
+		$this->assertFalse(username_exists($username));
+		$this->assertSame('alice.beth.example', get_userdata($user_id)->user_login);
+	}
+
+	public function test_username_from_email_checks_normalized_name_against_illegal_logins(): void {
+
+		$illegal_logins = static function ($logins) {
+			$logins[] = 'alice.beth.example';
+			return $logins;
+		};
+		add_filter('illegal_user_logins', $illegal_logins);
+
+		try {
+			$username = wu_username_from_email('username-probe@example.com', [
+				'first_name' => 'Alice Beth',
+				'last_name'  => 'Example',
+			]);
+
+			$this->assertMatchesRegularExpression('/^woo_user_\d{4}(?:-\d{4})?$/', $username);
+		} finally {
+			remove_filter('illegal_user_logins', $illegal_logins);
+		}
+	}
+
+	public function test_username_from_email_persists_without_spaces_when_password_is_generated(): void {
+
+		$email    = 'generated-username@example.com';
+		$username = wu_username_from_email($email, [
+			'first_name' => 'Alice Beth',
+			'last_name'  => 'Example',
+		]);
+		$customer = wu_create_customer([
+			'email'           => $email,
+			'username'        => $username,
+			'password'        => false,
+			'skip_validation' => true,
+		]);
+
+		$this->assertNotWPError($customer);
+		$this->assertInstanceOf(\WP_Ultimo\Models\Customer::class, $customer);
+		$this->assertSame('alice.beth.example', get_userdata($customer->get_user_id())->user_login);
+	}
+
+	/**
 	 * Test wu_username_from_email with common email prefix falls back to domain.
 	 */
 	public function test_username_from_email_common_prefix(): void {


### PR DESCRIPTION
## Summary

- Normalize whitespace to dots in `wu_username_from_email()` before checking blocked usernames and existing accounts.
- Match the dotted-username convention already used by `WooCommerce_Subscriptions_Compat::woocommerce_new_customer_username_no_space()`.
- Add regression coverage in `tests/WP_Ultimo/Functions/Customer_Functions_Test.php` for compound first/last names, repeated spaces, unchanged normalized names, collisions, blocked names, and persisted accounts created without a supplied password.

## Why

`sanitize_user(..., true)` preserves internal spaces. Ultimate Multisite's generator sanitizes first/last names and joins them with a dot, so `Alice Beth` / `Example` previously generated `alice beth.example`.

The auto-generated-password checkout path passes an empty password to `wu_create_customer()`, which uses `register_new_user()`. That path can persist the space-containing username. Normalizing the generated candidate before validation makes new names consistent without renaming existing users or changing explicitly supplied usernames.

Normalization must happen before `username_exists()` and `illegal_user_logins` checks: if `alice.beth.example` already exists or is blocked, the generator must handle that normalized name rather than checking a different space-containing name.

This is an independent preventive fix, not an attribution of the original SSO report to Ultimate Multisite's account generation. Related PR #1826 fixes authentication-cookie encoding for existing accounts containing spaces and remains necessary.

## Scope and compatibility

- Only the generated candidate changes; existing accounts are not migrated or renamed.
- Existing suffix generation and the final `wu_username_from_email` extension filter remain intact.
- Includes a targeted PHPCS exception for the pre-existing public `$default` parameter of `wu_get_customer_meta()`. The same warning was reproduced on the unchanged base file; keeping the parameter name avoids breaking PHP named-argument callers. No lint configuration or hook is weakened.

## Verification

Before the production fix, the username-focused run produced **6 expected failures**, including the saved username retaining its space.

After the fix:

- `vendor/bin/phpunit tests/WP_Ultimo/Functions/Customer_Functions_Test.php --no-coverage`: **28 tests, 45 assertions, passing**.
- `vendor/bin/phpcs inc/functions/customer.php tests/WP_Ultimo/Functions/Customer_Functions_Test.php`: passing.
- `vendor/bin/phpstan analyse inc/functions/customer.php tests/WP_Ultimo/Functions/Customer_Functions_Test.php --no-progress`: no errors.
- `php -l inc/functions/customer.php`: passing.
- `git diff --check`: passing.
- Pre-commit PHPCS and PHPStan hooks: passing.

The test run emits existing Rakit dependency deprecation notices on PHP 8.4, but no test failures.

<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.317 plugin for [OpenCode](https://opencode.ai) v1.18.30 with gpt-6-astra spent 23h 32m and 334,577 tokens on this with the user in an interactive session.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Customer usernames generated from names with spaces are now normalized using dots, including repeated spaces and compound names.
  - Username collisions continue to receive a unique suffix.
  - Invalid usernames still fall back to a safe generated format.

- **Tests**
  - Added coverage for username normalization, collisions, invalid login handling, and persistence during customer creation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->