### PR TITLE
GH#1853: fix(site-duplicator): refresh cloned site roles before hooks

### DIFF
--- a/inc/helpers/class-site-duplicator.php
+++ b/inc/helpers/class-site-duplicator.php
@@ -550,6 +550,15 @@ class Site_Duplicator {
 
 		$profile_stage = microtime(true);
 		wp_cache_flush();
+
+		/*
+		 * Rebuild the in-memory role map from the copied options table before
+		 * invoking extension hooks. A cache flush does not reset WP_Roles, and
+		 * a hook that adds a role with an empty role map would overwrite
+		 * user_roles with that single role.
+		 */
+		wp_roles()->for_site($args->to_site_id);
+
 		self::profile_sovereign_provisioning_stage(
 			(int) $args->to_site_id,
 			'um_duplicator.wp_cache_flush',

--- a/tests/WP_Ultimo/Helpers/Site_Duplicator_Test.php
+++ b/tests/WP_Ultimo/Helpers/Site_Duplicator_Test.php
@@ -822,6 +822,45 @@ class Site_Duplicator_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Test duplicated site roles are available to extension hooks.
+	 */
+	public function test_wu_duplicate_site_action_receives_reloaded_roles() {
+		$role_slug    = 'site_duplicator_template_role';
+		$role_at_hook = false;
+		$result       = false;
+		$role_hook    = function () use (&$role_at_hook, $role_slug) {
+			$role_at_hook = wp_roles()->get_role($role_slug);
+		};
+
+		switch_to_blog($this->template_site_id);
+		add_role($role_slug, 'Site Duplicator Template Role', ['read' => true]);
+		restore_current_blog();
+
+		add_action('wu_duplicate_site', $role_hook);
+
+		try {
+			$result = Site_Duplicator::duplicate_site(
+				$this->template_site_id,
+				'Role Hook Site',
+				[
+					'domain' => 'role-hook.example.com',
+					'path'   => '/',
+					'title'  => 'Role Hook Site',
+				]
+			);
+
+			$this->assertIsInt($result);
+			$this->assertNotFalse($role_at_hook);
+		} finally {
+			remove_action('wu_duplicate_site', $role_hook);
+
+			if ($result) {
+				wpmu_delete_blog($result, true);
+			}
+		}
+	}
+
+	/**
 	 * Test backfill_kit_settings is a no-op when template has no Kit.
 	 */
 	public function test_backfill_kit_settings_noop_without_elementor() {


### PR DESCRIPTION
## Summary

Refresh the cloned site's in-memory WordPress role map after copying its options table and before extension hooks run, preventing hook-added roles from replacing the copied map.

## Files Changed

inc/helpers/class-site-duplicator.php, tests/WP_Ultimo/Helpers/Site_Duplicator_Test.php

## Runtime Testing

- **Risk level:** Medium
- **Verification:** self-assessed — vendor/bin/phpunit --filter test_wu_duplicate_site_action_receives_reloaded_roles; vendor/bin/phpcs inc/helpers/class-site-duplicator.php tests/WP_Ultimo/Helpers/Site_Duplicator_Test.php; vendor/bin/phpstan analyse --no-progress --error-format=table inc/helpers/class-site-duplicator.php

Resolves #1853


<!-- aidevops:origin:worker -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.317 plugin for [OpenCode](https://opencode.ai) v1.18.30 with gpt-5.6-terra spent 8m and 124,959 tokens on this as a headless worker.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Site duplication now correctly reloads WordPress roles before duplication actions run.
  * Roles created on the template site are available on the duplicated site during duplication hooks.

* **Tests**
  * Added regression coverage to verify role availability during the site duplication process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->