### PR TITLE
GH#1833: preserve contact plan button labels

### DIFF
--- a/tests/WP_Ultimo/Checkout/Signup_Fields/Signup_Field_Pricing_Table_Test.php
+++ b/tests/WP_Ultimo/Checkout/Signup_Fields/Signup_Field_Pricing_Table_Test.php
@@ -7,6 +7,7 @@
 
 namespace WP_Ultimo\Checkout\Signup_Fields;
 
+use WP_Ultimo\Checkout\Signup_Fields\Field_Templates\Pricing_Table\List_Pricing_Table_Field_Template;
 use WP_UnitTestCase;
 
 /**
@@ -203,6 +204,56 @@ class Signup_Field_Pricing_Table_Test extends WP_UnitTestCase {
 
 		// With no valid products, the result should be an array with one note field (template rendered).
 		$this->assertIsArray( $fields );
+	}
+
+	/**
+	 * Test list template uses contact products' configured labels with a default fallback.
+	 */
+	public function test_list_template_renders_contact_us_labels(): void {
+		$custom_label_product = wu_create_product(
+			[
+				'name'          => 'Custom Contact Product',
+				'slug'          => 'custom-contact-product-' . wp_rand(),
+				'pricing_type'  => 'contact_us',
+				'type'          => 'plan',
+				'duration'      => 1,
+				'duration_unit' => 'month',
+				'active'        => true,
+			]
+		);
+
+		$default_label_product = wu_create_product(
+			[
+				'name'          => 'Default Contact Product',
+				'slug'          => 'default-contact-product-' . wp_rand(),
+				'pricing_type'  => 'contact_us',
+				'type'          => 'plan',
+				'duration'      => 1,
+				'duration_unit' => 'month',
+				'active'        => true,
+			]
+		);
+
+		$custom_label_product->set_contact_us_label( 'Talk to Sales' );
+		$custom_label_product->save();
+
+		$template = new List_Pricing_Table_Field_Template();
+		$output   = $template->render(
+			[
+				'products'                  => [
+					['id' => $custom_label_product->get_id()],
+					['id' => $default_label_product->get_id()],
+				],
+				'duration'                  => 1,
+				'duration_unit'             => 'month',
+				'force_different_durations' => false,
+				'classes'                   => '',
+			]
+		);
+
+		$this->assertStringContainsString( 'type="button"', $output );
+		$this->assertStringContainsString( 'value="Talk to Sales"', $output );
+		$this->assertStringContainsString( 'value="Contact us"', $output );
 	}
 
 	/**

--- a/views/checkout/templates/pricing-table/list.php
+++ b/views/checkout/templates/pricing-table/list.php
@@ -49,7 +49,7 @@ foreach ($products as $index => &$_product) {
 				v-else
 				v-on:click="$parent.open_url(<?php echo esc_attr(wp_json_encode(esc_url_raw($product->get_contact_us_link()))); ?>, '_blank');"
 				type="button"
-				value="<?php esc_attr_e('Contact us', 'ultimate-multisite'); ?>"
+				value="<?php echo esc_attr($product->get_contact_us_label() ?: __('Contact us', 'ultimate-multisite')); ?>"
 				class="button button-secondary wu-mr-3 wu-flex-shrink-0"
 			>
 


### PR DESCRIPTION
## Summary

- Uses each contact-priced product's configured button label in the list pricing template.
- Preserves the localized `Contact us` fallback for products without a label.
- Adds rendering coverage for configured and fallback labels.

## Testing

- `vendor/bin/phpcs views/checkout/templates/pricing-table/list.php tests/WP_Ultimo/Checkout/Signup_Fields/Signup_Field_Pricing_Table_Test.php`
- `vendor/bin/phpunit --filter Signup_Field_Pricing_Table_Test` (20 tests, 45 assertions)

## Runtime Testing

- Runtime-verified in the WordPress multisite test environment through list-template rendering coverage.

Resolves #1833

<!-- aidevops:origin:worker -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.317 plugin for [OpenCode](https://opencode.ai) v1.18.30 with gpt-5.6-terra spent 7m and 106,988 tokens on this as a headless worker.
