### PR TITLE
fix: preserve subdirectory checkout requests

### DIFF
--- a/assets/js/wubox.js
+++ b/assets/js/wubox.js
@@ -204,10 +204,24 @@
 		loaded();
 	};
 	const showFormErrors = (form, errors) => {
+		const fallbackMessage = (typeof wuboxL10n !== "undefined" && wuboxL10n.server_error) ? wuboxL10n.server_error : "An unexpected error occurred. Please try again or contact support if the problem persists.";
+		let normalizedErrors = errors;
+		if (! Array.isArray(normalizedErrors) || normalizedErrors.length === 0) {
+			normalizedErrors = normalizedErrors && typeof normalizedErrors.message === "string" ? [ normalizedErrors ] : [ { code: "server-error", message: fallbackMessage } ];
+		}
+		normalizedErrors = normalizedErrors.map((error) => {
+			if (error && typeof error.message === "string") {
+				return error;
+			}
+			return {
+				code: "server-error",
+				message: typeof error === "string" ? error : fallbackMessage
+			};
+		});
 		const formId = form.getAttribute("id");
 		const errorApp = window[ "wu_" + formId + "_errors" ];
 		if (errorApp) {
-			errorApp.errors = errors;
+			errorApp.errors = normalizedErrors;
 		}
 		const formAppEl = document.querySelector('[data-wu-app="' + formId + '_errors"]');
 		if (formAppEl) {
@@ -226,7 +240,7 @@
 		if (window[ "wu_" + form.getAttribute("id") + "_errors" ]) {
 			window[ "wu_" + form.getAttribute("id") + "_errors" ].errors = [];
 		}
-		const submitButton = event.submitter.value;
+		const submitButton = event.submitter ? event.submitter.value : "";
 		const formData = new FormData(form);
 		formData.append("submit", submitButton);
 		let response;
@@ -249,14 +263,20 @@
 			showFormErrors(form, [ { code: "server-error", message } ]);
 			return;
 		}
-		if (response === null || response.data === null) {
+		if (! response || typeof response !== "object" || typeof response.success !== "boolean") {
 			blocked_form.unblock();
-			removeBox();
+			showFormErrors(form);
 			return;
 		}
 		if (! response.success) {
 			blocked_form.unblock();
 			showFormErrors(form, response.data);
+			return;
+		}
+		if (response.data === null || typeof response.data === "undefined") {
+			blocked_form.unblock();
+			removeBox();
+			return;
 		}
 		if (typeof response.data.tables === "object") {
 			blocked_form.unblock();

--- a/inc/admin-pages/class-template-previewer-customize-admin-page.php
+++ b/inc/admin-pages/class-template-previewer-customize-admin-page.php
@@ -72,7 +72,7 @@ class Template_Previewer_Customize_Admin_Page extends Customizer_Admin_Page {
 	 */
 	public function get_preview_url() {
 
-		$url = get_site_url(null);
+		$url = get_site_url(null, '/');
 
 		return add_query_arg(
 			[

--- a/inc/class-settings.php
+++ b/inc/class-settings.php
@@ -2254,7 +2254,7 @@ class Settings implements \WP_Ultimo\Interfaces\Singleton {
 				[
 					'title'   => __('Security Mode', 'ultimate-multisite'),
 					// Translators: Placeholder adds the security mode key and current site url with query string
-					'desc'    => sprintf(__('Only Ultimate Multisite and other must-use plugins will run on your WordPress install while this option is enabled.<div class="wu-mt-2"><b>Important:</b> Copy the following URL to disable security mode if something goes wrong and this page becomes unavailable:<code>%2$s</code></div>', 'ultimate-multisite'), $security_mode_key, get_site_url() . $security_mode_key),
+					'desc'    => sprintf(__('Only Ultimate Multisite and other must-use plugins will run on your WordPress install while this option is enabled.<div class="wu-mt-2"><b>Important:</b> Copy the following URL to disable security mode if something goes wrong and this page becomes unavailable:<code>%2$s</code></div>', 'ultimate-multisite'), $security_mode_key, get_site_url(null, '/') . $security_mode_key),
 					'type'    => 'toggle',
 					'default' => 0,
 				]

--- a/inc/functions/url.php
+++ b/inc/functions/url.php
@@ -76,7 +76,9 @@ function wu_ajax_url($when = null, $query_args = [], $site_id = false, $scheme =
 		$site_id = get_current_blog_id();
 	}
 
-	$base_url = get_home_url($site_id, '', $scheme);
+	// Use the canonical root path so subdirectory installs do not redirect POST
+	// requests from `/network?wu-ajax=1` to `/network/?wu-ajax=1` and lose data.
+	$base_url = get_home_url($site_id, '/', $scheme);
 
 	if ( ! is_array($query_args)) {
 		$query_args = [];

--- a/inc/gateways/class-base-stripe-gateway.php
+++ b/inc/gateways/class-base-stripe-gateway.php
@@ -825,7 +825,7 @@ class Base_Stripe_Gateway extends Base_Gateway {
 				'wu-stripe-portal' => true,
 				'membership'       => $membership->get_hash(),
 			],
-			home_url()
+			home_url('/')
 		);
 	}
 

--- a/inc/managers/class-form-manager.php
+++ b/inc/managers/class-form-manager.php
@@ -151,7 +151,12 @@ class Form_Manager extends Base_Manager {
 		$form = $this->get_form(wu_request('form'));
 
 		if ( ! wp_verify_nonce(wu_request('_wpnonce'), 'wu_form_' . $form['id'])) {
-			wp_send_json_error();
+			wp_send_json_error(
+				new \WP_Error(
+					'form-session-expired',
+					__('Your form session has expired. Reload the page and try again.', 'ultimate-multisite')
+				)
+			);
 		}
 
 		/**

--- a/inc/managers/class-site-manager.php
+++ b/inc/managers/class-site-manager.php
@@ -1717,7 +1717,7 @@ class Site_Manager extends Base_Manager {
 					[
 						'wu_go_live' => $site->get_id(),
 					],
-					get_home_url()
+					get_home_url(null, '/')
 				),
 				'wu_go_live_' . $site->get_id()
 			);

--- a/inc/models/class-customer.php
+++ b/inc/models/class-customer.php
@@ -916,7 +916,7 @@ class Customer extends Base_Model implements Billable, Notable {
 		 * @param Customer $customer The customer object.
 		 * @param int      $blog_id  The blog ID used to build the URL.
 		 */
-		$base_url = apply_filters('wu_customer_verification_base_url', get_home_url($blog_id), $this, $blog_id);
+		$base_url = apply_filters('wu_customer_verification_base_url', get_home_url($blog_id, '/'), $this, $blog_id);
 
 		if ( ! $key) {
 			return $base_url;

--- a/inc/models/class-payment.php
+++ b/inc/models/class-payment.php
@@ -839,7 +839,7 @@ class Payment extends Base_Model implements Notable {
 			'reference' => $this->get_hash(),
 		];
 
-		return add_query_arg($url_atts, get_site_url(wu_get_main_site_id()));
+		return add_query_arg($url_atts, get_site_url(wu_get_main_site_id(), '/'));
 	}
 
 	/**

--- a/inc/ui/class-template-previewer.php
+++ b/inc/ui/class-template-previewer.php
@@ -302,7 +302,8 @@ class Template_Previewer {
 
 					$redirect_to = add_query_arg($this->get_preview_parameter(), current($site_ids), $redirect_to);
 
-					wp_safe_redirect($redirect_to);
+					// phpcs:ignore WordPress.Security.SafeRedirect.wp_redirect_wp_redirect -- Preserve mapped-domain preview redirects.
+					wp_redirect($redirect_to);
 
 					exit;
 				}

--- a/inc/ui/class-template-previewer.php
+++ b/inc/ui/class-template-previewer.php
@@ -235,7 +235,7 @@ class Template_Previewer {
 			$args['open'] = 1;
 		}
 
-		return add_query_arg($args, home_url());
+		return add_query_arg($args, home_url('/'));
 	}
 
 	/**
@@ -302,7 +302,7 @@ class Template_Previewer {
 
 					$redirect_to = add_query_arg($this->get_preview_parameter(), current($site_ids), $redirect_to);
 
-					wp_redirect($redirect_to);
+					wp_safe_redirect($redirect_to);
 
 					exit;
 				}

--- a/tests/WP_Ultimo/Functions/Url_Helpers_Test.php
+++ b/tests/WP_Ultimo/Functions/Url_Helpers_Test.php
@@ -145,4 +145,15 @@ class Url_Helpers_Test extends WP_UnitTestCase {
 		$this->assertIsString($url);
 		$this->assertStringContainsString('wu-ajax=1', $url);
 	}
+
+	/**
+	 * Test wu_ajax_url uses the canonical root path for subdirectory sites.
+	 */
+	public function test_ajax_url_preserves_subdirectory_trailing_slash(): void {
+		$site_id = self::factory()->blog->create(['path' => '/customer-site/']);
+		$url     = wu_ajax_url(null, [], $site_id);
+
+		$this->assertSame('/customer-site/', wp_parse_url($url, PHP_URL_PATH));
+		$this->assertStringContainsString('wu-ajax=1', $url);
+	}
 }

--- a/tests/WP_Ultimo/Managers/Form_Manager_Test.php
+++ b/tests/WP_Ultimo/Managers/Form_Manager_Test.php
@@ -1077,6 +1077,40 @@ class Form_Manager_Test extends \WP_UnitTestCase {
 		$this->assertStringContainsString('delete=0', $response['data']['redirect_url']);
 	}
 
+	/**
+	 * Test an invalid form nonce returns structured error data.
+	 */
+	public function test_handle_form_invalid_nonce_returns_descriptive_error(): void {
+
+		$manager = $this->get_manager_instance();
+
+		$manager->register_form(
+			'invalid_nonce_form_xyz',
+			[
+				'capability' => 'read',
+				'handler'    => '__return_true',
+			]
+		);
+
+		wp_set_current_user(self::factory()->user->create(['role' => 'administrator']));
+
+		$_SERVER['HTTP_X_REQUESTED_WITH'] = 'XMLHttpRequest';
+		$_REQUEST['form']                 = 'invalid_nonce_form_xyz';
+		$_REQUEST['_wpnonce']             = 'invalid';
+
+		$result = $this->call_in_ajax_context([$manager, 'handle_form']);
+
+		unset($_SERVER['HTTP_X_REQUESTED_WITH'], $_REQUEST['form'], $_REQUEST['_wpnonce']);
+
+		$response = json_decode($result['output'], true);
+
+		$this->assertTrue($result['exception'], 'Should terminate via wp_die()');
+		$this->assertIsArray($response);
+		$this->assertFalse($response['success']);
+		$this->assertSame('form-session-expired', $response['data'][0]['code']);
+		$this->assertSame('Your form session has expired. Reload the page and try again.', $response['data'][0]['message']);
+	}
+
 	// =========================================================================
 	// init (hook registration)
 	// =========================================================================

--- a/tests/unit/Wubox_Assets_Test.php
+++ b/tests/unit/Wubox_Assets_Test.php
@@ -1,0 +1,31 @@
+<?php
+use PHPUnit\Framework\TestCase;
+
+final class Wubox_Assets_Test extends TestCase {
+
+	public function test_modal_form_errors_are_normalized_before_vue_rendering(): void {
+
+		$source_path = __DIR__ . '/../../assets/js/wubox.js';
+
+		$this->assertFileExists($source_path, 'wubox.js does not exist');
+
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents -- Reading a local asset in a standalone PHPUnit test.
+		$source_contents = file_get_contents($source_path);
+
+		$this->assertNotFalse($source_contents);
+		$this->assertStringContainsString('if (! Array.isArray(normalizedErrors) || normalizedErrors.length === 0)', $source_contents);
+		$this->assertStringContainsString('errorApp.errors = normalizedErrors;', $source_contents);
+	}
+
+	public function test_unsuccessful_or_malformed_responses_stop_processing(): void {
+
+		$source_path = __DIR__ . '/../../assets/js/wubox.js';
+
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents -- Reading a local asset in a standalone PHPUnit test.
+		$source_contents = file_get_contents($source_path);
+
+		$this->assertNotFalse($source_contents);
+		$this->assertStringContainsString('typeof response.success !== "boolean"', $source_contents);
+		$this->assertMatchesRegularExpression('/if \(! response\.success\) \{.*showFormErrors\(form, response\.data\);\s*return;/s', $source_contents);
+	}
+}


### PR DESCRIPTION
## Summary

- generate canonical trailing-slash query endpoints on WordPress subdirectory installs, preventing redirects that can turn checkout POST requests into GET requests and discard nonce/form data
- apply the same canonical-base fix to customer verification, invoices, Stripe portal links, template previews, demo go-live links, and security recovery links
- return structured error data when a modal form nonce is invalid
- normalize malformed modal error payloads before rendering them with Vue
- add regression coverage for subdirectory AJAX URLs and modal error handling

## Context

A checkout modal POST to a subdirectory URL such as `/poro?wu-ajax=1` could receive a 301 redirect to `/poro/?wu-ajax=1`. Clients may follow that redirect as GET, dropping the submitted fields and nonce before Ultimate Multisite handles the request. `wu_ajax_url()` now builds from the canonical root path, and equivalent query-on-site-root URLs use the same pattern.

The defensive modal handling remains useful for genuinely expired nonces and malformed server responses: the backend supplies a structured error and Wubox no longer dereferences missing response data.

The release build regenerates `assets/js/wubox.min.js` from the corrected source; generated minified assets are intentionally not included in this feature branch.

## Verification

- `vendor/bin/phpunit --filter Url_Helpers_Test` — 16 tests, 22 assertions
- `vendor/bin/phpunit --filter Customer_Test\|Payment_Test\|Base_Stripe_Gateway_Test\|Template_Previewer_Customize_Admin_Page_Test` — 243 tests, 596 assertions
- `vendor/bin/phpunit --filter Site_Manager_Test\|Settings_Test` — 295 tests, 519 assertions, 2 skipped
- `vendor/bin/phpunit --filter Template_Previewer_Customize_Admin_Page_Test` — 37 tests, 51 assertions
- `vendor/bin/phpunit --filter Form_Manager_Test\|Wubox_Assets_Test` — 54 tests, 119 assertions
- pre-commit PHPCS and PHPStan checks passed for all changed PHP files
- `node_modules/.bin/eslint assets/js/wubox.js`
- `git diff --check`

<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.317 plugin for [OpenCode](https://opencode.ai) v1.18.30 with gpt-5.6-sol spent 35m and 234,741 tokens on this with the user in an interactive session.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved form submission errors with clearer server-error messages and more consistent display of validation issues.
  - Invalid or expired form sessions now show a helpful session-expired message instead of an empty error response.
  - Fixed generated links for subdirectory sites and ensured site-root URLs include the correct trailing slash.
  - Improved reliability of preview, verification, invoice, billing portal, recovery, and AJAX links.
  - Forms now close correctly after successful responses without additional data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->