### PR TITLE
fix(sso): preserve SSO for networks upgrading without a saved setting

### DIFF
--- a/inc/class-settings.php
+++ b/inc/class-settings.php
@@ -74,6 +74,8 @@ class Settings implements \WP_Ultimo\Interfaces\Singleton {
 	 */
 	public function init(): void {
 
+		add_action('init', [$this, 'maybe_preserve_legacy_sso_default'], 1);
+
 		add_action('init', [$this, 'handle_legacy_filters'], 2);
 
 		add_action('wu_render_settings', [$this, 'handle_legacy_scripts']);
@@ -90,6 +92,43 @@ class Settings implements \WP_Ultimo\Interfaces\Singleton {
 		// plugin deactivation in the correct state.
 		add_action('wu_activation', [$this, 'sync_wp_registration_option']);
 		add_action('wu_after_save_settings', [$this, 'sync_wp_registration_option']);
+	}
+
+	/**
+	 * Keep SSO on for networks that were relying on the pre-2.15.2 fallback.
+	 *
+	 * `get_setting_defaults()` returned `enable_sso => 1` until 2.15.1, so a network that
+	 * never opened the settings page still had SSO on. 2.15.2 changed that fallback to `0`
+	 * to give fresh installations a safer default, but the fallback is also what an older
+	 * network without a saved `enable_sso` key reads, so upgrading silently turns SSO off
+	 * for it — with no notice and nothing in the settings UI to explain the change.
+	 *
+	 * This writes the previous default once, and only for a network that is already set up
+	 * and has no value of its own. A fresh installation is untouched: the installer persists
+	 * the whole defaults map, so `enable_sso` is already present (and `0`) by the time this
+	 * runs. The saved key is its own guard — once written, this returns on the `isset()`
+	 * below and never writes again, so there is no migration flag to store or read.
+	 *
+	 * @since 2.15.3
+	 * @return void
+	 */
+	public function maybe_preserve_legacy_sso_default(): void {
+
+		$settings = $this->get_all();
+
+		/*
+		 * Nothing saved yet: the plugin has not been set up on this network, and the
+		 * installer will persist the current defaults, including the new SSO one.
+		 */
+		if (empty($settings)) {
+			return;
+		}
+
+		if (isset($settings['enable_sso'])) {
+			return;
+		}
+
+		$this->save_setting('enable_sso', 1);
 	}
 
 	/**

--- a/tests/WP_Ultimo/Settings_Test.php
+++ b/tests/WP_Ultimo/Settings_Test.php
@@ -90,6 +90,79 @@ class Settings_Test extends WP_UnitTestCase {
 	// get_setting / save_setting
 	// ------------------------------------------------------------------
 
+	// ------------------------------------------------------------------
+	// maybe_preserve_legacy_sso_default
+	// ------------------------------------------------------------------
+
+	/**
+	 * Replace the saved settings array and drop the in-memory cache.
+	 *
+	 * @param array $settings Settings to persist.
+	 */
+	private function replace_saved_settings(array $settings) {
+		wu_save_option(Settings::KEY, $settings);
+
+		$ref = new \ReflectionProperty(Settings::class, 'settings');
+		if (PHP_VERSION_ID < 80100) {
+			$ref->setAccessible(true);
+		}
+		$ref->setValue($this->settings, null);
+	}
+
+	public function test_legacy_sso_default_is_preserved_on_a_network_without_a_saved_value() {
+		$saved = $this->settings->get_all();
+
+		// A network set up before the enable_sso key existed.
+		$this->replace_saved_settings(['company_name' => 'Existing Network']);
+
+		$this->settings->maybe_preserve_legacy_sso_default();
+
+		$this->assertEquals(1, $this->settings->get_setting('enable_sso'), 'An upgrade must not silently turn SSO off.');
+
+		$this->replace_saved_settings($saved);
+	}
+
+	public function test_a_saved_sso_value_is_never_overwritten() {
+		$saved = $this->settings->get_all();
+
+		$this->replace_saved_settings(['enable_sso' => 0]);
+
+		$this->settings->maybe_preserve_legacy_sso_default();
+
+		$this->assertEquals(0, $this->settings->get_setting('enable_sso'), 'A network that chose to disable SSO keeps its choice.');
+
+		$this->replace_saved_settings($saved);
+	}
+
+	public function test_a_fresh_install_keeps_the_new_default() {
+		$saved = $this->settings->get_all();
+
+		// Nothing saved yet: the installer has not run, so there is nothing to preserve.
+		$this->replace_saved_settings([]);
+
+		$this->settings->maybe_preserve_legacy_sso_default();
+
+		$this->assertArrayNotHasKey('enable_sso', $this->settings->get_all(), 'A fresh installation must not be seeded by the migration.');
+
+		$this->replace_saved_settings($saved);
+	}
+
+	public function test_the_migration_writes_only_once() {
+		$saved = $this->settings->get_all();
+
+		$this->replace_saved_settings(['company_name' => 'Existing Network']);
+
+		$this->settings->maybe_preserve_legacy_sso_default();
+
+		// A later choice to disable SSO must survive the migration running again.
+		$this->settings->save_setting('enable_sso', 0);
+		$this->settings->maybe_preserve_legacy_sso_default();
+
+		$this->assertEquals(0, $this->settings->get_setting('enable_sso'), 'The migration must be a one-time write.');
+
+		$this->replace_saved_settings($saved);
+	}
+
 	public function test_save_setting_stores_value() {
 		$this->settings->save_setting('test_key_123', 'test_value_123');
 


### PR DESCRIPTION
## Summary

`#1741` changed the SSO fallback so that **fresh** installations start with SSO off. The
implementation changes `get_setting_defaults()`, and that map is also what an **existing**
network reads when it has no saved `enable_sso` key — so upgrading to 2.15.2 silently turns
SSO off for those networks.

```
inc/class-settings.php:2205  (2.15.1)   'enable_sso' => 1,
inc/class-settings.php:2235  (2.15.2)   'enable_sso' => 0,
```

`Settings::get_setting()` falls back to that map when the key is absent
(`inc/class-settings.php:279`), and nothing persists the previous value on upgrade. The PR
description for #1741 says it preserves *"existing installations' explicitly saved SSO
setting"* — which is exactly the set that was never at risk. The set that *is* at risk is the
one with **no** saved value.

**Who is affected:** a network whose saved settings array predates the `enable_sso` key. A
network that ran the installer after the key existed already has it persisted
(`inc/installers/class-default-content-installer.php:271` saves the whole defaults map), so
most installs are unaffected. The failure mode is what makes it worth fixing: SSO stops
working across mapped domains, the settings page shows the toggle off as if that had always
been the case, and nothing points at the upgrade.

## The change

`Settings::maybe_preserve_legacy_sso_default()` on `init` at priority 1: if the network has
settings saved but no `enable_sso` key, it writes the pre-2.15.2 value once.

- A **fresh** installation is untouched — the installer persists `enable_sso => 0` before this
  ever runs, so the `isset()` short-circuits and the new default stands.
- A network that **explicitly disabled** SSO keeps its choice.
- **No migration flag and no version marker.** The saved key is its own guard: once written,
  every later request returns on the `isset()`. The only cost in steady state is the settings
  array the plugin already loads.

## Verification

- `php -l` on both changed files.
- 4 unit tests added to `tests/WP_Ultimo/Settings_Test.php`: the value is restored for a
  network without one, a saved `0` is never overwritten, a fresh install is not seeded, and the
  migration writes only once (a later "disable SSO" survives a second run).
- I could not run `phpcs` / `phpstan` / `phpunit` locally (no `vendor/` in my checkout), so CI
  is the first full run.

## Context

We run 2.15.2 on a live 23-site network (upgraded 2026-09-09, staging first, then production)
and validated it end to end: a full signup creates the membership as `trialing` with the
expiration at exactly +15 days — the epoch expiration from #1692 is gone — the pending site is
published after the checkout transaction commits, third-party hooks at priority 9999 still
fire, and there were no fatals after the swap. Our own network was unaffected by this SSO issue
because `enable_sso` was explicitly saved; we found it while diffing 2.15.1 against 2.15.2
before rolling the update out.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved the previously enabled SSO default for existing networks without a saved SSO setting.
  * Existing saved SSO preferences remain unchanged.
  * New installations continue using the current default behavior.
  * The compatibility setting is applied only once.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->