### PR TITLE
fix(stripe): handle Basil invoice subscription references

### DIFF
--- a/inc/gateways/class-base-stripe-gateway.php
+++ b/inc/gateways/class-base-stripe-gateway.php
@@ -2806,9 +2806,17 @@ class Base_Stripe_Gateway extends Base_Gateway {
 
 		/*
 		 * Now try to get a subscription from the invoice object.
+		 * Basil moved the reference into parent.subscription_details. Keep the
+		 * legacy shape for older events, including expanded subscription objects.
 		 */
-		if ( ! empty($invoice->subscription)) {
-			$subscription = $this->get_stripe_client()->subscriptions->retrieve($invoice->subscription);
+		$invoice_subscription_id = $invoice->subscription ?? $invoice->parent->subscription_details->subscription ?? null;
+
+		if (is_object($invoice_subscription_id)) {
+			$invoice_subscription_id = $invoice_subscription_id->id ?? null;
+		}
+
+		if (is_string($invoice_subscription_id) && '' !== $invoice_subscription_id) {
+			$subscription = $this->get_stripe_client()->subscriptions->retrieve($invoice_subscription_id);
 		}
 
 		/*

--- a/inc/gateways/class-base-stripe-gateway.php
+++ b/inc/gateways/class-base-stripe-gateway.php
@@ -37,6 +37,13 @@ defined('ABSPATH') || exit;
 class Base_Stripe_Gateway extends Base_Gateway {
 
 	/**
+	 * Pin requests and new webhook endpoints independently of SDK upgrades.
+	 *
+	 * @var string
+	 */
+	private const STRIPE_API_VERSION = '2025-08-27.basil';
+
+	/**
 	 * Allow gateways to declare multiple additional ids.
 	 *
 	 * These ids can be retrieved alongside the main id,
@@ -153,7 +160,8 @@ class Base_Stripe_Gateway extends Base_Gateway {
 			}
 
 			$client_config = [
-				'api_key' => $this->secret_key,
+				'api_key'        => $this->secret_key,
+				'stripe_version' => self::STRIPE_API_VERSION,
 			];
 
 			// Set Stripe-Account header for Connect mode
@@ -673,6 +681,7 @@ class Base_Stripe_Gateway extends Base_Gateway {
 
 			$this->get_stripe_client()->webhookEndpoints->create(
 				[
+					'api_version'    => self::STRIPE_API_VERSION,
 					'enabled_events' => ['*'],
 					'url'            => $webhook_url,
 					'description'    => 'Added by Ultimate Multisite. Required to correctly handle changes in subscription status.',
@@ -1303,6 +1312,7 @@ class Base_Stripe_Gateway extends Base_Gateway {
 			 */
 			$this->get_stripe_client()->webhookEndpoints->create(
 				[
+					'api_version'    => self::STRIPE_API_VERSION,
 					'enabled_events' => ['*'],
 					'url'            => $webhook_url,
 					'description'    => 'Added by Ultimate Multisite. Required to correctly handle changes in subscription status.',
@@ -1777,9 +1787,8 @@ class Base_Stripe_Gateway extends Base_Gateway {
 		 * unlocks the multi-interval case without changing single-interval
 		 * behaviour.
 		 *
-		 * Requires Stripe API version 2025-06-30.basil or later. The bundled
-		 * stripe/stripe-php SDK pins a newer version (2025-08-27.basil at the
-		 * time of writing), so this is always satisfied.
+		 * Requires Stripe API version 2025-06-30.basil or later. The explicit
+		 * STRIPE_API_VERSION pin satisfies this independently of SDK upgrades.
 		 *
 		 * @since 2.5.x
 		 */

--- a/tests/WP_Ultimo/Gateways/Stripe_API_Version_Test.php
+++ b/tests/WP_Ultimo/Gateways/Stripe_API_Version_Test.php
@@ -1,0 +1,115 @@
+<?php
+/**
+ * Stripe request and webhook API version regression tests.
+ *
+ * @package WP_Ultimo
+ * @subpackage Tests/Gateways
+ * @since 2.15.2
+ */
+
+namespace WP_Ultimo\Gateways;
+
+defined('ABSPATH') || exit;
+
+class Stripe_API_Version_Test extends \WP_UnitTestCase {
+
+	public static function client_modes(): array {
+		return [
+			'stripe direct'   => [Stripe_Gateway::class, false],
+			'stripe OAuth'    => [Stripe_Gateway::class, true],
+			'checkout direct' => [Stripe_Checkout_Gateway::class, false],
+			'checkout OAuth'  => [Stripe_Checkout_Gateway::class, true],
+		];
+	}
+
+	/**
+	 * @dataProvider client_modes
+	 */
+	public function test_client_uses_pinned_version(string $gateway_class, bool $oauth): void {
+		$gateway = $this->getMockBuilder($gateway_class)
+			->disableOriginalConstructor()
+			->onlyMethods(['is_using_oauth'])
+			->getMock();
+		$gateway->method('is_using_oauth')->willReturn($oauth);
+
+		$reflection = new \ReflectionClass(Base_Stripe_Gateway::class);
+		$reflection->getProperty('secret_key')->setValue($gateway, 'sk_test_version_fixture');
+		$reflection->getProperty('oauth_account_id')->setValue($gateway, 'acct_version_fixture');
+		$client = $reflection->getMethod('get_stripe_client')->invoke($gateway);
+		$config = (new \ReflectionClass(\Stripe\BaseStripeClient::class))->getProperty('config')->getValue($client);
+
+		$this->assertSame('2025-08-27.basil', $config['stripe_version']);
+		$this->assertSame($oauth ? 'acct_version_fixture' : null, $client->getStripeAccount());
+	}
+
+	public static function webhook_paths(): array {
+		return [
+			'direct new'      => [false, ''],
+			'OAuth new'       => [true, ''],
+			'direct enabled'  => [false, 'enabled'],
+			'OAuth enabled'   => [true, 'enabled'],
+			'direct disabled' => [false, 'disabled'],
+			'OAuth disabled'  => [true, 'disabled'],
+		];
+	}
+
+	/**
+	 * @dataProvider webhook_paths
+	 */
+	public function test_webhook_version_is_pinned_only_on_creation(bool $oauth, string $status): void {
+		$gateway = $this->getMockBuilder(Stripe_Gateway::class)
+			->disableOriginalConstructor()
+			->onlyMethods(['setup_api_keys', 'has_webhook_installed', 'get_webhook_listener_url'])
+			->getMock();
+		$url     = home_url('/?wu-gateway=stripe');
+		$gateway->method('get_webhook_listener_url')->willReturn($url);
+		$gateway->method('has_webhook_installed')->willReturn(
+			$status ? \Stripe\WebhookEndpoint::constructFrom([
+				'id'          => 'we_version_fixture',
+				'status'      => $status,
+				'api_version' => '2024-06-20',
+			]) : false
+		);
+
+		$endpoints = $this->getMockBuilder(\Stripe\Service\WebhookEndpointService::class)
+			->disableOriginalConstructor()
+			->getMock();
+		$client    = $this->getMockBuilder(\Stripe\StripeClient::class)
+			->disableOriginalConstructor()
+			->getMock();
+		$client->method('__get')->with('webhookEndpoints')->willReturn($endpoints);
+		$gateway->set_stripe_client($client);
+
+		if ('' === $status) {
+			$endpoints->expects($this->once())->method('create')->with([
+				'api_version'    => '2025-08-27.basil',
+				'enabled_events' => ['*'],
+				'url'            => $url,
+				'description'    => 'Added by Ultimate Multisite. Required to correctly handle changes in subscription status.',
+			]);
+		} else {
+			$endpoints->expects($this->never())->method('create');
+		}
+
+		if ('disabled' === $status) {
+			$endpoints->expects($this->once())->method('update')->with('we_version_fixture', ['status' => 'enabled']);
+		} else {
+			$endpoints->expects($this->never())->method('update');
+		}
+
+		if ($oauth) {
+			(new \ReflectionMethod(Base_Stripe_Gateway::class, 'install_webhook_for_oauth'))->invoke($gateway);
+		} else {
+			$settings = [
+				'active_gateways'     => ['stripe'],
+				'stripe_sandbox_mode' => '1',
+				'stripe_test_pk_key'  => 'pk_test_version_fixture',
+				'stripe_test_sk_key'  => 'sk_test_version_fixture',
+				'stripe_live_pk_key'  => '',
+				'stripe_live_sk_key'  => '',
+			];
+			$previous = array_merge($settings, ['stripe_test_pk_key' => 'pk_test_previous_fixture']);
+			$gateway->install_webhook($settings, $settings, $previous);
+		}
+	}
+}

--- a/tests/WP_Ultimo/Gateways/Stripe_Webhook_Process_Test.php
+++ b/tests/WP_Ultimo/Gateways/Stripe_Webhook_Process_Test.php
@@ -155,6 +155,58 @@ class Stripe_Webhook_Process_Test extends \WP_UnitTestCase {
 		parent::tearDown();
 	}
 
+	public static function invoice_subscription_shapes(): array {
+		$expanded = [
+			'id'     => 'sub_test123',
+			'object' => 'subscription',
+		];
+		return [
+			'legacy ID'       => [['subscription' => 'sub_test123'], true],
+			'legacy expanded' => [['subscription' => $expanded], true],
+			'Basil ID'        => [['parent' => ['subscription_details' => ['subscription' => 'sub_test123']]], true],
+			'Basil expanded'  => [['parent' => ['subscription_details' => ['subscription' => $expanded]]], true],
+			'no reference'    => [[], false],
+		];
+	}
+
+	/**
+	 * @dataProvider invoice_subscription_shapes
+	 */
+	public function test_invoice_payment_completes_active_membership(array $shape, bool $linked): void {
+		$payment = wu_create_payment([
+			'customer_id'   => self::$customer->get_id(),
+			'membership_id' => $this->membership->get_id(),
+			'gateway'       => 'stripe',
+			'status'        => 'pending',
+			'subtotal'      => 29,
+			'total'         => 29,
+		]);
+		$this->assertNotWPError($payment);
+		$this->assertGreaterThan(0, $payment->get_id());
+
+		$this->subscriptions_mock->expects($linked ? $this->once() : $this->never())
+			->method('retrieve')
+			->with('sub_test123')
+			->willReturn($this->make_stripe_subscription());
+
+		$event = $this->make_stripe_event('invoice.payment_succeeded', array_merge([
+			'id'          => 'in_active_membership',
+			'object'      => 'invoice',
+			'customer'    => 'cus_test123',
+			'currency'    => 'usd',
+			'amount_paid' => 2900,
+			'total'       => 2900,
+		], $shape));
+
+		try {
+			$this->dispatch_webhook($event);
+			$this->assertSame($linked ? 'completed' : 'pending', wu_get_payment($payment->get_id())->get_status());
+			$this->assertSame(Membership_Status::ACTIVE, wu_get_membership($this->membership->get_id())->get_status());
+		} finally {
+			$payment->delete();
+		}
+	}
+
 	// -------------------------------------------------------------------------
 	// Helpers
 	// -------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Handle the Stripe Basil invoice subscription reference and explicitly pin outgoing Stripe requests and newly created webhook endpoints to `2025-08-27.basil`.

Basil places the invoice subscription reference under `parent.subscription_details.subscription`; looking only at the legacy top-level field can leave an existing membership payment pending after settlement. The pin makes the integration's chosen version independent of future Stripe SDK defaults. It matches the default in the currently bundled SDK; this is not an intentional API upgrade.

## Changes and review scope

- `inc/gateways/class-base-stripe-gateway.php`: resolve legacy or nested invoice subscription references, normalize expanded objects to their ID, and retrieve subscriptions only for nonempty string IDs.
- Add one private `STRIPE_API_VERSION` constant (`2025-08-27.basil`), used as the client's `stripe_version` and the webhook `api_version` in **both OAuth and direct-key creation paths**.
- Existing webhook endpoints keep their configured API version. Re-enabling a disabled endpoint still changes only its status. No endpoint replacement or account-wide version change.
- `tests/WP_Ultimo/Gateways/Stripe_Webhook_Process_Test.php`: existing five-case invoice-reference regression, covering legacy/Basil IDs and expanded objects plus absent reference.
- `tests/WP_Ultimo/Gateways/Stripe_API_Version_Test.php`: direct/OAuth client configuration for both Stripe gateways, both new-endpoint creation paths, and preservation of existing enabled/disabled endpoints.
- No credential, gateway-setting, public-routing, SDK-dependency, or release-metadata changes.

## Verification

For added pin commit `a20cb1ce`:

- Configured PHPCS passed for both files changed by that commit.
- PHPStan on the production gateway passed in the pre-commit hook.
- `vendor/bin/phpunit --no-coverage --filter Stripe_API_Version_Test` passed: **10 tests / 14 assertions**. No real Stripe requests are made by these tests.
- `git diff --check` passed.
- A combined run and a later invoice-only rerun encountered an existing customer fixture setup failure at `Stripe_Webhook_Process_Test.php:66` (`wu_create_customer()` returned `WP_Error`, assigned to a typed Customer property). Those reruns did not establish invoice-test success. The initial PR's isolated fixture run was reported as 5 tests / 25 assertions; it is separate evidence, not a claim that the latest combined local run passed.

Reproduction commands with the WordPress multisite test environment configured:

```bash
vendor/bin/phpcs inc/gateways/class-base-stripe-gateway.php tests/WP_Ultimo/Gateways/Stripe_API_Version_Test.php tests/WP_Ultimo/Gateways/Stripe_Webhook_Process_Test.php
vendor/bin/phpunit --no-coverage --filter Stripe_API_Version_Test
vendor/bin/phpunit --no-coverage --filter test_invoice_payment_completes_active_membership
```

No live charge, remote endpoint migration, release, or production deployment is part of this PR. Public webhook delivery and complete payment-provider sandbox flows remain separate integration checks. Existing installations may continue delivering older event shapes, so retain backward-compatible parsing.

<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.317 plugin for [OpenCode](https://opencode.ai) v1.18.30 with gpt-6-astra spent 7h 53m and 603,926 tokens on this with the user in an interactive session.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Stripe webhook processing for the latest API payload format while retaining support for legacy invoice data.
  * Correctly handles expanded subscription details and invoices without subscription references.
  * Ensures linked invoice payments complete successfully while unlinked invoices remain pending.

* **Improvements**
  * Stripe clients and newly created webhooks now use a consistent pinned API version.
  * Existing webhooks are preserved, while disabled webhooks can be re-enabled without unnecessary recreation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->