### PR TITLE
fix(limits): key the plugin caches by blog ID - one subsite can persist another subsite active_plugins list

### DIFF
--- a/inc/limits/class-plugin-limits.php
+++ b/inc/limits/class-plugin-limits.php
@@ -22,20 +22,24 @@ class Plugin_Limits {
 	use \WP_Ultimo\Traits\Singleton;
 
 	/**
-	 * Site-level plugins cache.
+	 * Site-level plugins cache, keyed by blog ID.
+	 *
+	 * The filters this class registers stay attached while WordPress is
+	 * switched to another site, so this cache must never be shared between
+	 * sites.
 	 *
 	 * @since 2.0.0
-	 * @var null|array
+	 * @var array<int, array>
 	 */
-	protected $plugins = null;
+	protected $plugins = [];
 
 	/**
-	 * Network plugins cache.
+	 * Network plugins cache, keyed by blog ID.
 	 *
 	 * @since 2.0.0
-	 * @var null|array
+	 * @var array<int, array>
 	 */
-	protected $network_plugins = null;
+	protected $network_plugins = [];
 
 	/**
 	 * Runs on the first and only instantiation.
@@ -70,6 +74,13 @@ class Plugin_Limits {
 			add_filter('show_network_active_plugins', '__return_true');
 
 			add_action('load-plugins.php', [$this, 'admin_page_hooks']);
+
+			/*
+			 * The option filters above are not removed when WordPress switches
+			 * to another site, so the lists they cache must not outlive the
+			 * site they were built for.
+			 */
+			add_action('switch_blog', [$this, 'flush_plugin_caches']);
 		}
 
 		add_action('wu_site_post_save', [$this, 'activate_and_inactive_plugins'], 10, 3);
@@ -226,11 +237,13 @@ class Plugin_Limits {
 			return $plugins;
 		}
 
+		$blog_id = get_current_blog_id();
+
 		/*
-		 * Get the network plugins cache, if they're set.
+		 * Get the network plugins cache for the current site, if it's set.
 		 */
-		if (is_array($this->network_plugins)) {
-			return $this->network_plugins;
+		if (isset($this->network_plugins[ $blog_id ])) {
+			return $this->network_plugins[ $blog_id ];
 		}
 
 		$plugin_limits = wu_get_current_site()->get_limitations()->plugins;
@@ -258,7 +271,7 @@ class Plugin_Limits {
 			}
 		}
 
-		$this->network_plugins = $plugins;
+		$this->network_plugins[ $blog_id ] = $plugins;
 
 		return $plugins;
 	}
@@ -279,11 +292,13 @@ class Plugin_Limits {
 			return $plugins;
 		}
 
+		$blog_id = get_current_blog_id();
+
 		/*
-		 * Get the site-level plugins cache, if they're set.
+		 * Get the site-level plugins cache for the current site, if it's set.
 		 */
-		if (is_array($this->plugins)) {
-			return $this->plugins;
+		if (isset($this->plugins[ $blog_id ])) {
+			return $this->plugins[ $blog_id ];
 		}
 
 		$plugin_limits = wu_get_current_site()->get_limitations()->plugins;
@@ -312,9 +327,29 @@ class Plugin_Limits {
 			}
 		}
 
-		$this->plugins = $plugins;
+		$this->plugins[ $blog_id ] = $plugins;
 
 		return $plugins;
+	}
+
+	/**
+	 * Flushes the plugin caches when WordPress switches to another site.
+	 *
+	 * The `option_active_plugins` and `site_option_active_sitewide_plugins`
+	 * filters stay attached across `switch_to_blog()`, so a list built for one
+	 * site must not be served on the next one. The per-site keys already
+	 * guarantee that; dropping the caches on every switch also keeps them from
+	 * growing in long-running processes and makes sure a site whose active
+	 * plugins changed while switched is read again instead of served stale.
+	 *
+	 * @since 2.16.1
+	 * @return void
+	 */
+	public function flush_plugin_caches(): void {
+
+		$this->plugins = [];
+
+		$this->network_plugins = [];
 	}
 
 	/**

--- a/tests/WP_Ultimo/Limits/Plugin_Limits_Test.php
+++ b/tests/WP_Ultimo/Limits/Plugin_Limits_Test.php
@@ -241,6 +241,24 @@ class Plugin_Limits_Test extends \WP_UnitTestCase {
 	}
 
 	/**
+	 * Creates a site for plugin cache tests.
+	 *
+	 * @return int
+	 */
+	private function create_test_site() {
+
+		$site = wu_create_site(
+			[
+				'domain' => 'plugin-limits-' . wp_rand() . '.example.com',
+			]
+		);
+
+		$this->assertNotWPError($site);
+
+		return $site->get_id();
+	}
+
+	/**
 	 * Test the site-level list of one site is never served to another site.
 	 *
 	 * The `option_active_plugins` filter stays attached across switch_to_blog(),
@@ -251,8 +269,8 @@ class Plugin_Limits_Test extends \WP_UnitTestCase {
 
 		$instance = $this->get_instance();
 
-		$site_a = self::factory()->blog->create();
-		$site_b = self::factory()->blog->create();
+		$site_a = $this->create_test_site();
+		$site_b = $this->create_test_site();
 
 		switch_to_blog($site_a);
 		$result_a = $instance->deactivate_plugins(['site-a/site-a.php']);
@@ -274,8 +292,8 @@ class Plugin_Limits_Test extends \WP_UnitTestCase {
 
 		$instance = $this->get_instance();
 
-		$site_a = self::factory()->blog->create();
-		$site_b = self::factory()->blog->create();
+		$site_a = $this->create_test_site();
+		$site_b = $this->create_test_site();
 
 		switch_to_blog($site_a);
 		$result_a = $instance->deactivate_network_plugins(['site-a/site-a.php' => 1]);
@@ -297,8 +315,8 @@ class Plugin_Limits_Test extends \WP_UnitTestCase {
 
 		$instance = $this->get_instance();
 
-		$site_a = self::factory()->blog->create();
-		$site_b = self::factory()->blog->create();
+		$site_a = $this->create_test_site();
+		$site_b = $this->create_test_site();
 
 		foreach ([$site_a, $site_b] as $site_id) {
 			switch_to_blog($site_id);
@@ -323,7 +341,7 @@ class Plugin_Limits_Test extends \WP_UnitTestCase {
 
 		$instance = $this->get_instance();
 
-		$site_id = self::factory()->blog->create();
+		$site_id = $this->create_test_site();
 
 		switch_to_blog($site_id);
 
@@ -343,7 +361,7 @@ class Plugin_Limits_Test extends \WP_UnitTestCase {
 
 		$instance = $this->get_instance();
 
-		$site_id = self::factory()->blog->create();
+		$site_id = $this->create_test_site();
 
 		switch_to_blog($site_id);
 
@@ -363,7 +381,7 @@ class Plugin_Limits_Test extends \WP_UnitTestCase {
 
 		$instance = $this->get_instance();
 
-		$site_id = self::factory()->blog->create();
+		$site_id = $this->create_test_site();
 
 		switch_to_blog($site_id);
 

--- a/tests/WP_Ultimo/Limits/Plugin_Limits_Test.php
+++ b/tests/WP_Ultimo/Limits/Plugin_Limits_Test.php
@@ -199,38 +199,185 @@ class Plugin_Limits_Test extends \WP_UnitTestCase {
 	}
 
 	/**
-	 * Test plugins property exists.
+	 * Test plugins property starts as an empty per-site cache.
 	 */
 	public function test_plugins_property() {
 
 		$instance = $this->get_instance();
 
-		$ref = new \ReflectionProperty($instance, 'plugins');
+		$value = $this->get_cache($instance, 'plugins');
 
-		if (PHP_VERSION_ID < 80100) {
-			$ref->setAccessible(true);
-		}
-
-		$value = $ref->getValue($instance);
-
-		$this->assertNull($value);
+		$this->assertSame([], $value);
 	}
 
 	/**
-	 * Test network_plugins property exists.
+	 * Test network_plugins property starts as an empty per-site cache.
 	 */
 	public function test_network_plugins_property() {
 
 		$instance = $this->get_instance();
 
-		$ref = new \ReflectionProperty($instance, 'network_plugins');
+		$value = $this->get_cache($instance, 'network_plugins');
+
+		$this->assertSame([], $value);
+	}
+
+	/**
+	 * Reads one of the protected caches.
+	 *
+	 * @param Plugin_Limits $instance The instance to read from.
+	 * @param string        $property The cache property name.
+	 * @return mixed
+	 */
+	private function get_cache($instance, $property) {
+
+		$ref = new \ReflectionProperty($instance, $property);
 
 		if (PHP_VERSION_ID < 80100) {
 			$ref->setAccessible(true);
 		}
 
-		$value = $ref->getValue($instance);
+		return $ref->getValue($instance);
+	}
 
-		$this->assertNull($value);
+	/**
+	 * Test the site-level list of one site is never served to another site.
+	 *
+	 * The `option_active_plugins` filter stays attached across switch_to_blog(),
+	 * and WordPress writes back what it reads through it, so a shared cache
+	 * stores one site's active plugins inside another site.
+	 */
+	public function test_deactivate_plugins_is_not_shared_between_sites() {
+
+		$instance = $this->get_instance();
+
+		$site_a = self::factory()->blog->create();
+		$site_b = self::factory()->blog->create();
+
+		switch_to_blog($site_a);
+		$result_a = $instance->deactivate_plugins(['site-a/site-a.php']);
+		restore_current_blog();
+
+		switch_to_blog($site_b);
+		$result_b = $instance->deactivate_plugins(['site-b/site-b.php']);
+		restore_current_blog();
+
+		$this->assertContains('site-a/site-a.php', $result_a);
+		$this->assertContains('site-b/site-b.php', $result_b);
+		$this->assertNotContains('site-a/site-a.php', $result_b);
+	}
+
+	/**
+	 * Test the network list of one site is never served to another site.
+	 */
+	public function test_deactivate_network_plugins_is_not_shared_between_sites() {
+
+		$instance = $this->get_instance();
+
+		$site_a = self::factory()->blog->create();
+		$site_b = self::factory()->blog->create();
+
+		switch_to_blog($site_a);
+		$result_a = $instance->deactivate_network_plugins(['site-a/site-a.php' => 1]);
+		restore_current_blog();
+
+		switch_to_blog($site_b);
+		$result_b = $instance->deactivate_network_plugins(['site-b/site-b.php' => 1]);
+		restore_current_blog();
+
+		$this->assertArrayHasKey('site-a/site-a.php', $result_a);
+		$this->assertArrayHasKey('site-b/site-b.php', $result_b);
+		$this->assertArrayNotHasKey('site-a/site-a.php', $result_b);
+	}
+
+	/**
+	 * Test both caches are stored under the ID of the site they were built for.
+	 */
+	public function test_caches_are_keyed_by_blog_id() {
+
+		$instance = $this->get_instance();
+
+		$site_a = self::factory()->blog->create();
+		$site_b = self::factory()->blog->create();
+
+		foreach ([$site_a, $site_b] as $site_id) {
+			switch_to_blog($site_id);
+
+			$instance->deactivate_plugins(['some/some.php']);
+			$instance->deactivate_network_plugins(['some/some.php' => 1]);
+
+			restore_current_blog();
+		}
+
+		$this->assertSame([$site_a, $site_b], array_keys($this->get_cache($instance, 'plugins')));
+		$this->assertSame([$site_a, $site_b], array_keys($this->get_cache($instance, 'network_plugins')));
+	}
+
+	/**
+	 * Test the cache is still reused within a single site.
+	 *
+	 * Non-regression guard: making the cache per-site must not turn it off. The
+	 * second call is answered from the cache, so its own argument is ignored.
+	 */
+	public function test_deactivate_plugins_still_caches_within_the_same_site() {
+
+		$instance = $this->get_instance();
+
+		$site_id = self::factory()->blog->create();
+
+		switch_to_blog($site_id);
+
+		$first  = $instance->deactivate_plugins(['first/first.php']);
+		$second = $instance->deactivate_plugins(['second/second.php']);
+
+		restore_current_blog();
+
+		$this->assertSame($first, $second);
+		$this->assertNotContains('second/second.php', $second);
+	}
+
+	/**
+	 * Test the network cache is still reused within a single site.
+	 */
+	public function test_deactivate_network_plugins_still_caches_within_the_same_site() {
+
+		$instance = $this->get_instance();
+
+		$site_id = self::factory()->blog->create();
+
+		switch_to_blog($site_id);
+
+		$first  = $instance->deactivate_network_plugins(['first/first.php' => 1]);
+		$second = $instance->deactivate_network_plugins(['second/second.php' => 1]);
+
+		restore_current_blog();
+
+		$this->assertSame($first, $second);
+		$this->assertArrayNotHasKey('second/second.php', $second);
+	}
+
+	/**
+	 * Test flush_plugin_caches empties both caches.
+	 */
+	public function test_flush_plugin_caches_empties_both_caches() {
+
+		$instance = $this->get_instance();
+
+		$site_id = self::factory()->blog->create();
+
+		switch_to_blog($site_id);
+
+		$instance->deactivate_plugins(['some/some.php']);
+		$instance->deactivate_network_plugins(['some/some.php' => 1]);
+
+		restore_current_blog();
+
+		$this->assertNotSame([], $this->get_cache($instance, 'plugins'));
+		$this->assertNotSame([], $this->get_cache($instance, 'network_plugins'));
+
+		$instance->flush_plugin_caches();
+
+		$this->assertSame([], $this->get_cache($instance, 'plugins'));
+		$this->assertSame([], $this->get_cache($instance, 'network_plugins'));
 	}
 }


### PR DESCRIPTION
# Fix: `Plugin_Limits` caches one sub-site's active plugins and serves it to the others

## The problem

`Plugin_Limits` is a singleton (`inc/limits/class-plugin-limits.php:22`, via
`WP_Ultimo\Traits\Singleton`), instantiated once per request from
`inc/class-sunrise.php:320`. It registers its option filters once, in
`load_limitations()`:

```php
// inc/limits/class-plugin-limits.php:57-78
public function load_limitations(): void {
    if (wu_get_current_site()->has_limitations()) {
        add_filter('site_option_active_sitewide_plugins', [$this, 'deactivate_network_plugins']); // :60
        add_filter('option_active_plugins', [$this, 'deactivate_plugins']);                       // :62
        ...
```

Both callbacks memoise the list they resolve, and **the cache is not keyed by
site**:

```php
// deactivate_plugins() — inc/limits/class-plugin-limits.php:274
if (is_network_admin() || is_main_site()) {   // :278  — this bail IS per-site
    return $plugins;
}

if (is_array($this->plugins)) {               // :285  — this cache is NOT
    return $this->plugins;
}
...
$this->plugins = $plugins;                    // :315
```

The same shape is in `deactivate_network_plugins()` with `$this->network_plugins`
(`:221`, cache read at `:232-234`, write at `:261`).

Nothing removes those filters when WordPress switches sites, and nothing
invalidates the cache on `switch_blog`. So in any request that touches more than
one sub-site — `switch_to_blog()`, `restore_current_blog()`, WP-CLI loops, cron,
Action Scheduler — **the first sub-site that resolves the list wins, and every
sub-site read after it gets that same list.**

The `is_main_site()` bail at `:278` keeps the main site itself safe; the leak is
strictly between sub-sites.

## Why this is data corruption, not just a stale read

`get_option()` applies the `option_{$option}` filter to its return value
(`wp-includes/option.php:256`), so `get_option('active_plugins')` is exactly
where `deactivate_plugins()` runs. And WordPress core **reads that option
through the filter and writes the result straight back**:

```php
// wp-admin/includes/plugin.php — activate_plugin(), :641
$current   = get_option( 'active_plugins', array() );   // :711  (filtered)
$current[] = $plugin;                                   // :712
sort( $current );                                       // :713
update_option( 'active_plugins', $current );            // :714  (written back)
```

```php
// wp-admin/includes/plugin.php — deactivate_plugins(), :758
$current = get_option( 'active_plugins', array() );     // :762  (filtered)
...
update_option( 'active_plugins', $current );            // :845  (written back)
```

(Line numbers verified identical in WordPress 6.8.2, 7.1 and trunk.)

Put together: if the cache was filled while switched to site A, then activating
or deactivating a plugin on site B does a read-modify-write over **site A's list
of active plugins**, and persists it into site B's `active_plugins` option. The
same read-back happens in `is_plugin_active()` (`wp-admin/includes/plugin.php:540`)
and in `validate_active_plugins()` (`:1070`, which can `update_option()` too),
so a sub-site can end up with another tenant's plugin set recorded as its own.

### Reproducing it

Preconditions — with either one missing the filters are never attached and
nothing happens:

* `wu_get_current_site()->has_limitations() === true` (the gate at `:59`), and
* `has_filter('option_active_plugins') === true`.

Then, in one request:

1. `switch_to_blog( $site_a ); get_option('active_plugins'); restore_current_blog();`
2. `switch_to_blog( $site_b ); get_option('active_plugins');`

Step 2 returns site A's list. Any `activate_plugin()` / `deactivate_plugins()`
call in that context then writes it into site B.

### Field evidence

An integrator running a 23-sub-site network hit this while switching site
templates: under `override_site()`, `get_option('active_plugins')`,
`is_plugin_active()` and `activate_plugin()` all returned the **pre-switch**
list. They had to stop using those APIs entirely and write `active_plugins`
directly with `$wpdb` so that a template switch stopped leaving plugins
activated against the wrong site. That workaround is only necessary because of
this cache.

Searching this repository for `active_plugins` returns no prior report, so as
far as I can tell this has not been raised before.

### Secondary impact — plausible, not verified

`Limitation_Manager::async_handle_plugins()`
(`inc/managers/class-limitation-manager.php:67-88`) does
`switch_to_blog($site_id)` and then calls `activate_plugins()` / `deactivate_plugins()`
(`:76`, `:79`, `:81`). If Action Scheduler drains several `wu_async_handle_plugins`
actions in one request, the first site would fill the cache and the rest would be
processed against its list. **I have not verified this path.** It only bites if
the filters were registered in that request at all, which for a queue runner
starting on the main site probably does not happen. Flagging it as something to
check, not as a confirmed second bug.

## The fix

Key both caches by `get_current_blog_id()` — the same thing
`wu_get_current_site()` already does for its own per-site cache
(`inc/functions/site.php:24-30`) — and clear them on `switch_blog`:

* `$plugins` and `$network_plugins` become `array<int, array>`, keyed by blog ID.
* The cache lookups become `isset($this->plugins[ $blog_id ])`.
* `flush_plugin_caches()` is hooked to `switch_blog` alongside the filters it
  protects. The per-site keys already make the fix correct on their own; the
  flush bounds memory in long-running processes and makes sure a site whose
  active plugins changed while switched is re-read instead of served stale —
  which is exactly the `async_handle_plugins()` situation above.

`switch_blog` is already used this way in the codebase
(`inc/database/engine/class-table.php:82`).

No behaviour changes apart from the fix: on a single-site request the caches are
filled and hit exactly as before.

## Verification

New tests in `tests/WP_Ultimo/Limits/Plugin_Limits_Test.php`:

| Test | What it pins |
|---|---|
| `test_deactivate_plugins_is_not_shared_between_sites` | site B's read returns site B's list, not site A's — **fails on `main`** |
| `test_deactivate_network_plugins_is_not_shared_between_sites` | same for the network list — **fails on `main`** |
| `test_caches_are_keyed_by_blog_id` | both caches are stored under the ID of the site they were built for |
| `test_deactivate_plugins_still_caches_within_the_same_site` | non-regression: the second read in one site is still answered from the cache |
| `test_deactivate_network_plugins_still_caches_within_the_same_site` | same for the network list |
| `test_flush_plugin_caches_empties_both_caches` | the `switch_blog` callback does clear both |

Two existing tests, `test_plugins_property` and `test_network_plugins_property`,
asserted the old `null` initial value of these protected caches. They now assert
the documented per-site shape (`[]`). That is the only existing behaviour this
PR changes.

I could not run PHPUnit while preparing this (no MySQL and no WordPress test
suite available), so the tests above are not empirically confirmed green. What I
did run is a standalone harness that extracts the two cache properties and the
two callbacks **verbatim** from each version of the file and drives the same
scenario through both:

```
=== BEFORE THE FIX (git main) ===
  option_active_plugins on site 2: ["site-a/site-a.php"]
  option_active_plugins on site 3: ["site-a/site-a.php"]     <-- site 3 gets site 2's list
  site_option_active_sitewide_plugins on site 3: {"site-a/site-a.php":1}
  site 3 gets its OWN list ............ FAIL
  site 3 gets its OWN network list .... FAIL
  cache still reused within one site ... PASS

=== AFTER THE FIX ===
  option_active_plugins on site 2: ["site-a/site-a.php"]
  option_active_plugins on site 3: ["site-b/site-b.php"]
  site_option_active_sitewide_plugins on site 3: {"site-b/site-b.php":1}
  site 3 gets its OWN list ............ PASS
  site 3 gets its OWN network list .... PASS
  cache still reused within one site ... PASS
```

`php -l` is clean on both changed files.

## Out of scope

`Theme_Limits` has the same cache shape — `$forced_theme_stylesheet` and
`$forced_theme_template` (`inc/limits/class-theme-limits.php:38`, `:46`,
memoised at `:316` and `:332`) are singleton properties filled from
`wu_get_current_site()` and not keyed by site either. It is a different file and
a much smaller blast radius, because WordPress does not read-modify-write the
`stylesheet` / `template` options the way it does `active_plugins`. Worth a
separate look; deliberately not touched here to keep this PR to one class and
one behaviour.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed plugin limit handling in multisite environments so plugin states remain isolated between sites.
  * Prevented cached plugin lists from being incorrectly reused after switching sites.
  * Preserved cache reuse when operating within the same site.

* **Tests**
  * Added coverage for multisite cache isolation, reuse, and cache clearing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->