### PR TITLE
fix(sunrise): the init hook must never deactivate - not seeing the plugin in this process is not proof it was deactivated

### DIFF
--- a/inc/class-sunrise.php
+++ b/inc/class-sunrise.php
@@ -509,14 +509,30 @@ class Sunrise {
 	/**
 	 * Makes sure the meta file accurately reflects the state of the main plugin.
 	 *
+	 * This method runs from sunrise.php, which is a drop-in: it is loaded on
+	 * every request, including processes that never load the plugin stack at
+	 * all - WP-CLI invoked with --skip-plugins, the WordPress installer and
+	 * upgrader, or any custom bootstrap that skips plugins. In those processes
+	 * the main plugin class is simply not there, and that says nothing about
+	 * whether the plugin is active for the network.
+	 *
+	 * Because the meta is network wide and persisted, this hook can only ever
+	 * turn the flag ON. Turning it OFF is the job of the deactivation hook,
+	 * \WP_Ultimo\Hooks::on_deactivation(), which only runs when the plugin is
+	 * genuinely deactivated.
+	 *
 	 * @since 2.0.11
+	 * @since 2.16.1 Never deactivates. Not seeing the plugin in the current
+	 *               process is not proof that it was deactivated.
 	 * @return void
 	 */
 	public static function maybe_tap_on_init(): void {
 
-		$state = function_exists('WP_Ultimo') && WP_Ultimo()->is_loaded();
+		if ( ! function_exists('WP_Ultimo') || ! WP_Ultimo()->is_loaded()) {
+			return;
+		}
 
-		self::maybe_tap($state ? 'activating' : 'deactivating');
+		self::maybe_tap('activating');
 	}
 
 	/**

--- a/tests/WP_Ultimo/Sunrise_Test.php
+++ b/tests/WP_Ultimo/Sunrise_Test.php
@@ -273,6 +273,156 @@ class Sunrise_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Seed the sunrise meta network option and reset the static read cache.
+	 *
+	 * Sunrise::read_sunrise_meta() caches the meta on a static property after
+	 * the first read, so the cache has to be dropped for the seeded value to
+	 * be visible to the code under test.
+	 *
+	 * @param bool $active Value to store under the `active` key.
+	 */
+	private function seed_sunrise_meta($active) {
+
+		update_network_option(
+			null,
+			'wu_sunrise_meta',
+			[
+				'active'           => $active,
+				'created'          => 1600000000,
+				'last_activated'   => 1600000000,
+				'last_deactivated' => 1600000000,
+				'last_modified'    => 1600000000,
+			]
+		);
+
+		Sunrise::$sunrise_meta = null;
+	}
+
+	/**
+	 * Read the `active` flag straight from the network option.
+	 *
+	 * Deliberately bypasses read_sunrise_meta() so the assertion measures what
+	 * was persisted, not what the static cache happens to hold.
+	 *
+	 * @return bool
+	 */
+	private function read_persisted_active_flag() {
+
+		$meta = get_network_option(null, 'wu_sunrise_meta', []);
+
+		return ! empty($meta['active']);
+	}
+
+	/**
+	 * Force WP_Ultimo::is_loaded() to a given value and return the previous one.
+	 *
+	 * @param bool $loaded Value to force.
+	 * @return bool The previous value, to restore afterwards.
+	 */
+	private function force_plugin_loaded_state($loaded) {
+
+		$plugin   = \WP_Ultimo();
+		$property = (new \ReflectionObject($plugin))->getProperty('loaded');
+
+		// Only call setAccessible() on PHP < 8.1 where it's needed
+		if (PHP_VERSION_ID < 80100) {
+			$property->setAccessible(true);
+		}
+
+		$previous = $property->getValue($plugin);
+
+		$property->setValue($plugin, $loaded);
+
+		return $previous;
+	}
+
+	/**
+	 * A process that does not have the plugin running must not deactivate sunrise.
+	 *
+	 * sunrise.php is a drop-in, so maybe_tap_on_init() also runs in processes
+	 * that never load plugins: `wp --skip-plugins`, the installer, or a custom
+	 * bootstrap. There the main plugin class is absent and the state observed
+	 * at the decision point is exactly the one reproduced here - `false`,
+	 * because function_exists() short circuits the very same expression.
+	 *
+	 * PHP cannot undeclare a function inside a running process, so the fixture
+	 * drives the other half of that same expression: is_loaded() returns false,
+	 * which is what a process without the plugin produces.
+	 *
+	 * Before the fix this wrote `active => false` for the whole network, which
+	 * takes down domain mapping until a process that does load plugins reaches
+	 * `init` again.
+	 */
+	public function test_maybe_tap_on_init_does_not_deactivate_when_plugin_is_not_loaded() {
+
+		$this->seed_sunrise_meta(true);
+
+		$previous = $this->force_plugin_loaded_state(false);
+
+		try {
+			Sunrise::maybe_tap_on_init();
+
+			$this->assertTrue(
+				$this->read_persisted_active_flag(),
+				'A process that does not have Ultimate Multisite loaded must not turn the network wide sunrise flag off.'
+			);
+		} finally {
+			$this->force_plugin_loaded_state($previous);
+
+			Sunrise::$sunrise_meta = null;
+		}
+	}
+
+	/**
+	 * The activation half of maybe_tap_on_init() must keep working.
+	 *
+	 * Control for the test above: when the plugin is loaded, init is still
+	 * allowed to turn the flag on.
+	 */
+	public function test_maybe_tap_on_init_still_activates_when_plugin_is_loaded() {
+
+		$this->seed_sunrise_meta(false);
+
+		$previous = $this->force_plugin_loaded_state(true);
+
+		try {
+			Sunrise::maybe_tap_on_init();
+
+			$this->assertTrue(
+				$this->read_persisted_active_flag(),
+				'With the plugin loaded, init must still turn the sunrise flag on.'
+			);
+		} finally {
+			$this->force_plugin_loaded_state($previous);
+
+			Sunrise::$sunrise_meta = null;
+		}
+	}
+
+	/**
+	 * A genuine deactivation must still turn the flag off.
+	 *
+	 * This is the call \WP_Ultimo\Hooks::on_deactivation() makes from the
+	 * register_deactivation_hook() callback, and it is the path that keeps the
+	 * meta accurate now that init no longer deactivates.
+	 */
+	public function test_explicit_deactivation_still_turns_the_flag_off() {
+
+		$this->seed_sunrise_meta(true);
+
+		try {
+			$this->assertTrue(Sunrise::maybe_tap('deactivating'));
+
+			$this->assertFalse(
+				$this->read_persisted_active_flag(),
+				'An explicit deactivation must still turn the sunrise flag off.'
+			);
+		} finally {
+			Sunrise::$sunrise_meta = null;
+		}
+	}
+
+	/**
 	 * Test manage_sunrise_updates method doesn't throw fatal errors.
 	 */
 	public function test_manage_sunrise_updates_no_fatal_errors() {


### PR DESCRIPTION
# fix(sunrise): do not deactivate when the plugin is not loaded

## The problem

`Sunrise::maybe_tap_on_init()` persists a network wide flag based on whether the main plugin class exists in the **current PHP process**. Line references are against `main` at `5b11251d` (`inc/class-sunrise.php`, unchanged between 2.15.2 and 2.16.0).

```php
// inc/class-sunrise.php:92
add_action('init', [self::class, 'maybe_tap_on_init']);

// inc/class-sunrise.php:515-520
public static function maybe_tap_on_init(): void {

    $state = function_exists('WP_Ultimo') && WP_Ultimo()->is_loaded();

    self::maybe_tap($state ? 'activating' : 'deactivating');
}
```

When `$state` is `false`, the chain is:

1. `maybe_tap('deactivating')` (`:530-543`) — the meta says `active => true`, so it does not return early.
2. `tap('deactivating', $meta)` (`:554-585`) — `:576` sets `$to_save['active'] = false`.
3. `:584` `update_network_option(null, 'wu_sunrise_meta', $to_save)` — persisted, network wide.

The consequences are immediate for every site on the network:

- `should_load_sunrise()` (`:502-507`) now returns `false`.
- `should_startup()` (`:109-116`) returns `false`.
- `load_domain_mapping()` (`:191-205`) never instantiates `Primary_Domain` (`:201`) or `Domain_Mapping` (`:203`).
- Every mapped domain falls through to the network's signup handling and answers `302` to `/wp-signup.php`.

This lasts until some other process that *does* load plugins reaches `init` and taps `activating` again.

## Why the drop-in cannot tell the two cases apart

`wp-content/sunrise.php` is a drop-in. WordPress loads it on every request, **before and independently of the plugin stack**, so `Sunrise::maybe_tap_on_init()` also runs in processes where plugins are never loaded at all:

- `wp <command> --skip-plugins` (WP-CLI, no plugin list)
- the WordPress installer and upgrader
- any custom bootstrap that loads `wp-load.php` without plugins

In all of them `function_exists('WP_Ultimo')` is `false`. That is a fact about the **current process**, not about the activation state stored in the database, but line 517 treats the two as the same thing and line 519 writes the conclusion to a network option.

A grep over `inc/class-sunrise.php` for `WP_CLI`, `DOING_CRON`, `wp_installing` or `skip-plugins` returns a single hit — line 517, and only because it contains the substring `is_loaded`. There is no context guard.

Note there is a second way to reach the same write without any CLI involvement: `WP_Ultimo::$loaded` is only set at `inc/class-wp-ultimo.php:208`, after the early return at `:195`. A plain web request where `Requirements::met()` or `Requirements::run_setup()` is `false`, or where `?page=wp-ultimo-multisite-setup` is requested, has the plugin active and loaded but `is_loaded()` returning `false`, so it also taps `deactivating`.

## Measured impact

Measured on a production network running 23 subsites with mapped client domains:

- An outage reproduced and timed on 2026-09-11 at 00:30:06 lasted **3 seconds** — one scheduled WP-CLI task with `--skip-plugins` ran, and mapped domains were down until the next request with plugins loaded re-armed the flag.
- The access log of **one** client domain recorded **22 `302` responses to `/wp-signup.php`** over a single month, each one a real visitor who did not reach the site.

The failure mode is why it went unnoticed for so long: it self-heals within seconds, so uptime monitoring never samples it, but visitors hitting the window do see it. The flag itself is the only reliable place to observe it:

```sql
SELECT meta_value FROM wp_sitemeta WHERE meta_key = 'wu_sunrise_meta';
-- active";b:1  = domain mapping live
-- active";b:0  = every mapped domain on the network is redirecting right now
```

## The fix

`init` may only ever turn the flag **on**. Not seeing the plugin in the current process is not proof that it was deactivated.

```php
public static function maybe_tap_on_init(): void {

    if ( ! function_exists('WP_Ultimo') || ! WP_Ultimo()->is_loaded()) {
        return;
    }

    self::maybe_tap('activating');
}
```

This single rule covers the whole family of false positives — `--skip-plugins`, installer, upgrader, custom bootstraps, and the requirements/setup path above — without needing separate `WP_CLI`, `DOING_CRON` or `wp_installing()` guards, which would each only patch one symptom of the same wrong inference.

## Why it is safe

Genuine deactivation never depended on this `init` hook. It is already written by the deactivation hook:

- `inc/class-hooks.php:43` — `register_deactivation_hook(WP_ULTIMO_PLUGIN_FILE, [self::class, 'on_deactivation'])`
- `inc/class-hooks.php:119-135` — `on_deactivation()`
- `inc/class-hooks.php:126` — `\WP_Ultimo\Sunrise::maybe_tap('deactivating')`

That fires on single site deactivation, network deactivation and `wp plugin deactivate`, and it is untouched by this change. The activation side is likewise untouched: `Hooks::on_activation_do()` (`:83`) and the `activating` branch of `maybe_tap_on_init()` both still work.

The remaining edge case is a plugin whose files are deleted outright. That case never reached this code in the first place: `wp-content/sunrise.php:48` only calls `Sunrise::init()` (`:63`) when `inc/class-sunrise.php` is found on disk, so with the plugin directory gone the `init` hook is never registered and nothing reads the flag. The stale value is inert, and `wu_remove_sunrise_warning()` (`sunrise.php:80`) still shows the network admin notice telling the user to remove `define('SUNRISE', true)`.

## Tests

Three tests added to `tests/WP_Ultimo/Sunrise_Test.php`, all driving the existing public entry point `Sunrise::maybe_tap_on_init()` rather than any new method, so they are meaningful against both the old and the new code:

1. `test_maybe_tap_on_init_does_not_deactivate_when_plugin_is_not_loaded` — seeds `active => true`, puts the process in the state a plugin-less process produces, calls `maybe_tap_on_init()`, asserts the persisted flag is still `true`. **Fails on `main`** (the flag is flipped to `false` at `:576`), passes with the fix.
2. `test_maybe_tap_on_init_still_activates_when_plugin_is_loaded` — control: with the plugin loaded, `init` still turns the flag on.
3. `test_explicit_deactivation_still_turns_the_flag_off` — asserts the call `Hooks::on_deactivation()` makes still flips the flag to `false`.

PHP cannot undeclare a function inside a running process, so test 1 drives the other half of the same expression on line 517: `is_loaded()` returns `false`. `function_exists()` short circuits, so a `--skip-plugins` process and this fixture produce the identical value at the decision point, which is the only input line 519 consumes. The fixture restores the singleton state and clears the `Sunrise::$sunrise_meta` static cache in a `finally` block.

The `function_exists()` half was verified separately against the unmodified class file in a standalone harness, one process per scenario, since that is the only way to have the global `WP_Ultimo()` genuinely absent:

| Scenario | `main` | this branch |
|---|---|---|
| `WP_Ultimo()` undefined, flag was on | flag → **off** | flag stays **on** |
| plugin present, `is_loaded()` false, flag was on | flag → **off** | flag stays **on** |
| plugin loaded, flag was off | flag → on | flag → **on** |
| explicit `maybe_tap('deactivating')`, flag was on | flag → off | flag → **off** |

## How to verify

On a multisite network with a mapped domain and the plugin active:

```bash
# flag before
wp network meta get 1 wu_sunrise_meta

# any plugin-less process
wp option get siteurl --skip-plugins

# flag after: 'active' is false on main, unchanged on this branch
wp network meta get 1 wu_sunrise_meta

# and the visible symptom on main
curl -sI https://mapped-client-domain.example | head -1   # 302 to /wp-signup.php
```

## Note on `@since`

The docblock uses `@since 2.16.1`, derived from `Version: 2.16.0` in `ultimate-multisite.php`. Adjust to whatever release this lands in.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Sunrise activation status is no longer turned off merely because the plugin is not loaded in a particular process.
  * Explicit deactivation continues to disable the Sunrise flag correctly.

* **Tests**
  * Added coverage for Sunrise activation, non-deactivation when unloaded, and explicit deactivation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->