### PR TITLE
feat(playground): add WordPress.org live preview

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -189,8 +189,17 @@ jobs:
           # Ensure readme.txt is in trunk for wp.org metadata
           cp readme.txt "${SVN_DIR}/trunk/readme.txt"
 
-          # Stage changes in trunk only
+          # Sync the Playground preview Blueprint to the Plugin Directory assets.
+          svn update --set-depth=infinity "${SVN_DIR}/assets"
+          mkdir -p "${SVN_DIR}/assets/blueprints"
+          cp assets/blueprints/blueprint.json "${SVN_DIR}/assets/blueprints/blueprint.json"
+
+          # Stage changes in plugin code and Plugin Directory assets.
           cd "${SVN_DIR}"
+
+          if svn status assets/blueprints/blueprint.json | grep -q '^?'; then
+            svn add --parents -q assets/blueprints/blueprint.json
+          fi
 
           # Add new files in batches of 500 to avoid arg list / memory limits
           # Use '|| true' to prevent grep returning exit 1 (no match) from killing the script under pipefail
@@ -217,17 +226,17 @@ jobs:
             done
           fi
 
-          echo "=== SVN Status (trunk) ==="
-          svn status trunk > /tmp/svn-status.txt || true
+          echo "=== SVN Status (trunk and assets) ==="
+          svn status trunk assets > /tmp/svn-status.txt || true
           head -50 /tmp/svn-status.txt
           CHANGES=$(wc -l < /tmp/svn-status.txt)
           echo "Total trunk changes: ${CHANGES}"
 
           if [ "${CHANGES}" -eq 0 ]; then
-            echo "No changes to commit to trunk"
+            echo "No changes to commit"
           else
             echo "Committing ${CHANGES} changes to WordPress.org SVN..."
-            svn commit \
+            svn commit trunk assets \
               --username "${SVN_USERNAME}" \
               --password "${SVN_PASSWORD}" \
               --no-auth-cache \

--- a/README.md
+++ b/README.md
@@ -11,6 +11,10 @@
 </p>
 
 <p align="center">
+  <a href="https://ultimatemultisite.com/demo/"><strong>Try the full Ultimate Multisite demo →</strong></a>
+</p>
+
+<p align="center">
   <a href="http://www.gnu.org/licenses/gpl-2.0.html"><img src="https://img.shields.io/badge/License-GPL%20v2-blue.svg" alt="License: GPL v2"></a>
   <a href="https://wordpress.org/"><img src="https://img.shields.io/badge/WordPress-6.8%20Tested-green.svg" alt="WordPress: 6.8 Tested"></a>
   <a href="https://php.net/"><img src="https://img.shields.io/badge/PHP-8.2%2B-purple.svg" alt="PHP: 8.2+"></a>

--- a/assets/blueprints/blueprint.json
+++ b/assets/blueprints/blueprint.json
@@ -2,7 +2,7 @@
   "$schema": "https://playground.wordpress.net/blueprint-schema.json",
   "meta": {
     "title": "Ultimate Multisite Demo",
-    "description": "A demo of Ultimate Multisite running in your browser - transform your WordPress Multisite into a Website as a Service platform.",
+    "description": "Explore Ultimate Multisite on a WordPress Multisite network in your browser.",
     "author": "Ultimate Multisite Community",
     "categories": ["Multisite", "Site Management", "WaaS"]
   },
@@ -36,7 +36,7 @@
     {
       "step": "login",
       "username": "admin",
-      "password": "password"
+      "password": "[redacted-credential]"
     }
   ]
 }


### PR DESCRIPTION
## Summary

- Install Ultimate Multisite from the WordPress.org Plugin Directory in the tracked Playground Blueprint.
- Add the Blueprint at the WordPress.org Plugin Directory path: `assets/blueprints/blueprint.json`.
- Deploy that asset during stable-release SVN publishing so committers can enable the public Live Preview control.

## Verification

- `jq empty blueprint.json assets/blueprints/blueprint.json`
- `node -e "require('yaml').parse(require('fs').readFileSync('.github/workflows/release.yml', 'utf8'))"`
- Browser: fresh WordPress Playground Multisite installed Ultimate Multisite 2.15.2 from WordPress.org and network-activated it successfully.

## Follow-up

After the next stable release deploys the Blueprint to WordPress.org SVN, a plugin-directory committer must enable the public preview in the listing's Advanced view.

<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.317 plugin for [OpenCode](https://opencode.ai) v1.18.30 with gpt-5.6-terra


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a WordPress Playground preview for an Ultimate Multisite Demo environment.
  - The preview configures multisite, creates a sample site, installs and network-activates Ultimate Multisite, and opens the network setup page.
  - Added a direct link in the README to try the full demo.

- **Improvements**
  - The main Playground blueprint now retrieves Ultimate Multisite through the WordPress.org plugin directory.
  - The preview blueprint is included with Plugin Directory assets for easier access.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->