### PR TITLE
fix(site-duplicator): make the URL rewrite serialize-aware so cloned sites do not inherit unreadable options/postmeta

### DIFF
--- a/inc/helpers/class-site-duplicator.php
+++ b/inc/helpers/class-site-duplicator.php
@@ -674,10 +674,22 @@ class Site_Duplicator {
 	 * commentmeta tables, correcting any template references left by the
 	 * backfill or missed by MUCD's pass.
 	 *
+	 * The substitution has to be serialize-aware. postmeta and options routinely
+	 * hold PHP-serialized values (Elementor `_extra`, image-optimizer LCP data,
+	 * plugin settings, currency tables...). A raw SQL REPLACE() rewrites the
+	 * bytes of every `s:N:"..."` string that contains the host but leaves N
+	 * untouched, so whenever the target host length differs from the template
+	 * host length every such value stops unserializing (unserialize() returns
+	 * false) and the plugin that owns it silently falls back to its defaults.
+	 * MUCD_Data::update() already implements the row-by-row, primary-key based,
+	 * serialize-aware pass that copy_data() runs on the copied rows; this method
+	 * reuses it instead of issuing REPLACE().
+	 *
 	 * Safe to run after MUCD has already rewritten the copied rows: those rows
-	 * no longer contain the source URL, so REPLACE() is a no-op for them.
+	 * no longer contain the source URL, so they are never selected.
 	 *
 	 * @since 2.3.2
+	 * @since 2.16.1 Routes the rewrite through MUCD_Data::update() (serialize-aware) instead of SQL REPLACE().
 	 * @see https://github.com/Ultimate-Multisite/ultimate-multisite/issues/834
 	 *
 	 * @param int $from_site_id Source (template) blog ID.
@@ -730,7 +742,7 @@ class Site_Duplicator {
 			"{$to_prefix}commentmeta" => 'meta_value',
 		];
 
-		// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQLPlaceholders.UnfinishedPrepare
+		// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
 		foreach ($tables as $table => $column) {
 
 			// Skip tables that don't exist (e.g. termmeta on older WP versions).
@@ -750,14 +762,13 @@ class Site_Duplicator {
 					continue;
 				}
 
-				$wpdb->query(
-					$wpdb->prepare(
-						"UPDATE `{$table}` SET `{$column}` = REPLACE(`{$column}`, %s, %s) WHERE `{$column}` LIKE %s",
-						$from,
-						$to,
-						'%' . $wpdb->esc_like($from) . '%'
-					)
-				);
+				/*
+				 * Serialize-aware, primary-key based replacement — the same
+				 * pass MUCD_Data::db_update_data() runs on the copied rows.
+				 * Rows that do not contain $from are never selected, and rows
+				 * whose value does not change are skipped by update().
+				 */
+				\MUCD_Data::update($table, [$column], $from, $to);
 			}
 		}
 		// phpcs:enable

--- a/tests/WP_Ultimo/Helpers/Site_Duplicator_Postmeta_Test.php
+++ b/tests/WP_Ultimo/Helpers/Site_Duplicator_Postmeta_Test.php
@@ -870,6 +870,206 @@ class Site_Duplicator_Postmeta_Test extends WP_UnitTestCase {
 	}
 
 	// =========================================================================
+	// rewrite_backfilled_postmeta_urls — serialized values
+	// =========================================================================
+
+	/**
+	 * Test that a serialized postmeta value holding the template URL stays
+	 * readable after the rewrite when the target host has a different length.
+	 *
+	 * The fixture hosts differ in length (template.example.com is 3 bytes
+	 * longer than clone.example.com). A raw SQL REPLACE() changes the bytes of
+	 * every s:N:"..." string but not N, so the whole value stops unserializing.
+	 * The rewrite must recount the lengths, i.e. be serialize-aware.
+	 */
+	public function test_rewrite_keeps_serialized_postmeta_readable_when_host_length_changes() {
+		$post_id = $this->create_target_post();
+
+		$meta_id = $this->insert_raw_postmeta(
+			$post_id,
+			'_extra',
+			maybe_serialize(
+				[
+					'image_url' => 'http://template.example.com/wp-content/uploads/sites/2/a.jpg',
+					'nested'    => [
+						'home' => 'http://template.example.com/',
+						'json' => '{"url":"http:\/\/template.example.com\/x"}',
+						'n'    => 3,
+					],
+				]
+			)
+		);
+
+		Testable_Site_Duplicator::rewrite_backfilled_postmeta_urls($this->from_blog_id, $this->to_blog_id);
+
+		$stored = $this->read_raw_postmeta($meta_id);
+		$parsed = maybe_unserialize($stored);
+
+		$this->assertIsArray($parsed, 'Rewritten serialized postmeta must still unserialize.');
+		$this->assertEquals('http://clone.example.com/wp-content/uploads/sites/2/a.jpg', $parsed['image_url']);
+		$this->assertEquals('http://clone.example.com/', $parsed['nested']['home']);
+		$this->assertEquals('{"url":"http:\/\/clone.example.com\/x"}', $parsed['nested']['json']);
+		$this->assertEquals(3, $parsed['nested']['n']);
+		$this->assertStringNotContainsString('template.example.com', $stored);
+	}
+
+	/**
+	 * Test that a serialized option holding the template URL stays readable.
+	 *
+	 * The options table is rewritten by the same method: plugin settings
+	 * (currency tables, analytics modules) live there as serialized arrays.
+	 */
+	public function test_rewrite_keeps_serialized_option_readable_when_host_length_changes() {
+		global $wpdb;
+
+		$table = $wpdb->get_blog_prefix($this->to_blog_id) . 'options';
+
+		$wpdb->insert(
+			$table,
+			[
+				'option_name'  => 'rewrite_test_settings',
+				'option_value' => maybe_serialize(
+					[
+						'logo' => 'http://template.example.com/logo.png',
+						'rate' => '1.25',
+					]
+				),
+				'autoload'     => 'no',
+			]
+		);
+
+		Testable_Site_Duplicator::rewrite_backfilled_postmeta_urls($this->from_blog_id, $this->to_blog_id);
+
+		$stored = $wpdb->get_var($wpdb->prepare("SELECT option_value FROM {$table} WHERE option_name = %s", 'rewrite_test_settings')); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Table name comes from get_blog_prefix().
+		$parsed = maybe_unserialize($stored);
+
+		$this->assertIsArray($parsed, 'Rewritten serialized option must still unserialize.');
+		$this->assertEquals('http://clone.example.com/logo.png', $parsed['logo']);
+		$this->assertEquals('1.25', $parsed['rate']);
+	}
+
+	/**
+	 * Test that a serialized string containing `";` is rewritten correctly.
+	 *
+	 * CSS such as content:""; and escaped JSON put `";` inside the string body.
+	 * A rewrite that located string ends by scanning for `";` would cut the
+	 * value short; the unserialize/replace/serialize pass must not care.
+	 */
+	public function test_rewrite_handles_embedded_quote_semicolon_in_serialized_string() {
+		$post_id = $this->create_target_post();
+
+		$css = 'a{content:"";} b{background:url(http://template.example.com/b.png)}';
+
+		$meta_id = $this->insert_raw_postmeta(
+			$post_id,
+			'_extra',
+			maybe_serialize(
+				[
+					'css'   => $css,
+					'after' => 'x',
+				]
+			)
+		);
+
+		Testable_Site_Duplicator::rewrite_backfilled_postmeta_urls($this->from_blog_id, $this->to_blog_id);
+
+		$parsed = maybe_unserialize($this->read_raw_postmeta($meta_id));
+
+		$this->assertIsArray($parsed);
+		$this->assertEquals('a{content:"";} b{background:url(http://clone.example.com/b.png)}', $parsed['css']);
+		$this->assertEquals('x', $parsed['after']);
+	}
+
+	/**
+	 * Test that hosts of the same length are still rewritten.
+	 *
+	 * Control case: with equal host lengths REPLACE() never corrupted anything,
+	 * so the change must not alter what happens there — the URL is rewritten
+	 * and the value stays readable. Only equal hosts short-circuit the method.
+	 */
+	public function test_rewrite_same_length_hosts_are_rewritten() {
+		// Same byte length as template.example.com.
+		update_blog_option($this->to_blog_id, 'siteurl', 'http://tempclon.example.com');
+
+		$post_id = $this->create_target_post();
+
+		$meta_id = $this->insert_raw_postmeta($post_id, '_extra', maybe_serialize(['u' => 'http://template.example.com/']));
+
+		Testable_Site_Duplicator::rewrite_backfilled_postmeta_urls($this->from_blog_id, $this->to_blog_id);
+
+		$parsed = maybe_unserialize($this->read_raw_postmeta($meta_id));
+
+		$this->assertIsArray($parsed);
+		$this->assertEquals('http://tempclon.example.com/', $parsed['u']);
+	}
+
+	/**
+	 * Test that a row without the template URL is left byte-identical.
+	 */
+	public function test_rewrite_leaves_rows_without_template_url_untouched() {
+		$post_id = $this->create_target_post();
+
+		$raw = maybe_serialize(
+			[
+				'u' => 'http://clone.example.com/already-ok',
+				'k' => 'v',
+			]
+		);
+
+		$meta_id = $this->insert_raw_postmeta($post_id, '_ok', $raw);
+
+		Testable_Site_Duplicator::rewrite_backfilled_postmeta_urls($this->from_blog_id, $this->to_blog_id);
+
+		$this->assertSame($raw, $this->read_raw_postmeta($meta_id));
+	}
+
+	/**
+	 * Create a post on the target blog and return its ID.
+	 */
+	private function create_target_post() {
+		switch_to_blog($this->to_blog_id);
+		$post_id = self::factory()->post->create(['post_type' => 'page']);
+		restore_current_blog();
+
+		return $post_id;
+	}
+
+	/**
+	 * Insert a raw postmeta row on the target blog, bypassing the meta API
+	 * (which would re-serialize) — this is the state backfill_all_postmeta()
+	 * leaves behind: template rows copied verbatim.
+	 *
+	 * @return int meta_id
+	 */
+	private function insert_raw_postmeta($post_id, $meta_key, $raw_value) {
+		global $wpdb;
+
+		// phpcs:disable WordPress.DB.SlowDBQuery -- Raw fixture row, not a query filter.
+		$wpdb->insert(
+			$wpdb->get_blog_prefix($this->to_blog_id) . 'postmeta',
+			[
+				'post_id'    => $post_id,
+				'meta_key'   => $meta_key,
+				'meta_value' => $raw_value,
+			]
+		);
+		// phpcs:enable
+
+		return (int) $wpdb->insert_id;
+	}
+
+	/**
+	 * Read a postmeta value on the target blog exactly as stored.
+	 */
+	private function read_raw_postmeta($meta_id) {
+		global $wpdb;
+
+		$table = $wpdb->get_blog_prefix($this->to_blog_id) . 'postmeta';
+
+		return (string) $wpdb->get_var($wpdb->prepare("SELECT meta_value FROM {$table} WHERE meta_id = %d", $meta_id)); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Table name comes from get_blog_prefix().
+	}
+
+	// =========================================================================
 	// Edge cases
 	// =========================================================================
 


### PR DESCRIPTION
## Summary

`Site_Duplicator::rewrite_backfilled_postmeta_urls()` (added in 2.3.2 for #834) rewrites
template-site URLs on the freshly cloned site with a raw SQL statement:

```
inc/helpers/class-site-duplicator.php:755  (main)
UPDATE `{$table}` SET `{$column}` = REPLACE(`{$column}`, %s, %s) WHERE `{$column}` LIKE %s
```

over `postmeta`, `posts`, `options`, `termmeta` and `commentmeta`.

MySQL `REPLACE()` is not serialize-aware. postmeta and options routinely hold PHP-serialized
arrays (Elementor `_extra`, image-optimizer LCP data, plugin settings, currency tables...).
Whenever the new site's host has a **different length** than the template host
(`demo.example.org` vs `template5.example.org`, a mapped custom domain, a longer or shorter
subdomain), `REPLACE()` changes the bytes of every `s:N:"..."` string that contains the host but
leaves `N` untouched, and from then on `unserialize()` returns `false` for the whole value.
The plugin that owns the row reads `false`, falls back to its defaults, and nothing is logged.

Sites cloned to a host of the **same** length are unaffected, which is why this goes unnoticed.

## What we measured

On a production network running 2.15.2 (the file is byte-identical in 2.16.0 and on `main`):

- **496 rows** of postmeta/options across **5 cloned sites** were unreadable
  (`unserialize() === false`). Keys included Elementor `_extra`, `wp-smush-lcp-data-*`,
  `_handle_urls`, analytics module options, an LMS settings log and the currency switcher's
  rate table. With that table unreadable the currency plugin silently used its built-in
  defaults (wrong exchange rate and symbol on a live storefront).
- Every broken value carries the same signature: each `s:N:` is off by
  `k × (len(new host) − len(template host))`, where `k` is the number of times the host
  appears in that string (we saw up to 37 occurrences in a single Elementor `_extra` value).
- Reproduced with a real signup on staging: **130 broken rows** with the current code,
  **0** with this change.

Why the rows reach this method un-rewritten: `backfill_all_postmeta()` copies raw template
rows *after* `MUCD_Data::copy_data()` has run its serialize-aware pass, and
`MUCD_Data::try_replace()` returns objects (`O:`) untouched, so those values still contain the
template host when `REPLACE()` runs.

## The change

Route the rewrite through the existing `\MUCD_Data::update($table, [$column], $from, $to)`
(`inc/duplication/data.php:580`) — the same serialize-aware, primary-key based pass that
`db_update_data()` already applies to the copied rows: `SELECT` by `LIKE`, `try_replace()`
(unserialize → replace recursively → serialize, double-serialized values included), `UPDATE`
by primary key.

- Non-serialized values behave exactly as before (`try_replace()` falls through to
  `str_replace()`).
- Rows that do not contain the template host are never selected; rows whose value does not
  change are skipped by `update()`.
- Serialized objects (`O:`) keep the template URL instead of becoming unreadable — the same
  limitation `copy_data()` has today, and strictly better than corrupting them. Can be
  improved separately.
- The `phpcs:disable` line loses the two `PreparedSQL` exclusions that only the removed
  interpolated query needed.

## Risk

- Cost: one `SELECT ... LIKE` per table per pattern (two patterns: plain and JSON-escaped)
  plus one `UPDATE` per affected row, instead of one bulk `UPDATE` per table. On a typical
  clone this is ~100-200 rows in postmeta: sub-second, and only at duplication time.
- `MUCD_Data::update()` issues `SET SQL_MODE='ALLOW_INVALID_DATES'` before each `SELECT`.
  `copy_data()` already does this earlier in the same `process_duplication()` request, so the
  session is already in that mode when this method runs; no new behaviour.
- A SQL error is now logged by `MUCD_Data::sql_error()` (`site-duplication-errors`); the
  previous `$wpdb->query()` call discarded it.
- Availability: `class-site-duplicator.php:17` requires `inc/duplication/duplicate.php`, which
  loads `data.php`, and the same method chain already calls `\MUCD_Data::copy_data()` earlier in
  `process_duplication()` — no new dependency.

## Tests

Five cases added to `tests/WP_Ultimo/Helpers/Site_Duplicator_Postmeta_Test.php`, using the
`Testable_Site_Duplicator` subclass that already exposed `rewrite_backfilled_postmeta_urls()`
(it had no callers). The fixture blogs of that file already have hosts of different length
(`template.example.com` → `clone.example.com`, −3 bytes), which is exactly the condition that
triggers the defect. Rows are inserted raw (bypassing the meta API, as `backfill_all_postmeta()`
does) and read back raw, asserting on `maybe_unserialize()` of the stored value:

| Test | With `REPLACE()` | With this change |
|---|---|---|
| serialized postmeta with the template URL (plain, nested, JSON-escaped) | `false` | array, new host, no template host left |
| serialized option with the template URL | `false` | array, new host |
| serialized string containing `";` (CSS `content:"";`) plus a URL | `false` | array, URL rewritten, following key intact |
| same-length hosts (control) | rewritten | rewritten, readable |
| row without the template URL | byte-identical | byte-identical |

Verification run locally:

- `php -l` on both files.
- `vendor/bin/phpcs` with the repo ruleset over `inc/` and `tests/`:
  `inc/helpers/class-site-duplicator.php` reports **0 violations**, and
  `tests/.../Site_Duplicator_Postmeta_Test.php` reports exactly the counts already recorded in
  `phpcs-baseline.json` (8 + 4 + 2 warnings, unchanged), so the baseline gate sees no new
  violation from this change.
- `vendor/bin/phpstan analyse inc/helpers/class-site-duplicator.php`: no errors, before and
  after.
- The replacement mechanics were exercised directly against the real
  `MUCD_Data::try_replace()` outside WordPress, on the same fixtures the PHPUnit tests use:
  for each one, `str_replace()` (what `REPLACE()` does byte-wise) makes the value
  unserializable, while `try_replace()` returns a value that unserializes and is
  **byte-identical** to `serialize()` of the correctly rewritten array — 15/15 assertions.
- I could not run the PHPUnit suite itself on this machine (no MySQL available for the
  WordPress test library), so CI is the first full run of the new tests.

## Follow-up (out of scope)

Networks that already cloned sites with the broken byte counts need a one-off repair
(recount `s:N:` where every delta is a multiple of the host-length delta). We run ours from a
small mu-plugin hooked to `wu_duplicate_site`; happy to share it if it is useful here.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved URL rewriting when duplicating sites so serialized metadata remains valid, even when source and destination hostnames have different lengths.
  * Preserved serialized values without the source URL byte-for-byte.
  * Continued supporting URL replacements for same-length hostnames and values containing embedded delimiters.

* **Tests**
  * Added coverage for serialized post metadata, options, unchanged rows, and varied hostname lengths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->