### PR TITLE
fix: preserve modal server errors

### DIFF
--- a/assets/js/wubox.js
+++ b/assets/js/wubox.js
@@ -206,7 +206,9 @@
 	const showFormErrors = (form, errors) => {
 		const fallbackMessage = (typeof wuboxL10n !== "undefined" && wuboxL10n.server_error) ? wuboxL10n.server_error : "An unexpected error occurred. Please try again or contact support if the problem persists.";
 		let normalizedErrors = errors;
-		if (! Array.isArray(normalizedErrors) || normalizedErrors.length === 0) {
+		if (typeof normalizedErrors === "string") {
+			normalizedErrors = [ { code: "server-error", message: normalizedErrors } ];
+		} else if (! Array.isArray(normalizedErrors) || normalizedErrors.length === 0) {
 			normalizedErrors = normalizedErrors && typeof normalizedErrors.message === "string" ? [ normalizedErrors ] : [ { code: "server-error", message: fallbackMessage } ];
 		}
 		normalizedErrors = normalizedErrors.map((error) => {

--- a/assets/js/wubox.js
+++ b/assets/js/wubox.js
@@ -206,7 +206,7 @@
 	const showFormErrors = (form, errors) => {
 		const fallbackMessage = (typeof wuboxL10n !== "undefined" && wuboxL10n.server_error) ? wuboxL10n.server_error : "An unexpected error occurred. Please try again or contact support if the problem persists.";
 		let normalizedErrors = errors;
-		if (typeof normalizedErrors === "string") {
+		if (typeof normalizedErrors === "string" && normalizedErrors) {
 			normalizedErrors = [ { code: "server-error", message: normalizedErrors } ];
 		} else if (! Array.isArray(normalizedErrors) || normalizedErrors.length === 0) {
 			normalizedErrors = normalizedErrors && typeof normalizedErrors.message === "string" ? [ normalizedErrors ] : [ { code: "server-error", message: fallbackMessage } ];

--- a/tests/WP_Ultimo/Integrations/Providers/Rocket_Domain_Mapping_Test.php
+++ b/tests/WP_Ultimo/Integrations/Providers/Rocket_Domain_Mapping_Test.php
@@ -215,19 +215,19 @@ class Rocket_Domain_Mapping_Test extends WP_UnitTestCase {
 	public function rocket_access_token_response_provider(): array {
 
 		return [
-			'direct token'        => [
+			'direct token'          => [
 				['token' => 'direct-token'],
 				'direct-token',
 			],
-			'direct access token' => [
+			'direct access token'   => [
 				['access_token' => 'direct-access-token'],
 				'direct-access-token',
 			],
-			'nested token'        => [
+			'nested token'          => [
 				['result' => ['token' => 'nested-token']],
 				'nested-token',
 			],
-			'nested access token' => [
+			'nested access token'   => [
 				['result' => ['access_token' => 'nested-access-token']],
 				'nested-access-token',
 			],

--- a/tests/WP_Ultimo/Integrations/Providers/Rocket_Domain_Mapping_Test.php
+++ b/tests/WP_Ultimo/Integrations/Providers/Rocket_Domain_Mapping_Test.php
@@ -215,19 +215,19 @@ class Rocket_Domain_Mapping_Test extends WP_UnitTestCase {
 	public function rocket_access_token_response_provider(): array {
 
 		return [
-			'direct token'          => [
+			'direct token'        => [
 				['token' => 'direct-token'],
 				'direct-token',
 			],
-			'direct access token'   => [
+			'direct access token' => [
 				['access_token' => 'direct-access-token'],
 				'direct-access-token',
 			],
-			'nested token'          => [
+			'nested token'        => [
 				['result' => ['token' => 'nested-token']],
 				'nested-token',
 			],
-			'nested access token'   => [
+			'nested access token' => [
 				['result' => ['access_token' => 'nested-access-token']],
 				'nested-access-token',
 			],

--- a/tests/unit/Wubox_Assets_Test.php
+++ b/tests/unit/Wubox_Assets_Test.php
@@ -13,6 +13,8 @@ final class Wubox_Assets_Test extends TestCase {
 		$source_contents = file_get_contents($source_path);
 
 		$this->assertNotFalse($source_contents);
+		$this->assertStringContainsString('if (typeof normalizedErrors === "string")', $source_contents);
+		$this->assertStringContainsString('normalizedErrors = [ { code: "server-error", message: normalizedErrors } ];', $source_contents);
 		$this->assertStringContainsString('if (! Array.isArray(normalizedErrors) || normalizedErrors.length === 0)', $source_contents);
 		$this->assertStringContainsString('errorApp.errors = normalizedErrors;', $source_contents);
 	}

--- a/tests/unit/Wubox_Assets_Test.php
+++ b/tests/unit/Wubox_Assets_Test.php
@@ -13,8 +13,9 @@ final class Wubox_Assets_Test extends TestCase {
 		$source_contents = file_get_contents($source_path);
 
 		$this->assertNotFalse($source_contents);
-		$this->assertStringContainsString('if (typeof normalizedErrors === "string")', $source_contents);
+		$this->assertStringContainsString('if (typeof normalizedErrors === "string" && normalizedErrors)', $source_contents);
 		$this->assertStringContainsString('normalizedErrors = [ { code: "server-error", message: normalizedErrors } ];', $source_contents);
+		$this->assertStringContainsString('normalizedErrors && typeof normalizedErrors.message === "string" ? [ normalizedErrors ] : [ { code: "server-error", message: fallbackMessage } ];', $source_contents);
 		$this->assertStringContainsString('if (! Array.isArray(normalizedErrors) || normalizedErrors.length === 0)', $source_contents);
 		$this->assertStringContainsString('errorApp.errors = normalizedErrors;', $source_contents);
 	}


### PR DESCRIPTION
## Summary

- Preserve top-level server error strings returned by modal form requests.
- Cover the string-normalization path with the existing Wubox asset test.

## Testing

- `vendor/bin/phpunit --filter Wubox_Assets_Test`
- `vendor/bin/phpcs tests/unit/Wubox_Assets_Test.php`
- `pnpm exec eslint assets/js/wubox.js --ignore-pattern '*.min.js'`

Resolves #1860

<!-- aidevops:origin:worker -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.317 plugin for [OpenCode](https://opencode.ai) v1.18.30 with gpt-5.6-terra


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved modal form error handling for plain-text server errors.
  - Empty error messages now use the standard fallback message instead of displaying a blank message.
  - Existing structured error formats continue to be supported.

- **Tests**
  - Expanded coverage for empty strings and other unsupported error formats.
  - Verified that valid string errors are normalized before display.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->