### PR TITLE
test: create username collisions through customer helper

### DIFF
--- a/tests/WP_Ultimo/Functions/Customer_Functions_Test.php
+++ b/tests/WP_Ultimo/Functions/Customer_Functions_Test.php
@@ -204,7 +204,14 @@ class Customer_Functions_Test extends WP_UnitTestCase {
 
 	public function test_username_from_email_checks_normalized_name_for_collisions(): void {
 
-		$user_id  = self::factory()->user->create(['user_login' => 'alice.beth.example']);
+		$customer = wu_create_customer([
+			'email'    => 'alice.beth.example@example.com',
+			'username' => 'alice.beth.example',
+			'password' => 'Str0ngP@ss!',
+		]);
+		$this->assertNotWPError($customer);
+
+		$user_id  = $customer->get_user_id();
 		$username = wu_username_from_email('username-probe@example.com', [
 			'first_name' => 'Alice Beth',
 			'last_name'  => 'Example',


### PR DESCRIPTION
## Summary

- Replace the direct WordPress user factory collision setup with `wu_create_customer()`.
- Preserve the normalized username collision behavior and assertion.

## Testing

- `vendor/bin/phpcs tests/WP_Ultimo/Functions/Customer_Functions_Test.php`
- `vendor/bin/phpunit --filter Customer_Functions_Test`

Resolves #1848

<!-- aidevops:origin:worker -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.317 plugin for [OpenCode](https://opencode.ai) v1.18.30 with gpt-5.6-terra


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Updated customer username collision coverage to create customers through the supported customer workflow.
  - Added validation that customer creation succeeds before checking the resulting user ID.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->