### PR TITLE
fix(release): align runtime version constant

### DIFF
--- a/inc/class-wp-ultimo.php
+++ b/inc/class-wp-ultimo.php
@@ -31,7 +31,7 @@ final class WP_Ultimo {
 	 * @since 2.1.0
 	 * @var string
 	 */
-	const VERSION = '2.16.0';
+	const VERSION = '2.16.1';
 
 	/**
 	 * Core log handle for Ultimate Multisite.


### PR DESCRIPTION
## Summary

- Align `WP_Ultimo::VERSION` with the v2.16.1 plugin release.
- Restore release-workflow version validation.

## Verification

- `vendor/bin/phpcs inc/class-wp-ultimo.php`
- Pre-commit PHPStan

<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.317 plugin for [OpenCode](https://opencode.ai) v1.18.30 with gpt-5.6-terra spent 7m and 115,009 tokens on this with the user in an interactive session.
