### PR TITLE
GH#1818: preserve the initial Manual payment period

### DIFF
--- a/inc/admin-pages/class-payment-edit-admin-page.php
+++ b/inc/admin-pages/class-payment-edit-admin-page.php
@@ -14,6 +14,7 @@ defined('ABSPATH') || exit;
 
 use WP_Ultimo\Models\Payment;
 use WP_Ultimo\Database\Payments\Payment_Status;
+use WP_Ultimo\Database\Memberships\Membership_Status;
 
 /**
  * Ultimate Multisite Payment Edit/Add New Admin Page.
@@ -1452,20 +1453,53 @@ class Payment_Edit_Admin_Page extends Edit_Admin_Page {
 	 */
 	public function handle_save(): bool {
 
-		$this->get_object()->recalculate_totals()->save();
+		$payment = $this->get_object();
 
-		$should_confirm_membership = wu_request('confirm_membership');
+		$should_confirm_membership = wu_request('confirm_membership')
+			&& Payment_Status::PENDING === $payment->get_status()
+			&& Payment_Status::COMPLETED === wu_request('status');
 
-		if ($should_confirm_membership) {
-			$membership = $this->get_object()->get_membership();
+		$payment->recalculate_totals();
+
+		// Persist the payment first: failed saves and repeat submissions grant nothing.
+		$saved = parent::handle_save();
+
+		if ($saved && $should_confirm_membership && Payment_Status::COMPLETED === $payment->get_status()) {
+			$membership = $payment->get_membership();
 
 			if ($membership) {
+				$is_initial_payment = Membership_Status::PENDING === $membership->get_status()
+					&& 0 === $membership->get_times_billed();
+
+				// The initial payment counts as a bill, but checkout already set its period.
 				$membership->add_to_times_billed(1);
 
-				$membership->renew(false, 'active');
+				if ($is_initial_payment) {
+					$membership->set_status(Membership_Status::ACTIVE);
+					$membership_saved = $membership->save();
+				} else {
+					$membership_saved = $membership->renew(false, Membership_Status::ACTIVE);
+				}
+
+				if (is_wp_error($membership_saved) || ! $membership_saved) {
+					// Leave the confirmation retryable when the membership could not be saved.
+					$payment->set_status(Payment_Status::PENDING);
+					$payment->save();
+
+					WP_Ultimo()->notices->add(
+						__('The membership could not be confirmed. Please review the membership and try again.', 'ultimate-multisite'),
+						'error',
+						'network-admin'
+					);
+					if ( ! headers_sent()) {
+						header_remove('Location');
+					}
+
+					return false;
+				}
 			}
 		}
 
-		return parent::handle_save();
+		return $saved;
 	}
 }

--- a/tests/WP_Ultimo/Admin_Pages/Payment_Edit_Admin_Page_Test.php
+++ b/tests/WP_Ultimo/Admin_Pages/Payment_Edit_Admin_Page_Test.php
@@ -35,6 +35,7 @@ class Testable_Payment_Edit_Admin_Page extends Payment_Edit_Admin_Page {
 /**
  * Test class for Payment_Edit_Admin_Page.
  */
+// phpcs:ignore Generic.Files.OneObjectStructurePerFile.MultipleFound -- The page fixture above is local to this test.
 class Payment_Edit_Admin_Page_Test extends WP_UnitTestCase {
 
 	/**
@@ -73,7 +74,10 @@ class Payment_Edit_Admin_Page_Test extends WP_UnitTestCase {
 			$_POST['cancel_membership'],
 			$_REQUEST['cancel_membership'],
 			$_POST['invoice_message'],
-			$_REQUEST['invoice_message']
+			$_REQUEST['invoice_message'],
+			$_POST['status'],
+			$_REQUEST['status'],
+			$_POST['active']
 		);
 		parent::tearDown();
 	}
@@ -737,6 +741,139 @@ class Payment_Edit_Admin_Page_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Confirmation preserves the first period and extends genuine renewals once.
+	 *
+	 * @dataProvider manual_confirmation_periods
+	 */
+	public function test_manual_confirmation_period(string $status, int $times_billed, bool $renews, bool $fail_first = false): void {
+		$customer = wu_create_customer([
+			'user_id'            => self::factory()->user->create(),
+			'email_verification' => 'none',
+		]);
+		$this->assertNotWPError($customer);
+		$product = wu_create_product([
+			'name'          => 'Manual Confirmation Plan',
+			'slug'          => 'manual-confirmation-' . wp_generate_password(8, false),
+			'type'          => 'plan',
+			'pricing_type'  => 'paid',
+			'amount'        => 29.99,
+			'recurring'     => true,
+			'duration'      => 1,
+			'duration_unit' => 'month',
+		]);
+		$this->assertNotWPError($product);
+		$expiration = gmdate('Y-m-09 23:59:59', strtotime('+1 year'));
+		$membership = wu_create_membership([
+			'customer_id'     => $customer->get_id(),
+			'plan_id'         => $product->get_id(),
+			'status'          => $status,
+			'amount'          => 29.99,
+			'recurring'       => true,
+			'duration'        => 1,
+			'duration_unit'   => 'month',
+			'times_billed'    => $times_billed,
+			'date_expiration' => $expiration,
+		]);
+		$this->assertNotWPError($membership);
+		$payment = wu_create_payment([
+			'customer_id'   => $customer->get_id(),
+			'membership_id' => $membership->get_id(),
+			'gateway'       => 'manual',
+			'status'        => Payment_Status::PENDING,
+			'total'         => 128.99,
+		]);
+		$this->assertNotWPError($payment);
+
+		$membership->create_pending_site([
+			'title'         => 'Manual Confirmation Site',
+			'path'          => '/manual-confirmation-' . strtolower(wp_generate_password(8, false)) . '/',
+			'customer_id'   => $customer->get_id(),
+			'membership_id' => $membership->get_id(),
+		]);
+		$force_sync = wu_get_setting('force_publish_sites_sync', false);
+		wu_save_setting('force_publish_sites_sync', true);
+		add_filter('wp_redirect', '__return_false');
+
+		$this->page->object             = $payment;
+		$_POST['confirm_membership']    = '1';
+		$_REQUEST['confirm_membership'] = '1';
+		$_POST['status']                = Payment_Status::COMPLETED;
+		$_REQUEST['status']             = Payment_Status::COMPLETED;
+		$expected_expiration            = $renews ? gmdate('Y-m-d H:i:s', strtotime('+1 month', strtotime($expiration))) : $expiration;
+
+		try {
+			if ($fail_first) {
+				$fail_save = static function ($data, $_original, $model) use ($membership) {
+					if ($model->get_id() === $membership->get_id()) {
+						$model->set_status('invalid-status');
+					}
+					return $data;
+				};
+				add_filter('wu_membership_pre_save', $fail_save, 10, 3);
+				try {
+					$this->assertFalse($this->page->handle_save());
+				} finally {
+					remove_filter('wu_membership_pre_save', $fail_save, 10);
+				}
+				$this->assertSame(Payment_Status::PENDING, wu_get_payment($payment->get_id())->get_status());
+				$this->assertSame($times_billed, wu_get_membership($membership->get_id())->get_times_billed());
+				$this->assertSame($expiration, wu_get_membership($membership->get_id())->get_date_expiration());
+				$this->page->object = wu_get_payment($payment->get_id());
+			}
+
+			$this->assertTrue($this->page->handle_save());
+			$membership = wu_get_membership($membership->get_id());
+			$this->assertSame('active', $membership->get_status());
+			$this->assertSame($expected_expiration, $membership->get_date_expiration());
+			$this->assertSame($times_billed + 1, $membership->get_times_billed());
+			$this->assertSame(Payment_Status::COMPLETED, wu_get_payment($payment->get_id())->get_status());
+			if ('pending' === $status) {
+				$this->assertEmpty($membership->get_pending_site());
+				$this->assertCount(1, $membership->get_sites());
+			}
+
+			// A fresh request reposting the confirmation must not bill or extend again.
+			$this->page->object = wu_get_payment($payment->get_id());
+			$this->assertTrue($this->page->handle_save());
+			$membership = wu_get_membership($membership->get_id());
+			$this->assertSame($expected_expiration, $membership->get_date_expiration());
+			$this->assertSame($times_billed + 1, $membership->get_times_billed());
+		} finally {
+			remove_filter('wp_redirect', '__return_false');
+			wu_save_setting('force_publish_sites_sync', $force_sync);
+		}
+	}
+
+	public function manual_confirmation_periods(): array {
+		return [
+			'initial payment'        => ['pending', 0, false],
+			'active renewal'         => ['active', 1, true],
+			'pending billed renewal' => ['pending', 1, true],
+			'expired renewal'        => ['expired', 1, true],
+			'initial save retry'     => ['pending', 0, false, true],
+			'renewal save retry'     => ['active', 1, true, true],
+		];
+	}
+
+	/**
+	 * A failed payment save must not grant entitlement before the admin retries.
+	 */
+	public function test_confirmation_does_not_apply_when_payment_save_fails(): void {
+		$payment = $this->createMock(Payment::class);
+		$payment->method('recalculate_totals')->willReturn($payment);
+		$payment->method('get_status')->willReturn(Payment_Status::PENDING);
+		$payment->method('save')->willReturn(new \WP_Error('test', 'Save failed'));
+		$payment->method('load_attributes_from_post')->willReturn(null);
+		$payment->expects($this->never())->method('get_membership');
+		$this->page->object             = $payment;
+		$_REQUEST['confirm_membership'] = '1';
+		$_REQUEST['status']             = Payment_Status::COMPLETED;
+		$_POST['status']                = Payment_Status::COMPLETED;
+
+		$this->assertFalse($this->page->handle_save());
+	}
+
+	/**
 	 * Test handle_save returns false when parent save fails.
 	 */
 	public function test_handle_save_returns_false_on_save_error(): void {
@@ -936,6 +1073,7 @@ class Payment_Edit_Admin_Page_Test extends WP_UnitTestCase {
 		} catch (\Throwable $e) {
 			// Source code bug: $payment->get_id() called before null check.
 			// This is expected behavior given the source code.
+			$this->assertInstanceOf(\Error::class, $e);
 		}
 		ob_end_clean();
 


### PR DESCRIPTION
## Summary

Resolves #1818.

- In `inc/admin-pages/class-payment-edit-admin-page.php`, activate a pending, never-billed membership without adding another billing period. The initial payment still increments `times_billed` from 0 to 1.
- Preserve `Membership::renew()` for previously billed memberships. Apply confirmation only to a successfully saved pending-to-completed payment, making ordinary repeat submissions a no-op for entitlement.
- If the membership save fails, restore the payment to pending and show an error so the administrator can retry.
- Extend `tests/WP_Ultimo/Admin_Pages/Payment_Edit_Admin_Page_Test.php` with initial activation, active/pending/expired renewal, repeat-save, payment failure, membership failure/retry, and real pending-site publication coverage.

The activation pattern follows `Customer_Edit_Admin_Page::confirm_memberships()`; publication continues through the existing membership status-transition hook. Existing confirmation-control visibility is unchanged rather than adding a new renewal UI in this bugfix.

## Verification

- PHPCS: both changed PHP files pass.
- PHPStan: changed production file passes.
- `XDEBUG_MODE=off vendor/bin/phpunit --no-coverage --filter Payment_Edit_Admin_Page_Test`: 66 tests, 178 assertions, four pre-existing skips. All added cases pass.
- Before the fix, regression tests reproduced the extra initial month, repeated-renewal extension, and entitlement work before a failed payment save.
- Independent billing-path review identified the membership-failure retry gap; it was repaired and covered by passing initial and renewal retry tests.
- Review bundle: `fb87edbdcf8fc705ae886e339a80967bf85315303193b39740129f1f0205f4b1`.

## Runtime Testing

**runtime-verified** — `pnpm run build:dev` and `composer archive-project` produced a ZIP exercised in an isolated WordPress 6.8.2 Multisite / PHP 8.4 Docker environment. Default products and checkout were provisioned using the existing installers; Manual was enabled.

An anonymous browser registered for Premium ($29.99/month + $99 setup fee = $128.99). Checkout advertised October 9, 2026 as the next charge. Before approval: payment pending, membership pending, expiration `2026-10-09 23:59:59`, `times_billed=0`, pending site present.

Network Admin: changed payment to Completed, enabled Activate Membership, and saved. After approval and a repeat save: payment completed, total still $128.99, membership active, expiration still `2026-10-09 23:59:59`, `times_billed=1`. The Memberships screen displays **October 9, 2026 — In 1 month**.

Docker's queued site-publication fallback was processed with `wp action-scheduler run --hooks=wu_async_publish_pending_site --batch-size=10`: one customer site exists and pending-site metadata is gone. No real payment was made. Generated assets and QA archives are not part of this PR.

<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.317 plugin for [OpenCode](https://opencode.ai) v1.18.30 with gpt-6-astra spent 48m and 305,363 tokens on this with the user in an interactive session. Overall, 4h 42m since this issue was created.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Payment confirmations now distinguish between initial membership activation and renewals.
  - Membership confirmation occurs only when a pending payment is completed with explicit confirmation.
  - Failed membership updates now return the payment to pending status, show an error, and prevent an incorrect redirect.
  - Payment data is recalculated before being saved to improve confirmation accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->