### PR TITLE
fix(a11y): preserve checkout plan focus

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -6,4 +6,5 @@ The default checkout pricing-table list presents each selectable plan with a
 visible native radio control. The focused control keeps the existing card focus
 ring, while the selected control retains the blue card border. Contact-us cards
 use a non-submitting button so they remain keyboard operable without becoming a
-checkout selection.
+checkout selection. After a plan refresh, focus returns to the selected radio
+only when the visitor has not moved it elsewhere during the request.

--- a/assets/js/checkout.js
+++ b/assets/js/checkout.js
@@ -398,19 +398,47 @@
 					});
 
 				},
-				remember_plan_focus(product_id, event) {
+				clear_plan_focus(plan_focus) {
 
-					if (! event || event.target !== event.target.ownerDocument.activeElement) {
-
-						this.plan_focus = null;
+					if (plan_focus && plan_focus !== this.plan_focus) {
 
 						return;
 					}
 
-					this.plan_focus = {
+					if (this.plan_focus && this.plan_focus.on_focus) {
+
+						this.$el.removeEventListener('focusin', this.plan_focus.on_focus);
+					}
+
+					this.plan_focus = null;
+
+				},
+				remember_plan_focus(product_id, event) {
+
+					this.clear_plan_focus();
+
+					if (! event || event.target !== event.target.ownerDocument.activeElement) {
+
+						return;
+					}
+
+					const plan_focus = {
 						element: event.target,
+						has_moved: false,
 						product_id,
 					};
+
+					plan_focus.on_focus = function (focus_event) {
+
+						if (focus_event.target !== plan_focus.element) {
+
+							plan_focus.has_moved = true;
+						}
+
+					};
+
+					this.$el.addEventListener('focusin', plan_focus.on_focus);
+					this.plan_focus = plan_focus;
 
 				},
 				restore_plan_focus(plan_focus) {
@@ -428,12 +456,15 @@
 						}
 
 						const active_element = this.$el.ownerDocument.activeElement;
-						this.plan_focus = null;
 
-						if (active_element !== this.$el.ownerDocument.body && active_element !== plan_focus.element) {
+						if (plan_focus.has_moved || (active_element !== this.$el.ownerDocument.body && active_element !== plan_focus.element)) {
+
+							this.clear_plan_focus(plan_focus);
 
 							return;
 						}
+
+						this.clear_plan_focus(plan_focus);
 
 						jQuery(this.$el).find('input[type="radio"][name="products[]"]').filter(function () {
 
@@ -585,7 +616,12 @@
 
 						that.restore_plan_focus(plan_focus);
 
-					}, this.handle_errors);
+					}, function (errors) {
+
+						that.clear_plan_focus(plan_focus);
+						that.handle_errors(errors);
+
+					});
 
 				},
 				get_errors() {

--- a/assets/js/checkout.js
+++ b/assets/js/checkout.js
@@ -179,6 +179,7 @@
 			inline_login_password: '',
 			custom_amounts: wu_checkout.custom_amounts || {},
 			pwyw_recurring: wu_checkout.pwyw_recurring || {},
+			plan_focus: null,
 		};
 
 		hooks.applyFilters('wu_before_form_init', initial_data);
@@ -397,7 +398,55 @@
 					});
 
 				},
-				add_plan(product_id) {
+				remember_plan_focus(product_id, event) {
+
+					if (! event || event.target !== event.target.ownerDocument.activeElement) {
+
+						this.plan_focus = null;
+
+						return;
+					}
+
+					this.plan_focus = {
+						element: event.target,
+						product_id,
+					};
+
+				},
+				restore_plan_focus(plan_focus) {
+
+					if (! plan_focus || plan_focus !== this.plan_focus) {
+
+						return;
+					}
+
+					this.$nextTick(function () {
+
+						if (plan_focus !== this.plan_focus || String(this.plan) !== String(plan_focus.product_id)) {
+
+							return;
+						}
+
+						const active_element = this.$el.ownerDocument.activeElement;
+						this.plan_focus = null;
+
+						if (active_element !== this.$el.ownerDocument.body && active_element !== plan_focus.element) {
+
+							return;
+						}
+
+						jQuery(this.$el).find('input[type="radio"][name="products[]"]').filter(function () {
+
+							return String(this.value) === String(plan_focus.product_id);
+
+						}).trigger('focus');
+
+					});
+
+				},
+				add_plan(product_id, event) {
+
+					this.remember_plan_focus(product_id, event);
 
 					if (this.plan) {
 
@@ -476,6 +525,7 @@
 					this.order = false;
 
 					const that = this;
+					const plan_focus = this.plan_focus;
 
 					const _request = this.debounce(this.request);
 
@@ -486,6 +536,7 @@
 					delete data.city_list;
 					delete data.uses_postal_code;
 					delete data.labels;
+					delete data.plan_focus;
 
 					_request('wu_create_order', this.filter_for_request(data, 'wu_create_order'), function (results) {
 
@@ -531,6 +582,8 @@
 						} // ed if;
 
 						that.unblock();
+
+						that.restore_plan_focus(plan_focus);
 
 					}, this.handle_errors);
 

--- a/tests/e2e/cypress/integration/010-manual-checkout-flow.spec.js
+++ b/tests/e2e/cypress/integration/010-manual-checkout-flow.spec.js
@@ -18,6 +18,56 @@ describe("Manual Gateway Checkout Flow", () => {
 		});
 	});
 
+	it("Preserves plan focus after checkout refreshes", () => {
+		const planSelector = '#wrapper-field-pricing_table input[type="radio"][name="products[]"]';
+
+		cy.intercept("POST", "**/admin-ajax.php*", (req) => {
+			if (req.body.action === "wu_create_order" || req.url.includes("action=wu_create_order")) {
+				req.alias = "createOrder";
+				req.continue((response) => {
+					response.setDelay(500);
+				});
+			}
+		});
+
+		cy.clearCookies();
+		cy.visit("/register", { failOnStatusCode: false });
+		cy.get("#field-email_address", { timeout: 30000 }).should("be.visible");
+		cy.wait("@createOrder");
+
+		cy.get(planSelector).should("have.length.at.least", 2).then(($plans) => {
+			const unselectedPlan = Array.from($plans).find((plan) => ! plan.checked);
+
+			expect(unselectedPlan).to.exist;
+			cy.wrap(unselectedPlan).focus().type(" ");
+			cy.wait("@createOrder");
+			cy.get(`${planSelector}[value="${unselectedPlan.value}"]`).should("be.focused");
+		});
+
+		cy.get(`${planSelector}:checked`).type("{rightarrow}");
+		cy.wait("@createOrder");
+		cy.get(`${planSelector}:checked`).should("be.focused");
+
+		cy.get(planSelector).then(($plans) => {
+			const unselectedPlan = Array.from($plans).find((plan) => ! plan.checked);
+
+			expect(unselectedPlan).to.exist;
+			cy.wrap(unselectedPlan).click();
+			cy.wait("@createOrder");
+			cy.get(`${planSelector}[value="${unselectedPlan.value}"]`).should("be.focused");
+		});
+
+		cy.get(planSelector).then(($plans) => {
+			const unselectedPlan = Array.from($plans).find((plan) => ! plan.checked);
+
+			expect(unselectedPlan).to.exist;
+			cy.wrap(unselectedPlan).click();
+			cy.get("#field-email_address").focus().type("focus").should("be.focused");
+			cy.wait("@createOrder");
+			cy.get("#field-email_address").should("be.focused");
+		});
+	});
+
 	it("Should complete the UM checkout form with manual gateway", {
 		retries: 0,
 	}, () => {

--- a/views/checkout/templates/pricing-table/list.php
+++ b/views/checkout/templates/pricing-table/list.php
@@ -37,7 +37,7 @@ foreach ($products as $index => &$_product) {
 		<div class="wu-flex wu-items-center">
 			<input
 				v-if="<?php echo wp_json_encode($product->get_pricing_type() !== 'contact_us'); ?>"
-				v-on:change="$parent.add_plan(<?php echo esc_attr($product->get_id()); ?>)"
+				v-on:change="$parent.add_plan(<?php echo esc_attr($product->get_id()); ?>, $event)"
 				v-bind:checked="$parent.plan === <?php echo esc_attr($product->get_id()); ?>"
 				type="radio"
 				name="products[]"


### PR DESCRIPTION
## Summary

- Preserve the selected checkout plan radio's focus after its order refresh.
- Leave focus on another field when the visitor moves it during the request.

## Testing

- `pnpm exec eslint assets/js/checkout.js`
- `vendor/bin/phpcs views/checkout/templates/pricing-table/list.php`

Resolves #1832

<!-- aidevops:origin:worker -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.317 plugin for [OpenCode](https://opencode.ai) v1.18.30 with gpt-5.6-terra
